### PR TITLE
Ux refinement

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -3,7 +3,7 @@ from fastapi.responses import FileResponse
 from services.auth import get_current_user
 from services.library import (
     list_documents, get_document, delete_document,
-    get_translation, get_pdf_path
+    get_translation, get_pdf_path, update_document_metadata
 )
 
 router = APIRouter()
@@ -97,4 +97,30 @@ async def get_library_document_images(doc_id: str):
         return {"images": images}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"이미지 좌표 추출 실패: {str(e)}")
+
+
+@router.put("/library/{doc_id}/metadata")
+async def update_doc_metadata(
+    doc_id: str,
+    payload: dict,
+    current_user: str = Depends(get_current_user)
+):
+    """문서의 메타데이터(예: 제목 등)를 업데이트합니다."""
+    doc = get_document(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    if doc.get("username") != current_user:
+        raise HTTPException(status_code=403, detail="권한이 없습니다.")
+    
+    meta = doc.get("metadata") or {}
+    meta.update(payload)
+    
+    update_document_metadata(doc_id, meta)
+    
+    # 활성 메모리 세션도 업데이트하여 정합성 유지
+    from routers.upload import sessions
+    if doc_id in sessions:
+        sessions[doc_id]["metadata"] = meta
+        
+    return {"status": "success", "metadata": meta}
 

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -5,6 +5,8 @@ from services.library import (
     list_documents, get_document, delete_document,
     get_translation, get_pdf_path, update_document_metadata
 )
+from pydantic import BaseModel
+import json
 
 router = APIRouter()
 
@@ -65,6 +67,44 @@ async def get_library_translation(
         "translation": full_cached["translation"],
         "sentences": full_cached.get("sentences", [])
     }
+
+
+class UpdateTranslationPayload(BaseModel):
+    translation: str
+    sentences: list[dict]
+
+
+@router.put("/library/{doc_id}/translation/{page_num}")
+async def update_library_translation(
+    doc_id: str,
+    page_num: int,
+    payload: UpdateTranslationPayload,
+    target_lang: Optional[str] = None,
+    style: Optional[str] = None,
+    ignore_math: Optional[bool] = None,
+    ignore_table: Optional[bool] = None,
+    ignore_refs: Optional[bool] = None
+):
+    """라이브러리의 특정 페이지 번역 데이터를 수정하여 캐시 및 DB에 저장합니다."""
+    suffix = ""
+    if target_lang is not None and style is not None:
+        suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
+
+    from services.library import save_translation
+    from services.cache import save_translation_cache
+
+    payload_dict = {
+        "translation": payload.translation,
+        "sentences": payload.sentences
+    }
+    payload_json = json.dumps(payload_dict, ensure_ascii=False)
+
+    # DB에 영구 저장
+    save_translation(doc_id, page_num, payload_json, suffix)
+    # 메모리 캐시 최신화
+    save_translation_cache(doc_id, page_num, payload_json, suffix)
+
+    return {"status": "success"}
 
 
 @router.get("/library/{doc_id}/pdf")

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -143,14 +143,107 @@ def clean_text_for_translation(text: str) -> str:
 
 
 
+def _extract_paper_title(doc: fitz.Document) -> str:
+    """PDF 첫 페이지의 텍스트와 폰트 크기를 분석하여 논문의 실제 제목을 추출합니다."""
+    if len(doc) == 0:
+        return ""
+    
+    try:
+        page = doc[0]
+        blocks = page.get_text("dict")["blocks"]
+        
+        spans_info = []
+        for b in blocks:
+            if "lines" not in b:
+                continue
+            for line in b["lines"]:
+                for span in line["spans"]:
+                    text = span["text"].strip()
+                    if not text or len(text) < 2:
+                        continue
+                    # 너무 작거나 숫자로만 이루어진 스팬은 무시
+                    if text.isdigit():
+                        continue
+                    
+                    bbox = span["bbox"]
+                    y0 = bbox[1]
+                    height = page.rect.height
+                    
+                    # 상단 8% 미만 또는 하단 15% 초과 영역에 있으면서 폰트가 작은 경우(헤더/푸터) 무시
+                    if (y0 < height * 0.08 or y0 > height * 0.85) and span["size"] < 12:
+                        continue
+                        
+                    spans_info.append({
+                        "text": text,
+                        "size": span["size"],
+                        "font": span["font"],
+                        "bbox": bbox
+                    })
+        
+        if not spans_info:
+            return ""
+            
+        # 가장 큰 폰트 크기 찾기
+        max_size = max(s["size"] for s in spans_info)
+        
+        # 최상위 폰트 크기(최대 크기의 90% 이상인 것들)에 해당하는 스팬 수집
+        title_spans = []
+        for s in spans_info:
+            if s["size"] >= max_size * 0.9:
+                title_spans.append(s)
+                
+        if not title_spans:
+            return ""
+            
+        # 읽기 순서대로 정렬 (y좌표 우선, x좌표 차선)
+        title_spans.sort(key=lambda s: (s["bbox"][1], s["bbox"][0]))
+        
+        # 연속된 텍스트 결합
+        title_parts = []
+        for s in title_spans:
+            lower_text = s["text"].lower()
+            if lower_text in ["abstract", "introduction", "keywords", "key words"]:
+                continue
+            title_parts.append(s["text"])
+            
+        title_text = " ".join(title_parts).strip()
+        title_text = re.sub(r'\s+', ' ', title_text)
+        
+        # 유효한 제목 길이 제한
+        if 5 <= len(title_text) <= 250:
+            return title_text
+    except Exception as e:
+        print(f"Failed to extract title from PDF content: {e}")
+        
+    return ""
+
+
 def get_pdf_metadata(pdf_path: str) -> Dict[str, Any]:
     """PDF 메타데이터를 반환합니다."""
     doc = fitz.open(pdf_path)
     meta = doc.metadata or {}
     page_count = len(doc)
+    
+    # 1. 문서 텍스트 분석을 통한 실제 논문 제목 추출 시도
+    extracted_title = _extract_paper_title(doc)
+    
+    # 2. 메타데이터 제목 획득
+    meta_title = meta.get("title", "").strip()
+    
+    # 3. 우선순위 결정: 추출된 제목이 있으면 최우선 사용, 없으면 메타데이터 제목 사용
+    # 단, 메타데이터 제목이 무의미한 템플릿(Word, untitled 등)인 경우도 필터링
+    title = ""
+    if extracted_title:
+        title = extracted_title
+    elif meta_title:
+        lower_meta = meta_title.lower()
+        invalid_keywords = ["microsoft", "word", "untitled", "layout", "template", "document", "pdf", "page"]
+        if not any(k in lower_meta for k in invalid_keywords) and len(meta_title) >= 4:
+            title = meta_title
+            
     doc.close()
     return {
-        "title": meta.get("title", ""),
+        "title": title,
         "author": meta.get("author", ""),
         "subject": meta.get("subject", ""),
         "total_pages": page_count,

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-DQNPfD--.js"></script>
+  <script type="module" crossorigin src="/assets/index-BMJa5uJC.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Dh7U78eV.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CLOUG5-u.css">
+  <script type="module" crossorigin src="/assets/index-BlwkCIDL.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-YQHEtqP_.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-CNKiC2BA.js"></script>
+  <script type="module" crossorigin src="/assets/index-BvPMVCnH.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CDjiOTIr.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BZZm3qzz.js"></script>
+  <script type="module" crossorigin src="/assets/index-CNKiC2BA.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CDjiOTIr.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BIrt4cKO.js"></script>
+  <script type="module" crossorigin src="/assets/index-D79lqC1q.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Dfm5J4nH.js"></script>
+  <script type="module" crossorigin src="/assets/index-gNgIpGmV.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-DgctnNZn.js"></script>
+  <script type="module" crossorigin src="/assets/index-ChO978BK.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-D991RaDE.js"></script>
+  <script type="module" crossorigin src="/assets/index-Dfm5J4nH.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-B0tPpvhm.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-C45ogv34.css">
+  <script type="module" crossorigin src="/assets/index-BVFvZpFK.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-B5yl053d.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-CQRh8tvj.js"></script>
+  <script type="module" crossorigin src="/assets/index-CoQ68PK8.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-QhKBXVH8.js"></script>
+  <script type="module" crossorigin src="/assets/index-D991RaDE.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-88J8ksGG.js"></script>
+  <script type="module" crossorigin src="/assets/index-CQRh8tvj.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -15,7 +15,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script type="module" crossorigin src="/assets/index-DsoEC_5h.js"></script>
+  <script type="module" crossorigin src="/assets/index-BltgbY3U.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BSh92gIU.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BVFvZpFK.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-B5yl053d.css">
+  <script type="module" crossorigin src="/assets/index-C__4Hxa7.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CtXvqNn5.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-lIpNHmL1.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CwQ804KP.css">
+  <script type="module" crossorigin src="/assets/index-B0tPpvhm.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-C45ogv34.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-DWVhl3TI.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
+  <script type="module" crossorigin src="/assets/index-Dh7U78eV.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CLOUG5-u.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-D79lqC1q.js"></script>
+  <script type="module" crossorigin src="/assets/index-88J8ksGG.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -91,7 +91,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;" onclick="alert('HTML inline click works!')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,9 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script type="module" crossorigin src="/assets/index-BltgbY3U.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BSh92gIU.css">
+  <script type="module" crossorigin src="/assets/index-DQNPfD--.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BHNpcLKy.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DIar45bK.css">
+  <script type="module" crossorigin src="/assets/index-HDYXL1kI.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DvyQYy2E.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-ChO978BK.js"></script>
+  <script type="module" crossorigin src="/assets/index-DWVhl3TI.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BNDHLP7v.js"></script>
+  <script type="module" crossorigin src="/assets/index-BjjaHFat.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CwQ804KP.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-OtBiTek9.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-ewm2zn2E.css">
+  <script type="module" crossorigin src="/assets/index-BHNpcLKy.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DIar45bK.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BYBzOzaU.js"></script>
+  <script type="module" crossorigin src="/assets/index-WXQ8kmo0.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Dr18TyXH.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Bnn2-otJ.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-C7Centeq.css">
+  <script type="module" crossorigin src="/assets/index-Dfk_3YHu.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-hMTQkigM.css">
 </head>
 <body>
 
@@ -110,6 +110,16 @@
         <div class="translation-status" id="translation-status">
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
+        </div>
+        <!-- 번역 패널 제어 (접기/크기조절) -->
+        <div class="trans-pane-controls" style="display: inline-flex; align-items: center; gap: 4px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 4px; margin-right: 8px;">
+          <button id="toggle-trans-pane-btn" class="icon-btn" title="번역 창 접기/펴기" style="border: none; background: none;">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+          </button>
+          <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+          <button id="trans-width-dec-btn" class="icon-btn" title="번역 창 너비 축소" style="border: none; background: none; width: 24px; height: 24px;">−</button>
+          <span id="trans-width-label" style="font-size: 11px; font-weight: 600; color: var(--text-secondary); min-width: 42px; text-align: center; user-select: none;">620px</span>
+          <button id="trans-width-inc-btn" class="icon-btn" title="번역 창 너비 확대" style="border: none; background: none; width: 24px; height: 24px;">+</button>
         </div>
         <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
         <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BMJa5uJC.js"></script>
+  <script type="module" crossorigin src="/assets/index-DgctnNZn.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CjJdgnge.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+  <script>
+    window.addEventListener('error', function(event) {
+      alert("Captured JS error: " + event.message + "\nFile: " + event.filename + "\nLine: " + event.lineno + ":" + event.colno);
+    }, true);
+    window.addEventListener('unhandledrejection', function(event) {
+      alert("Captured JS rejection: " + event.reason);
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EasyPaper — AI 논문 번역</title>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-gNgIpGmV.js"></script>
+  <script type="module" crossorigin src="/assets/index-BIrt4cKO.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-C__4Hxa7.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CtXvqNn5.css">
+  <script type="module" crossorigin src="/assets/index-OtBiTek9.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-ewm2zn2E.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Dfk_3YHu.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-hMTQkigM.css">
+  <script type="module" crossorigin src="/assets/index-zoGZuF__.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DTq16w-A.css">
 </head>
 <body>
 
@@ -110,16 +110,6 @@
         <div class="translation-status" id="translation-status">
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
-        </div>
-        <!-- 번역 패널 제어 (접기/크기조절) -->
-        <div class="trans-pane-controls" style="display: inline-flex; align-items: center; gap: 4px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 4px; margin-right: 8px;">
-          <button id="toggle-trans-pane-btn" class="icon-btn" title="번역 창 접기/펴기" style="border: none; background: none;">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
-          </button>
-          <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
-          <button id="trans-width-dec-btn" class="icon-btn" title="번역 창 너비 축소" style="border: none; background: none; width: 24px; height: 24px;">−</button>
-          <span id="trans-width-label" style="font-size: 11px; font-weight: 600; color: var(--text-secondary); min-width: 42px; text-align: center; user-select: none;">620px</span>
-          <button id="trans-width-inc-btn" class="icon-btn" title="번역 창 너비 확대" style="border: none; background: none; width: 24px; height: 24px;">+</button>
         </div>
         <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
         <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-zoGZuF__.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DTq16w-A.css">
+  <script type="module" crossorigin src="/assets/index-Cuz4qEC9.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-xsVSvZas.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,9 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-CoQ68PK8.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script type="module" crossorigin src="/assets/index-DsoEC_5h.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BSh92gIU.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BvPMVCnH.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CDjiOTIr.css">
+  <script type="module" crossorigin src="/assets/index-DuPE3Xe6.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BP10biE7.css">
 </head>
 <body>
 
@@ -103,6 +103,7 @@
         </span>
       </div>
       <div class="topbar-right">
+        <!-- 번역 작업 상태 정보 -->
         <div id="translation-progress-mini" class="progress-mini hidden">
           <div class="progress-mini-bar" id="progress-mini-bar"></div>
           <span id="progress-mini-text">0%</span>
@@ -111,45 +112,69 @@
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
         </div>
-        <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
-        <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">
-          <svg class="sun-icon hidden" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-          <svg class="moon-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-        </button>
-        <button id="zoom-out-btn" class="icon-btn" title="축소">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
-        </button>
-        <span id="zoom-level" class="zoom-label">100%</span>
-        <button id="zoom-in-btn" class="icon-btn" title="확대">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
-        </button>
-        <button id="sync-scroll-btn" class="icon-btn active hidden" title="스크롤 동기화" id="sync-btn">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
-        </button>
-        <button id="chat-toggle-btn" class="icon-btn" title="AI 어시스턴트 켜기/끄기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-        </button>
-        <button id="capture-area-btn" class="icon-btn" title="영역 캡처하여 질문하기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-            <circle cx="8.5" cy="8.5" r="1.5"/>
-            <polyline points="21 15 16 10 5 21"/>
-          </svg>
-        </button>
-        <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기 (기존 캐시 삭제)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-        </button>
-        <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-        </button>
-        <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역하기" style="color: var(--success);">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <polygon points="5 3 19 12 5 21 5 3"/>
-          </svg>
-        </button>
-        <button id="export-btn" class="icon-btn" title="번역 내보내기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        </button>
+
+        <!-- AI 번역 모델 선택 드롭다운 -->
+        <div id="viewer-trans-provider"></div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 뷰 확대/축소 조작 그룹 -->
+        <div class="toolbar-group view-group">
+          <button id="zoom-out-btn" class="icon-btn" title="축소">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="5 12 19 12"/></svg>
+          </button>
+          <span id="zoom-level" class="zoom-label">100%</span>
+          <button id="zoom-in-btn" class="icon-btn" title="확대">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- AI 어시스턴트 및 대화식 조작 도구 그룹 -->
+        <div class="toolbar-group tool-group">
+          <button id="capture-area-btn" class="icon-btn" title="영역 캡처하여 질문하기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+              <circle cx="8.5" cy="8.5" r="1.5"/>
+              <polyline points="21 15 16 10 5 21"/>
+            </svg>
+          </button>
+          <button id="chat-toggle-btn" class="icon-btn" title="AI 어시스턴트 토글">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </button>
+          <button id="sync-scroll-btn" class="icon-btn active hidden" title="스크롤 동기화">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 번역 작업 관리 그룹 -->
+        <div class="toolbar-group action-group">
+          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+          </button>
+          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+          </button>
+          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+          </button>
+          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 기타 환경 조작 그룹 -->
+        <div class="toolbar-group config-group">
+          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
+            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+        </div>
       </div>
     </header>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Cuz4qEC9.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-xsVSvZas.css">
+  <script type="module" crossorigin src="/assets/index-B1rgd65w.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CDjiOTIr.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-WXQ8kmo0.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Dr18TyXH.css">
+  <script type="module" crossorigin src="/assets/index-BZGmcifv.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-f5jks67b.css">
 </head>
 <body>
 
@@ -91,7 +91,10 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <span class="logo-small">⚗️ EasyPaper</span>
-        <span id="doc-title" class="doc-title"></span>
+        <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
+        <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
+        </button>
       </div>
       <div class="topbar-center">
         <span class="page-display">

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-B1rgd65w.js"></script>
+  <script type="module" crossorigin src="/assets/index-BZZm3qzz.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CDjiOTIr.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BZGmcifv.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-f5jks67b.css">
+  <script type="module" crossorigin src="/assets/index-Bnn2-otJ.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-C7Centeq.css">
 </head>
 <body>
 
@@ -90,7 +90,7 @@
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
-        <span class="logo-small">⚗️ EasyPaper</span>
+        <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-C1NBoN7g.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-chJlWE9f.css">
+  <script type="module" crossorigin src="/assets/index-BNDHLP7v.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CwQ804KP.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    window.addEventListener('error', function(event) {
-      alert("Captured JS error: " + event.message + "\nFile: " + event.filename + "\nLine: " + event.lineno + ":" + event.colno);
-    }, true);
-    window.addEventListener('unhandledrejection', function(event) {
-      alert("Captured JS rejection: " + event.reason);
-    });
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EasyPaper — AI 논문 번역</title>
@@ -22,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Wduyjq0P.js"></script>
+  <script type="module" crossorigin src="/assets/index-lIpNHmL1.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CwQ804KP.css">
 </head>
 <body>
@@ -99,7 +91,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;" onclick="alert('HTML inline click works!')">
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-DuPE3Xe6.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BP10biE7.css">
+  <script type="module" crossorigin src="/assets/index-s_zf6NyO.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-chJlWE9f.css">
 </head>
 <body>
 
@@ -91,6 +91,9 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
@@ -177,6 +180,17 @@
         </div>
       </div>
     </header>
+
+    <!-- 좌측 목차 사이드바 -->
+    <aside class="outline-sidebar hidden" id="outline-sidebar">
+      <div class="outline-header">
+        <span class="outline-title">📌 논문 목차</span>
+        <button id="outline-close-btn" class="outline-close-btn" title="목차 닫기">&times;</button>
+      </div>
+      <div class="outline-content" id="outline-content">
+        <!-- 목차 트리가 여기에 렌더링됨 -->
+      </div>
+    </aside>
 
     <!-- 메인 패널 -->
     <main class="panels">

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-NYOn0O4j.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-B_oFjdJu.css">
+  <script type="module" crossorigin src="/assets/index-QhKBXVH8.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CP4m-rTB.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BjjaHFat.js"></script>
+  <script type="module" crossorigin src="/assets/index-Wduyjq0P.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CwQ804KP.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BjIp7-8P.js"></script>
+  <script type="module" crossorigin src="/assets/index-NYOn0O4j.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-B_oFjdJu.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-HDYXL1kI.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DvyQYy2E.css">
+  <script type="module" crossorigin src="/assets/index-BjIp7-8P.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-B_oFjdJu.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-s_zf6NyO.js"></script>
+  <script type="module" crossorigin src="/assets/index-C1NBoN7g.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-chJlWE9f.css">
 </head>
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,7 +90,10 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <span class="logo-small">⚗️ EasyPaper</span>
-        <span id="doc-title" class="doc-title"></span>
+        <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
+        <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
+        </button>
       </div>
       <div class="topbar-center">
         <span class="page-display">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,7 +90,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;" onclick="alert('HTML inline click works!')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <script>
-    window.addEventListener('error', function(event) {
-      alert("Captured JS error: " + event.message + "\nFile: " + event.filename + "\nLine: " + event.lineno + ":" + event.colno);
-    }, true);
-    window.addEventListener('unhandledrejection', function(event) {
-      alert("Captured JS rejection: " + event.reason);
-    });
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EasyPaper — AI 논문 번역</title>
@@ -98,7 +90,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;" onclick="alert('HTML inline click works!')">
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+  <script>
+    window.addEventListener('error', function(event) {
+      alert("Captured JS error: " + event.message + "\nFile: " + event.filename + "\nLine: " + event.lineno + ":" + event.colno);
+    }, true);
+    window.addEventListener('unhandledrejection', function(event) {
+      alert("Captured JS rejection: " + event.reason);
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EasyPaper — AI 논문 번역</title>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,6 +90,9 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
@@ -176,6 +179,17 @@
         </div>
       </div>
     </header>
+
+    <!-- 좌측 목차 사이드바 -->
+    <aside class="outline-sidebar hidden" id="outline-sidebar">
+      <div class="outline-header">
+        <span class="outline-title">📌 논문 목차</span>
+        <button id="outline-close-btn" class="outline-close-btn" title="목차 닫기">&times;</button>
+      </div>
+      <div class="outline-content" id="outline-content">
+        <!-- 목차 트리가 여기에 렌더링됨 -->
+      </div>
+    </aside>
 
     <!-- 메인 패널 -->
     <main class="panels">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,6 +102,7 @@
         </span>
       </div>
       <div class="topbar-right">
+        <!-- 번역 작업 상태 정보 -->
         <div id="translation-progress-mini" class="progress-mini hidden">
           <div class="progress-mini-bar" id="progress-mini-bar"></div>
           <span id="progress-mini-text">0%</span>
@@ -110,45 +111,69 @@
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
         </div>
-        <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
-        <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">
-          <svg class="sun-icon hidden" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-          <svg class="moon-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-        </button>
-        <button id="zoom-out-btn" class="icon-btn" title="축소">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
-        </button>
-        <span id="zoom-level" class="zoom-label">100%</span>
-        <button id="zoom-in-btn" class="icon-btn" title="확대">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
-        </button>
-        <button id="sync-scroll-btn" class="icon-btn active hidden" title="스크롤 동기화" id="sync-btn">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
-        </button>
-        <button id="chat-toggle-btn" class="icon-btn" title="AI 어시스턴트 켜기/끄기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-        </button>
-        <button id="capture-area-btn" class="icon-btn" title="영역 캡처하여 질문하기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-            <circle cx="8.5" cy="8.5" r="1.5"/>
-            <polyline points="21 15 16 10 5 21"/>
-          </svg>
-        </button>
-        <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기 (기존 캐시 삭제)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-        </button>
-        <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-        </button>
-        <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역하기" style="color: var(--success);">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <polygon points="5 3 19 12 5 21 5 3"/>
-          </svg>
-        </button>
-        <button id="export-btn" class="icon-btn" title="번역 내보내기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        </button>
+
+        <!-- AI 번역 모델 선택 드롭다운 -->
+        <div id="viewer-trans-provider"></div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 뷰 확대/축소 조작 그룹 -->
+        <div class="toolbar-group view-group">
+          <button id="zoom-out-btn" class="icon-btn" title="축소">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="5 12 19 12"/></svg>
+          </button>
+          <span id="zoom-level" class="zoom-label">100%</span>
+          <button id="zoom-in-btn" class="icon-btn" title="확대">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- AI 어시스턴트 및 대화식 조작 도구 그룹 -->
+        <div class="toolbar-group tool-group">
+          <button id="capture-area-btn" class="icon-btn" title="영역 캡처하여 질문하기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+              <circle cx="8.5" cy="8.5" r="1.5"/>
+              <polyline points="21 15 16 10 5 21"/>
+            </svg>
+          </button>
+          <button id="chat-toggle-btn" class="icon-btn" title="AI 어시스턴트 토글">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </button>
+          <button id="sync-scroll-btn" class="icon-btn active hidden" title="스크롤 동기화">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 번역 작업 관리 그룹 -->
+        <div class="toolbar-group action-group">
+          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+          </button>
+          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+          </button>
+          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+          </button>
+          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          </button>
+        </div>
+
+        <div class="toolbar-divider"></div>
+
+        <!-- 기타 환경 조작 그룹 -->
+        <div class="toolbar-group config-group">
+          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
+            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+        </div>
       </div>
     </header>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,6 +110,16 @@
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
         </div>
+        <!-- 번역 패널 제어 (접기/크기조절) -->
+        <div class="trans-pane-controls" style="display: inline-flex; align-items: center; gap: 4px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 4px; margin-right: 8px;">
+          <button id="toggle-trans-pane-btn" class="icon-btn" title="번역 창 접기/펴기" style="border: none; background: none;">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+          </button>
+          <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+          <button id="trans-width-dec-btn" class="icon-btn" title="번역 창 너비 축소" style="border: none; background: none; width: 24px; height: 24px;">−</button>
+          <span id="trans-width-label" style="font-size: 11px; font-weight: 600; color: var(--text-secondary); min-width: 42px; text-align: center; user-select: none;">620px</span>
+          <button id="trans-width-inc-btn" class="icon-btn" title="번역 창 너비 확대" style="border: none; background: none; width: 24px; height: 24px;">+</button>
+        </div>
         <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
         <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">
           <svg class="sun-icon hidden" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,6 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,16 +110,6 @@
           <div class="spinner hidden" id="translate-spinner"></div>
           <span id="translate-status-text"></span>
         </div>
-        <!-- 번역 패널 제어 (접기/크기조절) -->
-        <div class="trans-pane-controls" style="display: inline-flex; align-items: center; gap: 4px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 4px; margin-right: 8px;">
-          <button id="toggle-trans-pane-btn" class="icon-btn" title="번역 창 접기/펴기" style="border: none; background: none;">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
-          </button>
-          <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
-          <button id="trans-width-dec-btn" class="icon-btn" title="번역 창 너비 축소" style="border: none; background: none; width: 24px; height: 24px;">−</button>
-          <span id="trans-width-label" style="font-size: 11px; font-weight: 600; color: var(--text-secondary); min-width: 42px; text-align: center; user-select: none;">620px</span>
-          <button id="trans-width-inc-btn" class="icon-btn" title="번역 창 너비 확대" style="border: none; background: none; width: 24px; height: 24px;">+</button>
-        </div>
         <div id="viewer-trans-provider" style="margin-right: 8px;"></div>
         <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 모드 전환">
           <svg class="sun-icon hidden" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,7 +89,7 @@
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
-        <span class="logo-small">⚗️ EasyPaper</span>
+        <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "easypaper-frontend",
       "version": "1.0.0",
+      "dependencies": {
+        "marked": "^18.0.5"
+      },
       "devDependencies": {
         "vite": "^5.3.1"
       }
@@ -850,6 +853,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/nanoid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,5 +13,8 @@
   },
   "allowScripts": {
     "esbuild@0.21.5": true
+  },
+  "dependencies": {
+    "marked": "^18.0.5"
   }
 }

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -36,3 +36,15 @@ export async function fetchLibraryDocImages(docId) {
   return res.json()
 }
 
+export async function updateLibraryDocMetadata(docId, payload) {
+  const res = await fetch(`${API_BASE}/library/${docId}/metadata`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+  if (!res.ok) throw new Error('메타데이터 업데이트 실패')
+  return res.json()
+}
+

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -48,3 +48,15 @@ export async function updateLibraryDocMetadata(docId, payload) {
   return res.json()
 }
 
+export async function updateLibraryTranslation(docId, pageNum, payload, options = {}) {
+  const res = await fetch(`${API_BASE}/library/${docId}/translation/${pageNum}${buildQuery(options)}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+  if (!res.ok) throw new Error('번역 수정 저장 실패')
+  return res.json()
+}
+

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -23,6 +23,7 @@ window.fetch = async function (...args) {
 const state = {
   sessionId: null,
   filename: null,
+  title: null,
   totalPages: 0,
   currentPage: 1,
   zoom: 1.5,
@@ -196,7 +197,7 @@ function resetState() {
   if (state.chatActiveStream) { state.chatActiveStream(); state.chatActiveStream = null }
   
   Object.assign(state, {
-    sessionId: null, filename: null, totalPages: 0, currentPage: 1,
+    sessionId: null, filename: null, title: null, totalPages: 0, currentPage: 1,
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
     chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null, isCropMode: false, documentImages: []
   })
@@ -249,6 +250,7 @@ async function handleFiles(files) {
   let lastSessionId = null
   let lastFilename = ""
   let lastTotalPages = 0
+  let lastTitle = ""
 
   for (let i = 0; i < pdfFiles.length; i++) {
     const file = pdfFiles[i]
@@ -271,6 +273,7 @@ async function handleFiles(files) {
       lastSessionId = result.session_id
       lastFilename = result.filename
       lastTotalPages = result.total_pages
+      lastTitle = (result.metadata && result.metadata.title) ? result.metadata.title : result.filename
       successCount++
 
       if (isLibraryActive) {
@@ -304,9 +307,11 @@ async function handleFiles(files) {
       loadDocumentImages(lastSessionId)
       state.filename   = lastFilename
       state.totalPages = lastTotalPages
+      state.title      = lastTitle
 
       await loadPDF(`/api/pdf-file/${state.sessionId}`)
-      docTitle.textContent = lastFilename
+      docTitle.textContent = lastTitle
+      docTitle.title = lastFilename
       pageTotal.textContent = `/ ${state.totalPages}`
       pageInput.max   = state.totalPages
       pageInput.value = 1
@@ -1838,11 +1843,13 @@ function createDocCard(doc) {
       `</div>`
   }
 
+  const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.innerHTML = `
     <div class="doc-card-icon">📄</div>
-    <div class="doc-card-title">${escapeHtml(doc.filename)}</div>
+    <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(displayTitle)}</div>
     ${tagsHtml}
     <div class="doc-card-meta">
       <span>📅 ${date}</span><span>📑 ${total}페이지</span>
@@ -1867,7 +1874,8 @@ function createDocCard(doc) {
   card.querySelector('.doc-open-btn').addEventListener('click', (e) => { e.stopPropagation(); openFromLibrary(doc) })
   card.querySelector('.doc-delete-btn').addEventListener('click', async (e) => {
     e.stopPropagation()
-    if (!confirm(`"${doc.filename}"을 삭제할까요?`)) return
+    const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+    if (!confirm(`"${displayTitle}"을 삭제할까요?`)) return
     try { await deleteLibraryDoc(doc.id); showToast('삭제되었습니다', 'success'); await renderLibrary() }
     catch { showToast('삭제 실패', 'error') }
   })
@@ -1898,6 +1906,8 @@ async function openFromLibrary(doc) {
   state.sessionId  = doc.id
   loadDocumentImages(doc.id)
   state.filename   = doc.filename
+  const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  state.title      = displayTitle
   state.totalPages = doc.total_pages
   state.translationCache = {}
   state.translationSentences = {}
@@ -1927,7 +1937,8 @@ async function openFromLibrary(doc) {
   }
 
   await loadPDF(`/api/library/${doc.id}/pdf`)
-  docTitle.textContent  = doc.filename
+  docTitle.textContent  = displayTitle
+  docTitle.title        = doc.filename
   pageTotal.textContent = `/ ${doc.total_pages}`
   pageInput.max   = doc.total_pages
   pageInput.value = 1

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -397,13 +397,23 @@ async function initScrollViewer() {
   startJobPolling(state.sessionId)
 }
 
+let isTransPaneCollapsed = false
+let currentTransPaneWidth = 620
+
 // ── 번역 블록 생성 ────────────────────────────────
 function createTransBlock(pageNum) {
   const block = document.createElement('div')
   block.className = 'trans-page-block'
   block.id = `trans-block-${pageNum}`
   block.dataset.page = pageNum
+  
+  const arrow = isTransPaneCollapsed ? '▶' : '◀'
+  const btnTitle = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
+  
   block.innerHTML = `
+    <div class="trans-resizer-handle">
+      <button class="trans-collapse-btn" title="${btnTitle}">${arrow}</button>
+    </div>
     <div class="trans-page-label">
       <span>📄 ${pageNum}페이지</span>
       <span class="trans-page-status" id="trans-status-${pageNum}">대기 중</span>
@@ -4266,86 +4276,77 @@ if (captureAreaBtn) {
 // 캡처 툴 초기화 실행
 initCropTool()
 
-// ── 번역 창 접기 및 너비 크기 조절 ──────────────────────
-const toggleTransPaneBtn = $('toggle-trans-pane-btn')
-const transWidthDecBtn   = $('trans-width-dec-btn')
-const transWidthIncBtn   = $('trans-width-inc-btn')
-const transWidthLabel    = $('trans-width-label')
-
-let isTransPaneCollapsed = false
-let currentTransPaneWidth = 620
-
+// ── 번역 창 접기 및 너비 크기 조절 (드래그/버튼 연동) ──────────────────────
 function updateTransPaneWidth(newWidth) {
   currentTransPaneWidth = Math.max(320, Math.min(newWidth, 820))
   document.documentElement.style.setProperty('--trans-pane-width', `${currentTransPaneWidth}px`)
-  if (transWidthLabel) {
-    transWidthLabel.textContent = `${currentTransPaneWidth}px`
-  }
   localStorage.setItem('trans-pane-width', currentTransPaneWidth)
 }
 
-if (toggleTransPaneBtn) {
-  toggleTransPaneBtn.addEventListener('click', () => {
-    isTransPaneCollapsed = !isTransPaneCollapsed
-    document.body.classList.toggle('collapse-translation', isTransPaneCollapsed)
-    toggleTransPaneBtn.classList.toggle('collapsed', isTransPaneCollapsed)
-    localStorage.setItem('trans-pane-collapsed', isTransPaneCollapsed)
-    
-    if (isTransPaneCollapsed) {
-      if (transWidthDecBtn) {
-        transWidthDecBtn.setAttribute('disabled', 'true')
-        transWidthDecBtn.style.opacity = '0.3'
-      }
-      if (transWidthIncBtn) {
-        transWidthIncBtn.setAttribute('disabled', 'true')
-        transWidthIncBtn.style.opacity = '0.3'
-      }
-      showToast('번역 창이 접혔습니다.', 'info')
-    } else {
-      if (transWidthDecBtn) {
-        transWidthDecBtn.removeAttribute('disabled')
-        transWidthDecBtn.style.opacity = '1'
-      }
-      if (transWidthIncBtn) {
-        transWidthIncBtn.removeAttribute('disabled')
-        transWidthIncBtn.style.opacity = '1'
-      }
-      showToast('번역 창이 펼쳐졌습니다.', 'info')
-    }
-  })
-}
+// 드래그 리사이저 핸들 조작 바인딩 (이벤트 위임)
+let isResizingTrans = false
+let resizerStartX = 0
+let resizerStartWidth = 0
 
-if (transWidthDecBtn) {
-  transWidthDecBtn.addEventListener('click', () => {
-    updateTransPaneWidth(currentTransPaneWidth - 50)
-  })
-}
+viewerScrollContainer.addEventListener('mousedown', (e) => {
+  const handle = e.target.closest('.trans-resizer-handle')
+  if (!handle) return
+  if (e.target.closest('.trans-collapse-btn')) return // 접기 버튼 클릭은 무시
+  if (isTransPaneCollapsed) return // 접혀있는 상태에서는 드래그 금지
+  
+  isResizingTrans = true
+  resizerStartX = e.clientX
+  resizerStartWidth = currentTransPaneWidth
+  document.body.style.cursor = 'col-resize'
+  document.body.style.userSelect = 'none'
+  document.body.classList.add('resizing-trans')
+})
 
-if (transWidthIncBtn) {
-  transWidthIncBtn.addEventListener('click', () => {
-    updateTransPaneWidth(currentTransPaneWidth + 50)
-  })
-}
+document.addEventListener('mousemove', (e) => {
+  if (!isResizingTrans) return
+  // 우측에 배치되어 있으므로 왼쪽으로 당기면(dx가 음수) 커지고, 오른쪽으로 밀면 작아짐
+  const dx = resizerStartX - e.clientX
+  updateTransPaneWidth(resizerStartWidth + dx)
+})
 
-// 초기 로드 시 localStorage 상태 복원
+document.addEventListener('mouseup', () => {
+  if (isResizingTrans) {
+    isResizingTrans = false
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+    document.body.classList.remove('resizing-trans')
+  }
+})
+
+// 인라인 접기/펴기 버튼 클릭 이벤트 바인딩 (이벤트 위임)
+viewerScrollContainer.addEventListener('click', (e) => {
+  const btn = e.target.closest('.trans-collapse-btn')
+  if (!btn) return
+  e.stopPropagation()
+  
+  isTransPaneCollapsed = !isTransPaneCollapsed
+  document.body.classList.toggle('collapse-translation', isTransPaneCollapsed)
+  localStorage.setItem('trans-pane-collapsed', isTransPaneCollapsed)
+  
+  // 모든 페이지 쌍의 인라인 화살표 상태 동기화
+  document.querySelectorAll('.trans-collapse-btn').forEach(b => {
+    b.textContent = isTransPaneCollapsed ? '▶' : '◀'
+    b.title = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
+  })
+  
+  showToast(isTransPaneCollapsed ? '번역 창이 접혔습니다.' : '번역 창이 펼쳐졌습니다.', 'info')
+})
+
+// 초기 로드 시 localStorage 상태 복원 및 초기화 실행
 (function initTransPaneControls() {
   const savedCollapsed = localStorage.getItem('trans-pane-collapsed') === 'true'
   const savedWidth = parseInt(localStorage.getItem('trans-pane-width')) || 620
 
   updateTransPaneWidth(savedWidth)
   
-  if (savedCollapsed && toggleTransPaneBtn) {
+  if (savedCollapsed) {
     isTransPaneCollapsed = true
     document.body.classList.add('collapse-translation')
-    toggleTransPaneBtn.classList.add('collapsed')
-    if (transWidthDecBtn) {
-      transWidthDecBtn.setAttribute('disabled', 'true')
-      transWidthDecBtn.style.opacity = '0.3'
-    }
-    if (transWidthIncBtn) {
-      transWidthIncBtn.setAttribute('disabled', 'true')
-      transWidthIncBtn.style.opacity = '0.3'
-    }
   }
 })()
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,3 +1,4 @@
+alert("main.js script started executing!");
 import './style.css'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -407,20 +407,21 @@ function createTransBlock(pageNum) {
   block.id = `trans-block-${pageNum}`
   block.dataset.page = pageNum
   
-  const arrow = isTransPaneCollapsed ? '▶' : '◀'
+  const leftChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`
+  const rightChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>`
+  const chevron = isTransPaneCollapsed ? rightChevron : leftChevron
   const btnTitle = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
   
   block.innerHTML = `
-    <div class="trans-resizer-handle">
-      <button class="trans-collapse-btn" title="${btnTitle}">${arrow}</button>
-    </div>
     <div class="trans-page-label">
       <span>📄 ${pageNum}페이지</span>
       <span class="trans-page-status" id="trans-status-${pageNum}">대기 중</span>
     </div>
     <div class="trans-page-content" id="trans-content-${pageNum}">
       <div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>
-    </div>`
+    </div>
+    <div class="trans-resizer-handle"></div>
+    <button class="trans-collapse-btn" title="${btnTitle}">${chevron}</button>`
   return block
 }
 
@@ -4304,8 +4305,8 @@ viewerScrollContainer.addEventListener('mousedown', (e) => {
 
 document.addEventListener('mousemove', (e) => {
   if (!isResizingTrans) return
-  // 우측에 배치되어 있으므로 왼쪽으로 당기면(dx가 음수) 커지고, 오른쪽으로 밀면 작아짐
-  const dx = resizerStartX - e.clientX
+  // 우측에 배치되어 있으므로 오른쪽으로 당기면(dx가 양수) 커지고, 왼쪽으로 밀면 작아짐
+  const dx = e.clientX - resizerStartX
   updateTransPaneWidth(resizerStartWidth + dx)
 })
 
@@ -4328,9 +4329,12 @@ viewerScrollContainer.addEventListener('click', (e) => {
   document.body.classList.toggle('collapse-translation', isTransPaneCollapsed)
   localStorage.setItem('trans-pane-collapsed', isTransPaneCollapsed)
   
+  const leftChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`
+  const rightChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>`
+  
   // 모든 페이지 쌍의 인라인 화살표 상태 동기화
   document.querySelectorAll('.trans-collapse-btn').forEach(b => {
-    b.textContent = isTransPaneCollapsed ? '▶' : '◀'
+    b.innerHTML = isTransPaneCollapsed ? rightChevron : leftChevron
     b.title = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
   })
   

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2680,7 +2680,8 @@ function renderPageMemos(pageNum) {
           updateCardContent()
         })
 
-        body.addEventListener('dblclick', (e) => {
+        body.addEventListener('click', (e) => {
+          if (e.target.closest('a')) return
           e.stopPropagation()
           isEditing = true
           updateCardContent()

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2140,7 +2140,8 @@ async function openFromLibrary(doc, shouldPushState = true) {
 }
 
 function escapeHtml(str) {
-  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')
 }
 
 libUploadBtn.addEventListener('click', () => { fileInput.click() })
@@ -4439,7 +4440,22 @@ async function loadPDFOutline() {
     outlineContent.innerHTML = ''
     
     if (!outline || outline.length === 0) {
-      outlineContent.innerHTML = '<div style="font-size:12px; color:var(--text-muted); text-align:center; padding:20px;">목차 정보가 없는 PDF입니다.</div>'
+      // 목차 메타데이터가 존재하지 않는 경우를 대비한 전체 페이지 리스트 폴백(Fallback) 렌더링
+      const infoMsg = document.createElement('div')
+      infoMsg.style.cssText = 'font-size:11px; color:var(--text-muted); padding:4px 10px 12px; border-bottom:1px dashed var(--border); margin-bottom:8px; line-height:1.4;'
+      infoMsg.textContent = '💡 본 PDF에 목차(TOC) 정보가 존재하지 않아, 전체 페이지 리스트를 대신 제공합니다.'
+      outlineContent.appendChild(infoMsg)
+      
+      for (let p = 1; p <= state.totalPages; p++) {
+        const div = document.createElement('div')
+        div.className = 'outline-item depth-0'
+        div.innerHTML = `<span>📄</span> <span>${p} 페이지</span>`
+        div.addEventListener('click', () => {
+          scrollToPage(viewerScrollContainer, p)
+        })
+        div.title = `${p}페이지로 이동`
+        outlineContent.appendChild(div)
+      }
       return
     }
     
@@ -4485,6 +4501,7 @@ function showOutlineSidebar() {
 // 목차 이벤트 바인딩
 if (outlineToggleBtn) {
   outlineToggleBtn.addEventListener('click', () => {
+    console.log("[Outline] Toggle button clicked. Sidebar hidden state:", outlineSidebar.classList.contains('hidden'))
     if (outlineSidebar.classList.contains('hidden')) {
       showOutlineSidebar()
     } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
 import './style.css'
+import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation } from './library.js'
@@ -2366,6 +2367,111 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations) {
   })
 }
 
+// PDF와 번역본의 문장 수 차이를 고려한 오프셋 기반 매핑 함수
+function getMappedElementsAndIndices(target, pageNum, sentenceIdx) {
+  let pdfIdx = -1;
+  let transIdx = -1;
+  let pdfElements = [];
+
+  const transSpans = Array.from(viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${pageNum}"]`));
+  const pdfSpans = Array.from(viewerScrollContainer.querySelectorAll(`.pdf-sentence[data-page="${pageNum}"]`));
+
+  if (transSpans.length === 0 || pdfSpans.length === 0) {
+    return { pdfIdx, transIdx, pdfElements };
+  }
+
+  // 양측의 고유한 문장 인덱스 집합
+  const transIdxSet = new Set(transSpans.map(s => parseInt(s.dataset.sentenceIdx || '0', 10)));
+  const pdfIdxSet = new Set(pdfSpans.map(s => parseInt(s.dataset.sentenceIdx || '0', 10)));
+  const pdfCount = pdfIdxSet.size;
+  const transCount = transIdxSet.size;
+  const maxPdfIdx = Math.max(...pdfIdxSet);
+  const maxTransIdx = Math.max(...transIdxSet);
+
+  // 만약 사전에 백엔드에서 정렬 매핑한 문장이 존재하면 1:1 직접 매핑을 적용합니다.
+  const sentences = state.translationSentences && state.translationSentences[pageNum];
+  if (sentences && sentences.length > 0) {
+    // LLM에 의해 병합된 빈 번역 문장을 감지하여 상위 그룹 인덱스로 매핑
+    const parentIdxMap = [];
+    let lastActiveIdx = 0;
+    for (let i = 0; i < sentences.length; i++) {
+      if (sentences[i].trans && sentences[i].trans.trim()) {
+        lastActiveIdx = i;
+      }
+      parentIdxMap[i] = lastActiveIdx;
+    }
+    let firstActiveIdx = sentences.findIndex(s => s.trans && s.trans.trim());
+    if (firstActiveIdx === -1) firstActiveIdx = 0;
+    for (let i = 0; i < firstActiveIdx; i++) {
+      parentIdxMap[i] = firstActiveIdx;
+    }
+
+    const parentIdx = parentIdxMap[sentenceIdx] ?? sentenceIdx;
+    pdfIdx = parentIdx;
+    transIdx = parentIdx;
+
+    // 동일한 그룹에 속하는 모든 PDF 엘리먼트 수집
+    pdfElements = pdfSpans.filter(el => {
+      const idx = parseInt(el.dataset.sentenceIdx || '0', 10);
+      return parentIdxMap[idx] === parentIdx;
+    });
+    return { pdfIdx, transIdx, pdfElements };
+  } else {
+    // 기존 오프셋/비례식 알고리즘 폴백 (기존 캐시 대응)
+    const diff = pdfCount - transCount;
+    const absDiff = Math.abs(diff);
+
+    if (absDiff === 0) {
+      // 1:1 직접 매핑
+      pdfIdx = Math.min(maxPdfIdx, sentenceIdx);
+      transIdx = Math.min(maxTransIdx, sentenceIdx);
+    } else if (absDiff <= 5) {
+      // 오프셋 기반 매핑 (PDF와 번역본 중 어느 쪽이 더 많은지를 구분)
+      if (diff > 0) {
+        // PDF가 더 많음: PDF 앞에 데더 먹을 문장이 diff개 있다고 가정
+        const offset = diff;
+        if (target.classList.contains('trans-sentence')) {
+          transIdx = sentenceIdx;
+          pdfIdx = Math.min(maxPdfIdx, sentenceIdx + offset);
+        } else {
+          pdfIdx = sentenceIdx;
+          transIdx = Math.max(0, Math.min(maxTransIdx, sentenceIdx - offset));
+        }
+      } else {
+        // 번역본이 더 많음: 번역 앞에 데더 먹을 문장이 offset개 있다고 가정
+        const offset = -diff; // transCount - pdfCount
+        if (target.classList.contains('trans-sentence')) {
+          transIdx = sentenceIdx;
+          pdfIdx = Math.max(0, Math.min(maxPdfIdx, sentenceIdx - offset));
+        } else {
+          pdfIdx = sentenceIdx;
+          transIdx = Math.min(maxTransIdx, sentenceIdx + offset);
+        }
+      }
+    } else {
+      // 큰 차이 → 비례(proportional) 매핑
+      if (pdfCount <= 1 || transCount <= 1) {
+        pdfIdx = 0;
+        transIdx = 0;
+      } else {
+        const fraction = sentenceIdx / Math.max(target.classList.contains('trans-sentence') ? (transCount - 1) : (pdfCount - 1), 1);
+        if (target.classList.contains('trans-sentence')) {
+          transIdx = sentenceIdx;
+          pdfIdx = Math.min(maxPdfIdx, Math.round(fraction * (pdfCount - 1)));
+        } else {
+          pdfIdx = sentenceIdx;
+          transIdx = Math.min(maxTransIdx, Math.round(fraction * (transCount - 1)));
+        }
+      }
+    }
+  }
+
+  // pdfIdx에 매핑되는 모든 PDF span 엘리먼트 수집
+  pdfElements = pdfSpans.filter(el => parseInt(el.dataset.sentenceIdx || '0', 10) === pdfIdx);
+
+  return { pdfIdx, transIdx, pdfElements };
+}
+
 // ── Floating Markdown Memo 관리 ─────────────────────────
 function loadMemos(sessionId) {
   if (!sessionId) return {}
@@ -2408,8 +2514,13 @@ function updateMemoConnectorLine(pageWrapper, memo, sentenceEl) {
     return
   }
 
-  const anchorX = sentenceEl.offsetLeft + sentenceEl.offsetWidth / 2
-  const anchorY = sentenceEl.offsetTop + sentenceEl.offsetHeight / 2
+  const sentenceIdx = memo.sentenceIdx
+  const pageNum = parseInt(pageWrapper.dataset.page, 10)
+  const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, sentenceIdx)
+  const startEl = (pdfElements && pdfElements.length > 0) ? pdfElements[0] : sentenceEl
+
+  const anchorX = startEl.offsetLeft
+  const anchorY = startEl.offsetTop + startEl.offsetHeight / 2
 
   const memoLeft = (memo.x / 100) * pageWrapper.offsetWidth
   const memoTop = (memo.y / 100) * pageWrapper.offsetHeight
@@ -2449,6 +2560,11 @@ function renderPageMemos(pageNum) {
   pageWrapper.querySelectorAll('.floating-memo').forEach(el => el.remove())
   const svg = pageWrapper.querySelector('.memo-connector-svg')
   if (svg) svg.innerHTML = ''
+  
+  // Clear any existing sentence has-memo highlights
+  pageWrapper.querySelectorAll('.pdf-sentence-has-memo').forEach(el => {
+    el.classList.remove('pdf-sentence-has-memo')
+  })
 
   if (!state.sessionId) return
   const allMemos = loadMemos(state.sessionId)
@@ -2462,6 +2578,13 @@ function renderPageMemos(pageNum) {
     memoEl.style.top = `${memo.y}%`
 
     const sentenceEl = pageWrapper.querySelector(`.pdf-sentence[data-sentence-idx="${memo.sentenceIdx}"]`)
+    if (sentenceEl) {
+      const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, memo.sentenceIdx)
+      if (pdfElements) {
+        pdfElements.forEach(el => el.classList.add('pdf-sentence-has-memo'))
+      }
+    }
+
     let isEditing = !memo.content.trim()
 
     function updateCardContent() {
@@ -2498,11 +2621,11 @@ function renderPageMemos(pageNum) {
         })
       } else {
         let renderedHtml = memo.content
-        if (window.marked) {
-          if (typeof window.marked.parse === 'function') {
-            renderedHtml = window.marked.parse(memo.content)
-          } else if (typeof window.marked === 'function') {
-            renderedHtml = window.marked(memo.content)
+        if (marked && typeof marked.parse === 'function') {
+          try {
+            renderedHtml = marked.parse(memo.content)
+          } catch (e) {
+            console.error("Markdown parsing failed:", e)
           }
         }
         body.innerHTML = `<div class="floating-memo-render">${renderedHtml}</div>`
@@ -2529,17 +2652,20 @@ function renderPageMemos(pageNum) {
           allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
           saveMemos(state.sessionId, allMemosObj)
           
-          memoEl.remove()
-          const pNode = pageWrapper.querySelector(`.memo-connector-svg #connector_${memo.id}`)
-          if (pNode) pNode.remove()
+          renderPageMemos(pageNum)
         }
       })
     }
 
+    const sentenceText = (sentenceEl ? sentenceEl.textContent.trim() : '') || memo.sentenceText || ''
+    const shortTitle = sentenceText
+      ? (sentenceText.length > 20 ? sentenceText.substring(0, 20) + '...' : sentenceText)
+      : 'Memo'
+
     memoEl.innerHTML = `
       <div class="floating-memo-header">
-        <div class="floating-memo-title">
-          <span>📝 Memo</span>
+        <div class="floating-memo-title" title="${sentenceText}">
+          <span>📝 ${shortTitle}</span>
         </div>
         <div class="floating-memo-actions"></div>
       </div>
@@ -2564,8 +2690,9 @@ function renderPageMemos(pageNum) {
         const dxPct = (dx / pageWrapper.offsetWidth) * 100
         const dyPct = (dy / pageWrapper.offsetHeight) * 100
 
-        const newX = Math.min(Math.max(1, startX + dxPct), 90)
-        const newY = Math.min(Math.max(1, startY + dyPct), 95)
+        // Clamp to a wide bounds so it can float outside page wrapper boundaries anywhere on screen
+        const newX = Math.min(Math.max(-150, startX + dxPct), 250)
+        const newY = Math.min(Math.max(-150, startY + dyPct), 250)
 
         memo.x = newX
         memo.y = newY
@@ -2604,6 +2731,8 @@ function createFloatingMemoForSentence(pageNum, sentenceIdx) {
   const sentenceEl = pageWrapper.querySelector(`.pdf-sentence[data-sentence-idx="${sentenceIdx}"]`)
   if (!sentenceEl) return
 
+  const sentenceText = sentenceEl ? sentenceEl.textContent.trim() : ''
+
   const leftPct = Math.min(Math.max(10, ((sentenceEl.offsetLeft + sentenceEl.offsetWidth / 2) / pageWrapper.offsetWidth) * 100), 70)
   const topPct = Math.min(Math.max(10, ((sentenceEl.offsetTop + sentenceEl.offsetHeight) / pageWrapper.offsetHeight) * 100 + 4), 85)
 
@@ -2616,6 +2745,7 @@ function createFloatingMemoForSentence(pageNum, sentenceIdx) {
     id: `memo_${Date.now()}`,
     pageNum: pageNum,
     sentenceIdx: sentenceIdx,
+    sentenceText: sentenceText,
     content: '',
     x: leftPct,
     y: topPct
@@ -4559,129 +4689,6 @@ function splitIntoSentences(fullText) {
 // 1대1 매칭 마우스 오버/아웃 및 클릭 이벤트 위임 등록
 if (viewerScrollContainer) {
   // PDF와 번역본의 문장 수 차이를 고려한 오프셋 기반 매핑 함수
-  function getMappedElementsAndIndices(target, pageNum, sentenceIdx) {
-    let pdfIdx = -1;
-    let transIdx = -1;
-    let pdfElements = [];
-
-    const transSpans = Array.from(viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${pageNum}"]`));
-    const pdfSpans = Array.from(viewerScrollContainer.querySelectorAll(`.pdf-sentence[data-page="${pageNum}"]`));
-
-    if (transSpans.length === 0 || pdfSpans.length === 0) {
-      return { pdfIdx, transIdx, pdfElements };
-    }
-
-    // 양측의 고유한 문장 인덱스 집합
-    const transIdxSet = new Set(transSpans.map(s => parseInt(s.dataset.sentenceIdx || '0', 10)));
-    const pdfIdxSet = new Set(pdfSpans.map(s => parseInt(s.dataset.sentenceIdx || '0', 10)));
-    const pdfCount = pdfIdxSet.size;
-    const transCount = transIdxSet.size;
-    const maxPdfIdx = Math.max(...pdfIdxSet);
-    const maxTransIdx = Math.max(...transIdxSet);
-
-    /**
-     * 핵심 매핑 로직:
-     * 
-     * PDF는 페이지 헤더(채널 이름, 학회명 등), 섹션 제목을 텍스트 레이어에 포함하지만
-     * LLM 번역본은 이를 생략하는 경우가 많습니다.
-     * => PDF 문장 수 > 번역본 문장 수 인 경우가 많음
-     * => 이 때 여분 문장은 페이지 앞부분에 몰림 (startOffset)
-     *
-     * 수식:
-     * - 문장 수 동일: 직접 1:1 매핑
-     * - PDF > 번역: startOffset = pdfCount - transCount
-     *   - 번역 idx i -> PDF idx = i + startOffset
-     *   - PDF idx j -> 번역 idx = max(0, j - startOffset)
-     * - 번역 > PDF: 이 경우도 표대화를 위해 동일하게 오프셋 기반로
-     *   - PDF idx j -> 번역 idx = j + (transCount - pdfCount)
-     *   - 번역 idx i -> PDF idx = max(0, i - (transCount - pdfCount))
-     *
-     * 크게 다륾 경우(차이 > 3)는 비례 매핑으로 폴백
-     */
-    // 만약 사전에 백엔드에서 정렬 매핑한 문장이 존재하면 1:1 직접 매핑을 적용합니다.
-    const sentences = state.translationSentences && state.translationSentences[pageNum];
-    if (sentences && sentences.length > 0) {
-      // LLM에 의해 병합된 빈 번역 문장을 감지하여 상위 그룹 인덱스로 매핑
-      const parentIdxMap = [];
-      let lastActiveIdx = 0;
-      for (let i = 0; i < sentences.length; i++) {
-        if (sentences[i].trans && sentences[i].trans.trim()) {
-          lastActiveIdx = i;
-        }
-        parentIdxMap[i] = lastActiveIdx;
-      }
-      let firstActiveIdx = sentences.findIndex(s => s.trans && s.trans.trim());
-      if (firstActiveIdx === -1) firstActiveIdx = 0;
-      for (let i = 0; i < firstActiveIdx; i++) {
-        parentIdxMap[i] = firstActiveIdx;
-      }
-
-      const parentIdx = parentIdxMap[sentenceIdx] ?? sentenceIdx;
-      pdfIdx = parentIdx;
-      transIdx = parentIdx;
-
-      // 동일한 그룹에 속하는 모든 PDF 엘리먼트 수집
-      pdfElements = pdfSpans.filter(el => {
-        const idx = parseInt(el.dataset.sentenceIdx || '0', 10);
-        return parentIdxMap[idx] === parentIdx;
-      });
-      return { pdfIdx, transIdx, pdfElements };
-    } else {
-      // 기존 오프셋/비례식 알고리즘 폴백 (기존 캐시 대응)
-      const diff = pdfCount - transCount;
-      const absDiff = Math.abs(diff);
-
-      if (absDiff === 0) {
-        // 1:1 직접 매핑
-        pdfIdx = Math.min(maxPdfIdx, sentenceIdx);
-        transIdx = Math.min(maxTransIdx, sentenceIdx);
-      } else if (absDiff <= 5) {
-        // 오프셋 기반 매핑 (PDF와 번역본 중 어느 쪽이 더 많은지를 구분)
-        if (diff > 0) {
-          // PDF가 더 많음: PDF 앞에 데더 먹을 문장이 diff개 있다고 가정
-          const offset = diff;
-          if (target.classList.contains('trans-sentence')) {
-            transIdx = sentenceIdx;
-            pdfIdx = Math.min(maxPdfIdx, sentenceIdx + offset);
-          } else {
-            pdfIdx = sentenceIdx;
-            transIdx = Math.max(0, Math.min(maxTransIdx, sentenceIdx - offset));
-          }
-        } else {
-          // 번역본이 더 많음: 번역 앞에 데더 먹을 문장이 offset개 있다고 가정
-          const offset = -diff; // transCount - pdfCount
-          if (target.classList.contains('trans-sentence')) {
-            transIdx = sentenceIdx;
-            pdfIdx = Math.max(0, Math.min(maxPdfIdx, sentenceIdx - offset));
-          } else {
-            pdfIdx = sentenceIdx;
-            transIdx = Math.min(maxTransIdx, sentenceIdx + offset);
-          }
-        }
-      } else {
-        // 큰 차이 → 비례(proportional) 매핑
-        if (pdfCount <= 1 || transCount <= 1) {
-          pdfIdx = 0;
-          transIdx = 0;
-        } else {
-          const fraction = sentenceIdx / Math.max(target.classList.contains('trans-sentence') ? (transCount - 1) : (pdfCount - 1), 1);
-          if (target.classList.contains('trans-sentence')) {
-            transIdx = sentenceIdx;
-            pdfIdx = Math.min(maxPdfIdx, Math.round(fraction * (pdfCount - 1)));
-          } else {
-            pdfIdx = sentenceIdx;
-            transIdx = Math.min(maxTransIdx, Math.round(fraction * (transCount - 1)));
-          }
-        }
-      }
-    }
-
-    // pdfIdx에 매핑되는 모든 PDF span 엘리먼트 수집
-    pdfElements = pdfSpans.filter(el => parseInt(el.dataset.sentenceIdx || '0', 10) === pdfIdx);
-
-    return { pdfIdx, transIdx, pdfElements };
-  }
-
   viewerScrollContainer.addEventListener('mousemove', () => {
     state.hoverSelectionDisabled = false;
   });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4325,13 +4325,22 @@ if (viewerScrollContainer) {
           const curSel = window.getSelection();
           if (curSel && !curSel.isCollapsed) return;
 
-          const range = document.createRange();
-          range.selectNodeContents(pdfTarget);
-          curSel.removeAllRanges();
-          curSel.addRange(range);
+          const walker = document.createTreeWalker(pdfTarget, NodeFilter.SHOW_TEXT);
+          const nodes = [];
+          while (walker.nextNode()) {
+            nodes.push(walker.currentNode);
+          }
+          if (nodes.length > 0) {
+            const range = document.createRange();
+            range.setStart(nodes[0], 0);
+            range.setEnd(nodes[nodes.length - 1], nodes[nodes.length - 1].length);
 
-          const rect = pdfTarget.getBoundingClientRect();
-          showSelectionMenu(rect, true);
+            curSel.removeAllRanges();
+            curSel.addRange(range);
+
+            const rect = pdfTarget.getBoundingClientRect();
+            showSelectionMenu(rect, true);
+          }
         }, 700);
       }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2529,13 +2529,13 @@ function createAnnHoverTooltip() {
   const tooltip = document.createElement('div')
   tooltip.id = 'ann-hover-tooltip'
   tooltip.className = 'selection-menu hidden'
-  tooltip.style.cssText = 'position: absolute; z-index: 10005; padding: 2px 4px; gap: 6px; height: 32px; display: flex; align-items: center; box-shadow: var(--shadow-md);'
+  tooltip.style.cssText = 'position: absolute; z-index: 10005;'
   tooltip.innerHTML = `
-    <button class="menu-btn delete-ann-btn" title="삭제" style="width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; cursor: pointer;">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+    <button class="menu-btn delete-ann-btn" title="삭제">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
     </button>
-    <div style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
-    <button class="menu-btn ask-ai-ann-btn" title="AI 어시스턴트에게 질문" style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--accent-mid); padding: 0 8px; background: transparent; border: none; cursor: pointer; height: 28px;">
+    <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+    <button class="menu-btn ask-ai-btn ask-ai-ann-btn" title="AI 어시스턴트에게 질문">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
       <span>Ask AI</span>
     </button>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -817,11 +817,7 @@ resumeTransBtn.addEventListener('click', async () => {
 
 // ── 뒤로 가기 ─────────────────────────────────────
 backBtn.addEventListener('click', () => {
-  if (hasLibraryStateInHistory) {
-    history.back()
-  } else {
-    showLibraryScreen(true)
-  }
+  showLibraryScreen()
 })
 
 if (logoBtn) {
@@ -4378,8 +4374,8 @@ async function handleRouting() {
       }
       location.hash = 'library'
     } else {
-      console.log("[Router] Routing to Library screen. Library active state:", libraryScreen.classList.contains('active'))
-      if (!libraryScreen.classList.contains('active')) {
+      console.log("[Router] Routing to Library screen. Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))
+      if (viewerScreen.classList.contains('active') || !libraryScreen.classList.contains('active')) {
         await showLibraryScreen(false)
       }
     }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,3 @@
-alert("main.js script started executing!");
 import './style.css'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
@@ -4374,7 +4373,7 @@ viewerScrollContainer.addEventListener('click', (e) => {
   })
   
   showToast(isTransPaneCollapsed ? '번역 창이 접혔습니다.' : '번역 창이 펼쳐졌습니다.', 'info')
-})
+});
 
 // 초기 로드 시 localStorage 상태 복원 및 초기화 실행
 (function initTransPaneControls() {
@@ -4502,7 +4501,6 @@ function showOutlineSidebar() {
 // 목차 이벤트 바인딩
 if (outlineToggleBtn) {
   outlineToggleBtn.addEventListener('click', () => {
-    alert("목차 버튼 클릭됨! 사이드바 클래스: " + outlineSidebar.className)
     console.log("[Outline] Toggle button clicked. Sidebar:", outlineSidebar, "ToggleBtn:", outlineToggleBtn)
     if (!outlineSidebar) {
       showToast('목차 사이드바를 찾을 수 없습니다.', 'error')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2243,7 +2243,7 @@ function applyAnnotationToRange(range, type, textLayerDiv, pageNum, color) {
   const chosenColor = color || (type === 'highlight' ? state.activeHighlightColor : state.activeUnderlineColor)
 
   // 1. DOM에 스타일 적용 (텍스트 노드 분할)
-  applyAnnotationToRangeWithoutSave(range, type, chosenColor)
+  applyAnnotationToRangeWithoutSave(range, type, chosenColor, offsets.startOffset, offsets.endOffset)
 
   // 2. LocalStorage에 저장
   const annotations = loadAnnotations(state.sessionId)
@@ -2262,7 +2262,7 @@ function applyAnnotationToRange(range, type, textLayerDiv, pageNum, color) {
 }
 
 // 저장 없이 DOM 상에 직접 span을 감싸서 스타일 입히는 헬퍼
-function applyAnnotationToRangeWithoutSave(range, type, color) {
+function applyAnnotationToRangeWithoutSave(range, type, color, overallStartOffset, overallEndOffset) {
   const textNodes = []
   const commonAncestor = range.commonAncestorContainer
   
@@ -2305,6 +2305,14 @@ function applyAnnotationToRangeWithoutSave(range, type, color) {
       span.className = 'pdf-annotation-underline'
       const baseColor = color || '#ef4444'
       span.style.borderBottomColor = baseColor
+    }
+    
+    // 호버 툴팁 매칭 및 간편 삭제 처리를 위해 데이터셋 부여
+    if (overallStartOffset !== undefined && overallStartOffset !== null) {
+      span.dataset.startOffset = overallStartOffset
+    }
+    if (overallEndOffset !== undefined && overallEndOffset !== null) {
+      span.dataset.endOffset = overallEndOffset
     }
     
     const subRange = document.createRange()
@@ -2350,7 +2358,7 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations) {
       try {
         range.setStart(startNode, startNodeOffset)
         range.setEnd(endNode, endNodeOffset)
-        applyAnnotationToRangeWithoutSave(range, ann.type, ann.color)
+        applyAnnotationToRangeWithoutSave(range, ann.type, ann.color, ann.startOffset, ann.endOffset)
       } catch (e) {
         console.warn("Failed to restore annotation:", ann, e)
       }
@@ -2371,7 +2379,7 @@ function createSelectionMenu() {
     <div class="menu-annotate-group" style="display: flex; gap: 6px; align-items: center; padding: 2px 4px;">
       <!-- 하이라이트 그룹 -->
       <div class="expand-wrapper highlight-wrapper">
-        <button class="menu-btn highlight-btn" title="하이라이트">
+        <button class="menu-btn highlight-btn" title="하이라이트 (우클릭: 색상 변경)">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
         </button>
         <div class="expand-colors highlight-colors">
@@ -2384,7 +2392,7 @@ function createSelectionMenu() {
       
       <!-- 밑줄 그룹 -->
       <div class="expand-wrapper underline-wrapper">
-        <button class="menu-btn underline-btn" title="밑줄">
+        <button class="menu-btn underline-btn" title="밑줄 (우클릭: 색상 변경)">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
         </button>
         <div class="expand-colors underline-colors">
@@ -2459,25 +2467,30 @@ function createSelectionMenu() {
     })
   })
 
-  // 메인 아이콘 클릭 시 즉시 토글 혹은 적용
+  // 메인 아이콘 좌클릭: 활성화된 기존 색상으로 즉시 마킹 처리 적용
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    if (highlightWrapper.classList.contains('expanded')) {
-      handleAnnotate('highlight', state.activeHighlightColor)
-    } else {
-      underlineWrapper.classList.remove('expanded')
-      highlightWrapper.classList.add('expanded')
-    }
+    handleAnnotate('highlight', state.activeHighlightColor)
   })
 
+  // 메인 아이콘 우클릭: 색상 선택기 확장 토글
+  highlightBtn.addEventListener('contextmenu', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    underlineWrapper.classList.remove('expanded')
+    highlightWrapper.classList.toggle('expanded')
+  })
+
+  // 메인 밑줄 좌클릭: 활성화된 기존 색상으로 즉시 마킹 처리 적용
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    if (underlineWrapper.classList.contains('expanded')) {
-      handleAnnotate('underline', state.activeUnderlineColor)
-    } else {
-      highlightWrapper.classList.remove('expanded')
-      underlineWrapper.classList.add('expanded')
-    }
+    handleAnnotate('underline', state.activeUnderlineColor)
+  })
+
+  // 메인 밑줄 우클릭: 색상 선택기 확장 토글
+  underlineBtn.addEventListener('contextmenu', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    highlightWrapper.classList.remove('expanded')
+    underlineWrapper.classList.toggle('expanded')
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
@@ -2502,6 +2515,122 @@ function createSelectionMenu() {
 
   updateActiveColors()
   return menu
+}
+
+// ── 어노테이션(하이라이트/밑줄) 마우스 호버 툴팁 관리 ──
+let annHoverTooltip = null
+let annHoverHideTimer = null
+let activeHoveredSpan = null
+
+function createAnnHoverTooltip() {
+  if (annHoverTooltip) return annHoverTooltip
+
+  const tooltip = document.createElement('div')
+  tooltip.id = 'ann-hover-tooltip'
+  tooltip.className = 'selection-menu hidden'
+  tooltip.style.cssText = 'position: absolute; z-index: 10005; padding: 2px 4px; gap: 4px; height: 32px; display: flex; align-items: center; box-shadow: var(--shadow-md);'
+  tooltip.innerHTML = `
+    <button class="menu-btn delete-ann-btn" title="삭제" style="width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; cursor: pointer;">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+    </button>
+    <div style="width: 1px; background: var(--border-strong); height: 12px; margin: 0 2px;"></div>
+    <button class="menu-btn ask-ai-ann-btn" title="AI에게 질문" style="display: flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: var(--accent-mid); padding: 0 4px; background: transparent; border: none; cursor: pointer; height: 26px;">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
+      <span>Ask AI</span>
+    </button>
+  `
+  document.body.appendChild(tooltip)
+  annHoverTooltip = tooltip
+
+  tooltip.addEventListener('mousedown', (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+  })
+
+  tooltip.addEventListener('mouseenter', () => {
+    if (annHoverHideTimer) {
+      clearTimeout(annHoverHideTimer)
+      annHoverHideTimer = null
+    }
+  })
+
+  tooltip.addEventListener('mouseleave', () => {
+    hideAnnHoverTooltipWithDelay()
+  })
+
+  tooltip.querySelector('.delete-ann-btn').addEventListener('click', async (e) => {
+    e.preventDefault(); e.stopPropagation()
+    if (!activeHoveredSpan) return
+
+    const startOffset = parseInt(activeHoveredSpan.dataset.startOffset)
+    const endOffset = parseInt(activeHoveredSpan.dataset.endOffset)
+    const pageWrapper = activeHoveredSpan.closest('.pdf-page-wrapper')
+    if (!pageWrapper) return
+    const pageNum = parseInt(pageWrapper.dataset.page)
+    const textLayerDiv = pageWrapper.querySelector('.textLayer')
+
+    const annotations = loadAnnotations(state.sessionId)
+    if (annotations[`page_${pageNum}`]) {
+      const originalCount = annotations[`page_${pageNum}`].length
+      annotations[`page_${pageNum}`] = annotations[`page_${pageNum}`].filter(ann => {
+        return !(ann.startOffset === startOffset && ann.endOffset === endOffset)
+      })
+
+      if (annotations[`page_${pageNum}`].length !== originalCount) {
+        saveAnnotations(state.sessionId, annotations)
+        showToast('어노테이션이 삭제되었습니다 ✓', 'success')
+        reRenderPageAnnotations(textLayerDiv, pageNum)
+      }
+    }
+    hideAnnHoverTooltip()
+  })
+
+  tooltip.querySelector('.ask-ai-ann-btn').addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation()
+    if (!activeHoveredSpan) return
+    const text = activeHoveredSpan.textContent.trim()
+    if (text) {
+      askAIAssistant(text)
+    }
+    hideAnnHoverTooltip()
+  })
+
+  return tooltip
+}
+
+function showAnnotationHoverTooltip(annSpan) {
+  if (annHoverHideTimer) {
+    clearTimeout(annHoverHideTimer)
+    annHoverHideTimer = null
+  }
+
+  activeHoveredSpan = annSpan
+  const tooltip = createAnnHoverTooltip()
+  tooltip.classList.remove('hidden')
+
+  const rect = annSpan.getBoundingClientRect()
+  const tooltipWidth = tooltip.offsetWidth || 110
+  const tooltipHeight = tooltip.offsetHeight || 32
+
+  const left = rect.left + rect.width / 2 - tooltipWidth / 2 + window.scrollX
+  const top = rect.top - tooltipHeight - 6 + window.scrollY
+
+  tooltip.style.left = `${Math.max(8, left)}px`
+  tooltip.style.top = `${Math.max(8, top)}px`
+}
+
+function hideAnnHoverTooltip() {
+  if (annHoverTooltip) {
+    annHoverTooltip.classList.add('hidden')
+  }
+  activeHoveredSpan = null
+}
+
+function hideAnnHoverTooltipWithDelay() {
+  if (annHoverHideTimer) clearTimeout(annHoverHideTimer)
+  annHoverHideTimer = setTimeout(() => {
+    hideAnnHoverTooltip()
+  }, 250)
 }
 
 function handleAnnotate(type, color) {
@@ -4170,6 +4299,12 @@ if (viewerScrollContainer) {
 
   viewerScrollContainer.addEventListener('mouseover', (e) => {
     try {
+      const annSpan = e.target.closest('.pdf-annotation-highlight, .pdf-annotation-underline');
+      if (annSpan) {
+        showAnnotationHoverTooltip(annSpan);
+        return;
+      }
+
       const selection = window.getSelection();
       if (selection && !selection.isCollapsed) return;
 
@@ -4212,6 +4347,13 @@ if (viewerScrollContainer) {
 
   viewerScrollContainer.addEventListener('mouseout', (e) => {
     try {
+      const annSpan = e.target.closest('.pdf-annotation-highlight, .pdf-annotation-underline');
+      if (annSpan) {
+        if (!e.relatedTarget || !e.relatedTarget.closest('#ann-hover-tooltip')) {
+          hideAnnHoverTooltipWithDelay();
+        }
+      }
+
       viewerScrollContainer.querySelectorAll('.sentence-highlight').forEach(el => {
         el.classList.remove('sentence-highlight');
       });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2635,6 +2635,37 @@ function hideAnnHoverTooltipWithDelay() {
 }
 
 function handleAnnotate(type, color) {
+  // 1. 호버 지연 대기에 의한 문장 전체 선택 모드 대응
+  if (state.hoverSelectedPdfElements && state.hoverSelectedPdfElements.length > 0) {
+    const pageNum = state.hoverSelectedPageNum;
+    const textLayerDiv = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"] .textLayer`);
+    if (textLayerDiv) {
+      state.hoverSelectedPdfElements.forEach(el => {
+        const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        while (walker.nextNode()) {
+          nodes.push(walker.currentNode);
+        }
+        if (nodes.length > 0) {
+          const r = document.createRange();
+          r.setStart(nodes[0], 0);
+          r.setEnd(nodes[nodes.length - 1], nodes[nodes.length - 1].length);
+          
+          if (type === 'clear') {
+            clearAnnotationsInRange(r, textLayerDiv, pageNum);
+          } else {
+            applyAnnotationToRange(r, type, textLayerDiv, pageNum, color);
+          }
+        }
+      });
+      window.getSelection().removeAllRanges();
+      hideSelectionMenu();
+      state.hoverSelectedPdfElements = null;
+      return;
+    }
+  }
+
+  // 2. 일반 마우스 드래그 선택 대응
   const selection = window.getSelection()
   if (!selection.rangeCount) return
   const range = selection.getRangeAt(0)
@@ -2737,6 +2768,7 @@ document.addEventListener('mouseup', (e) => {
       }
       const selection = window.getSelection()
       if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        state.hoverSelectedPdfElements = null
         hideSelectionMenu()
         return
       }
@@ -4325,21 +4357,35 @@ if (viewerScrollContainer) {
           const curSel = window.getSelection();
           if (curSel && !curSel.isCollapsed) return;
 
-          const walker = document.createTreeWalker(pdfTarget, NodeFilter.SHOW_TEXT);
-          const nodes = [];
-          while (walker.nextNode()) {
-            nodes.push(walker.currentNode);
-          }
-          if (nodes.length > 0) {
-            const range = document.createRange();
-            range.setStart(nodes[0], 0);
-            range.setEnd(nodes[nodes.length - 1], nodes[nodes.length - 1].length);
+          const sentenceIdx = parseInt(pdfTarget.dataset.sentenceIdx, 10);
+          if (isNaN(sentenceIdx)) return;
 
-            curSel.removeAllRanges();
-            curSel.addRange(range);
+          const pageWrapper = pdfTarget.closest('.pdf-page-wrapper');
+          if (!pageWrapper) return;
+          const pageNum = parseInt(pageWrapper.dataset.page, 10);
 
-            const rect = pdfTarget.getBoundingClientRect();
-            showSelectionMenu(rect, true);
+          const { pdfIdx, transIdx, pdfElements } = getMappedElementsAndIndices(pdfTarget, pageNum, sentenceIdx);
+
+          if (pdfElements && pdfElements.length > 0) {
+            state.hoverSelectedPdfElements = pdfElements;
+            state.hoverSelectedPageNum = pageNum;
+
+            const walker = document.createTreeWalker(pdfTarget, NodeFilter.SHOW_TEXT);
+            const nodes = [];
+            while (walker.nextNode()) {
+              nodes.push(walker.currentNode);
+            }
+            if (nodes.length > 0) {
+              const range = document.createRange();
+              range.setStart(nodes[0], 0);
+              range.setEnd(nodes[nodes.length - 1], nodes[nodes.length - 1].length);
+
+              curSel.removeAllRanges();
+              curSel.addRange(range);
+
+              const rect = pdfTarget.getBoundingClientRect();
+              showSelectionMenu(rect, true);
+            }
           }
         }, 700);
       }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
-import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata } from './library.js'
+import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation } from './library.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -143,6 +143,10 @@ const chatSidebar        = $('chat-sidebar')
 const chatResizer        = $('chat-resizer')
 const chatCloseBtn       = $('chat-close-btn')
 const chatMessages       = $('chat-messages')
+const outlineToggleBtn   = $('outline-toggle-btn')
+const outlineSidebar     = $('outline-sidebar')
+const outlineCloseBtn    = $('outline-close-btn')
+const outlineContent     = $('outline-content')
 const chatInput          = $('chat-input')
 const chatSendBtn        = $('chat-send-btn')
 
@@ -211,6 +215,7 @@ function resetState() {
   if (chatSidebar) chatSidebar.classList.add('hidden')
   if (chatResizer) chatResizer.classList.add('hidden')
   if (chatToggleBtn) chatToggleBtn.classList.remove('active')
+  hideOutlineSidebar()
   resetChatUI()
 }
 
@@ -321,6 +326,8 @@ async function handleFiles(files) {
 
       showViewer()
       await initScrollViewer()
+      hideOutlineSidebar()
+      await loadPDFOutline()
     } else if (!isLibraryActive) {
       await showLibraryScreen()
     }
@@ -389,6 +396,25 @@ async function initScrollViewer() {
           console.warn(`Failed to lazy load translation for page ${pageNum}:`, err)
           delete state.translationCache[pageNum]
         }
+      }
+
+      // 비동기 다음 페이지 번역 프리페칭 및 미리 렌더링
+      const nextPage = pageNum + 1
+      if (nextPage <= state.totalPages && !state.translationCache[nextPage] && state.translatedPages.has(nextPage)) {
+        state.translationCache[nextPage] = '__fetching__'
+        const currentSessionId = state.sessionId
+        const opts = getTranslationOptions()
+        fetchLibraryTranslation(currentSessionId, nextPage, opts).then(res => {
+          if (state.sessionId === currentSessionId) {
+            state.translationCache[nextPage] = res.translation
+            state.translationSentences[nextPage] = res.sentences || []
+            renderTransContent(nextPage, res.translation, true)
+          }
+        }).catch(err => {
+          if (state.sessionId === currentSessionId) {
+            delete state.translationCache[nextPage]
+          }
+        })
       }
     }
   })
@@ -2109,6 +2135,8 @@ async function openFromLibrary(doc, shouldPushState = true) {
 
   showViewer()
   await initScrollViewer()
+  hideOutlineSidebar()
+  await loadPDFOutline()
 }
 
 function escapeHtml(str) {
@@ -2313,14 +2341,21 @@ function createSelectionMenu() {
   menu.id = 'selection-menu'
   menu.className = 'selection-menu hidden'
   menu.innerHTML = `
-    <div class="menu-annotate-group" style="display: flex; gap: 6px; align-items: center;">
-      <button class="menu-btn highlight-btn" title="하이라이트">🟡</button>
-      <button class="menu-btn underline-btn" title="밑줄">🔴</button>
-      <button class="menu-btn clear-btn" title="지우기">❌</button>
-      <div class="menu-divider" style="width: 1px; background: var(--border-strong); margin: 0 4px; align-self: stretch;"></div>
+    <div class="menu-annotate-group" style="display: flex; gap: 4px; align-items: center;">
+      <button class="menu-btn highlight-btn" title="하이라이트">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+      </button>
+      <button class="menu-btn underline-btn" title="밑줄">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+      </button>
+      <button class="menu-btn clear-btn" title="지우기">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      </button>
+      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
     </div>
-    <button class="menu-btn ask-ai-btn" title="AI 어시스턴트에게 물어보기" style="display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: var(--text-primary); padding: 0 6px;">
-      <span>🤖 AI 어시스턴트에게 물어보기</span>
+    <button class="menu-btn ask-ai-btn" title="AI 어시스턴트에게 질문" style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--accent-mid); padding: 0 8px;">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
+      <span>Ask AI</span>
     </button>
   `
   document.body.appendChild(menu)
@@ -4393,4 +4428,157 @@ window.addEventListener('hashchange', () => {
   console.log("[Router] hashchange fired")
   handleRouting()
 })
+
+// ── 논문 목차(Outline) 제어 및 바인딩 ─────────────────
+async function loadPDFOutline() {
+  if (!outlineContent) return
+  outlineContent.innerHTML = '<div style="font-size:12px; color:var(--text-muted); text-align:center; padding:20px;">목차 로드 중...</div>'
+  
+  try {
+    const outline = await getPDFOutline()
+    outlineContent.innerHTML = ''
+    
+    if (!outline || outline.length === 0) {
+      outlineContent.innerHTML = '<div style="font-size:12px; color:var(--text-muted); text-align:center; padding:20px;">목차 정보가 없는 PDF입니다.</div>'
+      return
+    }
+    
+    function renderTree(items, depth = 0) {
+      items.forEach(item => {
+        const div = document.createElement('div')
+        div.className = `outline-item depth-${depth}`
+        div.innerHTML = `<span>🔖</span> <span style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${escapeHtml(item.title)}</span>`
+        if (item.pageNum) {
+          div.addEventListener('click', () => {
+            scrollToPage(viewerScrollContainer, item.pageNum)
+          })
+          div.title = `${item.pageNum}페이지로 이동`
+        }
+        outlineContent.appendChild(div)
+        if (item.items && item.items.length > 0) {
+          renderTree(item.items, depth + 1)
+        }
+      })
+    }
+    
+    renderTree(outline)
+  } catch (err) {
+    console.error("Outline load error:", err)
+    outlineContent.innerHTML = '<div style="font-size:12px; color:var(--error); text-align:center; padding:20px;">목차 로드 실패</div>'
+  }
+}
+
+function hideOutlineSidebar() {
+  if (outlineSidebar) {
+    outlineSidebar.classList.add('hidden')
+    if (outlineToggleBtn) outlineToggleBtn.classList.remove('active')
+  }
+}
+
+function showOutlineSidebar() {
+  if (outlineSidebar) {
+    outlineSidebar.classList.remove('hidden')
+    if (outlineToggleBtn) outlineToggleBtn.classList.add('active')
+  }
+}
+
+// 목차 이벤트 바인딩
+if (outlineToggleBtn) {
+  outlineToggleBtn.addEventListener('click', () => {
+    if (outlineSidebar.classList.contains('hidden')) {
+      showOutlineSidebar()
+    } else {
+      hideOutlineSidebar()
+    }
+  })
+}
+if (outlineCloseBtn) {
+  outlineCloseBtn.addEventListener('click', hideOutlineSidebar)
+}
+
+// ── 번역 문장 더블클릭 수동 수정 (Inline Edit) ──────
+if (viewerScrollContainer) {
+  viewerScrollContainer.addEventListener('dblclick', (e) => {
+    const span = e.target.closest('.trans-sentence')
+    if (!span) return
+    
+    if (span.getAttribute('contenteditable') === 'true') return
+    
+    e.preventDefault()
+    e.stopPropagation()
+    
+    const pageNum = parseInt(span.dataset.page)
+    const sentenceIdx = parseInt(span.dataset.sentenceIdx)
+    if (isNaN(pageNum) || isNaN(sentenceIdx)) return
+    
+    const originalText = span.textContent.trim()
+    span.contentEditable = true
+    span.classList.add('inline-editing')
+    span.focus()
+    
+    // 포커스 시 텍스트 맨 뒤에 캐럿 배치
+    const range = document.createRange()
+    range.selectNodeContents(span)
+    range.collapse(false)
+    const selection = window.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+    
+    let finished = false
+    
+    async function finishEdit(commit) {
+      if (finished) return
+      finished = true
+      span.contentEditable = false
+      span.classList.remove('inline-editing')
+      
+      if (commit) {
+        const newText = span.textContent.trim()
+        if (newText && newText !== originalText) {
+          try {
+            // 1. 상태 업데이트
+            const oldText = state.translationSentences[pageNum][sentenceIdx].trans
+            state.translationSentences[pageNum][sentenceIdx].trans = newText
+            
+            // 캐시 텍스트 치환
+            if (state.translationCache[pageNum]) {
+              state.translationCache[pageNum] = state.translationCache[pageNum].replace(oldText, newText)
+            }
+            
+            // 2. 백엔드 API 연동 저장
+            const payload = {
+              translation: state.translationCache[pageNum],
+              sentences: state.translationSentences[pageNum]
+            }
+            await updateLibraryTranslation(state.sessionId, pageNum, payload, getTranslationOptions())
+            
+            showToast('문장 번역이 수정되어 저장되었습니다.', 'success')
+          } catch (err) {
+            console.error("Failed to save edited translation:", err)
+            showToast('번역 수정 저장 실패', 'error')
+            span.textContent = originalText
+          }
+        } else {
+          span.textContent = originalText
+        }
+      } else {
+        span.textContent = originalText
+      }
+    }
+    
+    span.addEventListener('keydown', (evt) => {
+      if (evt.key === 'Enter') {
+        evt.preventDefault()
+        finishEdit(true)
+      } else if (evt.key === 'Escape') {
+        evt.preventDefault()
+        finishEdit(false)
+      }
+    })
+    
+    span.addEventListener('blur', () => {
+      finishEdit(true)
+    })
+  })
+}
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2563,24 +2563,53 @@ function createAnnHoverTooltip() {
     e.preventDefault(); e.stopPropagation()
     if (!activeHoveredSpan) return
 
-    const startOffset = parseInt(activeHoveredSpan.dataset.startOffset)
-    const endOffset = parseInt(activeHoveredSpan.dataset.endOffset)
+    const sentenceEl = activeHoveredSpan.closest('.pdf-sentence')
+    if (!sentenceEl) return
+    const sentenceIdx = parseInt(sentenceEl.dataset.sentenceIdx, 10)
     const pageWrapper = activeHoveredSpan.closest('.pdf-page-wrapper')
     if (!pageWrapper) return
-    const pageNum = parseInt(pageWrapper.dataset.page)
+    const pageNum = parseInt(pageWrapper.dataset.page, 10)
     const textLayerDiv = pageWrapper.querySelector('.textLayer')
 
-    const annotations = loadAnnotations(state.sessionId)
-    if (annotations[`page_${pageNum}`]) {
-      const originalCount = annotations[`page_${pageNum}`].length
-      annotations[`page_${pageNum}`] = annotations[`page_${pageNum}`].filter(ann => {
-        return !(ann.startOffset === startOffset && ann.endOffset === endOffset)
-      })
+    // 문장에 속하는 모든 PDF 엘리먼트 가져오기
+    const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, sentenceIdx)
 
-      if (annotations[`page_${pageNum}`].length !== originalCount) {
-        saveAnnotations(state.sessionId, annotations)
-        showToast('어노테이션이 삭제되었습니다 ✓', 'success')
-        reRenderPageAnnotations(textLayerDiv, pageNum)
+    if (pdfElements && pdfElements.length > 0) {
+      const firstEl = pdfElements[0]
+      const lastEl = pdfElements[pdfElements.length - 1]
+
+      const firstWalker = document.createTreeWalker(firstEl, NodeFilter.SHOW_TEXT)
+      const firstNodes = []
+      while (firstWalker.nextNode()) firstNodes.push(firstWalker.currentNode)
+
+      const lastWalker = document.createTreeWalker(lastEl, NodeFilter.SHOW_TEXT)
+      const lastNodes = []
+      while (lastWalker.nextNode()) lastNodes.push(lastWalker.currentNode)
+
+      if (firstNodes.length > 0 && lastNodes.length > 0) {
+        const r = document.createRange()
+        r.setStart(firstNodes[0], 0)
+        r.setEnd(lastNodes[lastNodes.length - 1], lastNodes[lastNodes.length - 1].length)
+
+        const sentenceOffsets = getPageTextOffset(r, textLayerDiv)
+        if (sentenceOffsets.startOffset !== null && sentenceOffsets.endOffset !== null) {
+          const annotations = loadAnnotations(state.sessionId)
+          if (annotations[`page_${pageNum}`]) {
+            const originalCount = annotations[`page_${pageNum}`].length
+            annotations[`page_${pageNum}`] = annotations[`page_${pageNum}`].filter(ann => {
+              // 문장 오프셋 내에 시작점 또는 끝점이 겹치는 하이라이트/밑줄들을 모두 삭제 대상으로 식별
+              const isOverlapping = (ann.startOffset >= sentenceOffsets.startOffset && ann.startOffset <= sentenceOffsets.endOffset) ||
+                                    (ann.endOffset >= sentenceOffsets.startOffset && ann.endOffset <= sentenceOffsets.endOffset);
+              return !isOverlapping;
+            })
+
+            if (annotations[`page_${pageNum}`].length !== originalCount) {
+              saveAnnotations(state.sessionId, annotations)
+              showToast('문장 어노테이션이 일괄 삭제되었습니다 ✓', 'success')
+              reRenderPageAnnotations(textLayerDiv, pageNum)
+            }
+          }
+        }
       }
     }
     hideAnnHoverTooltip()
@@ -4370,15 +4399,21 @@ if (viewerScrollContainer) {
             state.hoverSelectedPdfElements = pdfElements;
             state.hoverSelectedPageNum = pageNum;
 
-            const walker = document.createTreeWalker(pdfTarget, NodeFilter.SHOW_TEXT);
-            const nodes = [];
-            while (walker.nextNode()) {
-              nodes.push(walker.currentNode);
-            }
-            if (nodes.length > 0) {
+            const firstEl = pdfElements[0];
+            const lastEl = pdfElements[pdfElements.length - 1];
+
+            const firstWalker = document.createTreeWalker(firstEl, NodeFilter.SHOW_TEXT);
+            const firstNodes = [];
+            while (firstWalker.nextNode()) firstNodes.push(firstWalker.currentNode);
+
+            const lastWalker = document.createTreeWalker(lastEl, NodeFilter.SHOW_TEXT);
+            const lastNodes = [];
+            while (lastWalker.nextNode()) lastNodes.push(lastWalker.currentNode);
+
+            if (firstNodes.length > 0 && lastNodes.length > 0) {
               const range = document.createRange();
-              range.setStart(nodes[0], 0);
-              range.setEnd(nodes[nodes.length - 1], nodes[nodes.length - 1].length);
+              range.setStart(firstNodes[0], 0);
+              range.setEnd(lastNodes[lastNodes.length - 1], lastNodes[lastNodes.length - 1].length);
 
               curSel.removeAllRanges();
               curSel.addRange(range);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2366,6 +2366,260 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations) {
   })
 }
 
+// ── Floating Markdown Memo 관리 ─────────────────────────
+function loadMemos(sessionId) {
+  if (!sessionId) return {}
+  const key = `easypaper_memos_${sessionId}`
+  try {
+    return JSON.parse(localStorage.getItem(key)) || {}
+  } catch (e) {
+    return {}
+  }
+}
+
+function saveMemos(sessionId, memos) {
+  if (!sessionId) return
+  const key = `easypaper_memos_${sessionId}`
+  localStorage.setItem(key, JSON.stringify(memos))
+}
+
+function updateMemoConnectorLine(pageWrapper, memo, sentenceEl) {
+  let svg = pageWrapper.querySelector('.memo-connector-svg')
+  if (!svg) {
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('class', 'memo-connector-svg')
+    pageWrapper.appendChild(svg)
+  }
+
+  let path = svg.getElementById(`connector_${memo.id}`)
+  if (!path) {
+    path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttribute('id', `connector_${memo.id}`)
+    path.setAttribute('stroke', 'var(--accent-mid)')
+    path.setAttribute('stroke-width', '1.5')
+    path.setAttribute('stroke-dasharray', '4,4')
+    path.setAttribute('fill', 'none')
+    path.setAttribute('opacity', '0.6')
+    svg.appendChild(path)
+  }
+
+  if (!sentenceEl) {
+    path.setAttribute('d', '')
+    return
+  }
+
+  const anchorX = sentenceEl.offsetLeft + sentenceEl.offsetWidth / 2
+  const anchorY = sentenceEl.offsetTop + sentenceEl.offsetHeight / 2
+
+  const memoLeft = (memo.x / 100) * pageWrapper.offsetWidth
+  const memoTop = (memo.y / 100) * pageWrapper.offsetHeight
+  const memoWidth = 260
+  const memoEl = pageWrapper.querySelector(`.floating-memo[data-id="${memo.id}"]`)
+  const memoHeight = memoEl ? memoEl.offsetHeight : 160
+
+  const memoCenterX = memoLeft + memoWidth / 2
+  const memoCenterY = memoTop + memoHeight / 2
+
+  let targetX = memoCenterX
+  let targetY = memoCenterY
+
+  if (anchorX < memoLeft) {
+    targetX = memoLeft
+  } else if (anchorX > memoLeft + memoWidth) {
+    targetX = memoLeft + memoWidth
+  }
+
+  if (anchorY < memoTop) {
+    targetY = memoTop
+  } else if (anchorY > memoTop + memoHeight) {
+    targetY = memoTop + memoHeight
+  }
+
+  const cpX1 = anchorX + (targetX - anchorX) * 0.5
+  const cpY1 = anchorY
+  const cpX2 = anchorX + (targetX - anchorX) * 0.5
+  const cpY2 = targetY
+  path.setAttribute('d', `M ${anchorX} ${anchorY} C ${cpX1} ${cpY1}, ${cpX2} ${cpY2}, ${targetX} ${targetY}`)
+}
+
+function renderPageMemos(pageNum) {
+  const pageWrapper = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
+  if (!pageWrapper) return
+
+  pageWrapper.querySelectorAll('.floating-memo').forEach(el => el.remove())
+  const svg = pageWrapper.querySelector('.memo-connector-svg')
+  if (svg) svg.innerHTML = ''
+
+  if (!state.sessionId) return
+  const allMemos = loadMemos(state.sessionId)
+  const pageMemos = allMemos[`page_${pageNum}`] || []
+
+  pageMemos.forEach(memo => {
+    const memoEl = document.createElement('div')
+    memoEl.className = 'floating-memo'
+    memoEl.setAttribute('data-id', memo.id)
+    memoEl.style.left = `${memo.x}%`
+    memoEl.style.top = `${memo.y}%`
+
+    const sentenceEl = pageWrapper.querySelector(`.pdf-sentence[data-sentence-idx="${memo.sentenceIdx}"]`)
+    let isEditing = !memo.content.trim()
+
+    function updateCardContent() {
+      const body = memoEl.querySelector('.floating-memo-body')
+      const actions = memoEl.querySelector('.floating-memo-actions')
+
+      if (isEditing) {
+        body.innerHTML = `<textarea class="floating-memo-textarea" placeholder="메모를 입력하세요 (Markdown 지원)...">${memo.content}</textarea>`
+        actions.innerHTML = `
+          <button class="floating-memo-action-btn save-btn" title="저장">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+          </button>
+          <button class="floating-memo-action-btn delete delete-btn" title="삭제">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+          </button>
+        `
+
+        const textarea = body.querySelector('.floating-memo-textarea')
+        textarea.focus()
+        
+        actions.querySelector('.save-btn').addEventListener('click', (e) => {
+          e.stopPropagation()
+          memo.content = textarea.value
+          isEditing = false
+          
+          const allMemosObj = loadMemos(state.sessionId)
+          allMemosObj[`page_${pageNum}`] = pageMemos
+          saveMemos(state.sessionId, allMemosObj)
+          
+          updateCardContent()
+          setTimeout(() => {
+            updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+          }, 30)
+        })
+      } else {
+        const renderedHtml = window.marked ? window.marked.parse(memo.content) : memo.content
+        body.innerHTML = `<div class="floating-memo-render">${renderedHtml}</div>`
+        actions.innerHTML = `
+          <button class="floating-memo-action-btn edit-btn" title="편집">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/><path d="m15 5 3 3"/></svg>
+          </button>
+          <button class="floating-memo-action-btn delete delete-btn" title="삭제">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+          </button>
+        `
+
+        actions.querySelector('.edit-btn').addEventListener('click', (e) => {
+          e.stopPropagation()
+          isEditing = true
+          updateCardContent()
+        })
+      }
+
+      actions.querySelector('.delete-btn').addEventListener('click', (e) => {
+        e.stopPropagation()
+        if (confirm('이 메모를 삭제하시겠습니까?')) {
+          const allMemosObj = loadMemos(state.sessionId)
+          allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
+          saveMemos(state.sessionId, allMemosObj)
+          
+          memoEl.remove()
+          const pNode = pageWrapper.querySelector(`.memo-connector-svg #connector_${memo.id}`)
+          if (pNode) pNode.remove()
+        }
+      })
+    }
+
+    memoEl.innerHTML = `
+      <div class="floating-memo-header">
+        <div class="floating-memo-title">
+          <span>📝 Memo</span>
+        </div>
+        <div class="floating-memo-actions"></div>
+      </div>
+      <div class="floating-memo-body"></div>
+    `
+
+    updateCardContent()
+    pageWrapper.appendChild(memoEl)
+
+    const header = memoEl.querySelector('.floating-memo-header')
+    header.addEventListener('mousedown', (e) => {
+      e.preventDefault(); e.stopPropagation()
+      const startMouseX = e.clientX
+      const startMouseY = e.clientY
+      const startX = memo.x
+      const startY = memo.y
+
+      const onMouseMove = (moveEvt) => {
+        const dx = moveEvt.clientX - startMouseX
+        const dy = moveEvt.clientY - startMouseY
+
+        const dxPct = (dx / pageWrapper.offsetWidth) * 100
+        const dyPct = (dy / pageWrapper.offsetHeight) * 100
+
+        const newX = Math.min(Math.max(1, startX + dxPct), 90)
+        const newY = Math.min(Math.max(1, startY + dyPct), 95)
+
+        memo.x = newX
+        memo.y = newY
+
+        memoEl.style.left = `${newX}%`
+        memoEl.style.top = `${newY}%`
+
+        updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+      }
+
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+
+        const allMemosObj = loadMemos(state.sessionId)
+        allMemosObj[`page_${pageNum}`] = pageMemos
+        saveMemos(state.sessionId, allMemosObj)
+      }
+
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    })
+
+    setTimeout(() => {
+      updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+    }, 50)
+  })
+}
+
+function createFloatingMemoForSentence(pageNum, sentenceIdx) {
+  if (!state.sessionId) return
+
+  const pageWrapper = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
+  if (!pageWrapper) return
+
+  const sentenceEl = pageWrapper.querySelector(`.pdf-sentence[data-sentence-idx="${sentenceIdx}"]`)
+  if (!sentenceEl) return
+
+  const leftPct = Math.min(Math.max(10, ((sentenceEl.offsetLeft + sentenceEl.offsetWidth / 2) / pageWrapper.offsetWidth) * 100), 70)
+  const topPct = Math.min(Math.max(10, ((sentenceEl.offsetTop + sentenceEl.offsetHeight) / pageWrapper.offsetHeight) * 100 + 4), 85)
+
+  const allMemosObj = loadMemos(state.sessionId)
+  if (!allMemosObj[`page_${pageNum}`]) {
+    allMemosObj[`page_${pageNum}`] = []
+  }
+
+  const newMemo = {
+    id: `memo_${Date.now()}`,
+    pageNum: pageNum,
+    sentenceIdx: sentenceIdx,
+    content: '',
+    x: leftPct,
+    y: topPct
+  }
+
+  allMemosObj[`page_${pageNum}`].push(newMemo)
+  saveMemos(state.sessionId, allMemosObj)
+
+  renderPageMemos(pageNum)
+}
+
 // ── 팝업 툴팁 선택 메뉴 관리 ──
 let selectionMenu = null
 let sentenceHoverTimer = null
@@ -2407,6 +2661,11 @@ function createSelectionMenu() {
       <!-- 지우기 버튼 -->
       <button class="menu-btn clear-btn" title="지우기">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      </button>
+      
+      <!-- 메모 추가 버튼 -->
+      <button class="menu-btn memo-btn" title="메모 추가">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>
       </button>
       
       <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
@@ -2499,6 +2758,25 @@ function createSelectionMenu() {
     handleAnnotate('clear')
   })
 
+  menu.querySelector('.memo-btn').addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation()
+    const selection = window.getSelection()
+    if (!selection.rangeCount) return
+    const range = selection.getRangeAt(0)
+    let container = range.commonAncestorContainer
+    if (container && container.nodeType === 3) {
+      container = container.parentElement || container.parentNode
+    }
+    const sentenceEl = container.closest('.pdf-sentence')
+    const pageWrapper = container.closest('.pdf-page-wrapper')
+    if (sentenceEl && pageWrapper) {
+      const pageNum = parseInt(pageWrapper.dataset.page, 10)
+      const sentenceIdx = parseInt(sentenceEl.dataset.sentenceIdx, 10)
+      createFloatingMemoForSentence(pageNum, sentenceIdx)
+    }
+    hideSelectionMenu()
+  })
+
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
     if (state.pendingFigureQuote) {
@@ -2533,6 +2811,10 @@ function createAnnHoverTooltip() {
   tooltip.innerHTML = `
     <button class="menu-btn delete-ann-btn" title="삭제">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+    </button>
+    <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+    <button class="menu-btn memo-ann-btn" title="메모 추가">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>
     </button>
     <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
     <button class="menu-btn ask-ai-btn ask-ai-ann-btn" title="AI 어시스턴트에게 질문">
@@ -2611,6 +2893,19 @@ function createAnnHoverTooltip() {
           }
         }
       }
+    }
+    hideAnnHoverTooltip()
+  })
+
+  tooltip.querySelector('.memo-ann-btn').addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation()
+    if (!activeHoveredSpan) return
+    const sentenceEl = activeHoveredSpan.closest('.pdf-sentence')
+    const pageWrapper = activeHoveredSpan.closest('.pdf-page-wrapper')
+    if (sentenceEl && pageWrapper) {
+      const pageNum = parseInt(pageWrapper.dataset.page, 10)
+      const sentenceIdx = parseInt(sentenceEl.dataset.sentenceIdx, 10)
+      createFloatingMemoForSentence(pageNum, sentenceIdx)
     }
     hideAnnHoverTooltip()
   })
@@ -2754,6 +3049,9 @@ function reRenderPageAnnotations(textLayerDiv, pageNum) {
 
   const annotations = loadAnnotations(state.sessionId)
   applyAnnotationsFromOffsets(textLayerDiv, annotations[`page_${pageNum}`] || [])
+
+  // Restore floating memos for the page
+  renderPageMemos(pageNum)
 }
 
 function showSelectionMenu(rect, showAnnotateGroup) {
@@ -2868,6 +3166,9 @@ window.onTextLayerRendered = (textLayerDiv, pageNum) => {
   }
 
   renderImageOverlayLayer(textLayerDiv, pageNum)
+
+  // Render floating memos
+  renderPageMemos(pageNum)
 }
 
 function cropFigureFromCanvas(canvas, imgPercent) {
@@ -4743,11 +5044,28 @@ viewerScrollContainer.addEventListener('mousedown', (e) => {
   document.body.classList.add('resizing-trans')
 })
 
+function triggerMemosRedraw() {
+  document.querySelectorAll('.pdf-page-wrapper').forEach(wrapper => {
+    const pageNum = parseInt(wrapper.dataset.page, 10)
+    if (!isNaN(pageNum)) {
+      const allMemos = loadMemos(state.sessionId)
+      const pageMemos = allMemos[`page_${pageNum}`] || []
+      pageMemos.forEach(memo => {
+        const sentenceEl = wrapper.querySelector(`.pdf-sentence[data-sentence-idx="${memo.sentenceIdx}"]`)
+        if (sentenceEl) {
+          updateMemoConnectorLine(wrapper, memo, sentenceEl)
+        }
+      })
+    }
+  })
+}
+
 document.addEventListener('mousemove', (e) => {
   if (!isResizingTrans) return
   // 우측에 배치되어 있으므로 오른쪽으로 당기면(dx가 양수) 커지고, 왼쪽으로 밀면 작아짐
   const dx = e.clientX - resizerStartX
   updateTransPaneWidth(resizerStartWidth + dx)
+  triggerMemosRedraw()
 })
 
 document.addEventListener('mouseup', () => {
@@ -4758,6 +5076,8 @@ document.addEventListener('mouseup', () => {
     document.body.classList.remove('resizing-trans')
   }
 })
+
+window.addEventListener('resize', triggerMemosRedraw)
 
 // 인라인 접기/펴기 버튼 클릭 이벤트 바인딩 (이벤트 위임)
 viewerScrollContainer.addEventListener('click', (e) => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2528,14 +2528,14 @@ function createAnnHoverTooltip() {
   const tooltip = document.createElement('div')
   tooltip.id = 'ann-hover-tooltip'
   tooltip.className = 'selection-menu hidden'
-  tooltip.style.cssText = 'position: absolute; z-index: 10005; padding: 2px 4px; gap: 4px; height: 32px; display: flex; align-items: center; box-shadow: var(--shadow-md);'
+  tooltip.style.cssText = 'position: absolute; z-index: 10005; padding: 2px 4px; gap: 6px; height: 32px; display: flex; align-items: center; box-shadow: var(--shadow-md);'
   tooltip.innerHTML = `
-    <button class="menu-btn delete-ann-btn" title="삭제" style="width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; cursor: pointer;">
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+    <button class="menu-btn delete-ann-btn" title="삭제" style="width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; cursor: pointer;">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
     </button>
-    <div style="width: 1px; background: var(--border-strong); height: 12px; margin: 0 2px;"></div>
-    <button class="menu-btn ask-ai-ann-btn" title="AI에게 질문" style="display: flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: var(--accent-mid); padding: 0 4px; background: transparent; border: none; cursor: pointer; height: 26px;">
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
+    <div style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+    <button class="menu-btn ask-ai-ann-btn" title="AI 어시스턴트에게 질문" style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--accent-mid); padding: 0 8px; background: transparent; border: none; cursor: pointer; height: 28px;">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
       <span>Ask AI</span>
     </button>
   `
@@ -4362,14 +4362,20 @@ if (viewerScrollContainer) {
     }
   });
 
-  // 클릭 시 해당 매칭 문장으로 스크롤 이동 (양방향 지원)
+  // 클릭 시 해당 매칭 문장으로 스크롤 이동 및 양방향 고정 하이라이트 매칭 적용
   viewerScrollContainer.addEventListener('click', (e) => {
     try {
       const selection = window.getSelection();
       if (selection && !selection.isCollapsed) return;
 
       const target = e.target.closest('.trans-sentence') || e.target.closest('.pdf-sentence');
-      if (!target) return;
+      if (!target) {
+        // 문장이 아닌 곳 클릭 시 기존 매칭 하이라이트 제거
+        viewerScrollContainer.querySelectorAll('.active-mapped-sentence').forEach(el => {
+          el.classList.remove('active-mapped-sentence');
+        });
+        return;
+      }
 
       const pageWrapper = target.closest('.pdf-page-wrapper') || target.closest('.trans-page-block');
       if (!pageWrapper) return;
@@ -4381,6 +4387,23 @@ if (viewerScrollContainer) {
 
       const { pdfIdx, transIdx, pdfElements } = getMappedElementsAndIndices(target, pageNum, sentenceIdx);
       if (pdfIdx === -1 || transIdx === -1) return;
+
+      // 1. 기존 매칭 하이라이트 제거
+      viewerScrollContainer.querySelectorAll('.active-mapped-sentence').forEach(el => {
+        el.classList.remove('active-mapped-sentence');
+      });
+
+      // 2. 신규 고정 매칭 하이라이트 지정
+      pdfElements.forEach(el => {
+        el.classList.add('active-mapped-sentence');
+      });
+      if (transIdx !== -1) {
+        viewerScrollContainer.querySelectorAll(
+          `.trans-sentence[data-page="${pageNum}"][data-sentence-idx="${transIdx}"]`
+        ).forEach(el => {
+          el.classList.add('active-mapped-sentence');
+        });
+      }
 
       // 번역본 클릭 -> PDF로 스크롤
       if (target.classList.contains('trans-sentence')) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4501,6 +4501,7 @@ function showOutlineSidebar() {
 // 목차 이벤트 바인딩
 if (outlineToggleBtn) {
   outlineToggleBtn.addEventListener('click', () => {
+    alert("목차 버튼 클릭됨! 사이드바 클래스: " + outlineSidebar.className)
     console.log("[Outline] Toggle button clicked. Sidebar:", outlineSidebar, "ToggleBtn:", outlineToggleBtn)
     if (!outlineSidebar) {
       showToast('목차 사이드바를 찾을 수 없습니다.', 'error')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2599,11 +2599,8 @@ function renderPageMemos(pageNum) {
       const actions = memoEl.querySelector('.floating-memo-actions')
 
       if (isEditing) {
-        body.innerHTML = `<textarea class="floating-memo-textarea" placeholder="메모를 입력하세요 (Markdown 지원)...">${memo.content}</textarea>`
+        body.innerHTML = `<textarea class="floating-memo-textarea" placeholder="메모를 입력하세요 (Markdown 및 LaTeX 지원)...">${memo.content}</textarea>`
         actions.innerHTML = `
-          <button class="floating-memo-action-btn save-btn" title="저장">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-          </button>
           <button class="floating-memo-action-btn delete delete-btn" title="삭제">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
           </button>
@@ -2612,19 +2609,34 @@ function renderPageMemos(pageNum) {
         const textarea = body.querySelector('.floating-memo-textarea')
         textarea.focus()
         
-        actions.querySelector('.save-btn').addEventListener('click', (e) => {
-          e.stopPropagation()
+        textarea.addEventListener('input', () => {
           memo.content = textarea.value
-          isEditing = false
-          
           const allMemosObj = loadMemos(state.sessionId)
           allMemosObj[`page_${pageNum}`] = pageMemos
           saveMemos(state.sessionId, allMemosObj)
-          
-          updateCardContent()
+          updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+        })
+
+        textarea.addEventListener('blur', () => {
           setTimeout(() => {
-            updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
-          }, 30)
+            const exists = memoEl.parentNode !== null
+            if (exists) {
+              isEditing = false
+              updateCardContent()
+              updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+            }
+          }, 150)
+        })
+
+        actions.querySelector('.delete-btn').addEventListener('mousedown', (e) => {
+          e.stopPropagation()
+          e.preventDefault()
+          if (confirm('이 메모를 삭제하시겠습니까?')) {
+            const allMemosObj = loadMemos(state.sessionId)
+            allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
+            saveMemos(state.sessionId, allMemosObj)
+            renderPageMemos(pageNum)
+          }
         })
       } else {
         let renderedHtml = memo.content
@@ -2636,6 +2648,23 @@ function renderPageMemos(pageNum) {
           }
         }
         body.innerHTML = `<div class="floating-memo-render">${renderedHtml}</div>`
+        
+        if (window.renderMathInElement) {
+          try {
+            window.renderMathInElement(body, {
+              delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '$', right: '$', display: false },
+                { left: '\\(', right: '\\)', display: false },
+                { left: '\\[', right: '\\]', display: true }
+              ],
+              throwOnError: false
+            })
+          } catch (e) {
+            console.warn("KaTeX rendering failed inside memo:", e)
+          }
+        }
+
         actions.innerHTML = `
           <button class="floating-memo-action-btn edit-btn" title="편집">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/><path d="m15 5 3 3"/></svg>
@@ -2650,18 +2679,23 @@ function renderPageMemos(pageNum) {
           isEditing = true
           updateCardContent()
         })
-      }
 
-      actions.querySelector('.delete-btn').addEventListener('click', (e) => {
-        e.stopPropagation()
-        if (confirm('이 메모를 삭제하시겠습니까?')) {
-          const allMemosObj = loadMemos(state.sessionId)
-          allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
-          saveMemos(state.sessionId, allMemosObj)
-          
-          renderPageMemos(pageNum)
-        }
-      })
+        body.addEventListener('dblclick', (e) => {
+          e.stopPropagation()
+          isEditing = true
+          updateCardContent()
+        })
+
+        actions.querySelector('.delete-btn').addEventListener('click', (e) => {
+          e.stopPropagation()
+          if (confirm('이 메모를 삭제하시겠습니까?')) {
+            const allMemosObj = loadMemos(state.sessionId)
+            allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
+            saveMemos(state.sessionId, allMemosObj)
+            renderPageMemos(pageNum)
+          }
+        })
+      }
     }
 
     const sentenceText = (sentenceEl ? sentenceEl.textContent.trim() : '') || memo.sentenceText || ''

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2375,7 +2375,7 @@ function createSelectionMenu() {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
         </button>
         <!-- 서브 팝오버 툴팁 -->
-        <div class="color-popover highlight-popover hidden">
+        <div class="color-popover highlight-popover">
           <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
           <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
@@ -2389,7 +2389,7 @@ function createSelectionMenu() {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
         </button>
         <!-- 서브 팝오버 툴팁 -->
-        <div class="color-popover underline-popover hidden">
+        <div class="color-popover underline-popover">
           <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
           <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
@@ -2418,8 +2418,6 @@ function createSelectionMenu() {
   
   const highlightBtn = menu.querySelector('.highlight-btn')
   const underlineBtn = menu.querySelector('.underline-btn')
-  const highlightPopover = menu.querySelector('.highlight-popover')
-  const underlinePopover = menu.querySelector('.underline-popover')
 
   function updateActiveColors() {
     highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
@@ -2447,7 +2445,6 @@ function createSelectionMenu() {
       e.preventDefault(); e.stopPropagation();
       state.activeHighlightColor = dot.dataset.color
       updateActiveColors()
-      highlightPopover.classList.add('hidden')
       handleAnnotate('highlight', state.activeHighlightColor)
     })
   })
@@ -2457,35 +2454,28 @@ function createSelectionMenu() {
       e.preventDefault(); e.stopPropagation();
       state.activeUnderlineColor = dot.dataset.color
       updateActiveColors()
-      underlinePopover.classList.add('hidden')
       handleAnnotate('underline', state.activeUnderlineColor)
     })
   })
 
-  // 아이콘 클릭 핸들러 바인딩 (서브 컬러 팝오버 토글)
+  // 아이콘 클릭 시 즉시 활성화 색상으로 마킹 처리 적용
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    underlinePopover.classList.add('hidden')
-    highlightPopover.classList.toggle('hidden')
+    handleAnnotate('highlight', state.activeHighlightColor)
   })
 
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.toggle('hidden')
+    handleAnnotate('underline', state.activeUnderlineColor)
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     handleAnnotate('clear')
   })
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     if (state.pendingFigureQuote) {
       askAIAssistantImage(state.pendingFigureQuote.base64Img, state.pendingFigureQuote.pageNum)
     } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4308,7 +4308,6 @@ if (viewerScrollContainer) {
       const annSpan = e.target.closest('.pdf-annotation-highlight, .pdf-annotation-underline');
       if (annSpan) {
         showAnnotationHoverTooltip(annSpan);
-        return;
       }
 
       const selection = window.getSelection();
@@ -4319,8 +4318,9 @@ if (viewerScrollContainer) {
       if (!target) return;
 
       // PDF 텍스트 문장에 마우스가 700ms 동안 머물러 있으면 문장 단위 자동 드래그 선택 및 툴팁 띄우기
+      // 단, 이미 어노테이션이 입혀진 span 위에 올라온 경우는 작동 제외
       const pdfTarget = e.target.closest('.pdf-sentence');
-      if (pdfTarget) {
+      if (pdfTarget && !annSpan) {
         sentenceHoverTimer = setTimeout(() => {
           const curSel = window.getSelection();
           if (curSel && !curSel.isCollapsed) return;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2368,14 +2368,17 @@ function createSelectionMenu() {
   menu.id = 'selection-menu'
   menu.className = 'selection-menu hidden'
   menu.innerHTML = `
-    <div class="menu-annotate-group" style="display: flex; gap: 4px; align-items: center; padding: 2px 6px;">
-      <!-- 하이라이트 그룹 -->
-      <div class="annotate-button-wrapper highlight-wrapper" style="position: relative; display: flex;">
-        <button class="menu-btn highlight-btn" title="하이라이트">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+    <div class="menu-annotate-group" style="display: flex; gap: 6px; align-items: center; padding: 2px 4px;">
+      <!-- 하이라이트 스플릿 버튼 그룹 -->
+      <div class="annotate-split-wrapper highlight-wrapper" style="position: relative; display: flex; align-items: center;">
+        <button class="menu-btn highlight-btn" title="즉시 하이라이트" style="width: 28px; height: 100%; border-right: 1px solid var(--border-strong);">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
         </button>
-        <!-- 서브 팝오버 툴팁 -->
-        <div class="color-popover highlight-popover">
+        <button class="menu-btn highlight-arrow-btn" title="색상 선택" style="width: 14px; height: 100%; font-size: 8px; color: var(--text-muted); font-weight: bold;">
+          ▾
+        </button>
+        <!-- 서브 팝오버 툴팁 (기본값 hidden 유지) -->
+        <div class="color-popover highlight-popover hidden">
           <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
           <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
@@ -2383,13 +2386,16 @@ function createSelectionMenu() {
         </div>
       </div>
       
-      <!-- 밑줄 그룹 -->
-      <div class="annotate-button-wrapper underline-wrapper" style="position: relative; display: flex;">
-        <button class="menu-btn underline-btn" title="밑줄">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+      <!-- 밑줄 스플릿 버튼 그룹 -->
+      <div class="annotate-split-wrapper underline-wrapper" style="position: relative; display: flex; align-items: center;">
+        <button class="menu-btn underline-btn" title="즉시 밑줄" style="width: 28px; height: 100%; border-right: 1px solid var(--border-strong);">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
         </button>
-        <!-- 서브 팝오버 툴팁 -->
-        <div class="color-popover underline-popover">
+        <button class="menu-btn underline-arrow-btn" title="색상 선택" style="width: 14px; height: 100%; font-size: 8px; color: var(--text-muted); font-weight: bold;">
+          ▾
+        </button>
+        <!-- 서브 팝오버 툴팁 (기본값 hidden 유지) -->
+        <div class="color-popover underline-popover hidden">
           <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
           <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
@@ -2398,8 +2404,8 @@ function createSelectionMenu() {
       </div>
       
       <!-- 지우기 버튼 -->
-      <button class="menu-btn clear-btn" title="지우기">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      <button class="menu-btn clear-btn" title="지우기" style="border: 1px solid var(--border-strong); width: 28px; height: 28px; border-radius: var(--radius-sm);">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
       </button>
       <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
     </div>
@@ -2418,6 +2424,10 @@ function createSelectionMenu() {
   
   const highlightBtn = menu.querySelector('.highlight-btn')
   const underlineBtn = menu.querySelector('.underline-btn')
+  const highlightArrow = menu.querySelector('.highlight-arrow-btn')
+  const underlineArrow = menu.querySelector('.underline-arrow-btn')
+  const highlightPopover = menu.querySelector('.highlight-popover')
+  const underlinePopover = menu.querySelector('.underline-popover')
 
   function updateActiveColors() {
     highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
@@ -2445,6 +2455,7 @@ function createSelectionMenu() {
       e.preventDefault(); e.stopPropagation();
       state.activeHighlightColor = dot.dataset.color
       updateActiveColors()
+      highlightPopover.classList.add('hidden')
       handleAnnotate('highlight', state.activeHighlightColor)
     })
   })
@@ -2454,28 +2465,50 @@ function createSelectionMenu() {
       e.preventDefault(); e.stopPropagation();
       state.activeUnderlineColor = dot.dataset.color
       updateActiveColors()
+      underlinePopover.classList.add('hidden')
       handleAnnotate('underline', state.activeUnderlineColor)
     })
   })
 
-  // 아이콘 클릭 시 즉시 활성화 색상으로 마킹 처리 적용
+  // 메인 아이콘 클릭 시 즉시 활성화 색상으로 마킹 처리 적용
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     handleAnnotate('highlight', state.activeHighlightColor)
   })
 
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     handleAnnotate('underline', state.activeUnderlineColor)
+  })
+
+  // 우측 조그만 화살표 버튼 클릭 시 서브 컬러 팝오버 토글
+  highlightArrow.addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    underlinePopover.classList.add('hidden')
+    highlightPopover.classList.toggle('hidden')
+  })
+
+  underlineArrow.addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.toggle('hidden')
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     handleAnnotate('clear')
   })
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     if (state.pendingFigureQuote) {
       askAIAssistantImage(state.pendingFigureQuote.base64Img, state.pendingFigureQuote.pageNum)
     } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4358,33 +4358,43 @@ viewerScrollContainer.addEventListener('click', (e) => {
 
 // ── 해시 라우팅 및 뒤로가기 제어 ──────────────────────
 async function handleRouting() {
-  const hash = location.hash
-  if (hash.startsWith('#viewer?id=')) {
-    const docId = hash.split('?id=')[1]
-    if (docId) {
-      if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
-        return
-      }
-      try {
+  try {
+    const hash = location.hash
+    console.log("[Router] handleRouting triggered. Current hash:", hash)
+    
+    if (hash.startsWith('#viewer?id=')) {
+      const docId = hash.split('?id=')[1]
+      if (docId) {
+        if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
+          console.log("[Router] Viewer already active for document:", docId)
+          return
+        }
+        console.log("[Router] Routing to viewer for document:", docId)
         const doc = await fetchLibraryDoc(docId)
         if (doc) {
           await openFromLibrary(doc, false)
           return
         }
-      } catch (err) {
-        console.error("Failed to load doc from hash route:", err)
-        showToast("논문을 불러오지 못했습니다.", "error")
+      }
+      location.hash = 'library'
+    } else {
+      console.log("[Router] Routing to Library screen. Library active state:", libraryScreen.classList.contains('active'))
+      if (!libraryScreen.classList.contains('active')) {
+        await showLibraryScreen(false)
       }
     }
-    location.hash = 'library'
-  } else {
-    if (!libraryScreen.classList.contains('active')) {
-      await showLibraryScreen(false)
-    }
+  } catch (err) {
+    console.error("[Router] Error in handleRouting:", err)
   }
 }
 
-window.addEventListener('popstate', () => {
+window.addEventListener('popstate', (e) => {
+  console.log("[Router] popstate fired. state:", e.state)
+  handleRouting()
+})
+
+window.addEventListener('hashchange', () => {
+  console.log("[Router] hashchange fired")
   handleRouting()
 })
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages } from './pdfViewer.js'
-import { fetchLibrary, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages } from './library.js'
+import { fetchLibrary, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata } from './library.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -114,6 +114,7 @@ const uploadItemProgressBar = $('upload-item-progress-bar')
 const uploadItemSpinner  = $('upload-item-spinner')
 const uploadItemSuccessIcon = $('upload-item-success-icon')
 const docTitle          = $('doc-title')
+const docTitleEditBtn   = $('doc-title-edit-btn')
 const pageInput         = $('page-input')
 const pageTotal         = $('page-total')
 const zoomInBtn         = $('zoom-in-btn')
@@ -804,6 +805,73 @@ resumeTransBtn.addEventListener('click', async () => {
 backBtn.addEventListener('click', () => {
   showLibraryScreen()
 })
+
+// ── 논문 제목 수정 (Viewer 화면) ──────────────────
+if (docTitleEditBtn) {
+  docTitleEditBtn.addEventListener('click', () => {
+    const oldTitle = state.title || state.filename || ''
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.value = oldTitle
+    input.style.background = 'var(--bg-elevated)'
+    input.style.border = '1px solid var(--accent-mid)'
+    input.style.borderRadius = 'var(--radius-sm)'
+    input.style.color = 'var(--text-primary)'
+    input.style.fontSize = '14px'
+    input.style.fontWeight = '600'
+    input.style.padding = '2px 6px'
+    input.style.outline = 'none'
+    input.style.minWidth = '200px'
+    input.style.maxWidth = '400px'
+
+    docTitle.innerHTML = ''
+    docTitle.appendChild(input)
+    docTitleEditBtn.style.display = 'none'
+    input.focus()
+    input.select()
+
+    let isSaving = false
+    async function save() {
+      if (isSaving) return
+      isSaving = true
+      const newTitle = input.value.trim()
+      if (newTitle && newTitle !== oldTitle) {
+        try {
+          await updateLibraryDocMetadata(state.sessionId, { title: newTitle })
+          state.title = newTitle
+          docTitle.textContent = newTitle
+          showToast('제목이 변경되었습니다.', 'success')
+        } catch (err) {
+          showToast('제목 변경 실패: ' + err.message, 'error')
+          docTitle.textContent = oldTitle
+        }
+      } else {
+        docTitle.textContent = oldTitle
+      }
+      docTitleEditBtn.style.display = 'inline-flex'
+    }
+
+    input.addEventListener('keydown', async (ev) => {
+      if (ev.key === 'Enter') {
+        ev.preventDefault()
+        await save()
+      } else if (ev.key === 'Escape') {
+        ev.preventDefault()
+        isSaving = true
+        docTitle.textContent = oldTitle
+        docTitleEditBtn.style.display = 'inline-flex'
+      }
+    })
+
+    input.addEventListener('blur', async () => {
+      setTimeout(async () => {
+        if (!isSaving) {
+          await save()
+        }
+      }, 100)
+    })
+  })
+}
 
 // ── 구분선 드래그 ─────────────────────────────────
 const divider          = $('divider')
@@ -1863,6 +1931,9 @@ function createDocCard(doc) {
     </div>
     <div class="doc-card-actions">
       <button class="doc-open-btn" data-id="${doc.id}">열기</button>
+      <button class="doc-edit-btn" data-id="${doc.id}" title="제목 수정">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
+      </button>
       <button class="doc-delete-btn" data-id="${doc.id}" title="삭제">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
@@ -1878,6 +1949,68 @@ function createDocCard(doc) {
     if (!confirm(`"${displayTitle}"을 삭제할까요?`)) return
     try { await deleteLibraryDoc(doc.id); showToast('삭제되었습니다', 'success'); await renderLibrary() }
     catch { showToast('삭제 실패', 'error') }
+  })
+  
+  card.querySelector('.doc-edit-btn').addEventListener('click', (e) => {
+    e.stopPropagation()
+    const titleEl = card.querySelector('.doc-card-title')
+    const oldTitle = displayTitle
+    
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.value = oldTitle
+    input.style.width = '100%'
+    input.style.padding = '4px 8px'
+    input.style.background = 'var(--bg-elevated)'
+    input.style.border = '1px solid var(--accent-mid)'
+    input.style.borderRadius = 'var(--radius-sm)'
+    input.style.color = 'var(--text-primary)'
+    input.style.fontSize = '13px'
+    input.style.fontWeight = '600'
+    input.style.outline = 'none'
+    
+    titleEl.innerHTML = ''
+    titleEl.appendChild(input)
+    input.focus()
+    input.select()
+    
+    let isSaving = false
+    async function save() {
+      if (isSaving) return
+      isSaving = true
+      const newTitle = input.value.trim()
+      if (newTitle && newTitle !== oldTitle) {
+        try {
+          await updateLibraryDocMetadata(doc.id, { title: newTitle })
+          showToast('제목이 변경되었습니다.', 'success')
+          await renderLibrary()
+        } catch (err) {
+          showToast('제목 변경 실패: ' + err.message, 'error')
+          titleEl.textContent = oldTitle
+        }
+      } else {
+        titleEl.textContent = oldTitle
+      }
+    }
+    
+    input.addEventListener('keydown', async (ev) => {
+      if (ev.key === 'Enter') {
+        ev.preventDefault()
+        await save()
+      } else if (ev.key === 'Escape') {
+        ev.preventDefault()
+        isSaving = true
+        titleEl.textContent = oldTitle
+      }
+    })
+    
+    input.addEventListener('blur', async () => {
+      setTimeout(async () => {
+        if (!isSaving) {
+          await save()
+        }
+      }, 100)
+    })
   })
   card.addEventListener('click', () => openFromLibrary(doc))
   return card

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages } from './pdfViewer.js'
-import { fetchLibrary, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata } from './library.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -128,6 +128,7 @@ const cancelTransBtn    = $('cancel-trans-btn')
 const resumeTransBtn    = $('resume-trans-btn')
 // (viewer/chat pickers are now ProviderModelPicker instances – see below)
 const backBtn           = $('back-btn')
+const logoBtn           = $('logo-btn')
 const viewerScrollContainer = $('viewer-scroll-container')
 const translateSpinner      = $('translate-spinner')
 const translateStatusText   = $('translate-status-text')
@@ -309,6 +310,7 @@ async function handleFiles(files) {
       state.filename   = lastFilename
       state.totalPages = lastTotalPages
       state.title      = lastTitle
+      history.pushState({ screen: 'viewer', docId: lastSessionId }, '', `#viewer?id=${lastSessionId}`)
 
       await loadPDF(`/api/pdf-file/${state.sessionId}`)
       docTitle.textContent = lastTitle
@@ -320,7 +322,7 @@ async function handleFiles(files) {
       showViewer()
       await initScrollViewer()
     } else if (!isLibraryActive) {
-      showLibraryScreen()
+      await showLibraryScreen()
     }
   } else {
     uploadPopupTitle.textContent = '업로드 실패'
@@ -803,8 +805,18 @@ resumeTransBtn.addEventListener('click', async () => {
 
 // ── 뒤로 가기 ─────────────────────────────────────
 backBtn.addEventListener('click', () => {
-  showLibraryScreen()
+  if (history.state?.screen === 'viewer') {
+    history.back()
+  } else {
+    showLibraryScreen()
+  }
 })
+
+if (logoBtn) {
+  logoBtn.addEventListener('click', () => {
+    showLibraryScreen()
+  })
+}
 
 // ── 논문 제목 수정 (Viewer 화면) ──────────────────
 if (docTitleEditBtn) {
@@ -914,7 +926,11 @@ async function checkAuthentication() {
     loginScreen.classList.remove('active')
     globalLogoutBtn.classList.remove('hidden')
     globalSettingsBtn.classList.remove('hidden')
-    showLibraryScreen()
+    if (location.hash && location.hash.startsWith('#viewer?id=')) {
+      await handleRouting()
+    } else {
+      await showLibraryScreen()
+    }
     await loadLibraryCount()
     await refreshSystemSettings()
   } else {
@@ -1788,7 +1804,10 @@ async function loadLibraryCount() {
   } catch {}
 }
 
-async function showLibraryScreen() {
+async function showLibraryScreen(shouldPushState = true) {
+  if (shouldPushState) {
+    history.pushState({ screen: 'library' }, '', '#library')
+  }
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
   libraryScreen.classList.add('active')
@@ -2035,7 +2054,10 @@ async function loadDocumentImages(docId) {
   }
 }
 
-async function openFromLibrary(doc) {
+async function openFromLibrary(doc, shouldPushState = true) {
+  if (shouldPushState) {
+    history.pushState({ screen: 'viewer', docId: doc.id }, '', `#viewer?id=${doc.id}`)
+  }
   state.sessionId  = doc.id
   loadDocumentImages(doc.id)
   state.filename   = doc.filename
@@ -4243,4 +4265,36 @@ if (captureAreaBtn) {
 
 // 캡처 툴 초기화 실행
 initCropTool()
+
+// ── 해시 라우팅 및 뒤로가기 제어 ──────────────────────
+async function handleRouting() {
+  const hash = location.hash
+  if (hash.startsWith('#viewer?id=')) {
+    const docId = hash.split('?id=')[1]
+    if (docId) {
+      if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
+        return
+      }
+      try {
+        const doc = await fetchLibraryDoc(docId)
+        if (doc) {
+          await openFromLibrary(doc, false)
+          return
+        }
+      } catch (err) {
+        console.error("Failed to load doc from hash route:", err)
+        showToast("논문을 불러오지 못했습니다.", "error")
+      }
+    }
+    location.hash = 'library'
+  } else {
+    if (!libraryScreen.classList.contains('active')) {
+      await showLibraryScreen(false)
+    }
+  }
+}
+
+window.addEventListener('popstate', () => {
+  handleRouting()
+})
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2519,8 +2519,15 @@ function updateMemoConnectorLine(pageWrapper, memo, sentenceEl) {
   const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, sentenceIdx)
   const startEl = (pdfElements && pdfElements.length > 0) ? pdfElements[0] : sentenceEl
 
-  const anchorX = startEl.offsetLeft
-  const anchorY = startEl.offsetTop + startEl.offsetHeight / 2
+  let anchorX = startEl.offsetLeft
+  let anchorY = startEl.offsetTop + startEl.offsetHeight / 2
+
+  let curr = startEl.offsetParent
+  while (curr && curr !== pageWrapper) {
+    anchorX += curr.offsetLeft || 0
+    anchorY += curr.offsetTop || 0
+    curr = curr.offsetParent
+  }
 
   const memoLeft = (memo.x / 100) * pageWrapper.offsetWidth
   const memoTop = (memo.y / 100) * pageWrapper.offsetHeight
@@ -2733,8 +2740,17 @@ function createFloatingMemoForSentence(pageNum, sentenceIdx) {
 
   const sentenceText = sentenceEl ? sentenceEl.textContent.trim() : ''
 
-  const leftPct = Math.min(Math.max(10, ((sentenceEl.offsetLeft + sentenceEl.offsetWidth / 2) / pageWrapper.offsetWidth) * 100), 70)
-  const topPct = Math.min(Math.max(10, ((sentenceEl.offsetTop + sentenceEl.offsetHeight) / pageWrapper.offsetHeight) * 100 + 4), 85)
+  let sentenceX = sentenceEl.offsetLeft
+  let sentenceY = sentenceEl.offsetTop
+  let curr = sentenceEl.offsetParent
+  while (curr && curr !== pageWrapper) {
+    sentenceX += curr.offsetLeft || 0
+    sentenceY += curr.offsetTop || 0
+    curr = curr.offsetParent
+  }
+
+  const leftPct = Math.min(Math.max(10, ((sentenceX + sentenceEl.offsetWidth / 2) / pageWrapper.offsetWidth) * 100), 70)
+  const topPct = Math.min(Math.max(10, ((sentenceY + sentenceEl.offsetHeight) / pageWrapper.offsetHeight) * 100 + 4), 85)
 
   const allMemosObj = loadMemos(state.sessionId)
   if (!allMemosObj[`page_${pageNum}`]) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4311,7 +4311,7 @@ if (viewerScrollContainer) {
       }
 
       const selection = window.getSelection();
-      if (selection && !selection.isCollapsed) return;
+      if (selection && !selection.isCollapsed && !annSpan) return;
 
       // 타겟이 번역본 문장이거나, PDF 원본의 pdf-sentence 엘리먼트인 경우
       const target = e.target.closest('.trans-sentence') || e.target.closest('.pdf-sentence');

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -43,6 +43,8 @@ const state = {
   quotedImage: null,           // AI 질문 시 인용 이미지 보관용 (Base64)
   quotedImagePage: null,       // AI 질문 시 인용 이미지의 페이지 번호
   pendingFigureQuote: null,    // 클릭 후 AI 질문 전 대기중인 인용 이미지 정보
+  activeHighlightColor: '#eab308', // 기본 하이라이트 노란색
+  activeUnderlineColor: '#ef4444',  // 기본 밑줄 빨간색
   isCropMode: false,           // 영역 캡처 모드 여부
   pdfPageSentences: {},        // pageNum → sentenceRanges 보관용
   pdfPageElements: {},         // pageNum → elRanges 보관용
@@ -205,7 +207,8 @@ function resetState() {
   Object.assign(state, {
     sessionId: null, filename: null, title: null, totalPages: 0, currentPage: 1,
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
-    chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null, isCropMode: false, documentImages: []
+    chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null,
+    activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: []
   })
   if (typeof toggleCropMode === 'function') toggleCropMode(false)
   viewerScrollContainer.innerHTML = ''
@@ -2218,15 +2221,29 @@ function getPageTextOffset(range, textLayerDiv) {
   return { startOffset, endOffset }
 }
 
+function hexToRgba(hex, alpha) {
+  if (!hex) return '';
+  let cleanHex = hex.replace('#', '');
+  if (cleanHex.length === 3) {
+    cleanHex = cleanHex.split('').map(c => c + c).join('');
+  }
+  const num = parseInt(cleanHex, 16);
+  const r = (num >> 16) & 255;
+  const g = (num >> 8) & 255;
+  const b = num & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 // Range 객체를 받아와 화면에 어노테이션(하이라이트/밑줄)을 실제로 렌더링하고 로컬에 저장
-function applyAnnotationToRange(range, type, textLayerDiv, pageNum) {
+function applyAnnotationToRange(range, type, textLayerDiv, pageNum, color) {
   const offsets = getPageTextOffset(range, textLayerDiv)
   if (offsets.startOffset === null || offsets.endOffset === null) return
   
   const text = range.toString()
+  const chosenColor = color || (type === 'highlight' ? state.activeHighlightColor : state.activeUnderlineColor)
 
   // 1. DOM에 스타일 적용 (텍스트 노드 분할)
-  applyAnnotationToRangeWithoutSave(range, type)
+  applyAnnotationToRangeWithoutSave(range, type, chosenColor)
 
   // 2. LocalStorage에 저장
   const annotations = loadAnnotations(state.sessionId)
@@ -2237,14 +2254,15 @@ function applyAnnotationToRange(range, type, textLayerDiv, pageNum) {
     type,
     text,
     startOffset: offsets.startOffset,
-    endOffset: offsets.endOffset
+    endOffset: offsets.endOffset,
+    color: chosenColor
   })
   saveAnnotations(state.sessionId, annotations)
   showToast(type === 'highlight' ? '하이라이트가 추가되었습니다 ✓' : '밑줄이 추가되었습니다 ✓', 'success')
 }
 
 // 저장 없이 DOM 상에 직접 span을 감싸서 스타일 입히는 헬퍼
-function applyAnnotationToRangeWithoutSave(range, type) {
+function applyAnnotationToRangeWithoutSave(range, type, color) {
   const textNodes = []
   const commonAncestor = range.commonAncestorContainer
   
@@ -2279,7 +2297,15 @@ function applyAnnotationToRangeWithoutSave(range, type) {
     if (startOffset >= endOffset) return
 
     const span = document.createElement('span')
-    span.className = type === 'highlight' ? 'pdf-annotation-highlight' : 'pdf-annotation-underline'
+    if (type === 'highlight') {
+      span.className = 'pdf-annotation-highlight'
+      const baseColor = color || '#eab308'
+      span.style.backgroundColor = hexToRgba(baseColor, 0.4)
+    } else {
+      span.className = 'pdf-annotation-underline'
+      const baseColor = color || '#ef4444'
+      span.style.borderBottomColor = baseColor
+    }
     
     const subRange = document.createRange()
     subRange.setStart(node, startOffset)
@@ -2324,7 +2350,7 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations) {
       try {
         range.setStart(startNode, startNodeOffset)
         range.setEnd(endNode, endNodeOffset)
-        applyAnnotationToRangeWithoutSave(range, ann.type)
+        applyAnnotationToRangeWithoutSave(range, ann.type, ann.color)
       } catch (e) {
         console.warn("Failed to restore annotation:", ann, e)
       }
@@ -2342,13 +2368,36 @@ function createSelectionMenu() {
   menu.id = 'selection-menu'
   menu.className = 'selection-menu hidden'
   menu.innerHTML = `
-    <div class="menu-annotate-group" style="display: flex; gap: 4px; align-items: center;">
+    <div class="menu-annotate-group" style="display: flex; gap: 4px; align-items: center; padding: 2px 6px;">
+      <!-- 하이라이트 아이콘 버튼 -->
       <button class="menu-btn highlight-btn" title="하이라이트">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
       </button>
+      <!-- 하이라이트 색상 선택 서클 -->
+      <div class="color-options highlight-colors" style="display: flex; gap: 4px; margin-right: 6px;">
+        <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
+        <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
+        <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
+        <span class="color-dot" data-color="#ec4899" style="background: #ec4899;" title="핑크"></span>
+      </div>
+      
+      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
+      
+      <!-- 밑줄 아이콘 버튼 -->
       <button class="menu-btn underline-btn" title="밑줄">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
       </button>
+      <!-- 밑줄 색상 선택 서클 -->
+      <div class="color-options underline-colors" style="display: flex; gap: 4px; margin-right: 6px;">
+        <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
+        <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
+        <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
+        <span class="color-dot" data-color="#a855f7" style="background: #a855f7;" title="보라"></span>
+      </div>
+      
+      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
+      
+      <!-- 지우기 버튼 -->
       <button class="menu-btn clear-btn" title="지우기">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
       </button>
@@ -2367,16 +2416,62 @@ function createSelectionMenu() {
     e.stopPropagation();
   });
   
-  menu.querySelector('.highlight-btn').addEventListener('click', (e) => {
-    e.preventDefault(); e.stopPropagation(); handleAnnotate('highlight')
+  const highlightBtn = menu.querySelector('.highlight-btn')
+  const underlineBtn = menu.querySelector('.underline-btn')
+
+  function updateActiveColors() {
+    highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
+    underlineBtn.querySelector('svg').style.color = state.activeUnderlineColor
+    
+    menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
+      if (dot.dataset.color === state.activeHighlightColor) {
+        dot.classList.add('selected')
+      } else {
+        dot.classList.remove('selected')
+      }
+    })
+    menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
+      if (dot.dataset.color === state.activeUnderlineColor) {
+        dot.classList.add('selected')
+      } else {
+        dot.classList.remove('selected')
+      }
+    })
+  }
+
+  // 컬러 서클 클릭 핸들러 바인딩
+  menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
+    dot.addEventListener('click', (e) => {
+      e.preventDefault(); e.stopPropagation();
+      state.activeHighlightColor = dot.dataset.color
+      updateActiveColors()
+      handleAnnotate('highlight', state.activeHighlightColor)
+    })
+  })
+  
+  menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
+    dot.addEventListener('click', (e) => {
+      e.preventDefault(); e.stopPropagation();
+      state.activeUnderlineColor = dot.dataset.color
+      updateActiveColors()
+      handleAnnotate('underline', state.activeUnderlineColor)
+    })
   })
 
-  menu.querySelector('.underline-btn').addEventListener('click', (e) => {
-    e.preventDefault(); e.stopPropagation(); handleAnnotate('underline')
+  // 아이콘 클릭 핸들러 바인딩
+  highlightBtn.addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    handleAnnotate('highlight', state.activeHighlightColor)
+  })
+
+  underlineBtn.addEventListener('click', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    handleAnnotate('underline', state.activeUnderlineColor)
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
-    e.preventDefault(); e.stopPropagation(); handleAnnotate('clear')
+    e.preventDefault(); e.stopPropagation();
+    handleAnnotate('clear')
   })
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
@@ -2394,10 +2489,11 @@ function createSelectionMenu() {
     hideSelectionMenu()
   })
 
+  updateActiveColors()
   return menu
 }
 
-function handleAnnotate(type) {
+function handleAnnotate(type, color) {
   const selection = window.getSelection()
   if (!selection.rangeCount) return
   const range = selection.getRangeAt(0)
@@ -2416,7 +2512,7 @@ function handleAnnotate(type) {
   if (type === 'clear') {
     clearAnnotationsInRange(range, textLayerDiv, pageNum)
   } else {
-    applyAnnotationToRange(range, type, textLayerDiv, pageNum)
+    applyAnnotationToRange(range, type, textLayerDiv, pageNum, color)
   }
 
   hideSelectionMenu()
@@ -4449,7 +4545,8 @@ async function loadPDFOutline() {
       for (let p = 1; p <= state.totalPages; p++) {
         const div = document.createElement('div')
         div.className = 'outline-item depth-0'
-        div.innerHTML = `<span>📄</span> <span>${p} 페이지</span>`
+        const iconSvg = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" style="opacity:0.6; margin-right:8px; flex-shrink:0;"><circle cx="12" cy="12" r="8"/></svg>`
+        div.innerHTML = `${iconSvg}<span>${p} 페이지</span>`
         div.addEventListener('click', () => {
           scrollToPage(viewerScrollContainer, p)
         })
@@ -4463,7 +4560,10 @@ async function loadPDFOutline() {
       items.forEach(item => {
         const div = document.createElement('div')
         div.className = `outline-item depth-${depth}`
-        div.innerHTML = `<span>🔖</span> <span style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${escapeHtml(item.title)}</span>`
+        const iconSvg = depth === 0 
+          ? `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" style="opacity:0.6; margin-right:8px; flex-shrink:0;"><circle cx="12" cy="12" r="8"/></svg>`
+          : `<svg width="5" height="5" viewBox="0 0 24 24" fill="currentColor" style="opacity:0.4; margin-right:8px; flex-shrink:0; margin-left:4px;"><circle cx="12" cy="12" r="10"/></svg>`
+        div.innerHTML = `${iconSvg}<span style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${escapeHtml(item.title)}</span>`
         if (item.pageNum) {
           div.addEventListener('click', () => {
             scrollToPage(viewerScrollContainer, item.pageNum)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4501,13 +4501,19 @@ function showOutlineSidebar() {
 // 목차 이벤트 바인딩
 if (outlineToggleBtn) {
   outlineToggleBtn.addEventListener('click', () => {
-    console.log("[Outline] Toggle button clicked. Sidebar hidden state:", outlineSidebar.classList.contains('hidden'))
+    console.log("[Outline] Toggle button clicked. Sidebar:", outlineSidebar, "ToggleBtn:", outlineToggleBtn)
+    if (!outlineSidebar) {
+      showToast('목차 사이드바를 찾을 수 없습니다.', 'error')
+      return
+    }
     if (outlineSidebar.classList.contains('hidden')) {
       showOutlineSidebar()
     } else {
       hideOutlineSidebar()
     }
   })
+} else {
+  console.error("[Outline] outlineToggleBtn is null!")
 }
 if (outlineCloseBtn) {
   outlineCloseBtn.addEventListener('click', hideOutlineSidebar)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4266,6 +4266,89 @@ if (captureAreaBtn) {
 // 캡처 툴 초기화 실행
 initCropTool()
 
+// ── 번역 창 접기 및 너비 크기 조절 ──────────────────────
+const toggleTransPaneBtn = $('toggle-trans-pane-btn')
+const transWidthDecBtn   = $('trans-width-dec-btn')
+const transWidthIncBtn   = $('trans-width-inc-btn')
+const transWidthLabel    = $('trans-width-label')
+
+let isTransPaneCollapsed = false
+let currentTransPaneWidth = 620
+
+function updateTransPaneWidth(newWidth) {
+  currentTransPaneWidth = Math.max(320, Math.min(newWidth, 820))
+  document.documentElement.style.setProperty('--trans-pane-width', `${currentTransPaneWidth}px`)
+  if (transWidthLabel) {
+    transWidthLabel.textContent = `${currentTransPaneWidth}px`
+  }
+  localStorage.setItem('trans-pane-width', currentTransPaneWidth)
+}
+
+if (toggleTransPaneBtn) {
+  toggleTransPaneBtn.addEventListener('click', () => {
+    isTransPaneCollapsed = !isTransPaneCollapsed
+    document.body.classList.toggle('collapse-translation', isTransPaneCollapsed)
+    toggleTransPaneBtn.classList.toggle('collapsed', isTransPaneCollapsed)
+    localStorage.setItem('trans-pane-collapsed', isTransPaneCollapsed)
+    
+    if (isTransPaneCollapsed) {
+      if (transWidthDecBtn) {
+        transWidthDecBtn.setAttribute('disabled', 'true')
+        transWidthDecBtn.style.opacity = '0.3'
+      }
+      if (transWidthIncBtn) {
+        transWidthIncBtn.setAttribute('disabled', 'true')
+        transWidthIncBtn.style.opacity = '0.3'
+      }
+      showToast('번역 창이 접혔습니다.', 'info')
+    } else {
+      if (transWidthDecBtn) {
+        transWidthDecBtn.removeAttribute('disabled')
+        transWidthDecBtn.style.opacity = '1'
+      }
+      if (transWidthIncBtn) {
+        transWidthIncBtn.removeAttribute('disabled')
+        transWidthIncBtn.style.opacity = '1'
+      }
+      showToast('번역 창이 펼쳐졌습니다.', 'info')
+    }
+  })
+}
+
+if (transWidthDecBtn) {
+  transWidthDecBtn.addEventListener('click', () => {
+    updateTransPaneWidth(currentTransPaneWidth - 50)
+  })
+}
+
+if (transWidthIncBtn) {
+  transWidthIncBtn.addEventListener('click', () => {
+    updateTransPaneWidth(currentTransPaneWidth + 50)
+  })
+}
+
+// 초기 로드 시 localStorage 상태 복원
+(function initTransPaneControls() {
+  const savedCollapsed = localStorage.getItem('trans-pane-collapsed') === 'true'
+  const savedWidth = parseInt(localStorage.getItem('trans-pane-width')) || 620
+
+  updateTransPaneWidth(savedWidth)
+  
+  if (savedCollapsed && toggleTransPaneBtn) {
+    isTransPaneCollapsed = true
+    document.body.classList.add('collapse-translation')
+    toggleTransPaneBtn.classList.add('collapsed')
+    if (transWidthDecBtn) {
+      transWidthDecBtn.setAttribute('disabled', 'true')
+      transWidthDecBtn.style.opacity = '0.3'
+    }
+    if (transWidthIncBtn) {
+      transWidthIncBtn.setAttribute('disabled', 'true')
+      transWidthIncBtn.style.opacity = '0.3'
+    }
+  }
+})()
+
 // ── 해시 라우팅 및 뒤로가기 제어 ──────────────────────
 async function handleRouting() {
   const hash = location.hash

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2785,6 +2785,11 @@ function hideSelectionMenu() {
     selectionMenu.querySelectorAll('.expand-wrapper').forEach(w => w.classList.remove('expanded'))
   }
   state.pendingFigureQuote = null
+  state.hoverSelectionDisabled = true
+  if (sentenceHoverTimer) {
+    clearTimeout(sentenceHoverTimer)
+    sentenceHoverTimer = null
+  }
 }
 
 // 통합 텍스트 선택 종료 감지 리스너
@@ -4359,6 +4364,10 @@ if (viewerScrollContainer) {
     return { pdfIdx, transIdx, pdfElements };
   }
 
+  viewerScrollContainer.addEventListener('mousemove', () => {
+    state.hoverSelectionDisabled = false;
+  });
+
   viewerScrollContainer.addEventListener('mouseover', (e) => {
     try {
       if (sentenceHoverTimer) {
@@ -4379,9 +4388,9 @@ if (viewerScrollContainer) {
       if (!target) return;
 
       // PDF 텍스트 문장에 마우스가 700ms 동안 머물러 있으면 문장 단위 자동 드래그 선택 및 툴팁 띄우기
-      // 단, 이미 어노테이션이 입혀진 span 위에 올라온 경우는 작동 제외
+      // 단, 이미 어노테이션이 입혀진 span 위에 올라온 경우나 호버 자동 선택이 비활성화된 경우는 작동 제외
       const pdfTarget = e.target.closest('.pdf-sentence');
-      if (pdfTarget && !annSpan) {
+      if (pdfTarget && !annSpan && !state.hoverSelectionDisabled) {
         sentenceHoverTimer = setTimeout(() => {
           const curSel = window.getSelection();
           if (curSel && !curSel.isCollapsed) return;
@@ -4483,6 +4492,12 @@ if (viewerScrollContainer) {
   // 클릭 시 해당 매칭 문장으로 스크롤 이동 및 양방향 고정 하이라이트 매칭 적용
   viewerScrollContainer.addEventListener('click', (e) => {
     try {
+      state.hoverSelectionDisabled = true;
+      if (sentenceHoverTimer) {
+        clearTimeout(sentenceHoverTimer);
+        sentenceHoverTimer = null;
+      }
+
       const selection = window.getSelection();
       if (selection && !selection.isCollapsed) return;
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2366,48 +2366,48 @@ function createSelectionMenu() {
   
   const menu = document.createElement('div')
   menu.id = 'selection-menu'
-  menu.className = 'selection-menu hidden'
+  menu.className = 'selection-menu'
   menu.innerHTML = `
     <div class="menu-annotate-group" style="display: flex; gap: 6px; align-items: center; padding: 2px 4px;">
-      <!-- 하이라이트 스플릿 버튼 그룹 -->
-      <div class="annotate-split-wrapper highlight-wrapper" style="position: relative; display: flex; align-items: center;">
-        <button class="menu-btn highlight-btn" title="즉시 하이라이트" style="width: 28px; height: 100%; border-right: 1px solid var(--border-strong);">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
-        </button>
-        <button class="menu-btn highlight-arrow-btn" title="색상 선택" style="width: 14px; height: 100%; font-size: 8px; color: var(--text-muted); font-weight: bold;">
-          ▾
-        </button>
-        <!-- 서브 팝오버 툴팁 (기본값 hidden 유지) -->
-        <div class="color-popover highlight-popover hidden">
+      <!-- 하이라이트 아이콘 버튼 (즉시 적용) -->
+      <button class="menu-btn highlight-btn" title="하이라이트">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+      </button>
+      
+      <!-- 밑줄 아이콘 버튼 (즉시 적용) -->
+      <button class="menu-btn underline-btn" title="밑줄">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+      </button>
+      
+      <!-- 지우기 버튼 -->
+      <button class="menu-btn clear-btn" title="지우기">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      </button>
+      
+      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
+      
+      <!-- 색상 프리셋 그룹 -->
+      <div class="color-preset-section">
+        <!-- 하이라이트 색상 도트들 -->
+        <div class="inline-color-group highlight-colors" title="하이라이트 색상 변경 및 적용">
           <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
           <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
           <span class="color-dot" data-color="#ec4899" style="background: #ec4899;" title="핑크"></span>
         </div>
-      </div>
-      
-      <!-- 밑줄 스플릿 버튼 그룹 -->
-      <div class="annotate-split-wrapper underline-wrapper" style="position: relative; display: flex; align-items: center;">
-        <button class="menu-btn underline-btn" title="즉시 밑줄" style="width: 28px; height: 100%; border-right: 1px solid var(--border-strong);">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
-        </button>
-        <button class="menu-btn underline-arrow-btn" title="색상 선택" style="width: 14px; height: 100%; font-size: 8px; color: var(--text-muted); font-weight: bold;">
-          ▾
-        </button>
-        <!-- 서브 팝오버 툴팁 (기본값 hidden 유지) -->
-        <div class="color-popover underline-popover hidden">
+        
+        <div style="width: 1px; background: var(--border-strong); height: 12px; opacity: 0.5;"></div>
+        
+        <!-- 밑줄 색상 도트들 -->
+        <div class="inline-color-group underline-colors" title="밑줄 색상 변경 및 적용">
           <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
           <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
           <span class="color-dot" data-color="#a855f7" style="background: #a855f7;" title="보라"></span>
         </div>
       </div>
-      
-      <!-- 지우기 버튼 -->
-      <button class="menu-btn clear-btn" title="지우기" style="border: 1px solid var(--border-strong); width: 28px; height: 28px; border-radius: var(--radius-sm);">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
-      </button>
-      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
+
+      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
     </div>
     <button class="menu-btn ask-ai-btn" title="AI 어시스턴트에게 질문" style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--accent-mid); padding: 0 8px;">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
@@ -2424,23 +2424,19 @@ function createSelectionMenu() {
   
   const highlightBtn = menu.querySelector('.highlight-btn')
   const underlineBtn = menu.querySelector('.underline-btn')
-  const highlightArrow = menu.querySelector('.highlight-arrow-btn')
-  const underlineArrow = menu.querySelector('.underline-arrow-btn')
-  const highlightPopover = menu.querySelector('.highlight-popover')
-  const underlinePopover = menu.querySelector('.underline-popover')
 
   function updateActiveColors() {
     highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
     underlineBtn.querySelector('svg').style.color = state.activeUnderlineColor
     
-    menu.querySelectorAll('.highlight-popover .color-dot').forEach(dot => {
+    menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
       if (dot.dataset.color === state.activeHighlightColor) {
         dot.classList.add('selected')
       } else {
         dot.classList.remove('selected')
       }
     })
-    menu.querySelectorAll('.underline-popover .color-dot').forEach(dot => {
+    menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
       if (dot.dataset.color === state.activeUnderlineColor) {
         dot.classList.add('selected')
       } else {
@@ -2449,66 +2445,43 @@ function createSelectionMenu() {
     })
   }
 
-  // 컬러 서클 클릭 핸들러 바인딩
-  menu.querySelectorAll('.highlight-popover .color-dot').forEach(dot => {
+  // 컬러 서클 클릭 핸들러 바인딩 (클릭 시 마킹 즉시 적용)
+  menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
     dot.addEventListener('click', (e) => {
       e.preventDefault(); e.stopPropagation();
       state.activeHighlightColor = dot.dataset.color
       updateActiveColors()
-      highlightPopover.classList.add('hidden')
       handleAnnotate('highlight', state.activeHighlightColor)
     })
   })
   
-  menu.querySelectorAll('.underline-popover .color-dot').forEach(dot => {
+  menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
     dot.addEventListener('click', (e) => {
       e.preventDefault(); e.stopPropagation();
       state.activeUnderlineColor = dot.dataset.color
       updateActiveColors()
-      underlinePopover.classList.add('hidden')
       handleAnnotate('underline', state.activeUnderlineColor)
     })
   })
 
-  // 메인 아이콘 클릭 시 즉시 활성화 색상으로 마킹 처리 적용
+  // 메인 아이콘 클릭 시 즉시 대표 활성화 색상으로 마킹 처리 적용
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     handleAnnotate('highlight', state.activeHighlightColor)
   })
 
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     handleAnnotate('underline', state.activeUnderlineColor)
-  })
-
-  // 우측 조그만 화살표 버튼 클릭 시 서브 컬러 팝오버 토글
-  highlightArrow.addEventListener('click', (e) => {
-    e.preventDefault(); e.stopPropagation();
-    underlinePopover.classList.add('hidden')
-    highlightPopover.classList.toggle('hidden')
-  })
-
-  underlineArrow.addEventListener('click', (e) => {
-    e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.toggle('hidden')
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     handleAnnotate('clear')
   })
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    highlightPopover.classList.add('hidden')
-    underlinePopover.classList.add('hidden')
     if (state.pendingFigureQuote) {
       askAIAssistantImage(state.pendingFigureQuote.base64Img, state.pendingFigureQuote.pageNum)
     } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2680,12 +2680,6 @@ function renderPageMemos(pageNum) {
           updateCardContent()
         })
 
-        body.addEventListener('click', (e) => {
-          if (e.target.closest('a')) return
-          e.stopPropagation()
-          isEditing = true
-          updateCardContent()
-        })
 
         actions.querySelector('.delete-btn').addEventListener('click', (e) => {
           e.stopPropagation()
@@ -2715,6 +2709,16 @@ function renderPageMemos(pageNum) {
     `
 
     updateCardContent()
+
+    const body = memoEl.querySelector('.floating-memo-body')
+    body.addEventListener('click', (e) => {
+      if (isEditing) return
+      if (e.target.closest('a')) return
+      e.stopPropagation()
+      isEditing = true
+      updateCardContent()
+    })
+
     pageWrapper.appendChild(memoEl)
 
     const header = memoEl.querySelector('.floating-memo-header')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2369,33 +2369,33 @@ function createSelectionMenu() {
   menu.className = 'selection-menu hidden'
   menu.innerHTML = `
     <div class="menu-annotate-group" style="display: flex; gap: 4px; align-items: center; padding: 2px 6px;">
-      <!-- 하이라이트 아이콘 버튼 -->
-      <button class="menu-btn highlight-btn" title="하이라이트">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
-      </button>
-      <!-- 하이라이트 색상 선택 서클 -->
-      <div class="color-options highlight-colors" style="display: flex; gap: 4px; margin-right: 6px;">
-        <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
-        <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
-        <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
-        <span class="color-dot" data-color="#ec4899" style="background: #ec4899;" title="핑크"></span>
+      <!-- 하이라이트 그룹 -->
+      <div class="annotate-button-wrapper highlight-wrapper" style="position: relative; display: flex;">
+        <button class="menu-btn highlight-btn" title="하이라이트">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+        </button>
+        <!-- 서브 팝오버 툴팁 -->
+        <div class="color-popover highlight-popover hidden">
+          <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
+          <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
+          <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
+          <span class="color-dot" data-color="#ec4899" style="background: #ec4899;" title="핑크"></span>
+        </div>
       </div>
       
-      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
-      
-      <!-- 밑줄 아이콘 버튼 -->
-      <button class="menu-btn underline-btn" title="밑줄">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
-      </button>
-      <!-- 밑줄 색상 선택 서클 -->
-      <div class="color-options underline-colors" style="display: flex; gap: 4px; margin-right: 6px;">
-        <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
-        <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
-        <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
-        <span class="color-dot" data-color="#a855f7" style="background: #a855f7;" title="보라"></span>
+      <!-- 밑줄 그룹 -->
+      <div class="annotate-button-wrapper underline-wrapper" style="position: relative; display: flex;">
+        <button class="menu-btn underline-btn" title="밑줄">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+        </button>
+        <!-- 서브 팝오버 툴팁 -->
+        <div class="color-popover underline-popover hidden">
+          <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
+          <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
+          <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
+          <span class="color-dot" data-color="#a855f7" style="background: #a855f7;" title="보라"></span>
+        </div>
       </div>
-      
-      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 4px;"></div>
       
       <!-- 지우기 버튼 -->
       <button class="menu-btn clear-btn" title="지우기">
@@ -2418,19 +2418,21 @@ function createSelectionMenu() {
   
   const highlightBtn = menu.querySelector('.highlight-btn')
   const underlineBtn = menu.querySelector('.underline-btn')
+  const highlightPopover = menu.querySelector('.highlight-popover')
+  const underlinePopover = menu.querySelector('.underline-popover')
 
   function updateActiveColors() {
     highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
     underlineBtn.querySelector('svg').style.color = state.activeUnderlineColor
     
-    menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
+    menu.querySelectorAll('.highlight-popover .color-dot').forEach(dot => {
       if (dot.dataset.color === state.activeHighlightColor) {
         dot.classList.add('selected')
       } else {
         dot.classList.remove('selected')
       }
     })
-    menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
+    menu.querySelectorAll('.underline-popover .color-dot').forEach(dot => {
       if (dot.dataset.color === state.activeUnderlineColor) {
         dot.classList.add('selected')
       } else {
@@ -2440,42 +2442,50 @@ function createSelectionMenu() {
   }
 
   // 컬러 서클 클릭 핸들러 바인딩
-  menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
+  menu.querySelectorAll('.highlight-popover .color-dot').forEach(dot => {
     dot.addEventListener('click', (e) => {
       e.preventDefault(); e.stopPropagation();
       state.activeHighlightColor = dot.dataset.color
       updateActiveColors()
+      highlightPopover.classList.add('hidden')
       handleAnnotate('highlight', state.activeHighlightColor)
     })
   })
   
-  menu.querySelectorAll('.underline-colors .color-dot').forEach(dot => {
+  menu.querySelectorAll('.underline-popover .color-dot').forEach(dot => {
     dot.addEventListener('click', (e) => {
       e.preventDefault(); e.stopPropagation();
       state.activeUnderlineColor = dot.dataset.color
       updateActiveColors()
+      underlinePopover.classList.add('hidden')
       handleAnnotate('underline', state.activeUnderlineColor)
     })
   })
 
-  // 아이콘 클릭 핸들러 바인딩
+  // 아이콘 클릭 핸들러 바인딩 (서브 컬러 팝오버 토글)
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    handleAnnotate('highlight', state.activeHighlightColor)
+    underlinePopover.classList.add('hidden')
+    highlightPopover.classList.toggle('hidden')
   })
 
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    handleAnnotate('underline', state.activeUnderlineColor)
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.toggle('hidden')
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     handleAnnotate('clear')
   })
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
+    highlightPopover.classList.add('hidden')
+    underlinePopover.classList.add('hidden')
     if (state.pendingFigureQuote) {
       askAIAssistantImage(state.pendingFigureQuote.base64Img, state.pendingFigureQuote.pageNum)
     } else {
@@ -2581,6 +2591,7 @@ function showSelectionMenu(rect, showAnnotateGroup) {
 function hideSelectionMenu() {
   if (selectionMenu) {
     selectionMenu.classList.add('hidden')
+    selectionMenu.querySelectorAll('.color-popover').forEach(p => p.classList.add('hidden'))
   }
   state.pendingFigureQuote = null
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -399,6 +399,7 @@ async function initScrollViewer() {
 
 let isTransPaneCollapsed = false
 let currentTransPaneWidth = 620
+let hasLibraryStateInHistory = false
 
 // ── 번역 블록 생성 ────────────────────────────────
 function createTransBlock(pageNum) {
@@ -816,10 +817,10 @@ resumeTransBtn.addEventListener('click', async () => {
 
 // ── 뒤로 가기 ─────────────────────────────────────
 backBtn.addEventListener('click', () => {
-  if (history.state?.screen === 'viewer') {
+  if (hasLibraryStateInHistory) {
     history.back()
   } else {
-    showLibraryScreen()
+    showLibraryScreen(true)
   }
 })
 
@@ -1816,6 +1817,7 @@ async function loadLibraryCount() {
 }
 
 async function showLibraryScreen(shouldPushState = true) {
+  hasLibraryStateInHistory = true
   if (shouldPushState) {
     history.pushState({ screen: 'library' }, '', '#library')
   }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2369,44 +2369,37 @@ function createSelectionMenu() {
   menu.className = 'selection-menu'
   menu.innerHTML = `
     <div class="menu-annotate-group" style="display: flex; gap: 6px; align-items: center; padding: 2px 4px;">
-      <!-- 하이라이트 아이콘 버튼 (즉시 적용) -->
-      <button class="menu-btn highlight-btn" title="하이라이트">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
-      </button>
-      
-      <!-- 밑줄 아이콘 버튼 (즉시 적용) -->
-      <button class="menu-btn underline-btn" title="밑줄">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
-      </button>
-      
-      <!-- 지우기 버튼 -->
-      <button class="menu-btn clear-btn" title="지우기">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
-      </button>
-      
-      <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
-      
-      <!-- 색상 프리셋 그룹 -->
-      <div class="color-preset-section">
-        <!-- 하이라이트 색상 도트들 -->
-        <div class="inline-color-group highlight-colors" title="하이라이트 색상 변경 및 적용">
+      <!-- 하이라이트 그룹 -->
+      <div class="expand-wrapper highlight-wrapper">
+        <button class="menu-btn highlight-btn" title="하이라이트">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+        </button>
+        <div class="expand-colors highlight-colors">
           <span class="color-dot" data-color="#eab308" style="background: #eab308;" title="노랑"></span>
           <span class="color-dot" data-color="#22c55e" style="background: #22c55e;" title="초록"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
           <span class="color-dot" data-color="#ec4899" style="background: #ec4899;" title="핑크"></span>
         </div>
-        
-        <div style="width: 1px; background: var(--border-strong); height: 12px; opacity: 0.5;"></div>
-        
-        <!-- 밑줄 색상 도트들 -->
-        <div class="inline-color-group underline-colors" title="밑줄 색상 변경 및 적용">
+      </div>
+      
+      <!-- 밑줄 그룹 -->
+      <div class="expand-wrapper underline-wrapper">
+        <button class="menu-btn underline-btn" title="밑줄">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v7a6 6 0 0 0 12 0V3"/><line x1="4" y1="21" x2="20" y2="21"/></svg>
+        </button>
+        <div class="expand-colors underline-colors">
           <span class="color-dot" data-color="#ef4444" style="background: #ef4444;" title="빨강"></span>
           <span class="color-dot" data-color="#f97316" style="background: #f97316;" title="주황"></span>
           <span class="color-dot" data-color="#3b82f6" style="background: #3b82f6;" title="파랑"></span>
           <span class="color-dot" data-color="#a855f7" style="background: #a855f7;" title="보라"></span>
         </div>
       </div>
-
+      
+      <!-- 지우기 버튼 -->
+      <button class="menu-btn clear-btn" title="지우기">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      </button>
+      
       <div class="menu-divider" style="width: 1px; background: var(--border-strong); height: 16px; margin: 0 2px;"></div>
     </div>
     <button class="menu-btn ask-ai-btn" title="AI 어시스턴트에게 질문" style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--accent-mid); padding: 0 8px;">
@@ -2424,6 +2417,8 @@ function createSelectionMenu() {
   
   const highlightBtn = menu.querySelector('.highlight-btn')
   const underlineBtn = menu.querySelector('.underline-btn')
+  const highlightWrapper = menu.querySelector('.highlight-wrapper')
+  const underlineWrapper = menu.querySelector('.underline-wrapper')
 
   function updateActiveColors() {
     highlightBtn.querySelector('svg').style.color = state.activeHighlightColor
@@ -2445,7 +2440,7 @@ function createSelectionMenu() {
     })
   }
 
-  // 컬러 서클 클릭 핸들러 바인딩 (클릭 시 마킹 즉시 적용)
+  // 컬러 서클 클릭 핸들러 바인딩 (클릭 시 마킹 즉시 적용 및 메뉴 닫기)
   menu.querySelectorAll('.highlight-colors .color-dot').forEach(dot => {
     dot.addEventListener('click', (e) => {
       e.preventDefault(); e.stopPropagation();
@@ -2464,15 +2459,25 @@ function createSelectionMenu() {
     })
   })
 
-  // 메인 아이콘 클릭 시 즉시 대표 활성화 색상으로 마킹 처리 적용
+  // 메인 아이콘 클릭 시 즉시 토글 혹은 적용
   highlightBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    handleAnnotate('highlight', state.activeHighlightColor)
+    if (highlightWrapper.classList.contains('expanded')) {
+      handleAnnotate('highlight', state.activeHighlightColor)
+    } else {
+      underlineWrapper.classList.remove('expanded')
+      highlightWrapper.classList.add('expanded')
+    }
   })
 
   underlineBtn.addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    handleAnnotate('underline', state.activeUnderlineColor)
+    if (underlineWrapper.classList.contains('expanded')) {
+      handleAnnotate('underline', state.activeUnderlineColor)
+    } else {
+      highlightWrapper.classList.remove('expanded')
+      underlineWrapper.classList.add('expanded')
+    }
   })
 
   menu.querySelector('.clear-btn').addEventListener('click', (e) => {
@@ -2587,7 +2592,7 @@ function showSelectionMenu(rect, showAnnotateGroup) {
 function hideSelectionMenu() {
   if (selectionMenu) {
     selectionMenu.classList.add('hidden')
-    selectionMenu.querySelectorAll('.color-popover').forEach(p => p.classList.add('hidden'))
+    selectionMenu.querySelectorAll('.expand-wrapper').forEach(w => w.classList.remove('expanded'))
   }
   state.pendingFigureQuote = null
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2368,6 +2368,7 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations) {
 
 // ── 팝업 툴팁 선택 메뉴 관리 ──
 let selectionMenu = null
+let sentenceHoverTimer = null
 
 function createSelectionMenu() {
   if (selectionMenu) return selectionMenu
@@ -4299,6 +4300,11 @@ if (viewerScrollContainer) {
 
   viewerScrollContainer.addEventListener('mouseover', (e) => {
     try {
+      if (sentenceHoverTimer) {
+        clearTimeout(sentenceHoverTimer);
+        sentenceHoverTimer = null;
+      }
+
       const annSpan = e.target.closest('.pdf-annotation-highlight, .pdf-annotation-underline');
       if (annSpan) {
         showAnnotationHoverTooltip(annSpan);
@@ -4311,6 +4317,23 @@ if (viewerScrollContainer) {
       // 타겟이 번역본 문장이거나, PDF 원본의 pdf-sentence 엘리먼트인 경우
       const target = e.target.closest('.trans-sentence') || e.target.closest('.pdf-sentence');
       if (!target) return;
+
+      // PDF 텍스트 문장에 마우스가 700ms 동안 머물러 있으면 문장 단위 자동 드래그 선택 및 툴팁 띄우기
+      const pdfTarget = e.target.closest('.pdf-sentence');
+      if (pdfTarget) {
+        sentenceHoverTimer = setTimeout(() => {
+          const curSel = window.getSelection();
+          if (curSel && !curSel.isCollapsed) return;
+
+          const range = document.createRange();
+          range.selectNodeContents(pdfTarget);
+          curSel.removeAllRanges();
+          curSel.addRange(range);
+
+          const rect = pdfTarget.getBoundingClientRect();
+          showSelectionMenu(rect, true);
+        }, 700);
+      }
 
       const pageWrapper = target.closest('.pdf-page-wrapper') || target.closest('.trans-page-block');
       if (!pageWrapper) return;
@@ -4347,6 +4370,11 @@ if (viewerScrollContainer) {
 
   viewerScrollContainer.addEventListener('mouseout', (e) => {
     try {
+      if (sentenceHoverTimer) {
+        clearTimeout(sentenceHoverTimer);
+        sentenceHoverTimer = null;
+      }
+
       const annSpan = e.target.closest('.pdf-annotation-highlight, .pdf-annotation-underline');
       if (annSpan) {
         if (!e.relatedTarget || !e.relatedTarget.closest('#ann-hover-tooltip')) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2472,6 +2472,57 @@ function getMappedElementsAndIndices(target, pageNum, sentenceIdx) {
   return { pdfIdx, transIdx, pdfElements };
 }
 
+// 커스텀 다이얼로그 확인 모달 유틸리티
+function showCustomConfirm(message) {
+  return new Promise((resolve) => {
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `
+      <div class="custom-confirm-modal">
+        <div class="custom-confirm-modal-header">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          <span class="custom-confirm-modal-title">메모 삭제</span>
+        </div>
+        <div class="custom-confirm-modal-body">
+          ${message.replace(/\n/g, '<br>')}
+        </div>
+        <div class="custom-confirm-modal-footer">
+          <button class="custom-confirm-btn cancel-btn">취소</button>
+          <button class="custom-confirm-btn confirm-btn">삭제</button>
+        </div>
+      </div>
+    `
+    document.body.appendChild(modal)
+
+    // Trigger transition
+    setTimeout(() => modal.classList.add('active'), 10)
+
+    const cleanup = (value) => {
+      modal.classList.remove('active')
+      setTimeout(() => {
+        modal.remove()
+        resolve(value)
+      }, 200)
+    }
+
+    modal.querySelector('.cancel-btn').addEventListener('click', (e) => {
+      e.stopPropagation()
+      cleanup(false)
+    })
+
+    modal.querySelector('.confirm-btn').addEventListener('click', (e) => {
+      e.stopPropagation()
+      cleanup(true)
+    })
+
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        cleanup(false)
+      }
+    })
+  })
+}
+
 // ── Floating Markdown Memo 관리 ─────────────────────────
 function loadMemos(sessionId) {
   if (!sessionId) return {}
@@ -2628,10 +2679,11 @@ function renderPageMemos(pageNum) {
           }, 150)
         })
 
-        actions.querySelector('.delete-btn').addEventListener('mousedown', (e) => {
+        actions.querySelector('.delete-btn').addEventListener('mousedown', async (e) => {
           e.stopPropagation()
           e.preventDefault()
-          if (confirm('이 메모를 삭제하시겠습니까?')) {
+          const confirmDelete = await showCustomConfirm('이 메모를 삭제하시겠습니까?')
+          if (confirmDelete) {
             const allMemosObj = loadMemos(state.sessionId)
             allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
             saveMemos(state.sessionId, allMemosObj)
@@ -2681,9 +2733,10 @@ function renderPageMemos(pageNum) {
         })
 
 
-        actions.querySelector('.delete-btn').addEventListener('click', (e) => {
+        actions.querySelector('.delete-btn').addEventListener('click', async (e) => {
           e.stopPropagation()
-          if (confirm('이 메모를 삭제하시겠습니까?')) {
+          const confirmDelete = await showCustomConfirm('이 메모를 삭제하시겠습니까?')
+          if (confirmDelete) {
             const allMemosObj = loadMemos(state.sessionId)
             allMemosObj[`page_${pageNum}`] = pageMemos.filter(m => m.id !== memo.id)
             saveMemos(state.sessionId, allMemosObj)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2497,7 +2497,14 @@ function renderPageMemos(pageNum) {
           }, 30)
         })
       } else {
-        const renderedHtml = window.marked ? window.marked.parse(memo.content) : memo.content
+        let renderedHtml = memo.content
+        if (window.marked) {
+          if (typeof window.marked.parse === 'function') {
+            renderedHtml = window.marked.parse(memo.content)
+          } else if (typeof window.marked === 'function') {
+            renderedHtml = window.marked(memo.content)
+          }
+        }
         body.innerHTML = `<div class="floating-memo-render">${renderedHtml}</div>`
         actions.innerHTML = `
           <button class="floating-memo-action-btn edit-btn" title="편집">
@@ -2760,15 +2767,25 @@ function createSelectionMenu() {
 
   menu.querySelector('.memo-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation()
-    const selection = window.getSelection()
-    if (!selection.rangeCount) return
-    const range = selection.getRangeAt(0)
-    let container = range.commonAncestorContainer
-    if (container && container.nodeType === 3) {
-      container = container.parentElement || container.parentNode
+    let sentenceEl = null
+    let pageWrapper = null
+
+    if (state.hoverSelectedPdfElements && state.hoverSelectedPdfElements.length > 0) {
+      sentenceEl = state.hoverSelectedPdfElements[0]
+      pageWrapper = sentenceEl.closest('.pdf-page-wrapper')
+    } else {
+      const selection = window.getSelection()
+      if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0)
+        let startContainer = range.startContainer
+        if (startContainer) {
+          const parent = startContainer.nodeType === 3 ? startContainer.parentElement : startContainer
+          sentenceEl = parent.closest('.pdf-sentence')
+          pageWrapper = parent.closest('.pdf-page-wrapper')
+        }
+      }
     }
-    const sentenceEl = container.closest('.pdf-sentence')
-    const pageWrapper = container.closest('.pdf-page-wrapper')
+
     if (sentenceEl && pageWrapper) {
       const pageNum = parseInt(pageWrapper.dataset.page, 10)
       const sentenceIdx = parseInt(sentenceEl.dataset.sentenceIdx, 10)

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -121,12 +121,26 @@ export async function renderScrollView(container, zoom, { onPageVisible } = {}) 
 
     if (maxPageNum !== -1) {
       onPageVisible?.(maxPageNum)
+      // 비동기 다음 페이지 프리렌더링 (Canvas 로딩 속도 최적화)
+      setTimeout(() => {
+        triggerRender(maxPageNum + 1)
+      }, 150)
     }
   }, {
     root: container,
     rootMargin: '0px 0px',
     threshold: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], // 정밀한 노출 비율 판정
   })
+
+  function triggerRender(pNum) {
+    if (pNum >= 1 && pNum <= numPages && !rendered.has(pNum)) {
+      const targetWrapper = container.querySelector(`.pdf-page-wrapper[data-page="${pNum}"]`)
+      if (targetWrapper) {
+        rendered.add(pNum)
+        _renderPage(targetWrapper, pNum)
+      }
+    }
+  }
 
   wrappers.forEach(w => {
     pageObserver.observe(w)
@@ -234,3 +248,50 @@ export async function reRenderAll(container, newZoom, callbacks) {
 export function setScale(s) { currentScale = s }
 export function getScale()  { return currentScale }
 export function getTotalPages() { return pdfDoc ? pdfDoc.numPages : 0 }
+
+/** PDF.js 목차(Outline) 비동기 추출 함수 */
+export async function getPDFOutline() {
+  if (!pdfDoc) return null
+  try {
+    const outline = await pdfDoc.getOutline()
+    if (!outline || outline.length === 0) return null
+
+    async function resolveItems(items) {
+      const resolved = []
+      for (const item of items) {
+        let pageNum = null
+        if (item.dest) {
+          try {
+            let destObj = item.dest
+            if (typeof destObj === 'string') {
+              destObj = await pdfDoc.getDestination(destObj)
+            }
+            if (Array.isArray(destObj) && destObj.length > 0) {
+              const ref = destObj[0]
+              if (ref && typeof ref === 'object') {
+                const pageIndex = await pdfDoc.getPageIndex(ref)
+                pageNum = pageIndex + 1
+              } else if (typeof ref === 'number') {
+                pageNum = ref + 1
+              }
+            }
+          } catch (e) {
+            console.warn("Failed to resolve destination for outline item:", item.title, e)
+          }
+        }
+        const subItems = (item.items && item.items.length > 0) ? await resolveItems(item.items) : []
+        resolved.push({
+          title: item.title,
+          pageNum: pageNum,
+          items: subItems
+        })
+      }
+      return resolved
+    }
+
+    return await resolveItems(outline)
+  } catch (err) {
+    console.error("Error loading PDF outline:", err)
+    return null
+  }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1252,22 +1252,22 @@ body:not(.light-theme) .pdf-page-inner canvas {
 
 /* ── PDF 텍스트 하이라이트 & 밑줄 스타일 ── */
 .pdf-annotation-highlight {
-  background-color: rgba(255, 235, 59, 0.4) !important; /* Soft yellow highlight */
+  background-color: rgba(255, 235, 59, 0.4); /* Soft yellow highlight */
   border-radius: 2px;
   color: transparent !important;
 }
 
 body.light-theme .pdf-annotation-highlight {
-  background-color: rgba(255, 215, 0, 0.45) !important; /* Gold highlight in light theme */
+  background-color: rgba(255, 215, 0, 0.45); /* Gold highlight in light theme */
 }
 
 .pdf-annotation-underline {
-  border-bottom: 2px solid rgba(239, 68, 68, 0.85) !important; /* Premium red underline */
+  border-bottom: 2px solid rgba(239, 68, 68, 0.85); /* Premium red underline */
   color: transparent !important;
 }
 
 body.light-theme .pdf-annotation-underline {
-  border-bottom: 2px solid rgba(220, 53, 69, 0.9) !important;
+  border-bottom: 2px solid rgba(220, 53, 69, 0.9);
 }
 
 /* ── 텍스트 선택 팝업 메뉴 리파인 ── */
@@ -2934,6 +2934,32 @@ body.resizing-trans .trans-resizer-handle::after {
   padding: 2px 4px;
   cursor: text !important;
   box-shadow: 0 0 10px rgba(139, 92, 246, 0.3);
+}
+
+/* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
+.color-options {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+.color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+.color-dot:hover {
+  transform: scale(1.2);
+}
+.color-dot.selected {
+  transform: scale(1.25);
+  box-shadow: 0 0 0 2px var(--accent-mid);
+  border-color: transparent;
+}
+body.light-theme .color-dot {
+  border-color: rgba(0, 0, 0, 0.15);
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -10,6 +10,7 @@
   --bg-surface:     rgba(13, 11, 22, 0.7);
   --bg-elevated:    rgba(23, 20, 38, 0.75);
   --bg-hover:       rgba(39, 34, 64, 0.8);
+  --bg-panel:       rgba(20, 18, 36, 0.95);
 
   --border:         rgba(255, 255, 255, 0.05);
   --border-strong:  rgba(255, 255, 255, 0.1);
@@ -61,6 +62,7 @@ body.light-theme {
   --bg-surface:     rgba(255, 255, 255, 0.8);
   --bg-elevated:    rgba(241, 245, 249, 0.85);
   --bg-hover:       rgba(226, 232, 240, 0.9);
+  --bg-panel:       rgba(255, 255, 255, 0.98);
 
   --border:         rgba(0, 0, 0, 0.04);
   --border-strong:  rgba(0, 0, 0, 0.08);
@@ -3181,7 +3183,7 @@ body.light-theme .floating-memo-render code {
   width: 100vw;
   height: 100vh;
   z-index: 11000;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.65);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   display: flex;
@@ -3198,9 +3200,9 @@ body.light-theme .floating-memo-render code {
 .custom-confirm-modal {
   width: 320px;
   background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: var(--radius-lg);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255,255,255,0.06);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.08);
   padding: 20px;
   transform: scale(0.92);
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
@@ -3209,6 +3211,10 @@ body.light-theme .floating-memo-render code {
   gap: 14px;
   backdrop-filter: blur(30px);
   -webkit-backdrop-filter: blur(30px);
+}
+body.light-theme .custom-confirm-modal {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05);
 }
 .custom-confirm-modal-wrapper.active .custom-confirm-modal {
   transform: scale(1);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3011,4 +3011,148 @@ body.light-theme .pdf-sentence.active-mapped-sentence, body.light-theme .trans-s
   background-color: rgba(139, 92, 246, 0.18) !important;
 }
 
+/* ── Floating Markdown Memo Styles ── */
+.floating-memo {
+  position: absolute;
+  z-index: 10000;
+  width: 260px;
+  min-height: 160px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.35), 0 0 0 1px rgba(255,255,255,0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+body.light-theme .floating-memo {
+  box-shadow: 0 12px 30px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.03);
+}
+
+.floating-memo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--border);
+  cursor: grab;
+  user-select: none;
+}
+.floating-memo-header:active {
+  cursor: grabbing;
+}
+body.light-theme .floating-memo-header {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.floating-memo-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.floating-memo-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.floating-memo-action-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: all 0.12s;
+}
+.floating-memo-action-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.floating-memo-action-btn.delete:hover {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.floating-memo-body {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+}
+
+.floating-memo-textarea {
+  width: 100%;
+  flex: 1;
+  min-height: 100px;
+  background: transparent;
+  border: none;
+  resize: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 13px;
+  color: inherit;
+  line-height: 1.5;
+}
+
+.floating-memo-render {
+  flex: 1;
+  word-break: break-word;
+}
+.floating-memo-render p {
+  margin: 0 0 8px 0;
+}
+.floating-memo-render p:last-child {
+  margin-bottom: 0;
+}
+.floating-memo-render h1, .floating-memo-render h2, .floating-memo-render h3 {
+  margin: 6px 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.floating-memo-render h1 { font-size: 16px; }
+.floating-memo-render h2 { font-size: 14px; }
+.floating-memo-render h3 { font-size: 13px; }
+.floating-memo-render code {
+  background: rgba(255,255,255,0.08);
+  padding: 1px 4px;
+  border-radius: var(--radius-xs);
+  font-family: monospace;
+  font-size: 11px;
+}
+body.light-theme .floating-memo-render code {
+  background: rgba(0,0,0,0.06);
+}
+.floating-memo-render ul, .floating-memo-render ol {
+  margin: 0 0 8px 0;
+  padding-left: 18px;
+}
+
+.memo-connector-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9990;
+}
+
+
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2954,15 +2954,16 @@ body.resizing-trans .trans-resizer-handle::after {
   z-index: 10000;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.12s cubic-bezier(0.16, 1, 0.3, 1), transform 0.12s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity 0.15s cubic-bezier(0.16, 1, 0.3, 1) 0.15s, transform 0.15s cubic-bezier(0.16, 1, 0.3, 1) 0.15s;
   height: 26px;
   align-items: center;
   box-sizing: border-box;
 }
-.color-popover:not(.hidden) {
+.annotate-button-wrapper:hover .color-popover {
   opacity: 1;
   pointer-events: all;
   transform: translateX(-50%) translateY(0);
+  transition-delay: 0s;
 }
 .color-popover::after {
   content: '';

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2653,6 +2653,7 @@ body.light-theme .message-quote-img {
 .trans-page-block {
   width: var(--trans-pane-width, 620px) !important;
   position: relative !important;
+  overflow: visible !important; /* 핸들이 외부에 노출될 수 있도록 클리핑 방지 */
 }
 
 /* 번역 창 접기 상태 클래스 */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2652,21 +2652,109 @@ body.light-theme .message-quote-img {
 /* ── 번역 창 너비 커스텀 변수 바인딩 ── */
 .trans-page-block {
   width: var(--trans-pane-width, 620px) !important;
+  position: relative !important;
 }
 
 /* 번역 창 접기 상태 클래스 */
 .collapse-translation .trans-page-block {
-  display: none !important;
-}
-.collapse-translation .page-pair {
-  justify-content: center !important;
+  width: 0 !important;
+  min-width: 0 !important;
+  max-width: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+  box-shadow: none !important;
+  overflow: visible !important;
 }
 
-/* 접혀있을 때 버튼 상태 가시화 */
-#toggle-trans-pane-btn.collapsed {
-  color: var(--accent-mid) !important;
-  background: rgba(139, 92, 246, 0.15) !important;
-  border-color: var(--accent-mid) !important;
+.collapse-translation .trans-page-block .trans-page-label,
+.collapse-translation .trans-page-block .trans-page-content {
+  display: none !important;
+}
+
+.collapse-translation .page-pair {
+  justify-content: center !important;
+  gap: 0 !important; /* 접혔을 때는 갭 제거 */
+}
+
+/* 드래그 너비 조절 핸들 */
+.trans-resizer-handle {
+  position: absolute;
+  top: 0;
+  left: -24px; /* gap 40px의 한가운데 배치 */
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 100;
+  background: transparent;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.trans-resizer-handle:hover,
+body.resizing-trans .trans-resizer-handle {
+  background: rgba(139, 92, 246, 0.25) !important;
+}
+.trans-resizer-handle::after {
+  content: '';
+  width: 2px;
+  height: 32px;
+  background: var(--border-strong);
+  border-radius: 1px;
+  opacity: 0.4;
+  transition: opacity 0.2s;
+}
+.trans-resizer-handle:hover::after,
+body.resizing-trans .trans-resizer-handle::after {
+  opacity: 1;
+}
+
+/* 접혔을 때 핸들 위치 밀착 조정 */
+.collapse-translation .trans-resizer-handle {
+  left: -12px !important;
+  width: 24px !important;
+  cursor: default !important;
+}
+.collapse-translation .trans-resizer-handle::after {
+  display: none !important;
+}
+
+/* 번역 창 접기/펴기 인라인 버튼 */
+.trans-collapse-btn {
+  position: absolute;
+  top: 16px;
+  left: -8px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  font-size: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  z-index: 110;
+  outline: none;
+}
+.trans-collapse-btn:hover {
+  background: var(--bg-hover);
+  color: var(--accent-mid);
+  border-color: var(--accent-mid);
+  transform: scale(1.1);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.25);
+}
+.trans-collapse-btn:active {
+  transform: scale(0.95);
+}
+
+.collapse-translation .trans-collapse-btn {
+  left: 0px !important;
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1270,48 +1270,61 @@ body.light-theme .pdf-annotation-underline {
   border-bottom: 2px solid rgba(220, 53, 69, 0.9) !important;
 }
 
-/* ── 텍스트 선택 팝업 메뉴 ── */
+/* ── 텍스트 선택 팝업 메뉴 리파인 ── */
 .selection-menu {
   position: absolute;
   display: flex;
-  background: var(--bg-surface);
+  align-items: center;
+  background: var(--bg-panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
-  padding: 4px 8px;
-  gap: 6px;
-  box-shadow: var(--shadow-md), var(--shadow-glow);
+  padding: 3px 6px;
+  gap: 4px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(255,255,255,0.05);
   z-index: 9999;
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  height: 38px;
+  box-sizing: border-box;
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 @keyframes popupScale {
-  from { transform: scale(0.8) translateY(10px); opacity: 0; }
+  from { transform: scale(0.8) translateY(8px); opacity: 0; }
   to { transform: scale(1) translateY(0); opacity: 1; }
 }
 
 .selection-menu .menu-btn {
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   border: none;
   background: transparent;
-  font-size: 16px;
   cursor: pointer;
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s;
+  color: var(--text-secondary);
+  transition: all 0.15s ease;
+  padding: 0;
 }
 
 .selection-menu .menu-btn:hover {
   background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .selection-menu .menu-btn.ask-ai-btn {
   width: auto;
   white-space: nowrap;
-  padding: 0 10px;
+  padding: 0 8px;
+  color: var(--accent-mid) !important;
+  font-family: var(--font-sans);
+}
+
+.selection-menu .menu-btn.ask-ai-btn:hover {
+  background: rgba(139, 92, 246, 0.15) !important;
+  color: var(--accent-mid) !important;
 }
 
 /* ── 비밀번호 변경 모달 스타일 ── */
@@ -2829,6 +2842,98 @@ body.resizing-trans .trans-resizer-handle::after {
   margin: 0 4px;
   opacity: 0.5;
   align-self: center;
+}
+
+/* ── 좌측 목차 사이드바 ── */
+.outline-sidebar {
+  position: fixed;
+  top: var(--topbar-h);
+  left: 0;
+  bottom: 0;
+  width: 260px;
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border-strong);
+  box-shadow: 4px 0 30px rgba(0, 0, 0, 0.2);
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateX(0);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+.outline-sidebar.hidden {
+  transform: translateX(-100%);
+  display: flex !important; /* 슬라이딩 동작을 위해 숨겨진 상태에서도 layout 유지 */
+}
+.outline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.outline-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.outline-close-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 20px;
+  cursor: pointer;
+  line-height: 1;
+  transition: color 0.15s;
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.outline-close-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.outline-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+.outline-item {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 0.12s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+.outline-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.outline-item.depth-1 { padding-left: 22px; font-weight: 400; opacity: 0.85; }
+.outline-item.depth-2 { padding-left: 32px; font-weight: 400; opacity: 0.75; }
+.outline-item.depth-3 { padding-left: 42px; font-weight: 400; opacity: 0.65; }
+
+/* ── 문장 더블클릭 수정 모드 스타일 ── */
+.trans-sentence.inline-editing {
+  background: rgba(139, 92, 246, 0.15) !important;
+  outline: 2px solid var(--accent-mid) !important;
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  cursor: text !important;
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.3);
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2937,21 +2937,62 @@ body.resizing-trans .trans-resizer-handle::after {
 }
 
 /* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
-.color-options {
+.color-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 6px;
   display: flex;
-  gap: 4px;
-  align-items: center;
+  gap: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  z-index: 10000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s, transform 0.15s;
+}
+.color-popover:not(.hidden) {
+  opacity: 1;
+  pointer-events: all;
+  transform: translateX(-50%) translateY(0);
+}
+.color-popover::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--bg-panel) transparent transparent transparent;
+}
+.color-popover::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--border-strong) transparent transparent transparent;
+  z-index: -1;
+  margin-top: 1px;
 }
 .color-dot {
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 .color-dot:hover {
-  transform: scale(1.2);
+  transform: scale(1.25);
 }
 .color-dot.selected {
   transform: scale(1.25);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2854,7 +2854,7 @@ body.resizing-trans .trans-resizer-handle::after {
   background: var(--bg-panel);
   border-right: 1px solid var(--border-strong);
   box-shadow: 4px 0 30px rgba(0, 0, 0, 0.2);
-  z-index: 90;
+  z-index: 120 !important;
   display: flex;
   flex-direction: column;
   transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -375,6 +375,31 @@ html, body {
   background-clip: text;
 }
 
+.logo-small-btn {
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+  font-family: 'Outfit', var(--font-body);
+  background: linear-gradient(135deg, #ffffff, #a1a1aa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  transition: opacity 0.2s, transform 0.2s;
+}
+.logo-small-btn:hover {
+  opacity: 0.8;
+  transform: scale(0.98);
+}
+.logo-small-btn:active {
+  transform: scale(0.95);
+}
+
 .doc-title {
   font-size: 13px;
   font-weight: 500;
@@ -2268,7 +2293,8 @@ body.light-theme .orb-2 { background: rgba(168, 85, 247, 0.05); }
 body.light-theme .orb-3 { background: rgba(16, 185, 129, 0.04); }
 
 body.light-theme .logo-text,
-body.light-theme .logo-small {
+body.light-theme .logo-small,
+body.light-theme .logo-small-btn {
   background: linear-gradient(135deg, var(--text-primary), var(--text-secondary));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2678,17 +2678,16 @@ body.light-theme .message-quote-img {
   gap: 0 !important; /* 접혔을 때는 갭 제거 */
 }
 
-/* 드래그 너비 조절 핸들 */
+/* 드래그 너비 조절 핸들 (우측 사이드 배치) */
 .trans-resizer-handle {
   position: absolute;
   top: 0;
-  left: -24px; /* gap 40px의 한가운데 배치 */
+  right: -4px; /* 우측 테두리에 걸쳐 배치 */
   width: 8px;
   height: 100%;
   cursor: col-resize;
   z-index: 100;
   background: transparent;
-  border-radius: 4px;
   transition: background-color 0.2s;
   display: flex;
   align-items: center;
@@ -2714,7 +2713,7 @@ body.resizing-trans .trans-resizer-handle::after {
 
 /* 접혔을 때 핸들 위치 밀착 조정 */
 .collapse-translation .trans-resizer-handle {
-  left: -12px !important;
+  right: -12px !important;
   width: 24px !important;
   cursor: default !important;
 }
@@ -2722,40 +2721,42 @@ body.resizing-trans .trans-resizer-handle::after {
   display: none !important;
 }
 
-/* 번역 창 접기/펴기 인라인 버튼 */
+/* 번역 창 접기/펴기 임머시브(Immersive) 버튼 */
 .trans-collapse-btn {
   position: absolute;
-  top: 16px;
-  left: -8px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
+  top: 40px; /* 상단 부근 고정 */
+  right: -12px; /* 테두리 바깥에 결합 */
+  width: 12px;
+  height: 48px;
+  border-radius: 0 4px 4px 0;
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);
+  border-left: none; /* 왼쪽 테두리를 지워 일체감 구현 */
   color: var(--text-secondary);
-  font-size: 10px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
   transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   z-index: 110;
+  padding: 0;
   outline: none;
+}
+.trans-collapse-btn svg {
+  transition: transform 0.2s;
 }
 .trans-collapse-btn:hover {
   background: var(--bg-hover);
   color: var(--accent-mid);
-  border-color: var(--accent-mid);
-  transform: scale(1.1);
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.25);
+  width: 16px;
+  right: -16px;
+  border-radius: 0 6px 6px 0;
+  box-shadow: 4px 0 12px rgba(139, 92, 246, 0.2);
 }
 .trans-collapse-btn:active {
-  transform: scale(0.95);
-}
-
-.collapse-translation .trans-collapse-btn {
-  left: 0px !important;
+  width: 12px;
+  right: -12px;
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2939,22 +2939,25 @@ body.resizing-trans .trans-resizer-handle::after {
 /* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
 .color-popover {
   position: absolute;
-  bottom: calc(100% + 8px);
+  bottom: calc(100% + 10px);
   left: 50%;
   transform: translateX(-50%) translateY(4px);
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
-  padding: 6px;
+  padding: 4px 6px;
   display: flex;
   gap: 6px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   z-index: 10000;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.15s, transform 0.15s;
+  transition: opacity 0.12s cubic-bezier(0.16, 1, 0.3, 1), transform 0.12s cubic-bezier(0.16, 1, 0.3, 1);
+  height: 26px;
+  align-items: center;
+  box-sizing: border-box;
 }
 .color-popover:not(.hidden) {
   opacity: 1;
@@ -2967,7 +2970,7 @@ body.resizing-trans .trans-resizer-handle::after {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  border-width: 5px;
+  border-width: 4px;
   border-style: solid;
   border-color: var(--bg-panel) transparent transparent transparent;
 }
@@ -2977,7 +2980,7 @@ body.resizing-trans .trans-resizer-handle::after {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  border-width: 6px;
+  border-width: 5px;
   border-style: solid;
   border-color: var(--border-strong) transparent transparent transparent;
   z-index: -1;
@@ -2988,19 +2991,28 @@ body.resizing-trans .trans-resizer-handle::after {
   height: 14px;
   border-radius: 50%;
   cursor: pointer;
-  transition: transform 0.15s, box-shadow 0.15s;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.15s ease;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-sizing: border-box;
 }
 .color-dot:hover {
   transform: scale(1.25);
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.4);
 }
 .color-dot.selected {
   transform: scale(1.25);
-  box-shadow: 0 0 0 2px var(--accent-mid);
-  border-color: transparent;
+  box-shadow: 0 0 0 1.5px var(--accent-mid);
+  border-color: #fff;
 }
 body.light-theme .color-dot {
   border-color: rgba(0, 0, 0, 0.15);
+}
+body.light-theme .color-dot:hover {
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
+}
+body.light-theme .color-dot.selected {
+  border-color: #fff;
+  box-shadow: 0 0 0 1.5px var(--accent-mid);
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3011,6 +3011,24 @@ body.light-theme .pdf-sentence.active-mapped-sentence, body.light-theme .trans-s
   background-color: rgba(139, 92, 246, 0.18) !important;
 }
 
+/* 메모를 보유한 원문 문장 하이라이트 스타일 */
+.pdf-sentence.pdf-sentence-has-memo {
+  background-color: rgba(99, 102, 241, 0.18) !important;
+  border-bottom: 1.5px dashed rgba(99, 102, 241, 0.6) !important;
+  border-radius: var(--radius-xs);
+  transition: all 0.2s ease;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo {
+  background-color: rgba(99, 102, 241, 0.1) !important;
+  border-bottom: 1.5px dashed rgba(99, 102, 241, 0.45) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo:hover {
+  background-color: rgba(99, 102, 241, 0.28) !important;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo:hover {
+  background-color: rgba(99, 102, 241, 0.16) !important;
+}
+
 /* ── Floating Markdown Memo Styles ── */
 .floating-memo {
   position: absolute;
@@ -3152,6 +3170,7 @@ body.light-theme .floating-memo-render code {
   height: 100%;
   pointer-events: none;
   z-index: 9990;
+  overflow: visible !important;
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3173,5 +3173,94 @@ body.light-theme .floating-memo-render code {
   overflow: visible !important;
 }
 
+/* ── Custom Confirm Modal ── */
+.custom-confirm-modal-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 11000;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+}
+.custom-confirm-modal-wrapper.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+.custom-confirm-modal {
+  width: 320px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255,255,255,0.06);
+  padding: 20px;
+  transform: scale(0.92);
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+}
+.custom-confirm-modal-wrapper.active .custom-confirm-modal {
+  transform: scale(1);
+}
+.custom-confirm-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.custom-confirm-modal-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.custom-confirm-modal-body {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.custom-confirm-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+.custom-confirm-btn {
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+}
+.custom-confirm-btn.cancel-btn {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+  color: var(--text-secondary);
+}
+.custom-confirm-btn.cancel-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.custom-confirm-btn.confirm-btn {
+  background: #ef4444;
+  color: white;
+  font-weight: 700;
+}
+.custom-confirm-btn.confirm-btn:hover {
+  background: #dc2626;
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.4);
+}
+
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2937,18 +2937,40 @@ body.resizing-trans .trans-resizer-handle::after {
 }
 
 /* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
-/* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
-.color-preset-section {
+.expand-wrapper {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0 4px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  height: 32px;
+  transition: all 0.2s ease;
 }
-.inline-color-group {
+.expand-wrapper.expanded {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--border-strong);
+}
+body.light-theme .expand-wrapper.expanded {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.expand-colors {
   display: flex;
-  gap: 5px;
+  gap: 4px;
+  overflow: hidden;
+  width: 0;
+  opacity: 0;
+  height: 100%;
   align-items: center;
+  transition: width 0.2s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.2s ease, padding 0.2s ease;
+  box-sizing: border-box;
 }
+.expand-wrapper.expanded .expand-colors {
+  width: 82px;
+  opacity: 1;
+  padding: 0 6px;
+}
+
 .color-dot {
   width: 14px;
   height: 14px;
@@ -2957,6 +2979,7 @@ body.resizing-trans .trans-resizer-handle::after {
   transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.15s ease;
   border: 1px solid rgba(255, 255, 255, 0.25);
   box-sizing: border-box;
+  flex-shrink: 0;
 }
 .color-dot:hover {
   transform: scale(1.25);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3001,4 +3001,14 @@ body.light-theme .color-dot.selected {
   box-shadow: 0 0 0 1.5px var(--accent-mid);
 }
 
+/* 클릭으로 매칭/이동 시 고정 하이라이트 유지 스타일 */
+.pdf-sentence.active-mapped-sentence, .trans-sentence.active-mapped-sentence {
+  background-color: rgba(139, 92, 246, 0.28) !important;
+  border-radius: var(--radius-xs);
+  transition: background-color 0.15s ease;
+}
+body.light-theme .pdf-sentence.active-mapped-sentence, body.light-theme .trans-sentence.active-mapped-sentence {
+  background-color: rgba(139, 92, 246, 0.18) !important;
+}
+
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2954,16 +2954,40 @@ body.resizing-trans .trans-resizer-handle::after {
   z-index: 10000;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.15s cubic-bezier(0.16, 1, 0.3, 1) 0.15s, transform 0.15s cubic-bezier(0.16, 1, 0.3, 1) 0.15s;
+  transition: opacity 0.12s cubic-bezier(0.16, 1, 0.3, 1), transform 0.12s cubic-bezier(0.16, 1, 0.3, 1);
   height: 26px;
   align-items: center;
   box-sizing: border-box;
 }
-.annotate-button-wrapper:hover .color-popover {
+.color-popover:not(.hidden) {
   opacity: 1;
   pointer-events: all;
   transform: translateX(-50%) translateY(0);
-  transition-delay: 0s;
+}
+
+/* 스플릿 버튼 스타일 */
+.annotate-split-wrapper {
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  height: 28px;
+  box-sizing: border-box;
+}
+body.light-theme .annotate-split-wrapper {
+  background: rgba(0, 0, 0, 0.02);
+}
+.annotate-split-wrapper .menu-btn {
+  border: none !important;
+  background: transparent !important;
+  transition: background 0.15s;
+  height: 100% !important;
+  border-radius: 0 !important;
+}
+.annotate-split-wrapper .menu-btn:hover {
+  background: var(--bg-hover) !important;
 }
 .color-popover::after {
   content: '';

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2649,4 +2649,24 @@ body.light-theme .message-quote-img {
   box-shadow: 0 0 8px rgba(139, 92, 246, 0.4);
 }
 
+/* ── 번역 창 너비 커스텀 변수 바인딩 ── */
+.trans-page-block {
+  width: var(--trans-pane-width, 620px) !important;
+}
+
+/* 번역 창 접기 상태 클래스 */
+.collapse-translation .trans-page-block {
+  display: none !important;
+}
+.collapse-translation .page-pair {
+  justify-content: center !important;
+}
+
+/* 접혀있을 때 버튼 상태 가시화 */
+#toggle-trans-pane-btn.collapsed {
+  color: var(--accent-mid) !important;
+  background: rgba(139, 92, 246, 0.15) !important;
+  border-color: var(--accent-mid) !important;
+}
+
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2759,4 +2759,76 @@ body.resizing-trans .trans-resizer-handle::after {
   right: -12px;
 }
 
+/* ── 뷰어 상단 툴바 리파인 디자인 ── */
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px !important;
+}
+
+/* 캡슐 스타일 세그먼트 버튼 그룹 */
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 2px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.toolbar-group:hover {
+  border-color: var(--border-strong-hover, rgba(255, 255, 255, 0.15));
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
+}
+
+/* 그룹 내 아이콘 버튼 */
+.toolbar-group .icon-btn {
+  background: transparent !important;
+  border: none !important;
+  border-radius: var(--radius-sm) !important;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  transition: all 0.15s ease;
+  box-shadow: none !important;
+}
+.toolbar-group .icon-btn:hover {
+  background: var(--bg-hover) !important;
+  color: var(--text-primary);
+}
+.toolbar-group .icon-btn.active {
+  background: rgba(139, 92, 246, 0.15) !important;
+  color: var(--accent-mid) !important;
+}
+
+/* 그룹 내 줌 레벨 스팬 */
+.toolbar-group .zoom-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-primary);
+  padding: 0 6px;
+  min-width: 44px;
+  text-align: center;
+  user-select: none;
+  font-family: var(--font-sans);
+}
+
+/* 세그먼트 구분선 */
+.toolbar-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--border-strong);
+  margin: 0 4px;
+  opacity: 0.5;
+  align-self: center;
+}
+
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2937,79 +2937,17 @@ body.resizing-trans .trans-resizer-handle::after {
 }
 
 /* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
-.color-popover {
-  position: absolute;
-  bottom: calc(100% + 10px);
-  left: 50%;
-  transform: translateX(-50%) translateY(4px);
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  padding: 4px 6px;
-  display: flex;
-  gap: 6px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  z-index: 10000;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.12s cubic-bezier(0.16, 1, 0.3, 1), transform 0.12s cubic-bezier(0.16, 1, 0.3, 1);
-  height: 26px;
-  align-items: center;
-  box-sizing: border-box;
-}
-.color-popover:not(.hidden) {
-  opacity: 1;
-  pointer-events: all;
-  transform: translateX(-50%) translateY(0);
-}
-
-/* 스플릿 버튼 스타일 */
-.annotate-split-wrapper {
+/* ── 텍스트 선택 메뉴 내 컬러 피커 스타일 ── */
+.color-preset-section {
   display: flex;
   align-items: center;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  height: 28px;
-  box-sizing: border-box;
+  gap: 8px;
+  padding: 0 4px;
 }
-body.light-theme .annotate-split-wrapper {
-  background: rgba(0, 0, 0, 0.02);
-}
-.annotate-split-wrapper .menu-btn {
-  border: none !important;
-  background: transparent !important;
-  transition: background 0.15s;
-  height: 100% !important;
-  border-radius: 0 !important;
-}
-.annotate-split-wrapper .menu-btn:hover {
-  background: var(--bg-hover) !important;
-}
-.color-popover::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-width: 4px;
-  border-style: solid;
-  border-color: var(--bg-panel) transparent transparent transparent;
-}
-.color-popover::before {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-width: 5px;
-  border-style: solid;
-  border-color: var(--border-strong) transparent transparent transparent;
-  z-index: -1;
-  margin-top: 1px;
+.inline-color-group {
+  display: flex;
+  gap: 5px;
+  align-items: center;
 }
 .color-dot {
   width: 14px;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1160,6 +1160,34 @@ body:not(.light-theme) .pdf-page-inner canvas {
   transform: translateY(0);
 }
 
+.doc-edit-btn {
+  width: 36px; height: 36px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  flex-shrink: 0;
+}
+.doc-edit-btn:hover {
+  border-color: rgba(139, 92, 246, 0.3);
+  color: var(--accent-mid);
+  background: rgba(139, 92, 246, 0.12);
+  transform: translateY(-1px);
+}
+.doc-edit-btn:active {
+  transform: translateY(0);
+}
+
+.doc-title-edit-btn:hover {
+  opacity: 1 !important;
+  color: var(--accent-mid) !important;
+}
+
 /* ── 글로벌 테마 토글 버튼 ── */
 .global-theme-toggle {
   position: fixed;


### PR DESCRIPTION
# Summary
## 1. 📝 유리 감각의 Floating 메모장 및 지능형 앵커링
- **화면 전체 드래그 자유 배치**: 메모의 위치 제약 범위를 확장하여 PDF 본문 바깥 영역(여백 및 번역 패널 근처)까지 어디서나 배치할 수 있게 함. 백분율(%) 기반으로 내부 저장되어 배율 확대/축소 시에도 정확하게 정비례 스케일링됨.
- **시작 지점 베지에 곡선(Bezier Curve) 연결**: 메모장과 매핑 문장 간의 부드러운 연결 점선이 문장의 한가운데가 아닌 **문장 첫 단어의 좌측 시작점**에 완벽히 밀착되어 나오도록 누적 오프셋 계산식을 적용.
- **타겟 문장 자동 하이라이트**: 메모가 존재하는 원본 본문 문장 영역에 테마별 은은한 보랏빛 배경 하이라이트 및 점선 테두리 디자인(`.pdf-sentence-has-memo`)이 활성화됨.
-  **문장 첫머리 기반 동적 제목**: 메모가 생성될 때 연결된 원문의 첫 20자를 자동 추출하여 헤더 제목으로 설정하고, 마우스 호버 시 전체 문장 툴팁을 제공.

## 2. 마크다운 & LaTeX 실시간 렌더링 및 모듈 번들링
- **로컬 Marked.js 모듈화**: 보안정책(CSP) 및 네트워크 연결 유무에 영향받지 않도록 `marked` NPM 패키지를 로컬에 이식하여 번들링.
- **실시간 LaTeX 수식 지원**: KaTeX의 `renderMathInElement`를 연동하여 메모 뷰 모드 내에서 인라인(`$ ... `$ ... $$`) 수식 기호가 실시간 렌더링되도록 구현.
## 3. 단일 클릭 편집 개방 및 100% 자동 저장 (No-Save-Button UX)
- **Keystroke 실시간 저장**: 텍스트를 입력하는 도중에도 내용이 실시간 자동 저장(`input`)되며 메모창 높이에 맞춰 연결선이 즉각 갱신됨.
- **포커스 아웃(Blur) 자동 저장 및 뷰 전환**: 메모 수정 중 외부 영역을 클릭하는 즉시 수정한 내용이 저장되며 깔끔한 마크다운 보기 모드로 즉각 전환됨.
- **단일 클릭 편집 돌입**: 더블 클릭이나 편집 아이콘을 찾을 필요 없이 본문 글자 영역을 **한 번만 클릭**하면 즉시 자연스럽게 입력 필드가 열림. (중복 이벤트 핸들러 누적 누수 현상 방어)

## 4. 커스텀 컨펌(Confirm) 모달 신설 및 테마 명암비 패치
- **자체 확인창 설계**: 메모 삭제 시 뜨는 브라우저 기본 알림창 대신, 흐림 필터 배경이 적용된 미려한 비동기 경고 모달을 구축하여 `confirm` 함수를 완전 대체.
- **디자인 토큰 누락 보완**: 누락되어 있었던 `--bg-panel` 디자인 시스템 변수를 라이트/다크 테마 스펙에 따라 모달과 사이드바의 명암비 및 가독성을 대폭 끌어올림.