### PR TITLE
Feat/library history

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-Bc1ruh8V.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BEaVu7B9.css">
+  <script type="module" crossorigin src="/assets/index-GxIfiiFb.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-Bt_wyhvl.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-PkdLwhoU.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-RktzOnr2.css">
+  <script type="module" crossorigin src="/assets/index-BT1lvotj.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-Wiyxm8c5.css">
 </head>
 <body>
 
@@ -70,8 +70,8 @@
 
       <!-- 탭 영역 -->
       <div class="library-tabs-container">
-        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">보관함</button>
-        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">히스토리</button>
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
       </div>
 
       <!-- 카테고리 필터 영역 -->

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-a5xo3mrO.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-D1N2LEBl.css">
+  <script type="module" crossorigin src="/assets/index-PkdLwhoU.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-RktzOnr2.css">
 </head>
 <body>
 
@@ -66,6 +66,12 @@
         <button id="lib-upload-btn" class="file-btn" style="padding:8px 20px;font-size:13px">
           + 새 논문 추가
         </button>
+      </div>
+
+      <!-- 탭 영역 -->
+      <div class="library-tabs-container">
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">히스토리</button>
       </div>
 
       <!-- 카테고리 필터 영역 -->

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-GxIfiiFb.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Bt_wyhvl.css">
+  <script type="module" crossorigin src="/assets/index-D9si93Dl.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CZpIrRgH.css">
 </head>
 <body>
 
@@ -73,6 +73,9 @@
         <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
       </div>
+
+      <!-- 독서 통계 위젯 영역 -->
+      <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
 
       <!-- 카테고리 필터 영역 -->
       <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; align-items: center;"></div>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BT1lvotj.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Wiyxm8c5.css">
+  <script type="module" crossorigin src="/assets/index-B13Cli7s.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-B7eIL5aV.css">
 </head>
 <body>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-B13Cli7s.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-B7eIL5aV.css">
+  <script type="module" crossorigin src="/assets/index-Bc1ruh8V.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BEaVu7B9.css">
 </head>
 <body>
 
@@ -97,6 +97,14 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
+        <!-- 독서 완료 토글 버튼 -->
+        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글" style="margin-left: 8px;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+            <polyline points="22 4 12 14.01 9 11.01"></polyline>
+          </svg>
+          <span class="read-btn-text">독서 완료</span>
+        </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,6 +67,12 @@
         </button>
       </div>
 
+      <!-- 탭 영역 -->
+      <div class="library-tabs-container">
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">히스토리</button>
+      </div>
+
       <!-- 카테고리 필터 영역 -->
       <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; align-items: center;"></div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -73,6 +73,9 @@
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
       </div>
 
+      <!-- 독서 통계 위젯 영역 -->
+      <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
+
       <!-- 카테고리 필터 영역 -->
       <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; align-items: center;"></div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,8 +69,8 @@
 
       <!-- 탭 영역 -->
       <div class="library-tabs-container">
-        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">보관함</button>
-        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">히스토리</button>
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
       </div>
 
       <!-- 카테고리 필터 영역 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -96,6 +96,14 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
+        <!-- 독서 완료 토글 버튼 -->
+        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글" style="margin-left: 8px;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+            <polyline points="22 4 12 14.01 9 11.01"></polyline>
+          </svg>
+          <span class="read-btn-text">독서 완료</span>
+        </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         </button>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -110,6 +110,7 @@ const libraryCategoryFilters = $('library-category-filters')
 const libraryCountBadge = $('library-count-badge')
 const libTabArchive     = $('lib-tab-archive')
 const libTabHistory     = $('lib-tab-history')
+const libraryStatsContainer = $('library-stats-container')
 
 // Google Drive Style Upload Popup references
 const uploadPopup        = $('upload-popup')
@@ -1979,20 +1980,23 @@ async function renderLibrary() {
         return rDate.getFullYear() === thisYear && rDate.getMonth() === thisMonth
       }).length
       
-      const statsWidget = document.createElement('div')
-      statsWidget.className = 'library-stats-widget'
-      statsWidget.innerHTML = `
-        <div class="library-stats-item">
-          <span class="library-stats-label">📅 이번 달 읽은 논문</span>
-          <span class="library-stats-value">${thisMonthCount}<span>편</span></span>
-        </div>
-        <div style="width: 1px; height: 28px; background: var(--border-strong);"></div>
-        <div class="library-stats-item">
-          <span class="library-stats-label">🏆 누적 완독 논문</span>
-          <span class="library-stats-value">${readDocs.length}<span>편</span></span>
+      libraryStatsContainer.innerHTML = `
+        <div class="library-stats-widget">
+          <div class="library-stats-item">
+            <span class="library-stats-label">📅 이번 달 읽은 논문</span>
+            <span class="library-stats-value">${thisMonthCount}<span>편</span></span>
+          </div>
+          <div style="width: 1px; height: 28px; background: var(--border-strong);"></div>
+          <div class="library-stats-item">
+            <span class="library-stats-label">🏆 누적 완독 논문</span>
+            <span class="library-stats-value">${readDocs.length}<span>편</span></span>
+          </div>
         </div>
       `
-      libraryGrid.appendChild(statsWidget)
+      libraryStatsContainer.classList.remove('hidden')
+    } else {
+      libraryStatsContainer.classList.add('hidden')
+      libraryStatsContainer.innerHTML = ''
     }
 
     if (docs.length === 0) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -23,6 +23,8 @@ window.fetch = async function (...args) {
 // ── 상태 ──────────────────────────────────────────
 const state = {
   currentLibraryTab: 'archive', // 'archive' (보관함) 또는 'history' (히스토리)
+  currentDocId: null,
+  currentDocMetadata: {},
   sessionId: null,
   filename: null,
   title: null,
@@ -135,6 +137,7 @@ const resumeTransBtn    = $('resume-trans-btn')
 // (viewer/chat pickers are now ProviderModelPicker instances – see below)
 const backBtn           = $('back-btn')
 const logoBtn           = $('logo-btn')
+const viewerReadToggleBtn = $('viewer-read-toggle-btn')
 const viewerScrollContainer = $('viewer-scroll-container')
 const translateSpinner      = $('translate-spinner')
 const translateStatusText   = $('translate-status-text')
@@ -883,6 +886,32 @@ backBtn.addEventListener('click', () => {
 if (logoBtn) {
   logoBtn.addEventListener('click', () => {
     showLibraryScreen()
+  })
+}
+
+// ── 뷰어 내 독서 완료 토글 버튼 바인딩 ──
+if (viewerReadToggleBtn) {
+  viewerReadToggleBtn.addEventListener('click', async () => {
+    if (!state.currentDocId) return
+    const currentReadState = state.currentDocMetadata.read === true
+    const nextReadState = !currentReadState
+    const payload = { read: nextReadState }
+    if (nextReadState) {
+      payload.read_at = new Date().toISOString()
+    } else {
+      payload.read_at = null
+    }
+    
+    try {
+      await updateLibraryDocMetadata(state.currentDocId, payload)
+      state.currentDocMetadata.read = nextReadState
+      state.currentDocMetadata.read_at = payload.read_at
+      viewerReadToggleBtn.classList.toggle('active', nextReadState)
+      showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
+      await loadLibraryCount()
+    } catch (err) {
+      showToast('상태 변경 실패: ' + err.message, 'error')
+    }
   })
 }
 
@@ -1937,6 +1966,35 @@ async function renderLibrary() {
       return state.currentLibraryTab === 'history' ? isRead : !isRead
     })
 
+    // 히스토리 탭인 경우 상단에 독서 현황 통계 요약 카드 렌더링
+    if (state.currentLibraryTab === 'history') {
+      const now = new Date()
+      const thisYear = now.getFullYear()
+      const thisMonth = now.getMonth()
+      
+      const readDocs = allDocs.filter(d => d.metadata?.read === true)
+      const thisMonthCount = readDocs.filter(d => {
+        if (!d.metadata?.read_at) return false
+        const rDate = new Date(d.metadata.read_at)
+        return rDate.getFullYear() === thisYear && rDate.getMonth() === thisMonth
+      }).length
+      
+      const statsWidget = document.createElement('div')
+      statsWidget.className = 'library-stats-widget'
+      statsWidget.innerHTML = `
+        <div class="library-stats-item">
+          <span class="library-stats-label">📅 이번 달 읽은 논문</span>
+          <span class="library-stats-value">${thisMonthCount}<span>편</span></span>
+        </div>
+        <div style="width: 1px; height: 28px; background: var(--border-strong);"></div>
+        <div class="library-stats-item">
+          <span class="library-stats-label">🏆 누적 완독 논문</span>
+          <span class="library-stats-value">${readDocs.length}<span>편</span></span>
+        </div>
+      `
+      libraryGrid.appendChild(statsWidget)
+    }
+
     if (docs.length === 0) {
       libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'history')); return
     }
@@ -2037,6 +2095,12 @@ function createDocCard(doc) {
   const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
   const isRead = doc.metadata?.read === true
 
+  let dateHtml = `<span>📅 등록: ${date}</span>`
+  if (isRead && doc.metadata?.read_at) {
+    const readDateStr = new Date(doc.metadata.read_at).toLocaleDateString('ko-KR', { year:'numeric', month:'short', day:'numeric' })
+    dateHtml = `<span>✅ 완독: ${readDateStr}</span>`
+  }
+
   const checkBtnHtml = `
     <button class="doc-card-check-btn ${isRead ? 'checked' : ''}" data-id="${doc.id}" title="${isRead ? '읽지 않음으로 표시' : '읽음으로 표시'}">
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -2053,7 +2117,7 @@ function createDocCard(doc) {
     <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(displayTitle)}</div>
     ${tagsHtml}
     <div class="doc-card-meta">
-      <span>📅 ${date}</span><span>📑 ${total}페이지</span>
+      ${dateHtml}<span>📑 ${total}페이지</span>
     </div>
     <div class="doc-card-progress">
       <div class="doc-progress-bar-wrap"><div class="doc-progress-bar" style="width:${pct}%"></div></div>
@@ -2079,8 +2143,15 @@ function createDocCard(doc) {
     e.stopPropagation()
     const currentReadState = doc.metadata?.read === true
     const nextReadState = !currentReadState
+    const payload = { read: nextReadState }
+    if (nextReadState) {
+      payload.read_at = new Date().toISOString()
+    } else {
+      payload.read_at = null
+    }
+    
     try {
-      await updateLibraryDocMetadata(doc.id, { read: nextReadState })
+      await updateLibraryDocMetadata(doc.id, payload)
       showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
       await renderLibrary()
       await loadLibraryCount()
@@ -2189,6 +2260,13 @@ async function openFromLibrary(doc, shouldPushState = true) {
   state.sessionId  = doc.id
   loadDocumentImages(doc.id)
   state.filename   = doc.filename
+  state.currentDocId = doc.id
+  state.currentDocMetadata = doc.metadata || {}
+  
+  if (viewerReadToggleBtn) {
+    const isRead = state.currentDocMetadata.read === true
+    viewerReadToggleBtn.classList.toggle('active', isRead)
+  }
   const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
   state.title      = displayTitle
   state.totalPages = doc.total_pages

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -22,6 +22,7 @@ window.fetch = async function (...args) {
 
 // ── 상태 ──────────────────────────────────────────
 const state = {
+  currentLibraryTab: 'archive', // 'archive' (보관함) 또는 'history' (히스토리)
   sessionId: null,
   filename: null,
   title: null,
@@ -105,6 +106,8 @@ const libUploadBtn      = $('lib-upload-btn')
 const libraryGrid       = $('library-grid')
 const libraryCategoryFilters = $('library-category-filters')
 const libraryCountBadge = $('library-count-badge')
+const libTabArchive     = $('lib-tab-archive')
+const libTabHistory     = $('lib-tab-history')
 
 // Google Drive Style Upload Popup references
 const uploadPopup        = $('upload-popup')
@@ -1861,12 +1864,35 @@ setInterval(checkAIStatus, 30000)
 async function loadLibraryCount() {
   try {
     const data = await fetchLibrary(getTranslationOptions())
-    const count = data.total || 0
-    if (count > 0 && libraryCountBadge) {
-      libraryCountBadge.textContent = count
+    const docs = data.documents || []
+    const unreadCount = docs.filter(doc => doc.metadata?.read !== true).length
+    if (unreadCount > 0 && libraryCountBadge) {
+      libraryCountBadge.textContent = unreadCount
       libraryCountBadge.classList.remove('hidden')
+    } else if (libraryCountBadge) {
+      libraryCountBadge.classList.add('hidden')
     }
   } catch {}
+}
+
+// 탭 클릭 이벤트 리스너 등록
+if (libTabArchive && libTabHistory) {
+  libTabArchive.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'archive') return
+    state.currentLibraryTab = 'archive'
+    libTabArchive.classList.add('active')
+    libTabHistory.classList.remove('active')
+    activeCategoryFilter = 'ALL'
+    renderLibrary()
+  })
+  libTabHistory.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'history') return
+    state.currentLibraryTab = 'history'
+    libTabHistory.classList.add('active')
+    libTabArchive.classList.remove('active')
+    activeCategoryFilter = 'ALL'
+    renderLibrary()
+  })
 }
 
 async function showLibraryScreen(shouldPushState = true) {
@@ -1894,19 +1920,25 @@ async function renderLibrary() {
   libraryCategoryFilters.innerHTML = ''
   try {
     const data = await fetchLibrary(getTranslationOptions())
-    const docs = data.documents || []
-    if (docs.length > 0) {
-      if (libraryCountBadge) {
-        libraryCountBadge.textContent = docs.length
-        libraryCountBadge.classList.remove('hidden')
-      }
-    } else {
-      if (libraryCountBadge) {
-        libraryCountBadge.classList.add('hidden')
-      }
+    const allDocs = data.documents || []
+
+    // 보관함 뱃지에는 안읽은 논문 개수 표시
+    const unreadCount = allDocs.filter(doc => doc.metadata?.read !== true).length
+    if (unreadCount > 0 && libraryCountBadge) {
+      libraryCountBadge.textContent = unreadCount
+      libraryCountBadge.classList.remove('hidden')
+    } else if (libraryCountBadge) {
+      libraryCountBadge.classList.add('hidden')
     }
+
+    // 현재 선택된 탭에 따라 논문 목록 필터링
+    const docs = allDocs.filter(doc => {
+      const isRead = doc.metadata?.read === true
+      return state.currentLibraryTab === 'history' ? isRead : !isRead
+    })
+
     if (docs.length === 0) {
-      libraryGrid.appendChild(createEmptyState()); return
+      libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'history')); return
     }
 
     // Extract unique categories
@@ -1966,18 +1998,24 @@ function filterLibraryCards(docs) {
     : docs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
 
   if (filteredDocs.length === 0) {
-    libraryGrid.appendChild(createEmptyState()); return
+    libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'history')); return
   }
 
   filteredDocs.forEach(doc => libraryGrid.appendChild(createDocCard(doc)))
 }
 
-function createEmptyState() {
+function createEmptyState(isHistory = false) {
   const el = document.createElement('div')
   el.className = 'lib-empty'
-  el.innerHTML = `<div style="font-size:48px;margin-bottom:16px">📚</div>
-    <p>저장된 논문이 없습니다</p>
-    <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>`
+  if (isHistory) {
+    el.innerHTML = `<div style="font-size:48px;margin-bottom:16px">📖</div>
+      <p>읽은 논문이 없습니다</p>
+      <p style="font-size:13px;color:var(--text-muted);margin-top:8px">보관함에서 논문의 체크 아이콘을 눌러 읽음 처리해 보세요</p>`
+  } else {
+    el.innerHTML = `<div style="font-size:48px;margin-bottom:16px">📚</div>
+      <p>보관함에 저장된 논문이 없습니다</p>
+      <p style="font-size:13px;color:var(--text-muted);margin-top:8px">새 논문을 추가하거나 PDF를 업로드해 보세요</p>`
+  }
   return el
 }
 
@@ -1997,10 +2035,20 @@ function createDocCard(doc) {
   }
 
   const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  const isRead = doc.metadata?.read === true
+
+  const checkBtnHtml = `
+    <button class="doc-card-check-btn ${isRead ? 'checked' : ''}" data-id="${doc.id}" title="${isRead ? '읽지 않음으로 표시' : '읽음으로 표시'}">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="20 6 9 17 4 12"></polyline>
+      </svg>
+    </button>
+  `
 
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.innerHTML = `
+    ${checkBtnHtml}
     <div class="doc-card-icon">📄</div>
     <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(displayTitle)}</div>
     ${tagsHtml}
@@ -2026,6 +2074,20 @@ function createDocCard(doc) {
         </svg>
       </button>
     </div>`
+
+  card.querySelector('.doc-card-check-btn').addEventListener('click', async (e) => {
+    e.stopPropagation()
+    const currentReadState = doc.metadata?.read === true
+    const nextReadState = !currentReadState
+    try {
+      await updateLibraryDocMetadata(doc.id, { read: nextReadState })
+      showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
+      await renderLibrary()
+      await loadLibraryCount()
+    } catch (err) {
+      showToast('상태 변경 실패: ' + err.message, 'error')
+    }
+  })
 
   card.querySelector('.doc-open-btn').addEventListener('click', (e) => { e.stopPropagation(); openFromLibrary(doc) })
   card.querySelector('.doc-delete-btn').addEventListener('click', async (e) => {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3604,16 +3604,13 @@ body.light-theme .doc-card-check-btn.checked {
 
 /* ── Library Statistics Widget ── */
 .library-stats-widget {
-  grid-column: 1 / -1;
-  justify-self: start;
+  display: inline-flex;
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
   padding: 12px 24px;
-  display: flex;
   gap: 40px;
   align-items: center;
-  margin-bottom: 8px;
   box-shadow: var(--shadow-sm);
   backdrop-filter: blur(20px);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3515,5 +3515,77 @@ body.light-theme .floating-memo.color-red .floating-memo-render {
   color: #9f1239 !important;
 }
 
+/* ── Library Tab Styles ── */
+.library-tabs-container {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 2px;
+}
+.library-tab-btn {
+  background: none;
+  border: none;
+  padding: 8px 18px;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s ease;
+  font-family: var(--font-sans);
+  position: relative;
+}
+.library-tab-btn:hover {
+  color: var(--text-primary);
+}
+.library-tab-btn.active {
+  color: var(--accent-mid);
+  border-bottom-color: var(--accent-mid);
+  font-weight: 600;
+}
+
+/* ── Checkbox/Read Mark button style on doc-card ── */
+.doc-card-check-btn {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1.5px solid var(--border-strong);
+  background: var(--bg-elevated);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+.doc-card-check-btn svg {
+  opacity: 0;
+  transform: scale(0.6);
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  color: var(--accent-mid);
+}
+.doc-card-check-btn:hover {
+  border-color: var(--accent-mid);
+  background: var(--bg-hover);
+}
+.doc-card-check-btn:hover svg {
+  opacity: 0.5;
+  transform: scale(1);
+}
+.doc-card-check-btn.checked {
+  background: rgba(139, 92, 246, 0.15);
+  border-color: var(--accent-mid);
+}
+.doc-card-check-btn.checked svg {
+  opacity: 1;
+  transform: scale(1);
+  color: var(--accent-mid);
+}
+
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3605,10 +3605,11 @@ body.light-theme .doc-card-check-btn.checked {
 /* ── Library Statistics Widget ── */
 .library-stats-widget {
   grid-column: 1 / -1;
+  justify-self: start;
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
-  padding: 16px 24px;
+  padding: 12px 24px;
   display: flex;
   gap: 40px;
   align-items: center;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3515,76 +3515,90 @@ body.light-theme .floating-memo.color-red .floating-memo-render {
   color: #9f1239 !important;
 }
 
-/* ── Library Tab Styles ── */
+/* ── Library Tab Styles (Pill Capsule Layout) ── */
 .library-tabs-container {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 20px;
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 2px;
+  display: inline-flex;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  padding: 4px;
+  gap: 4px;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-sm);
 }
 .library-tab-btn {
   background: none;
   border: none;
-  padding: 8px 18px;
-  color: var(--text-muted);
-  font-size: 14px;
-  font-weight: 500;
+  padding: 6px 18px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: all 0.15s ease;
+  border-radius: 20px;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   font-family: var(--font-sans);
-  position: relative;
 }
 .library-tab-btn:hover {
   color: var(--text-primary);
+  background: var(--bg-hover);
 }
 .library-tab-btn.active {
-  color: var(--accent-mid);
-  border-bottom-color: var(--accent-mid);
-  font-weight: 600;
+  color: #fff !important;
+  background: var(--accent-mid);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+body.light-theme .library-tab-btn.active {
+  color: #fff !important;
 }
 
-/* ── Checkbox/Read Mark button style on doc-card ── */
+/* ── Custom Checked Badge on Document Card ── */
 .doc-card-check-btn {
   position: absolute;
-  top: 20px;
-  right: 20px;
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
-  border: 1.5px solid var(--border-strong);
-  background: var(--bg-elevated);
+  top: 18px;
+  right: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   padding: 0;
-  transition: all 0.2s ease;
+  transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
   z-index: 10;
+  color: var(--text-muted);
 }
 .doc-card-check-btn svg {
   opacity: 0;
-  transform: scale(0.6);
+  transform: scale(0.5);
   transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  color: var(--accent-mid);
 }
 .doc-card-check-btn:hover {
   border-color: var(--accent-mid);
-  background: var(--bg-hover);
+  background: rgba(139, 92, 246, 0.05);
+  color: var(--accent-mid);
+  transform: scale(1.05);
 }
 .doc-card-check-btn:hover svg {
-  opacity: 0.5;
+  opacity: 0.6;
   transform: scale(1);
 }
 .doc-card-check-btn.checked {
-  background: rgba(139, 92, 246, 0.15);
-  border-color: var(--accent-mid);
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #10b981;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.15);
 }
 .doc-card-check-btn.checked svg {
   opacity: 1;
   transform: scale(1);
-  color: var(--accent-mid);
+}
+body.light-theme .doc-card-check-btn.checked {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.5);
+  color: #059669;
 }
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3602,5 +3602,89 @@ body.light-theme .doc-card-check-btn.checked {
   color: #059669;
 }
 
+/* ── Library Statistics Widget ── */
+.library-stats-widget {
+  grid-column: 1 / -1;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 16px 24px;
+  display: flex;
+  gap: 40px;
+  align-items: center;
+  margin-bottom: 8px;
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(20px);
+}
+.library-stats-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.library-stats-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.library-stats-value {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.library-stats-value span {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* ── Viewer Topbar "독서 완료" Toggle Button ── */
+.viewer-read-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 15px;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  font-family: var(--font-sans);
+}
+.viewer-read-btn svg {
+  color: var(--text-muted);
+  transition: color 0.2s;
+}
+.viewer-read-btn:hover {
+  border-color: var(--accent-mid);
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.viewer-read-btn.active {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #10b981;
+}
+.viewer-read-btn.active svg {
+  color: #10b981;
+}
+body.light-theme .viewer-read-btn.active {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.45);
+  color: #059669;
+}
+body.light-theme .viewer-read-btn.active svg {
+  color: #059669;
+}
+
 
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3518,6 +3518,7 @@ body.light-theme .floating-memo.color-red .floating-memo-render {
 /* ── Library Tab Styles (Pill Capsule Layout) ── */
 .library-tabs-container {
   display: inline-flex;
+  align-self: flex-start;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 30px;


### PR DESCRIPTION
# Summary
## Library History 
- 보관함(📥) / 히스토리(✅) 탭 분리:
  - 캡슐 컨트롤러 배치 및 각 탭 소속 논문에 맞춰 카테고리 태그 동적 격리 필터링 적용.
- 완독 타임스탬프( read_at ) 도입:
  - 읽음 체크 완료 시점 기록 및 SQLite DB 메타데이터에 연동.
  - 히스토리 탭 내 카드는  ✅ 완독: YYYY.MM.DD  형태로 일자 레이아웃 자동 전환.
- 독서 현황 통계 요약 카드(캡슐형) 추가:
  - 이번 달 읽은 논문 수 및 누적 완독 수 요약 시각화.
  - 필터 갱신 및 빈 그리드 전환 시 삭제되는 버그를 고치기 위해 독립 컨테이너로 완전 격리 및 크기 피팅 최적화.
- 뷰어 상세 내  독서 완료  버튼 신설:
  - 상세 뷰어 상단 바(Topbar) 좌측에 원클릭 체크 토글 버튼 주입.
  - 뷰어를 끄지 않고 상태 즉시 반영 및 라이브러리 미독 배지 카운트와 양방향 동기화.
