### PR TITLE
Ux refinement

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-B1mxIovI.js"></script>
+  <script type="module" crossorigin src="/assets/index-SLiv04zF.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Bz9rWCHl.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BlwkCIDL.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-YQHEtqP_.css">
+  <script type="module" crossorigin src="/assets/index-x-q96yj2.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-B7Jrwa3H.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-x-q96yj2.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-B7Jrwa3H.css">
+  <script type="module" crossorigin src="/assets/index-B1mxIovI.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-Bz9rWCHl.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2548,16 +2548,26 @@ function updateMemoConnectorLine(pageWrapper, memo, sentenceEl) {
     pageWrapper.appendChild(svg)
   }
 
+  const isLight = document.body.classList.contains('light-theme')
+  let strokeColor = 'var(--accent-mid)'
+  const colorMode = memo.color || 'default'
+  if (colorMode === 'yellow') strokeColor = isLight ? '#ca8a04' : '#eab308'
+  else if (colorMode === 'green') strokeColor = isLight ? '#059669' : '#10b981'
+  else if (colorMode === 'blue') strokeColor = isLight ? '#2563eb' : '#3b82f6'
+  else if (colorMode === 'red') strokeColor = isLight ? '#e11d48' : '#f43f5e'
+
   let path = svg.getElementById(`connector_${memo.id}`)
   if (!path) {
     path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
     path.setAttribute('id', `connector_${memo.id}`)
-    path.setAttribute('stroke', 'var(--accent-mid)')
+    path.setAttribute('stroke', strokeColor)
     path.setAttribute('stroke-width', '1.5')
     path.setAttribute('stroke-dasharray', '4,4')
     path.setAttribute('fill', 'none')
     path.setAttribute('opacity', '0.6')
     svg.appendChild(path)
+  } else {
+    path.setAttribute('stroke', strokeColor)
   }
 
   if (!sentenceEl) {
@@ -2630,7 +2640,7 @@ function renderPageMemos(pageNum) {
 
   pageMemos.forEach(memo => {
     const memoEl = document.createElement('div')
-    memoEl.className = 'floating-memo'
+    memoEl.className = `floating-memo color-${memo.color || 'default'}`
     memoEl.setAttribute('data-id', memo.id)
     memoEl.style.left = `${memo.x}%`
     memoEl.style.top = `${memo.y}%`
@@ -2756,6 +2766,13 @@ function renderPageMemos(pageNum) {
         <div class="floating-memo-title" title="${sentenceText}">
           <span>📝 ${shortTitle}</span>
         </div>
+        <div class="floating-memo-color-picker">
+          <span class="color-dot default ${!memo.color || memo.color === 'default' ? 'selected' : ''}" data-color="default" title="기본"></span>
+          <span class="color-dot yellow ${memo.color === 'yellow' ? 'selected' : ''}" data-color="yellow" title="노랑"></span>
+          <span class="color-dot green ${memo.color === 'green' ? 'selected' : ''}" data-color="green" title="초록"></span>
+          <span class="color-dot blue ${memo.color === 'blue' ? 'selected' : ''}" data-color="blue" title="파랑"></span>
+          <span class="color-dot red ${memo.color === 'red' ? 'selected' : ''}" data-color="red" title="빨강"></span>
+        </div>
         <div class="floating-memo-actions"></div>
       </div>
       <div class="floating-memo-body"></div>
@@ -2770,6 +2787,26 @@ function renderPageMemos(pageNum) {
       e.stopPropagation()
       isEditing = true
       updateCardContent()
+    })
+
+    const colorDots = memoEl.querySelectorAll('.color-dot')
+    colorDots.forEach(dot => {
+      dot.addEventListener('click', (e) => {
+        e.stopPropagation()
+        const selectedColor = dot.getAttribute('data-color')
+        
+        colorDots.forEach(d => d.classList.remove('selected'))
+        dot.classList.add('selected')
+        
+        memoEl.className = `floating-memo color-${selectedColor}`
+        
+        memo.color = selectedColor
+        const allMemosObj = loadMemos(state.sessionId)
+        allMemosObj[`page_${pageNum}`] = pageMemos
+        saveMemos(state.sessionId, allMemosObj)
+        
+        updateMemoConnectorLine(pageWrapper, memo, sentenceEl)
+      })
     })
 
     pageWrapper.appendChild(memoEl)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4850,11 +4850,21 @@ if (viewerScrollContainer) {
         showAnnotationHoverTooltip(annSpan);
       }
 
-      const selection = window.getSelection();
-      if (selection && !selection.isCollapsed && !annSpan) return;
-
-      // 타겟이 번역본 문장이거나, PDF 원본의 pdf-sentence 엘리먼트인 경우
       const target = e.target.closest('.trans-sentence') || e.target.closest('.pdf-sentence');
+
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed && !annSpan) {
+        if (e.buttons === 1) {
+          return;
+        }
+        if (target) {
+          selection.removeAllRanges();
+          hideSelectionMenu();
+        } else {
+          return;
+        }
+      }
+
       if (!target) return;
 
       // PDF 텍스트 문장에 마우스가 700ms 동안 머물러 있으면 문장 단위 자동 드래그 선택 및 툴팁 띄우기

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4858,8 +4858,21 @@ if (viewerScrollContainer) {
           return;
         }
         if (target) {
-          selection.removeAllRanges();
-          hideSelectionMenu();
+          const pageWrapper = target.closest('.pdf-page-wrapper') || target.closest('.trans-page-block');
+          const hoveredPageNum = pageWrapper ? parseInt(pageWrapper.dataset.page, 10) : -1;
+          const hoveredSentenceIdx = parseInt(target.dataset.sentenceIdx, 10);
+
+          const isSameAsSelected = (hoveredPageNum === state.hoverSelectedPageNum && hoveredSentenceIdx === state.hoverSelectedSentenceIdx);
+
+          if (!isSameAsSelected) {
+            selection.removeAllRanges();
+            hideSelectionMenu();
+            state.hoverSelectedPdfElements = null;
+            state.hoverSelectedPageNum = null;
+            state.hoverSelectedSentenceIdx = null;
+          } else {
+            return;
+          }
         } else {
           return;
         }
@@ -4887,6 +4900,7 @@ if (viewerScrollContainer) {
           if (pdfElements && pdfElements.length > 0) {
             state.hoverSelectedPdfElements = pdfElements;
             state.hoverSelectedPageNum = pageNum;
+            state.hoverSelectedSentenceIdx = pdfIdx;
 
             const firstEl = pdfElements[0];
             const lastEl = pdfElements[pdfElements.length - 1];

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3078,6 +3078,15 @@ body.light-theme .floating-memo-header {
   display: flex;
   align-items: center;
   gap: 4px;
+  max-width: 110px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+.floating-memo-title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
 }
 
 .floating-memo-actions {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3268,5 +3268,112 @@ body.light-theme .custom-confirm-modal {
   box-shadow: 0 0 12px rgba(239, 68, 68, 0.4);
 }
 
+/* ── Color picker in memo header ── */
+.floating-memo-color-picker {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  margin-right: 8px;
+  opacity: 0.4;
+  transition: opacity 0.2s ease;
+}
+.floating-memo:hover .floating-memo-color-picker {
+  opacity: 1;
+}
+.color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+.color-dot:hover {
+  transform: scale(1.3);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+.color-dot.selected {
+  transform: scale(1.2);
+  box-shadow: 0 0 0 1.5px var(--accent-mid);
+  border-color: #fff;
+}
+body.light-theme .color-dot {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+}
+body.light-theme .color-dot.selected {
+  border-color: #000;
+  box-shadow: 0 0 0 1.5px var(--accent-mid);
+}
+
+/* Color dot themes */
+.color-dot.default { background: var(--text-muted); }
+.color-dot.yellow  { background: #eab308; }
+.color-dot.green   { background: #10b981; }
+.color-dot.blue    { background: #3b82f6; }
+.color-dot.red     { background: #f43f5e; }
+
+/* Floating memo color themes */
+.floating-memo.color-default {
+  background: var(--bg-panel);
+  border-color: var(--border-strong);
+}
+.floating-memo.color-yellow {
+  background: rgba(234, 179, 8, 0.1) !important;
+  border-color: rgba(234, 179, 8, 0.35) !important;
+}
+body.light-theme .floating-memo.color-yellow {
+  background: #fef9c3 !important;
+  border-color: rgba(234, 179, 8, 0.3) !important;
+  color: #713f12 !important;
+}
+body.light-theme .floating-memo.color-yellow .floating-memo-title span,
+body.light-theme .floating-memo.color-yellow .floating-memo-textarea,
+body.light-theme .floating-memo.color-yellow .floating-memo-render {
+  color: #713f12 !important;
+}
+.floating-memo.color-green {
+  background: rgba(16, 185, 129, 0.1) !important;
+  border-color: rgba(16, 185, 129, 0.35) !important;
+}
+body.light-theme .floating-memo.color-green {
+  background: #d1fae5 !important;
+  border-color: rgba(16, 185, 129, 0.3) !important;
+  color: #065f46 !important;
+}
+body.light-theme .floating-memo.color-green .floating-memo-title span,
+body.light-theme .floating-memo.color-green .floating-memo-textarea,
+body.light-theme .floating-memo.color-green .floating-memo-render {
+  color: #065f46 !important;
+}
+.floating-memo.color-blue {
+  background: rgba(59, 130, 246, 0.1) !important;
+  border-color: rgba(59, 130, 246, 0.35) !important;
+}
+body.light-theme .floating-memo.color-blue {
+  background: #dbeafe !important;
+  border-color: rgba(59, 130, 246, 0.3) !important;
+  color: #1e40af !important;
+}
+body.light-theme .floating-memo.color-blue .floating-memo-title span,
+body.light-theme .floating-memo.color-blue .floating-memo-textarea,
+body.light-theme .floating-memo.color-blue .floating-memo-render {
+  color: #1e40af !important;
+}
+.floating-memo.color-red {
+  background: rgba(244, 63, 94, 0.1) !important;
+  border-color: rgba(244, 63, 94, 0.35) !important;
+}
+body.light-theme .floating-memo.color-red {
+  background: #ffe4e6 !important;
+  border-color: rgba(244, 63, 94, 0.3) !important;
+  color: #9f1239 !important;
+}
+body.light-theme .floating-memo.color-red .floating-memo-title span,
+body.light-theme .floating-memo.color-red .floating-memo-textarea,
+body.light-theme .floating-memo.color-red .floating-memo-render {
+  color: #9f1239 !important;
+}
+
 
 


### PR DESCRIPTION
# Summary                                                                                                    
## 1. Floating 메모장 & 컬러 테마                                                                                
 - PDF 경계 외부까지 자유롭게 드래그 배치 가능                                                                        
 - 메모-문장 연결 점선의 시작점을 문장 첫 글자 기준으로 정밀 앵커링                                                   
 - 5색 컬러 피커(기본/노랑/초록/파랑/빨강) 추가 — 카드 배경·테두리·연결선 색상이 실시간 동기화됨                      
 - 메모 제목을 연결 문장 첫 20자에서 자동 추출                                                                        
                                                                                                                       
## 2. Markdown & LaTeX 렌더링                                                                                    
 - `marked` 패키지 로컬 번들링으로 Markdown 렌더링 안정화                                                             
 - 뷰 모드 전환 시 KaTeX 수식(`$ $`, `$$ $$`) 자동 렌더링 연동                                                        
                                                                                                                       
## 3. 자동 저장 & 원클릭 편집                                                                                    
 - 타이핑 즉시 LocalStorage 자동 저장 (저장 버튼 불필요)                                                              
 - 외부 클릭 시 뷰 모드로 자동 전환                                                                                   
 - 본문 영역 단일 클릭으로 즉시 편집 모드 진입                                                                        
 - 뷰 갱신 시 이벤트 리스너 중복 등록 버그 수정                                                                       
                                                                                                                       
## 4. 커스텀 Confirm 모달                                                                                        
 - 브라우저 기본 `confirm()` → 글래스모피즘 커스텀 모달로 교체                                                        
 - 누락된 `--bg-panel` CSS 토큰 정의하여 모달/메모 명암비 복구                                                        
                                                                                                                       
## 5. 문장 호버 & 툴팁 버그 수정                                                                                 
 - 문장 자동 선택 후 툴팁으로 커서 이동 시 메뉴가 닫히던 현상 수정                                                    
 - `state.hoverSelectedSentenceIdx` 추가로 동일 문장 내 마우스 이동은 툴팁 유지, 다른 문장 진입 시에만 갱신하도록 제어
  
