### PR TITLE
Fix/chat session split

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -70,7 +70,7 @@ async def chat_stream(data: ChatRequest):
         yield " "
         full_response = []
         try:
-            async for token in stream_chat(system_prompt, history_messages):
+            async for token in stream_chat(system_prompt, history_messages, session_id=session_id):
                 full_response.append(token)
                 yield token
             

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -110,7 +110,8 @@ async def translate_page(
                     ignore_table=ignore_table,
                     ignore_refs=ignore_refs,
                     doc_title=doc_title,
-                    prev_context=prev_context
+                    prev_context=prev_context,
+                    session_id=session_id
                 ):
                     chunk_result.append(token)
                     data = json.dumps({"content": token, "done": False, "cached": False}, ensure_ascii=False)

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -175,6 +175,10 @@ async def delete_session(session_id: str):
 
     session = sessions.pop(session_id)
     session_dir = os.path.dirname(session["pdf_path"])
+    
+    from services.library import delete_chat_sessions
+    delete_chat_sessions(session_id)
+    
     shutil.rmtree(session_dir, ignore_errors=True)
 
     from services.cache import clear_session_cache

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -138,13 +138,48 @@ def list_documents(
     return docs
 
 
+def delete_chat_sessions(doc_id: str) -> None:
+    """논문 삭제 시 연동된 Claude Code 및 Antigravity 채팅 세션을 삭제합니다."""
+    # 1. Claude Code 세션 캐시 디렉터리 삭제
+    cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cache")
+    claude_home = os.path.join(cache_dir, f"claude_home_{doc_id}")
+    if os.path.exists(claude_home):
+        try:
+            shutil.rmtree(claude_home, ignore_errors=True)
+            print(f"[delete_chat_sessions] Deleted Claude Code session directory: {claude_home}")
+        except Exception as e:
+            print(f"[delete_chat_sessions Claude Code Error] {e}")
+
+    # 2. Antigravity 세션 삭제
+    conv_txt_path = os.path.join(LIBRARY_DIR, doc_id, "conversation_id.txt")
+    if os.path.exists(conv_txt_path):
+        try:
+            with open(conv_txt_path, "r", encoding="utf-8") as f:
+                conv_id = f.read().strip()
+            if conv_id:
+                # conversations/<conv_id>.db 파일 삭제
+                db_path = f"/home/ubuntu/.gemini/antigravity-cli/conversations/{conv_id}.db"
+                if os.path.exists(db_path):
+                    os.remove(db_path)
+                    print(f"[delete_chat_sessions] Deleted Antigravity conversation db: {db_path}")
+                # brain/<conv_id>/ 디렉터리 삭제
+                brain_dir = f"/home/ubuntu/.gemini/antigravity-cli/brain/{conv_id}"
+                if os.path.exists(brain_dir):
+                    shutil.rmtree(brain_dir, ignore_errors=True)
+                    print(f"[delete_chat_sessions] Deleted Antigravity brain directory: {brain_dir}")
+        except Exception as e:
+            print(f"[delete_chat_sessions Antigravity Error] {e}")
+
+
 def delete_document(doc_id: str) -> bool:
     """라이브러리에서 문서 파일 및 데이터베이스 레코드를 삭제합니다."""
     doc_dir = os.path.join(LIBRARY_DIR, doc_id)
-    # 1. 파일 삭제
+    # 1. 채팅 세션 삭제
+    delete_chat_sessions(doc_id)
+    # 2. 파일 삭제
     if os.path.exists(doc_dir):
         shutil.rmtree(doc_dir, ignore_errors=True)
-    # 2. DB 삭제
+    # 3. DB 삭제
     return db_delete_document(doc_id)
 
 

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -781,7 +781,7 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
 
 from typing import List
 
-async def classify_paper_category(title: str, text: str) -> List[str]:
+async def classify_paper_category(title: str, text: str, session_id: str = None) -> List[str]:
     prompt = f"""You are an academic paper classifier. Analyze the following paper title and beginning text (abstract) and classify it into one or two specific sub-categories of computer science / artificial intelligence (e.g. LLM, VLM, VLA, VAE, GAN, Diffusion, Optimizer, Object Detection, Segmentation, Speech Synthesis, RL, GNN, Transformer, etc.).
 Output ONLY the category name(s) as a comma-separated list of words (e.g., "LLM" or "LLM, VLM" or "GAN, VAE" or "Optimizer"). Do not include any explanations, introduction, punctuation (other than commas), or markdown formatting. Keep the tags concise and uppercase if appropriate.
 
@@ -810,10 +810,10 @@ Category Tags:"""
             async for token in stream_claude(messages, model=model, temperature=0.1):
                 tokens.append(token)
         elif provider == "antigravity":
-            async for token in stream_antigravity(prompt, model=model):
+            async for token in stream_antigravity(prompt, model=model, session_id=session_id):
                 tokens.append(token)
         elif provider == "claude_code":
-            async for token in stream_claude_code(prompt, model=model):
+            async for token in stream_claude_code(prompt, model=model, session_id=session_id):
                 tokens.append(token)
         else:
             # Fallback to Ollama chat api

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -656,6 +656,43 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
         print(f"[Claude Code CLI Exec Error] {e}")
 
 
+def get_mapped_conversation_id(session_id: str) -> str:
+    if not session_id:
+        return None
+    import os
+    from config import LIBRARY_DIR
+    path = os.path.join(LIBRARY_DIR, session_id, "conversation_id.txt")
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+        except Exception:
+            pass
+    return None
+
+def save_mapped_conversation_id(session_id: str, conversation_id: str) -> None:
+    if not session_id or not conversation_id:
+        return
+    import os
+    from config import LIBRARY_DIR
+    path = os.path.join(LIBRARY_DIR, session_id, "conversation_id.txt")
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(conversation_id.strip())
+    except Exception as e:
+        print(f"[save_mapped_conversation_id Error] {e}")
+
+def get_existing_conversations() -> set:
+    import glob
+    import os
+    try:
+        db_files = glob.glob("/home/ubuntu/.gemini/antigravity-cli/conversations/*.db")
+        return {os.path.basename(f)[:-3] for f in db_files}
+    except Exception:
+        return set()
+
+
 async def stream_antigravity(prompt: str, model: str = None, session_id: str = None) -> AsyncGenerator[str, None]:
     import asyncio
     import os
@@ -664,13 +701,20 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
     if not os.path.exists(agy_path):
         agy_path = "agy"
         
+    mapped_conv_id = get_mapped_conversation_id(session_id)
+    target_conv_id = mapped_conv_id if mapped_conv_id else session_id
+
     cmd = [agy_path, "--dangerously-skip-permissions"]
     if model and model.strip() and model.strip().lower() != "custom":
         cmd.extend(["--model", model.strip()])
-    if session_id:
-        cmd.extend(["--conversation", session_id])
+    if target_conv_id:
+        cmd.extend(["--conversation", target_conv_id])
 
-    # agy --print 는 단일 프롬프트를 받아 출력을 스트리밍함
+    # 만약 기존에 매핑된 conversation ID가 없다면, 백그라운드에서 새로 생성되는 ID를 감지해 저장함
+    before_set = set()
+    if session_id and not mapped_conv_id:
+        before_set = get_existing_conversations()
+
     # 충분한 제약을 주어서 확실하게 완전한 출력을 유도
     guided_prompt = (
         "You are a direct-output assistant. "
@@ -696,6 +740,20 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
             env=get_agy_env()
         )
         
+        # 새 대화 ID를 비동기적으로 감지하여 매핑 테이블에 저장하는 백그라운드 태스크 기동
+        if session_id and not mapped_conv_id:
+            async def detect_and_save():
+                for _ in range(20): # 최대 10초 대기
+                    await asyncio.sleep(0.5)
+                    current_set = get_existing_conversations()
+                    new_ids = current_set - before_set
+                    if new_ids:
+                        new_id = list(new_ids)[0]
+                        save_mapped_conversation_id(session_id, new_id)
+                        print(f"[stream_antigravity] Mapped session {session_id} to new Antigravity conversation {new_id}")
+                        break
+            asyncio.create_task(detect_and_save())
+
         import codecs
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -247,7 +247,7 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
             from services.llm_client import classify_paper_category
             from services.library import update_document_metadata
             
-            tags = await classify_paper_category(doc_title, combined_text)
+            tags = await classify_paper_category(doc_title, combined_text, session_id=session_id)
             if tags:
                 doc = get_document(session_id)
                 if doc:


### PR DESCRIPTION
# Summary                                                                                                                
## 1. 번역 및 채팅 API에서의 AI 세션 ID 연동 누락 수정                                                                   
 - `backend/routers/translate.py` 내의 실시간 번역 처리기에서 `stream_translation` 호출 시 `session_id` 파라미터를 넘겨주지 않던 누락 수정함.                                                                                                 
 - `backend/routers/chat.py` 내의 실시간 대화 처리기에서 `stream_chat` 호출 시 `session_id` 파라미터를 넘겨주지 않던 누락 수정함.                                                                                                                    
                                                                                                                           
## 2. Antigravity 서버 대화 ID 매핑 구조 도입                                                                            
 - `backend/services/llm_client.py` 내에 `get_mapped_conversation_id`, `save_mapped_conversation_id`, `get_existing_conversations` 헬퍼 함수를 추가함.
 - 신규 세션 호출 시 Antigravity 서버 측에서 임의의 다른 세션 UUID를 재생성하는 동작을 방지하기 위해, 최초 기동 시 개설된 실제 세션 ID를 식별하고 이를 문서 라이브러리 내 `conversation_id.txt`에 기록 및 캐싱하여 후속 호출에서 영구적으로 재사용하도록 로직을 구현함.                                                                                                
                                                                                                                           
## 3. 논문 카테고리 태깅 기능의 세션 통합                                                                                
 - `backend/services/llm_client.py` 내 `classify_paper_category` 함수 시그니처 및 내부 호출 구조에 `session_id` 전달 흐름 추가함.                                                                                                                    
 - `backend/services/translation_job.py` 내의 태그 분석 비동기 태스크에서 카테고리 분류 함수 호출 시 문서의 `session_id`를 파라미터로 명시적으로 연동시켜, 태깅 동작 수행 시 세션이 분할 개설되는 현상을 해결함.    

## 4. 논문 삭제 시 채팅 세션 삭제 기능 구현
 - `backend/services/library.py`에  delete_chat_sessions(doc_id)  함수를 구현하여 논문 삭제 시 다음 데이터를 함께 파괴하도록 조치.                    
   - Claude Code: 해당 문서의 격리된 캐시 디렉터리( cache/claude_home_{doc_id} ) 삭제.
   - Antigravity:  conversation_id.txt 를 읽어 실제 개설되어 있던 Antigravity 대화 DB( conversations/{conv_id}.db )와 데이터 디렉터리( brain/{conv_id} ) 삭제.
 - 라이브러리 및 임시 업로드 세션 삭제 로직( delete_document ,  delete_session ) 수행 시 위 함수가 먼저 연동되도록 수정.