### PR TITLE
Feat/claude streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,5 +155,37 @@ Linux 서버에서 `easypaper.service` 데몬을 통해 실행할 경우, system
 
 > **Antigravity를 사용하지 않는 경우:** `.env` 파일에서 `TRANS_PROVIDER`와 `CHAT_PROVIDER`를 `ollama`로 설정하거나, Gemini·OpenAI·Claude API 키를 등록하여 사용하세요.
 
+---
 
+## 🤖 Claude Code CLI (`claude`) 연동 가이드
 
+EasyPaper는 Anthropic의 Claude Code CLI(`claude`)를 서브프로세스로 연동하여 실시간 논문 번역 및 AI 어시스턴트(채팅), 그리고 자동 카테고리 태깅 엔진으로 사용할 수 있는 `claude_code` LLM Provider를 지원합니다.
+
+`claude_code`를 사용하여 우수한 한국어 번역 결과와 뛰어난 논문 분석 기능을 경험해 보세요.
+
+### 1. `claude` CLI 설치 확인
+서버 환경에 Claude Code CLI가 설치되어 있어야 합니다.
+- EasyPaper는 기본적으로 `/home/ubuntu/.local/bin/claude` 경로를 먼저 확인합니다.
+- 해당 경로에 없으면 시스템 `PATH`에서 `claude`를 찾아 실행합니다.
+- 환경변수 `CLAUDE_CODE_PATH`를 통해 커스텀 설치 경로를 수동 지정할 수도 있습니다.
+
+### 2. Anthropic 계정 인증
+Claude Code CLI는 EasyPaper 서버를 실행하는 OS 사용자 계정에서 미리 로그인이 완료되어 있어야 합니다.
+
+```bash
+# 최초 1회 로그인을 수행합니다 (인증 창이 열립니다)
+claude auth
+```
+
+인증이 성공적으로 완료되었는지 확인하려면 다음 명령어를 터미널에서 실행하여 정상 작동하는지 점검하세요:
+```bash
+/home/ubuntu/.local/bin/claude --version
+```
+
+### 3. 무인 자동 실행 및 권한 정책
+EasyPaper는 논문 번역 및 채팅 요청을 백그라운드에서 실시간으로 스트리밍하기 위해 `--permission-mode dontAsk` 플래그를 사용합니다. 이를 통해 대화형 동의 확인 절차를 건너뛰고 비대화식(`--print`) 출력을 바로 수집합니다.
+
+### 4. 동적 드롭다운 표시
+EasyPaper는 기동 시 로컬 환경에 `claude` 실행 파일이 유효하게 설치되어 있고 실행 가능한지 백엔드에서 자체 진단합니다.
+- 설치가 확인되면 라이브러리 및 뷰어 화면의 모델 선택 드롭다운에 **`🤖 Claude Code`** 공급자 그룹과 관련 모델(`Sonnet`, `Fable`, `Opus`, `Haiku`)이 자동으로 활성화되어 나타납니다.
+- 설치되어 있지 않다면 드롭다운 목록에 노출되지 않아 잘못된 선택으로 인한 오류를 예방합니다.

--- a/backend/config.py
+++ b/backend/config.py
@@ -178,6 +178,7 @@ APP_PORT = int(os.getenv("APP_PORT", "8000"))
 
 # Antigravity CLI path
 AGY_PATH = os.getenv("AGY_PATH", "/home/ubuntu/.local/bin/agy")
+CLAUDE_CODE_PATH = os.getenv("CLAUDE_CODE_PATH", "/home/ubuntu/.local/bin/claude")
 
 def get_app_host() -> str:
     return APP_HOST
@@ -187,6 +188,9 @@ def get_app_port() -> int:
 
 def get_agy_path() -> str:
     return AGY_PATH
+
+def get_claude_code_path() -> str:
+    return CLAUDE_CODE_PATH
 
 def get_agy_env() -> dict:
     env = os.environ.copy()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -175,7 +175,7 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
     trans_provider = data.trans_provider.strip().lower()
     chat_provider = data.chat_provider.strip().lower()
     
-    if trans_provider not in ["ollama", "openai", "gemini", "claude", "antigravity"] or chat_provider not in ["ollama", "openai", "gemini", "claude", "antigravity"]:
+    if trans_provider not in ["ollama", "openai", "gemini", "claude", "antigravity", "claude_code"] or chat_provider not in ["ollama", "openai", "gemini", "claude", "antigravity", "claude_code"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="올바르지 않은 AI 제공업체입니다."

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -185,6 +185,27 @@ async def health_check():
     return health
 
 
+@router.get("/availability")
+async def get_providers_availability():
+    """각 제공자(CLI)가 로컬에 설치되어 사용 가능한지 여부를 확인합니다."""
+    import os
+    import shutil
+    from config import get_agy_path, get_claude_code_path
+    
+    # 1. antigravity (agy)
+    agy_path = get_agy_path()
+    has_agy = bool(os.path.exists(agy_path) or shutil.which(agy_path))
+    
+    # 2. claude_code (claude)
+    claude_path = get_claude_code_path()
+    has_claude_code = bool(os.path.exists(claude_path) or shutil.which(claude_path))
+    
+    return {
+        "antigravity": has_agy,
+        "claude_code": has_claude_code
+    }
+
+
 @router.get("/translation-status/{session_id}")
 async def translation_status(session_id: str):
     """세션의 번역 완료 페이지 목록을 반환합니다."""

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -172,6 +172,13 @@ async def health_check():
         agy_path = get_agy_path()
         has_cli = bool(os.path.exists(agy_path) or shutil.which(agy_path))
         return {"status": "ok" if has_cli else "error", "provider": "antigravity", "model_available": has_cli}
+    elif provider == "claude_code":
+        import os
+        import shutil
+        from config import get_claude_code_path
+        claude_path = get_claude_code_path()
+        has_cli = bool(os.path.exists(claude_path) or shutil.which(claude_path))
+        return {"status": "ok" if has_cli else "error", "provider": "claude_code", "model_available": has_cli}
         
     health = await check_ollama_health()
     health["provider"] = "ollama"

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -558,7 +558,7 @@ async def stream_claude_code(prompt: str, model: str = None) -> AsyncGenerator[s
         claude_path = "claude"
         
     cmd = [claude_path, "--permission-mode", "dontAsk"]
-    if model and model.strip() and model.strip().lower() != "custom":
+    if model and model.strip() and model.strip().lower() not in ["custom", "default"]:
         cmd.extend(["--model", model.strip()])
 
     guided_prompt = (

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -12,6 +12,7 @@ from config import (
     get_claude_api_key,
     get_agy_path,
     get_agy_env,
+    get_claude_code_path,
     get_translation_prompt_template
 )
 
@@ -120,6 +121,10 @@ async def stream_translation(
         return
     elif provider == "antigravity":
         async for token in stream_antigravity(prompt, model=model):
+            yield token
+        return
+    elif provider == "claude_code":
+        async for token in stream_claude_code(prompt, model=model):
             yield token
         return
 
@@ -447,6 +452,25 @@ async def stream_chat(
         async for token in stream_antigravity(chat_prompt, model=model):
             yield token
         return
+    elif provider == "claude_code":
+        try:
+            from services.usage_tracker import record_call
+            record_call("chat")
+        except Exception:
+            pass
+        formatted_prompt = []
+        formatted_prompt.append(f"System instructions:\n{system_prompt}\n")
+        formatted_prompt.append("Conversation history:")
+        for msg in history_messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            role_label = "User" if role == "user" else "Assistant"
+            formatted_prompt.append(f"[{role_label}]: {content}")
+        
+        chat_prompt = "\n".join(formatted_prompt)
+        async for token in stream_claude_code(chat_prompt, model=model):
+            yield token
+        return
 
     # Fallback to Ollama:
     payload = {
@@ -523,6 +547,66 @@ async def check_ollama_health() -> dict:
             }
     except Exception as e:
         return {"status": "error", "detail": str(e), "model_available": False}
+
+
+async def stream_claude_code(prompt: str, model: str = None) -> AsyncGenerator[str, None]:
+    import asyncio
+    import os
+    
+    claude_path = get_claude_code_path()
+    if not os.path.exists(claude_path):
+        claude_path = "claude"
+        
+    cmd = [claude_path, "--permission-mode", "dontAsk"]
+    if model and model.strip() and model.strip().lower() != "custom":
+        cmd.extend(["--model", model.strip()])
+
+    guided_prompt = (
+        "You are a direct-output assistant. "
+        "Output ONLY the result — no preambles, no explanations, no 'Here is the translation', "
+        "no markdown code fences around the entire output, no commentary at the start or end. "
+        "Start the output immediately with the translated/answered content.\n\n"
+        f"{prompt}"
+    )
+
+    try:
+        from services.usage_tracker import record_call
+        record_call("translate")
+    except Exception:
+        pass
+
+    cmd.extend(["--print", guided_prompt])
+    
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=get_agy_env()
+        )
+        
+        import codecs
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        
+        while True:
+            chunk = await process.stdout.read(1024)
+            if not chunk:
+                break
+            decoded = decoder.decode(chunk)
+            if decoded:
+                yield decoded
+        
+        final_decoded = decoder.decode(b"", final=True)
+        if final_decoded:
+            yield final_decoded
+            
+        await process.wait()
+        
+        if process.returncode and process.returncode != 0:
+            stderr_out = await process.stderr.read()
+            print(f"[Claude Code CLI Error] code={process.returncode} stderr={stderr_out.decode('utf-8', errors='replace')}")
+    except Exception as e:
+        print(f"[Claude Code CLI Exec Error] {e}")
 
 
 async def stream_antigravity(prompt: str, model: str = None) -> AsyncGenerator[str, None]:
@@ -620,6 +704,9 @@ Category Tags:"""
                 tokens.append(token)
         elif provider == "antigravity":
             async for token in stream_antigravity(prompt, model=model):
+                tokens.append(token)
+        elif provider == "claude_code":
+            async for token in stream_claude_code(prompt, model=model):
                 tokens.append(token)
         else:
             # Fallback to Ollama chat api

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BSDPK7Pk.js"></script>
+  <script type="module" crossorigin src="/assets/index-CGa6lgkj.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DjMvEv7c.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-BNjLbxug.js"></script>
+  <script type="module" crossorigin src="/assets/index-BSDPK7Pk.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DjMvEv7c.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
-  <script type="module" crossorigin src="/assets/index-CGa6lgkj.js"></script>
+  <script type="module" crossorigin src="/assets/index-BkNHcWY-.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DjMvEv7c.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -40,6 +40,12 @@ export async function checkHealth() {
   return res.json()
 }
 
+export async function fetchCliAvailability() {
+  const res = await fetch(`${API_BASE}/translate/availability`)
+  if (!res.ok) throw new Error('CLI 상태 조회 실패')
+  return res.json()
+}
+
 export async function getSession(sessionId) {
   const res = await fetch(`${API_BASE}/session/${sessionId}`)
   if (!res.ok) throw new Error('세션 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1091,12 +1091,13 @@ const PROVIDER_CONFIG = [
     ]
   },
   {
-    id: 'claude_code', label: 'Claude Code (CLI)', icon: '🤖',
+    id: 'claude_code', label: 'Claude Code', icon: '🤖',
     models: [
-      { value: 'sonnet', label: 'Claude 3.5 Sonnet (추천)' },
-      { value: 'haiku',  label: 'Claude 3.5 Haiku' },
-      { value: 'opus',   label: 'Claude 3 Opus' },
-      { value: 'fable',  label: 'Claude Fable 5' }
+      { value: 'default', label: 'Default (추천) · Sonnet 5' },
+      { value: 'sonnet',  label: 'Sonnet · Sonnet 5' },
+      { value: 'fable',   label: 'Fable · Fable 5' },
+      { value: 'opus',    label: 'Opus · Opus 4.8' },
+      { value: 'haiku',   label: 'Haiku · Haiku 4.5' }
     ]
   },
   {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1091,6 +1091,15 @@ const PROVIDER_CONFIG = [
     ]
   },
   {
+    id: 'claude_code', label: 'Claude Code (CLI)', icon: '🤖',
+    models: [
+      { value: 'sonnet', label: 'Claude 3.5 Sonnet (추천)' },
+      { value: 'haiku',  label: 'Claude 3.5 Haiku' },
+      { value: 'opus',   label: 'Claude 3 Opus' },
+      { value: 'fable',  label: 'Claude Fable 5' }
+    ]
+  },
+  {
     id: 'ollama', label: 'Ollama (로컬)', icon: '🦙',
     models: [
       { value: 'gemma4:e4b', label: 'gemma4 e4b' },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, getAgyUsageAPI, cancelJobAPI, fetchCliAvailability } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation } from './library.js'
 
@@ -52,6 +52,7 @@ const state = {
   isCropMode: false,           // 영역 캡처 모드 여부
   pdfPageSentences: {},        // pageNum → sentenceRanges 보관용
   pdfPageElements: {},         // pageNum → elRanges 보관용
+  cliAvailability: { antigravity: true, claude_code: true }
 }
 
 // ── DOM 참조 ──────────────────────────────────────
@@ -1200,7 +1201,11 @@ class ProviderModelPicker {
       return instClean === baseClean
     }
     
-    let config = PROVIDER_CONFIG.map(p => {
+    let config = PROVIDER_CONFIG.filter(p => {
+      if (p.id === 'antigravity') return state.cliAvailability?.antigravity !== false
+      if (p.id === 'claude_code') return state.cliAvailability?.claude_code !== false
+      return true
+    }).map(p => {
       if (p.id === 'ollama') {
         const baseModels = p.models
         if (this.compact) {
@@ -1562,8 +1567,14 @@ async function refreshSystemSettings() {
     if (promptTemplate) {
       promptTemplate.value = sys.translation_prompt_template || promptTemplate.value
     }
-    
     updateSettingsUIVisibility()
+    
+    try {
+      const avail = await fetchCliAvailability()
+      state.cliAvailability = avail
+    } catch (e) {
+      console.warn('CLI availability load error:', e)
+    }
     
   } catch (err) {
     console.warn('System settings load error:', err)


### PR DESCRIPTION
 # Summary
Anthropic의 **Claude Code CLI( claude )**를 로컬 서브프로세스로 연결하여 실시간 번역, AI 채팅(어시스턴트), 카테고리 태깅 엔진으로 사용할 수 있는  claude_code  LLM Provider 구현.

## 주요 변경 사항  
- 비동기 스트리밍 연동 ( stream_claude_code ):
  - asyncio.create_subprocess_exec 을 통해 로컬  claude  CLI의 표준 출력을 실시간 스트리밍으로 연동.
  - 무인/비대화식 실행 제어 옵션( --permission-mode dontAsk --print ) 적용.
  - 논문 번역, AI 어시스턴트(채팅), 논문 분류 엔진에  claude_code  핸들러 주입 완료.
- 로컬 설치 상태 진단 및 동적 드롭다운 여과:
  - 백엔드에  /api/translate/availability  엔드포인트를 신설하여 CLI 프로그램의 로컬 실제 유무 확인.
  - CLI가 서버에 설치되지 않은 경우, 모델 선택 드롭다운 목록에서 공급자( Claude Code )를 자동으로 보이지 않게 처리해 오동작 차단.
  - 드롭다운에서 불필요한  Default  옵션을 삭제하고 명시적인 4대 에일리어스( Sonnet ,  Fable ,  Opus ,  Haiku )만 단정하게 표기.
- 설치 및 구동 가이드 작성:
  - README.md 에 Claude Code CLI 필수 설치 검증,  claude auth  1회성 웹 로그인 인증 방법, 백그라운드 환경 변수 유의 사항 추가 작성.