### PR TITLE
fix: 수식 복사 시 LaTeX 문법으로 복사되도록 수정 (번역본 + PDF 원문 패널)

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CPpP49Qg.js"></script>
+  <script type="module" crossorigin src="/assets/index-Co_uJ3Yu.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DN-MDCJk.js"></script>
+  <script type="module" crossorigin src="/assets/index-DNCv34MV.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Cfa3Uw7h.js"></script>
+  <script type="module" crossorigin src="/assets/index-DN-MDCJk.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DShMHg4b.js"></script>
+  <script type="module" crossorigin src="/assets/index-CPpP49Qg.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CE3jmT2Y.js"></script>
+  <script type="module" crossorigin src="/assets/index-DShMHg4b.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Co_uJ3Yu.js"></script>
+  <script type="module" crossorigin src="/assets/index-CEtFnVpz.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CEtFnVpz.js"></script>
+  <script type="module" crossorigin src="/assets/index-wqkipLr_.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DxF2_aeP.js"></script>
+  <script type="module" crossorigin src="/assets/index-Cfa3Uw7h.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-wqkipLr_.js"></script>
+  <script type="module" crossorigin src="/assets/index-DxF2_aeP.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIxwLJwT.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5963,12 +5963,23 @@ let activeHighlightPage = null;
 let activeHighlightSentenceIdx = null;
 
 // VirtualTextMap에서 특정 문자 위치에 해당하는 sentenceRange를 이진 탐색
+// alignSentencesToText는 아주 드물게 서로 겹치는 두 문장 범위를 만들어낼 수 있다
+// (전역/프리픽스 폴백 검색이 이미 다른 문장이 차지한 구간보다 앞에서 매칭되는 경우).
+// 겹치는 두 범위 중 더 넓은 쪽이 먼저 반환되면, 실제로는 무관한 옆 문장까지 포함한
+// 범위가 호버/드웰선택에 그대로 쓰여서 화면상 서로 떨어진 두 위치가 함께 강조되거나
+// 선택되는 것처럼 보인다. charIdx를 포함하는 후보가 여럿이면 그 중 가장 좁은(가장
+// 구체적인) 범위를 골라, 옆 문장의 여분 영역을 끌고 오지 않도록 한다.
 function findSentenceAtChar(charIdx, sentenceRanges) {
   if (!sentenceRanges || sentenceRanges.length === 0) return null;
+  let best = null;
   for (const r of sentenceRanges) {
-    if (charIdx >= r.charStart && charIdx < r.charEnd) return r;
+    if (charIdx >= r.charStart && charIdx < r.charEnd) {
+      if (!best || (r.charEnd - r.charStart) < (best.charEnd - best.charStart)) {
+        best = r;
+      }
+    }
   }
-  return null;
+  return best;
 }
 
 // 마우스 위치로부터 대략적인 charIdx를 추정 (caretRangeFromPoint 또는 비율 계산 폴백)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -562,7 +562,7 @@ function formatTranslationHtml(text) {
     if (!item) return _
     if (window.katex) {
       try {
-        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'html' })
+        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'htmlAndMathml' })
         if (item.display) {
           return `<div class="katex-display-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="true">${r}</div>`
         } else {
@@ -587,7 +587,7 @@ function applyKatexToElement(el) {
     try {
       const formula = decodeURIComponent(code.dataset.formula || '')
       const display = code.dataset.display === 'true'
-      const r = window.katex.renderToString(formula, { displayMode: display, throwOnError: false, output: 'html' })
+      const r = window.katex.renderToString(formula, { displayMode: display, throwOnError: false, output: 'htmlAndMathml' })
       const wrapper = display
         ? Object.assign(document.createElement('div'), { className: 'katex-display-wrap', innerHTML: r })
         : Object.assign(document.createElement('span'), { className: 'katex-inline-wrap', innerHTML: r })
@@ -4146,7 +4146,7 @@ function formatChatHtml(text) {
     if (!item) return _
     if (window.katex) {
       try {
-        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'html' })
+        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'htmlAndMathml' })
         if (item.display) {
           return `<div class="katex-display-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="true">${r}</div>`
         } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5237,154 +5237,51 @@ function buildVirtualTextMap(container, pageNum) {
 
   if (spans.length === 0) return null;
 
-  // 시각적 "줄" 단위로 스팬을 묶은 뒤, 줄 내부는 좌->우로 정렬한다.
+  // spans는 pdf.js가 만든 DOM 순서(=PDF 콘텐츠 스트림 순서) 그대로 담겨 있다. 2단
+  // 논문이라도 LaTeX 등 조판 엔진은 왼쪽 컬럼 전체를 위에서 아래로 다 쓴 뒤에
+  // 오른쪽 컬럼을 쓰므로, 이 순서 자체가 이미 올바른 읽기 순서다(실측 확인: 페이지
+  // 앞쪽 수십 개 스팬이 전부 왼쪽 컬럼이고 top이 정확히 오름차순으로 이어지며,
+  // 오른쪽 컬럼 내용은 전혀 섞여 있지 않았다). 예전에는 이 순서를 무시하고 top
+  // 좌표만으로 전체를 다시 정렬한 뒤 거터를 추정해 좌/우로 재조립하는 로직을
+  // 썼는데, 그 재정렬 자체가 왼쪽 컬럼 맨 아래 줄과 오른쪽 컬럼 맨 위 줄처럼 top이
+  // 우연히 비슷한 두 스팬을 섞어버리는 원인이었다(수식·헤딩이 섞인 페이지에서
+  // 특히 잦고, 기하학적 방법만으로는 "우연히 가까움"과 "진짜 같은 줄"을 구분할
+  // 수 없었다). 따라서 원래 순서를 그대로 신뢰하고, "같은 시각적 줄"인지만 그
+  // 순서를 따라가며 판정한다.
   //
-  // 고정 픽셀 임계값으로 top을 비교하는 방식(예: "9px 미만이면 같은 줄")은 페이지
-  // 전체를 대상으로 하면 위험하다: 서로 다른 두 줄이라도 첨자 때문에 한쪽의 top이
-  // 다른 쪽과 우연히 9px 이내로 가까워질 수 있고, 그러면 전혀 무관한 두 줄의 스팬들이
-  // 하나의 그룹으로 잘못 합쳐져 버린다(그 사이에 낀 다른 줄들의 글자 수만큼 문자
-  // 오프셋이 널뛰는 현상으로 관측됨). 따라서 top 값 자체가 아니라 각 스팬의 실제
-  // 세로 구간([top, top+height])이 서로 "겹치는지"로 판단하고, 같은 줄로 합쳐질 때마다
-  // 그 줄의 세로 구간(envelope)을 확장해 나가는 구간 병합(interval merging) 방식을 쓴다.
-  // 첨자처럼 조금씩 어긋나는 스팬들은 서로 겹치는 구간이 연쇄적으로 이어지므로 같은
-  // 줄로 안전하게 묶이고, 실제 다른 줄은 세로 구간 자체가 겹치지 않으므로 섞이지 않는다.
-  // 세로 구간 폭은 fontSize에 비례시키지 않는다 - 논문마다 실제 줄간격 대비
-  // fontSize 비율이 달라서(빽빽하게 조판된 2단 논문 등), fontSize를 그대로 쓰면
-  // 한 줄의 구간이 바로 다음 줄까지 삼켜버리고 그게 연쇄적으로 이어져 문단 여러
-  // 개가 통째로 한 줄로 합쳐지는 문제가 있었다(실측). 대신 첨자 오프셋 실측치
-  // (~6~8px)에 맞춘 고정값을 쓴다 - 이 정도면 첨자는 여전히 같은 줄로 묶이면서도,
-  // 다음 실제 줄(보통 14px 이상 떨어짐)까지 삼키지는 않는다.
+  // 세로 구간이 겹치는 동안 줄을 이어붙이는 구간 병합(interval merging)은 그대로
+  // 쓰되, 순서를 따라갈 때 위험한 지점이 하나 있다: 왼쪽 컬럼의 마지막 줄에서
+  // 오른쪽 컬럼의 첫 줄로 넘어갈 때 top이 페이지 하단에서 상단으로 "역행"한다.
+  // 이 역행한 top이 마침 직전 줄의 늘어난 세로 구간(envelope) 안에 들어가면 두
+  // 컬럼이 하나의 줄로 잘못 합쳐진다. 그래서 세로 구간이 겹치는지 뿐 아니라, 그
+  // 줄이 시작된 top에서 위로 크게 벗어나지 않는지도 함께 확인한다 - 첨자는
+  // 기준선보다 위/아래로 살짝만(~6~8px) 벗어나지만, 컬럼 전환은 수백 px씩
+  // 역행하므로 이 둘은 확실히 구분된다.
   const LINE_ENVELOPE_REACH = 8;
-  function groupSpansIntoLines(spansArr) {
-    const byTop = [...spansArr].sort((a, b) => a.top - b.top);
-    const lines = [];
-    let current = [];
-    let envelopeBottom = -Infinity;
-    for (const s of byTop) {
-      const sBottom = s.top + LINE_ENVELOPE_REACH;
-      if (current.length === 0 || s.top < envelopeBottom) {
-        current.push(s);
-        envelopeBottom = Math.max(envelopeBottom, sBottom);
-      } else {
-        lines.push(current);
-        current = [s];
-        envelopeBottom = sBottom;
-      }
+  const lineGroups = [];
+  let currentLine = [];
+  let lineTop = null;
+  let envelopeBottom = -Infinity;
+  for (const s of spans) {
+    const sBottom = s.top + LINE_ENVELOPE_REACH;
+    const withinLine = currentLine.length > 0
+      && s.top < envelopeBottom
+      && s.top > lineTop - LINE_ENVELOPE_REACH;
+    if (currentLine.length === 0 || withinLine) {
+      if (currentLine.length === 0) lineTop = s.top;
+      currentLine.push(s);
+      envelopeBottom = Math.max(envelopeBottom, sBottom);
+    } else {
+      lineGroups.push(currentLine);
+      currentLine = [s];
+      lineTop = s.top;
+      envelopeBottom = sBottom;
     }
-    if (current.length > 0) lines.push(current);
-    lines.forEach(line => line.sort((a, b) => a.left - b.left));
-    return lines;
   }
+  if (currentLine.length > 0) lineGroups.push(currentLine);
 
-  // 2단 레이아웃 감지
-  // "중앙 좌우에 각각 스팬이 있는가"나 "중앙 근처에 시작하는 스팬이 적은가" 같은
-  // 집계 기반 판정은 판별력이 낮다 - 폭 넓은 단일 컬럼도, 실제 2단 컬럼도(전체 폭
-  // 제목/캡션이 섞여 있으면) 중앙 근처 스팬 비율이 비슷하게 나올 수 있다(실측: 두
-  // 경우 모두 약 13~15%). "줄 안에 큰 가로 간격이 있는가"만 보는 것도 부족하다 -
-  // 수식 번호(예: "... = f(x)      (1)")도 한 줄 안에 큰 간격을 만들기 때문에
-  // 단일 컬럼 논문에서도 다수의 줄이 큰 간격을 갖는다(실측 40%+). 진짜 거터와
-  // 수식 번호 간격의 결정적 차이는: 거터는 페이지의 모든 줄에서 항상 같은 x좌표에
-  // 나타나지만, 수식 번호 간격은 수식마다 길이가 달라 x좌표가 줄마다 들쭉날쭉하다.
-  // 그래서 "중앙 부근"인지가 아니라 "큰 간격들이 하나의 x좌표에 얼마나 몰려있는지
-  // (일관성)"로 판정한다 - 실측상 거터의 x좌표는 페이지 정중앙(pageWidth/2)이
-  // 아닐 수 있다(여백이 좌우 비대칭인 논문들이 있음).
-  const mid = pageWidth / 2;
-  const probeLines = groupSpansIntoLines(spans);
-  function lineBiggestGap(line) {
-    let biggest = null;
-    for (let i = 0; i < line.length - 1; i++) {
-      const gap = line[i + 1].left - line[i].left;
-      if (gap > pageWidth * 0.06 && (!biggest || gap > biggest.gap)) {
-        biggest = { gap, mid: (line[i + 1].left + line[i].left) / 2 };
-      }
-    }
-    return biggest;
-  }
-  const bigGapMids = [];
-  for (const line of probeLines) {
-    const biggest = lineBiggestGap(line);
-    if (biggest) bigGapMids.push(biggest.mid);
-  }
-  // 페이지 전체에서 "그럴듯한 거터 후보 x좌표"가 있는지만 우선 찾는다. 실제로 이
-  // 좌표를 기준으로 분할할지는 아래에서 줄(line) 단위로 별도 판정한다 - 제목/저자/
-  // 초록처럼 폭 넓은 단일 컬럼 블록과, 그 아래에 이어지는 진짜 2단 본문이 한
-  // 페이지에 섞여 있는 경우(혼합 레이아웃), 페이지 전체를 2단 여부 하나로만
-  // 판정하면 혼합 레이아웃에서 틀리기 때문이다.
-  // 페이지 전체 간격 위치들의 "전역 중앙값"을 거터 후보로 쓰면, 제목/저자/초록처럼
-  // 폭 넓은 단일 컬럼 블록이 페이지 대부분을 차지하는 혼합 레이아웃에서 틀릴 수
-  // 있다 - 그런 블록에서 생기는 잡음성 큰 간격들의 개수가 실제 거터 간격 개수보다
-  // 많아지면, 전역 중앙값이 잡음 쪽으로 쏠려 진짜 거터를 놓친다(실측: 진짜 거터는
-  // 12개 줄에서 x≈282에 뚜렷이 몰려 있었는데도, 잡음 22개가 더 낮은 값대에 퍼져
-  // 있어 전역 중앙값은 x≈194로 계산됨). 따라서 전역 중앙값 대신, 값들 중 가장
-  // 촘촘하게 몰려있는 군집(최빈 위치)을 찾아 그 군집을 거터 후보로 삼는다.
-  let gutterX = null;
-  if (spans.length > 5 && probeLines.length > 3 && bigGapMids.length >= 4) {
-    let bestMid = null;
-    let bestCount = 0;
-    for (const m of bigGapMids) {
-      const count = bigGapMids.filter(x => Math.abs(x - m) < pageWidth * 0.03).length;
-      if (count > bestCount) { bestCount = count; bestMid = m; }
-    }
-    if (bestCount >= 4) {
-      const cluster = bigGapMids.filter(x => Math.abs(x - bestMid) < pageWidth * 0.03);
-      gutterX = cluster.reduce((a, b) => a + b, 0) / cluster.length;
-    }
-  }
-
-  // 2단 레이아웃에서는 좌단 전체를 다 훑은 뒤 우단으로 넘어가므로, 이어붙인 배열
-  // 안에서 top이 다시 페이지 상단 값으로 되돌아가는 지점(컬럼 경계)이 생긴다.
-  // findDisplayEquationsFromVTM처럼 top 값만으로 순차적으로 "같은 줄"을 재판정하는
-  // 코드가 있으면, 이 역행 지점에서 직전 줄의 늘어난 세로 구간(envelope) 안에
-  // 다음 컬럼의 첫 줄이 우연히 걸려 두 컬럼이 하나의 "줄"로 잘못 합쳐질 수 있다.
-  // 그래서 각 스팬에 실제로 몇 번째 줄에 속하는지(lineIndex)를 미리 기록해두고,
-  // 이후 단계는 top을 다시 비교하지 않고 이 lineIndex로만 줄 경계를 판정한다.
-  let sortedSpans;
-  let lineGroups;
-  if (gutterX !== null) {
-    // 줄 하나를 gutterX 기준으로 스팬 단위로 쪼개는 방식은 위험하다 - 좌/우 컬럼은
-    // 문단 길이가 달라 독립적으로 흐르므로, 어느 한쪽 컬럼의 줄이 유난히 길어 단어
-    // 하나가 gutterX를 살짝 넘기기만 해도(자연스러운 폭 변동) 그 단어가 반대쪽
-    // 스팬 목록에 섞여 들어가고, 우연히 비슷한 높이에 있는 반대쪽 컬럼의 무관한
-    // 내용과 하나의 줄로 잘못 합쳐지는 연쇄 문제가 생긴다(실측). 그래서 원칙을
-    // 바꾼다: 줄 내부에 실제로 큰 간격이 있는 경우에만(=이 줄 자체가 좌우 두 컬럼이
-    // 나란히 합쳐진 줄) 그 간격 위치에서 나누고, 간격이 없는 줄은 시작 위치만으로
-    // 통째로 좌/우 판정한다(줄 중간 단어가 gutterX를 넘어도 줄 자체는 쪼개지 않음).
-    lineGroups = [];
-    let leftBuf = [];
-    let rightBuf = [];
-    const flushColumns = () => {
-      if (leftBuf.length) lineGroups.push(...groupSpansIntoLines(leftBuf));
-      if (rightBuf.length) lineGroups.push(...groupSpansIntoLines(rightBuf));
-      leftBuf = [];
-      rightBuf = [];
-    };
-    for (const line of probeLines) {
-      const gap = lineBiggestGap(line);
-      if (gap) {
-        for (const s of line) {
-          if (s.left < gap.mid) leftBuf.push(s); else rightBuf.push(s);
-        }
-        continue;
-      }
-      const lineLeft = line[0].left;
-      const lineRight = line[line.length - 1].left;
-      const isWide = (lineRight - lineLeft) >= pageWidth * 0.55;
-      if (isWide) {
-        // 폭 넓은 단일 컬럼 줄(제목/초록/헤딩 등): 누적된 좌/우 버퍼를 먼저
-        // 흘려보낸 뒤, 이 줄은 원래 세로 위치 그대로 삽입한다.
-        flushColumns();
-        lineGroups.push(line);
-      } else {
-        // 좁은 한쪽 컬럼 줄: 시작 위치만으로 판정해 줄 전체를 통째로 축적한다.
-        if (lineLeft < gutterX) leftBuf.push(...line); else rightBuf.push(...line);
-      }
-    }
-    flushColumns();
-  } else {
-    lineGroups = groupSpansIntoLines(spans);
-  }
   lineGroups.forEach((line, idx) => line.forEach(s => { s.lineIndex = idx; }));
-  sortedSpans = lineGroups.flat();
+  const sortedSpans = lineGroups.flat();
 
   // 줄간격 중앙값 및 폰트 크기 중앙값 계산
   const gaps = [];
@@ -5466,7 +5363,7 @@ function buildVirtualTextMap(container, pageNum) {
     prevFontSize = fontSize;
   }
 
-  return { fullText, spans: sortedSpans, nodeRanges, isTwoColumn: gutterX !== null, pageNum };
+  return { fullText, spans: sortedSpans, nodeRanges, pageNum };
 }
 
 // 독립 수식 검출 (VirtualTextMap 기반)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4756,15 +4756,28 @@ function convertRawTextToLatex(text) {
 // 수식 부분은 LaTeX($...$ / $$...$$)로 변환하여 클립보드에 쓰는 방식.
 // 기존 .pdf-sentence DOM 분할에 의존하지 않습니다.
 
-// 범위와 텍스트 노드 교차 감지 (하위 호환용 유틸리티)
-function rangeIntersectsNode(range, node) {
-  if (range.intersectsNode) return range.intersectsNode(node);
-  const nr = document.createRange();
+// 선택 영역과 텍스트 노드가 화면상 기하학적으로 겹치는지 감지.
+// range.intersectsNode()는 DOM 트리 순서를 기준으로 판단하는데, 수식은 첨자·분수·
+// 적분 기호 등이 PDF 콘텐츠 스트림 순서상 시각적 순서와 다르게 기록되는 경우가 흔해서
+// DOM 순서 기반 판정은 선택 범위 밖의 노드까지 끌어들이거나(과다 포함) 반대로
+// 선택 범위 안의 노드를 누락시킬 수 있다. 대신 실제 렌더링된 사각형끼리의 겹침으로 판단한다.
+// 단순 "겹침"(rectsOverlap)은 줄간격이 촘촘한 학술 논문에서 바로 아래/위 줄의
+// 사각형과 경계선이 살짝 스치기만 해도 참으로 판정되어 인접 줄의 텍스트까지
+// 끌려 들어온다. 대신 노드 사각형의 중심점이 선택 사각형 "안"에 실제로 들어있는지로
+// 판단하면 애매하게 스치는 인접 줄은 배제되고 실제로 선택된 줄만 남는다.
+function rectContainsPoint(r, x, y) {
+  return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+}
+
+function getNodeClientRect(node) {
   try {
-    nr.selectNode(node);
-    return range.compareBoundaryPoints(Range.END_TO_START, nr) < 0 &&
-           range.compareBoundaryPoints(Range.START_TO_END, nr) > 0;
-  } catch (e) { return false; }
+    const r = document.createRange();
+    r.selectNode(node);
+    const rects = r.getClientRects();
+    return rects.length > 0 ? rects[0] : r.getBoundingClientRect();
+  } catch (e) {
+    return null;
+  }
 }
 
 document.addEventListener('copy', (e) => {
@@ -4792,10 +4805,29 @@ document.addEventListener('copy', (e) => {
     // VirtualTextMap 없이는 기본 텍스트 복사로 폴백 (브라우저 기본 동작 허용)
     if (!vtm || !sentenceRanges) return;
 
-    // 1. 선택된 텍스트의 charStart/charEnd 계산 (nodeRanges 기반)
+    // 1. 선택된 텍스트의 charStart/charEnd 계산 (nodeRanges 기반, 화면 좌표 겹침으로 판정)
+    let selRects = Array.from(range.getClientRects()).filter(r => r.width > 0 || r.height > 0);
+    if (selRects.length === 0) {
+      const bounding = range.getBoundingClientRect();
+      if (bounding.width > 0 || bounding.height > 0) selRects = [bounding];
+    }
+    if (selRects.length === 0) return;
+
     let selCharStart = Infinity, selCharEnd = 0;
     for (const nr of vtm.nodeRanges) {
-      if (!rangeIntersectsNode(range, nr.node)) continue;
+      // 선택의 시작/끝 컨테이너는 브라우저가 이미 정확한 오프셋을 알려주므로 항상 포함한다.
+      // PDF.js는 일반 본문을 한 줄 전체를 하나의 텍스트 노드로 렌더링하는 경우가 많아,
+      // 그 줄의 일부만 드래그해도 노드 자체의 중심점은 선택 영역 바깥에 있을 수 있기
+      // 때문에(노드 전체 폭 > 실제 선택 폭), 기하학적 필터를 시작/끝 노드에는 적용하지 않는다.
+      const isBoundaryNode = nr.node === range.startContainer || nr.node === range.endContainer;
+      if (!isBoundaryNode) {
+        const nodeRect = getNodeClientRect(nr.node);
+        if (!nodeRect || (nodeRect.width === 0 && nodeRect.height === 0)) continue;
+        const cx = (nodeRect.left + nodeRect.right) / 2;
+        const cy = (nodeRect.top + nodeRect.bottom) / 2;
+        if (!selRects.some(r => rectContainsPoint(r, cx, cy))) continue;
+      }
+
       const nodeStart = nr.node === range.startContainer ? range.startOffset : 0;
       const nodeEnd   = nr.node === range.endContainer   ? range.endOffset   : nr.node.length;
       const absStart  = nr.start + nodeStart;
@@ -5099,21 +5131,35 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
 //  3. Native Selection 보존: 브라우저 기본 텍스트 드래그/선택 완전 보존
 //
 // buildVirtualTextMap: textLayer 내부 스팬을 읽어 가상 텍스트 인덱스 맵 구성 (DOM 비수정)
+// PDF.js 텍스트 레이어의 left/top은 px 리터럴이 아니라 "18.24%"처럼 퍼센트 문자열이거나
+// "round(var(--scale-factor) * 612px, 1px)" 같은 CSS 수식 문자열일 수 있다.
+// px 단위만 찾는 정규식으로는 항상 매치에 실패해 모든 좌표가 0으로 취급되어 버리므로,
+// 퍼센트 단위는 실제 렌더링된 컨테이너 크기(dimensionPx) 기준의 px 값으로 환산한다.
+function parsePositionPx(styleValue, dimensionPx) {
+  if (!styleValue) return 0;
+  const pctMatch = styleValue.match(/([\d.-]+)%/);
+  if (pctMatch) return (parseFloat(pctMatch[1]) / 100) * dimensionPx;
+  const pxMatch = styleValue.match(/([\d.-]+)px/);
+  if (pxMatch) return parseFloat(pxMatch[1]);
+  return 0;
+}
+
 function buildVirtualTextMap(container, pageNum) {
   const allElements = Array.from(container.children).filter(el => el.nodeType === 1);
   if (allElements.length === 0) return null;
 
-  const pageWidth = parseFloat(container.style.width) || 600;
+  // style.width/height는 "round(var(--scale-factor) * 612px, 1px)" 같은 CSS 수식일 수 있어
+  // parseFloat로 직접 읽을 수 없으므로, 실제 렌더링된 픽셀 크기(clientWidth/Height)를 사용한다.
+  const pageWidth  = container.clientWidth  || parseFloat(container.style.width)  || 600;
+  const pageHeight = container.clientHeight || parseFloat(container.style.height) || 792;
 
   // 줄 번호 필터링 + 노드 메타데이터 수집
   const spans = [];
   allElements.forEach(el => {
     const text = el.textContent.trim();
-    const leftMatch = el.style.left?.match(/([\d.-]+)px/);
-    const topMatch  = el.style.top?.match(/([\d.-]+)px/);
+    const leftVal   = parsePositionPx(el.style.left, pageWidth);
+    const topVal    = parsePositionPx(el.style.top, pageHeight);
     const fsMatch   = el.style.fontSize?.match(/([\d.]+)/);
-    const leftVal   = leftMatch ? parseFloat(leftMatch[1]) : 0;
-    const topVal    = topMatch  ? parseFloat(topMatch[1])  : 0;
     const fsVal     = fsMatch   ? parseFloat(fsMatch[1])   : 10;
     const ratio     = leftVal / pageWidth;
 
@@ -5131,23 +5177,62 @@ function buildVirtualTextMap(container, pageNum) {
 
   if (spans.length === 0) return null;
 
+  // 시각적 "줄" 단위로 스팬을 묶은 뒤, 줄 내부는 좌->우로 정렬한다.
+  //
+  // 고정 픽셀 임계값으로 top을 비교하는 방식(예: "9px 미만이면 같은 줄")은 페이지
+  // 전체를 대상으로 하면 위험하다: 서로 다른 두 줄이라도 첨자 때문에 한쪽의 top이
+  // 다른 쪽과 우연히 9px 이내로 가까워질 수 있고, 그러면 전혀 무관한 두 줄의 스팬들이
+  // 하나의 그룹으로 잘못 합쳐져 버린다(그 사이에 낀 다른 줄들의 글자 수만큼 문자
+  // 오프셋이 널뛰는 현상으로 관측됨). 따라서 top 값 자체가 아니라 각 스팬의 실제
+  // 세로 구간([top, top+height])이 서로 "겹치는지"로 판단하고, 같은 줄로 합쳐질 때마다
+  // 그 줄의 세로 구간(envelope)을 확장해 나가는 구간 병합(interval merging) 방식을 쓴다.
+  // 첨자처럼 조금씩 어긋나는 스팬들은 서로 겹치는 구간이 연쇄적으로 이어지므로 같은
+  // 줄로 안전하게 묶이고, 실제 다른 줄은 세로 구간 자체가 겹치지 않으므로 섞이지 않는다.
+  function groupSpansIntoLines(spansArr) {
+    const byTop = [...spansArr].sort((a, b) => a.top - b.top);
+    const lines = [];
+    let current = [];
+    let envelopeBottom = -Infinity;
+    for (const s of byTop) {
+      const sBottom = s.top + (s.fontSize || 10);
+      if (current.length === 0 || s.top < envelopeBottom) {
+        current.push(s);
+        envelopeBottom = Math.max(envelopeBottom, sBottom);
+      } else {
+        lines.push(current);
+        current = [s];
+        envelopeBottom = sBottom;
+      }
+    }
+    if (current.length > 0) lines.push(current);
+    lines.forEach(line => line.sort((a, b) => a.left - b.left));
+    return lines;
+  }
+
   // 2단 레이아웃 감지
+  // 단순히 "중앙 좌우에 각각 30% 이상 스팬이 있는가"만 보면, 폭이 넓은 단일 컬럼
+  // 페이지(문장이나 수식이 페이지 중앙을 자연스럽게 가로지르는 경우)도 좌/우 양쪽에
+  // 스팬이 골고루 분포하므로 2단으로 오판된다. 실제 2단 레이아웃이라면 두 컬럼 사이에
+  // 텍스트가 거의 없는 "거터(gutter)"가 존재해야 하므로, 중앙 근처 좁은 띠에 시작하는
+  // 스팬 비율이 충분히 낮을 때만 2단으로 판정한다.
   const mid = pageWidth / 2;
   const leftCount  = spans.filter(n => n.left < mid * 1.05).length;
   const rightCount = spans.filter(n => n.left > mid * 0.95).length;
+  const gutterLo = mid - pageWidth * 0.04;
+  const gutterHi = mid + pageWidth * 0.04;
+  const gutterCount = spans.filter(n => n.left >= gutterLo && n.left <= gutterHi).length;
   const isTwoColumn = spans.length > 5
     && (leftCount  / spans.length > 0.3)
-    && (rightCount / spans.length > 0.3);
+    && (rightCount / spans.length > 0.3)
+    && (gutterCount / spans.length < 0.05);
 
   let sortedSpans;
   if (isTwoColumn) {
-    const leftNs  = spans.filter(n => n.left < mid).sort((a, b) => a.top - b.top || a.left - b.left);
-    const rightNs = spans.filter(n => n.left >= mid).sort((a, b) => a.top - b.top || a.left - b.left);
-    sortedSpans = leftNs.concat(rightNs);
+    const leftLines  = groupSpansIntoLines(spans.filter(n => n.left < mid));
+    const rightLines = groupSpansIntoLines(spans.filter(n => n.left >= mid));
+    sortedSpans = leftLines.flat().concat(rightLines.flat());
   } else {
-    sortedSpans = [...spans].sort((a, b) =>
-      Math.abs(a.top - b.top) < 4 ? a.left - b.left : a.top - b.top
-    );
+    sortedSpans = groupSpansIntoLines(spans).flat();
   }
 
   // 줄간격 중앙값 및 폰트 크기 중앙값 계산
@@ -5240,18 +5325,20 @@ function findDisplayEquationsFromVTM(vtm) {
   const lines = [];
   let currentLine = [];
 
+  // groupSpansIntoLines와 동일한 구간 병합(interval merging) 방식.
+  // spans는 이미 buildVirtualTextMap에서 줄 단위로 정렬되어 들어오므로 순차적으로
+  // 세로 구간이 겹치는 동안만 같은 줄로 묶는다.
+  let envelopeBottom = -Infinity;
   for (const spanInfo of spans) {
     if (spanInfo.charStart === undefined || spanInfo.charEnd === undefined) continue;
-    if (currentLine.length === 0) {
+    const sBottom = spanInfo.top + (spanInfo.fontSize || 10);
+    if (currentLine.length === 0 || spanInfo.top < envelopeBottom) {
       currentLine.push(spanInfo);
+      envelopeBottom = Math.max(envelopeBottom, sBottom);
     } else {
-      const prev = currentLine[currentLine.length - 1];
-      if (Math.abs(spanInfo.top - prev.top) < 5) {
-        currentLine.push(spanInfo);
-      } else {
-        lines.push(currentLine);
-        currentLine = [spanInfo];
-      }
+      lines.push(currentLine);
+      currentLine = [spanInfo];
+      envelopeBottom = sBottom;
     }
   }
   if (currentLine.length > 0) lines.push(currentLine);
@@ -5392,18 +5479,38 @@ function segmentPdfElements(container, pageNum) {
     const displayEqs = findDisplayEquationsFromVTM(vtm);
     sentenceRanges.forEach((r, idx) => { r.sentenceIdx = idx; r.charStart = r.start; r.charEnd = r.end; });
 
+    // displayEqs(기하학적으로 검출된 수식 줄)와 sentenceRanges(번역 문장 정렬 결과)는
+    // 서로 완전히 다른 방식으로 계산된 범위라 경계가 정확히 일치하는 경우가 드물고,
+    // 대부분 부분적으로만 겹친다. "완전히 포함" 관계만 처리하면 실제로는 수식인
+    // 구간의 상당수가 그냥 지나쳐져 isEquation이 설정되지 않으므로, 겹치는 부분이
+    // 조금이라도 있으면 그 교집합만 수식으로 잘라내는 일반화된 겹침 처리로 바꾼다.
     let currentRanges = [...sentenceRanges];
     for (const eq of displayEqs) {
       const nextRanges = [];
       for (const sent of currentRanges) {
-        if (sent.charStart < eq.start && sent.charEnd > eq.end) {
-          nextRanges.push({ ...sent, charEnd: eq.start, end: eq.start, text: fullText.substring(sent.charStart, eq.start) });
-          nextRanges.push({ start: eq.start, end: eq.end, charStart: eq.start, charEnd: eq.end, sentenceIdx: 10000 + eq.start, originalSentenceIdx: sent.sentenceIdx, text: eq.text, isEquation: true });
-          nextRanges.push({ ...sent, charStart: eq.end, start: eq.end, text: fullText.substring(eq.end, sent.charEnd) });
-        } else if (sent.charStart >= eq.start && sent.charEnd <= eq.end) {
-          nextRanges.push({ ...sent, sentenceIdx: 10000 + eq.start, originalSentenceIdx: sent.sentenceIdx, isEquation: true });
-        } else {
+        // 이미 앞선 eq에서 수식으로 잘려나온 조각은 다시 잘라내지 않는다.
+        // 그렇지 않으면 두 수식 줄의 정렬 경계가 서로 살짝 겹칠 때 아주 짧은(1~2자)
+        // 잔여 조각이 다음 eq와 또 겹쳐 잘못된(이전) 수식의 latexData를 물려받는다.
+        if (sent.isEquation) {
           nextRanges.push(sent);
+          continue;
+        }
+        const overlapStart = Math.max(sent.charStart, eq.start);
+        const overlapEnd   = Math.min(sent.charEnd, eq.end);
+        if (overlapStart >= overlapEnd) {
+          nextRanges.push(sent);
+          continue;
+        }
+        if (sent.charStart < overlapStart) {
+          nextRanges.push({ ...sent, charEnd: overlapStart, end: overlapStart, text: fullText.substring(sent.charStart, overlapStart) });
+        }
+        nextRanges.push({
+          start: overlapStart, end: overlapEnd, charStart: overlapStart, charEnd: overlapEnd,
+          sentenceIdx: 10000 + overlapStart, originalSentenceIdx: sent.sentenceIdx,
+          text: fullText.substring(overlapStart, overlapEnd), isEquation: true
+        });
+        if (sent.charEnd > overlapEnd) {
+          nextRanges.push({ ...sent, charStart: overlapEnd, start: overlapEnd, text: fullText.substring(overlapEnd, sent.charEnd) });
         }
       }
       currentRanges = nextRanges.filter(r => r.charStart < r.charEnd);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4712,7 +4712,10 @@ window.addEventListener('resize', hideSelectionMenu);
 function looksLikeEquationFragment(text) {
   const t = text.trim();
   if (!t || t.length >= 100) return false;
-  const hasMathSymbol = /[=<>+−⋅Ͱ-Ͽ∀-⋿\-*/×÷_\^\\]/.test(t);
+  // 앞뒤가 모두 글자인 하이픈(영어 복합어 하이픈, 예: "state-of-the-art")은
+  // 수학 기호로 치지 않는다 - findDisplayEquationsFromVTM과 동일한 이유.
+  const hasMathSymbol = /[=<>+−⋅Ͱ-Ͽ∀-⋿*/×÷_\^\\]/.test(t)
+    || /(?<![a-zA-Z])-(?![a-zA-Z])/.test(t);
   if (!hasMathSymbol) return false;
   const words = t.split(/\s+/);
   const engWordCount = words.filter(w => {
@@ -5084,7 +5087,6 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
     if (idx !== -1) {
       const cleanStart = idx;
       const cleanEnd = Math.min(cleanText.length, idx + cleanSent.length);
-      
       const rawStart = cleanToRaw[cleanStart] ?? (cleanToRaw[cleanToRaw.length - 1] ?? 0);
       const lastCleanIdx = cleanEnd - 1;
       const rawEnd = (cleanToRaw[lastCleanIdx] !== undefined)
@@ -5184,6 +5186,13 @@ function buildVirtualTextMap(container, pageNum) {
   const spans = [];
   allElements.forEach(el => {
     const text = el.textContent.trim();
+    // 텍스트가 없는(공백뿐이거나 빈) 요소는 건너뛴다. PDF.js가 줄마다 끼워 넣는
+    // 빈 마커/공백 전용 스팬은 어차피 fullText에 아무 글자도 보태지 않는데,
+    // getBoundingClientRect()가 0,0 같은 퇴화된 좌표를 반환하는 경우가 있어
+    // 그대로 두면 줄 안의 최대 간격(gap) 계산이 이 가짜 좌표에 낚여 엉뚱한
+    // 위치를 거터로 오판하게 만든다(실측: 실제 텍스트는 left=88부터 시작하는데
+    // 빈 스팬이 left=0에 끼어들어 "0~88" 사이를 간격으로 오인).
+    if (!text) return;
     const rect = el.getBoundingClientRect();
     const leftVal   = rect.left - containerRect.left;
     const topVal    = rect.top  - containerRect.top;
@@ -5309,16 +5318,14 @@ function buildVirtualTextMap(container, pageNum) {
   let sortedSpans;
   let lineGroups;
   if (gutterX !== null) {
-    // 줄 단위로 "이 줄이 실제로 좌/우로 갈라져야 하는가"를 개별 판정한다.
-    //  1) 줄 폭이 좁으면(페이지 폭의 55% 미만) 한쪽 컬럼의 내용만 담고 있을
-    //     가능성이 높다 - 반대쪽 컬럼과 세로 위치가 조금 어긋나 같은 줄로 묶이지
-    //     못한 경우(제목 폰트 크기 차이 등으로 기준선이 8px 이상 어긋나는 경우)다.
-    //     이미 찾아둔 gutterX를 기준으로 스팬 단위로 좌/우를 나눈다.
-    //  2) 줄 폭이 넓어도(제목/초록처럼 페이지 폭 대부분을 차지) 그 줄 내부에
-    //     gutterX 부근의 큰 간격이 있다면 좌/우 컬럼이 한 줄로 합쳐진 것이므로
-    //     역시 분할한다.
-    //  3) 그 외(폭이 넓고 gutterX 부근에 간격도 없음)는 페이지 폭을 그대로 쓰는
-    //     단일 컬럼 줄(제목/초록 등)이므로 분할하지 않고 원래 순서 그대로 둔다.
+    // 줄 하나를 gutterX 기준으로 스팬 단위로 쪼개는 방식은 위험하다 - 좌/우 컬럼은
+    // 문단 길이가 달라 독립적으로 흐르므로, 어느 한쪽 컬럼의 줄이 유난히 길어 단어
+    // 하나가 gutterX를 살짝 넘기기만 해도(자연스러운 폭 변동) 그 단어가 반대쪽
+    // 스팬 목록에 섞여 들어가고, 우연히 비슷한 높이에 있는 반대쪽 컬럼의 무관한
+    // 내용과 하나의 줄로 잘못 합쳐지는 연쇄 문제가 생긴다(실측). 그래서 원칙을
+    // 바꾼다: 줄 내부에 실제로 큰 간격이 있는 경우에만(=이 줄 자체가 좌우 두 컬럼이
+    // 나란히 합쳐진 줄) 그 간격 위치에서 나누고, 간격이 없는 줄은 시작 위치만으로
+    // 통째로 좌/우 판정한다(줄 중간 단어가 gutterX를 넘어도 줄 자체는 쪼개지 않음).
     lineGroups = [];
     let leftBuf = [];
     let rightBuf = [];
@@ -5329,18 +5336,24 @@ function buildVirtualTextMap(container, pageNum) {
       rightBuf = [];
     };
     for (const line of probeLines) {
+      const gap = lineBiggestGap(line);
+      if (gap) {
+        for (const s of line) {
+          if (s.left < gap.mid) leftBuf.push(s); else rightBuf.push(s);
+        }
+        continue;
+      }
       const lineLeft = line[0].left;
       const lineRight = line[line.length - 1].left;
-      const isNarrow = (lineRight - lineLeft) < pageWidth * 0.55;
-      const gap = lineBiggestGap(line);
-      const hasGapAtGutter = gap && Math.abs(gap.mid - gutterX) < pageWidth * 0.05;
-      if (isNarrow || hasGapAtGutter) {
-        for (const s of line) {
-          if (s.left < gutterX) leftBuf.push(s); else rightBuf.push(s);
-        }
-      } else {
+      const isWide = (lineRight - lineLeft) >= pageWidth * 0.55;
+      if (isWide) {
+        // 폭 넓은 단일 컬럼 줄(제목/초록/헤딩 등): 누적된 좌/우 버퍼를 먼저
+        // 흘려보낸 뒤, 이 줄은 원래 세로 위치 그대로 삽입한다.
         flushColumns();
         lineGroups.push(line);
+      } else {
+        // 좁은 한쪽 컬럼 줄: 시작 위치만으로 판정해 줄 전체를 통째로 축적한다.
+        if (lineLeft < gutterX) leftBuf.push(...line); else rightBuf.push(...line);
       }
     }
     flushColumns();
@@ -5463,7 +5476,13 @@ function findDisplayEquationsFromVTM(vtm) {
     if (!lineText) continue;
 
     const hasEqNum = /[\(\[][\d\w\.]+[\]\)]\s*$/.test(lineText);
-    const hasMathSymbol = /[=<>+\u2212\u22c5\u0370-\u03ff\u2200-\u22ff\-*/\u00d7\u00f7_\^\\]/.test(lineText);
+    // \uc77c\ubc18 ASCII \ud558\uc774\ud508(-)\uc740 \uc218\ud559 \uae30\ud638 \ud310\uc815\uc5d0\uc11c \ube7c\uace0, \uae00\uc790\ub85c \ub458\ub7ec\uc2f8\uc774\uc9c0 \uc54a\uc740
+    // \uacbd\uc6b0\uc5d0\ub9cc(\uc608: "a - b", "x-1") \ubcc4\ub3c4\ub85c \uac80\uc0ac\ud55c\ub2e4. "state-of-the-art"\ucc98\ub7fc
+    // \uc55e\ub4a4\uac00 \ubaa8\ub450 \uae00\uc790\uc778 \ud558\uc774\ud508\uc740 \uc601\uc5b4 \ubcf5\ud569\uc5b4 \ud558\uc774\ud508\uc77c \ubfd0\uc778\ub370, \uc774\ub97c \uc218\uc2dd \uae30\ud638\ub85c
+    // \uc624\ud310\ud558\uba74 \uc774\ub7f0 \ub2e8\uc5b4\uac00 \ud3ec\ud568\ub41c \uc9e7\uc740 \uc904(\ud2b9\ud788 \uc904\ubc14\uafc8\uc73c\ub85c \ub2e8\uc5b4 \uc218\uac00 \uc801\uc5b4\uc9c0\ub294
+    // \ub9c8\uc9c0\ub9c9 \uc904)\uc774 \uc218\uc2dd\uc73c\ub85c \uc798\ubabb \ubd84\ub958\ub418\uc5b4 \ubb38\uc7a5 \ubc94\uc704\uac00 \uc911\uac04\uc5d0 \uc798\ub824\ub098\uac04\ub2e4(\uc2e4\uce21).
+    const hasMathSymbol = /[=<>+\u2212\u22c5\u0370-\u03ff\u2200-\u22ff*/\u00d7\u00f7_\^\\]/.test(lineText)
+      || /(?<![a-zA-Z])-(?![a-zA-Z])/.test(lineText);
     const words = lineText.split(/\s+/);
     const engWordCount = words.filter(w => {
       const c = w.replace(/[^a-zA-Z]/g, '');
@@ -5652,7 +5671,6 @@ function segmentPdfElements(container, pageNum) {
     if (!state.pdfPageSentences)  state.pdfPageSentences  = {};
     state.virtualTextMaps[pageNum]  = vtm;
     state.pdfPageSentences[pageNum] = sentenceRanges;
-
     container.dataset.segmented = 'true';
 
     // 6. 오버레이 레이어 생성 (pageWrapper 기준)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5166,36 +5166,29 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
 //  3. Native Selection 보존: 브라우저 기본 텍스트 드래그/선택 완전 보존
 //
 // buildVirtualTextMap: textLayer 내부 스팬을 읽어 가상 텍스트 인덱스 맵 구성 (DOM 비수정)
-// PDF.js 텍스트 레이어의 left/top은 px 리터럴이 아니라 "18.24%"처럼 퍼센트 문자열이거나
-// "round(var(--scale-factor) * 612px, 1px)" 같은 CSS 수식 문자열일 수 있다.
-// px 단위만 찾는 정규식으로는 항상 매치에 실패해 모든 좌표가 0으로 취급되어 버리므로,
-// 퍼센트 단위는 실제 렌더링된 컨테이너 크기(dimensionPx) 기준의 px 값으로 환산한다.
-function parsePositionPx(styleValue, dimensionPx) {
-  if (!styleValue) return 0;
-  const pctMatch = styleValue.match(/([\d.-]+)%/);
-  if (pctMatch) return (parseFloat(pctMatch[1]) / 100) * dimensionPx;
-  const pxMatch = styleValue.match(/([\d.-]+)px/);
-  if (pxMatch) return parseFloat(pxMatch[1]);
-  return 0;
-}
-
 function buildVirtualTextMap(container, pageNum) {
   const allElements = Array.from(container.children).filter(el => el.nodeType === 1);
   if (allElements.length === 0) return null;
 
-  // style.width/height는 "round(var(--scale-factor) * 612px, 1px)" 같은 CSS 수식일 수 있어
-  // parseFloat로 직접 읽을 수 없으므로, 실제 렌더링된 픽셀 크기(clientWidth/Height)를 사용한다.
-  const pageWidth  = container.clientWidth  || parseFloat(container.style.width)  || 600;
-  const pageHeight = container.clientHeight || parseFloat(container.style.height) || 792;
+  // left/top을 el.style.left/top 문자열(px, %, calc() 등 PDF.js 버전·문서마다 다를 수
+  // 있음)로 역산하는 대신, 브라우저가 실제로 계산한 렌더링 좌표(getBoundingClientRect)를
+  // 컨테이너 기준 상대좌표로 직접 사용한다. 이전에 퍼센트 단위를 컨테이너 크기 기준으로
+  // 환산하는 방식을 썼었는데, 일부 문서에서는 그 환산값이 실제 렌더링 위치와 수십~백
+  // px씩 어긋났다(원인 불명 - 아마도 PDF.js가 퍼센트의 기준으로 삼는 상자와 textLayer의
+  // clientWidth/Height가 문서에 따라 정확히 일치하지 않는 경우가 있는 듯하다). 실제
+  // 렌더링 좌표를 직접 읽으면 이런 불일치가 원천적으로 발생하지 않는다.
+  const containerRect = container.getBoundingClientRect();
+  const pageWidth  = container.clientWidth  || containerRect.width  || 600;
 
   // 줄 번호 필터링 + 노드 메타데이터 수집
   const spans = [];
   allElements.forEach(el => {
     const text = el.textContent.trim();
-    const leftVal   = parsePositionPx(el.style.left, pageWidth);
-    const topVal    = parsePositionPx(el.style.top, pageHeight);
+    const rect = el.getBoundingClientRect();
+    const leftVal   = rect.left - containerRect.left;
+    const topVal    = rect.top  - containerRect.top;
     const fsMatch   = el.style.fontSize?.match(/([\d.]+)/);
-    const fsVal     = fsMatch   ? parseFloat(fsMatch[1])   : 10;
+    const fsVal     = fsMatch   ? parseFloat(fsMatch[1])   : (rect.height || 10);
     const ratio     = leftVal / pageWidth;
 
     // 줄 번호: 3~4자리 숫자, 좌측 마진 8% 이내
@@ -5223,13 +5216,20 @@ function buildVirtualTextMap(container, pageNum) {
   // 그 줄의 세로 구간(envelope)을 확장해 나가는 구간 병합(interval merging) 방식을 쓴다.
   // 첨자처럼 조금씩 어긋나는 스팬들은 서로 겹치는 구간이 연쇄적으로 이어지므로 같은
   // 줄로 안전하게 묶이고, 실제 다른 줄은 세로 구간 자체가 겹치지 않으므로 섞이지 않는다.
+  // 세로 구간 폭은 fontSize에 비례시키지 않는다 - 논문마다 실제 줄간격 대비
+  // fontSize 비율이 달라서(빽빽하게 조판된 2단 논문 등), fontSize를 그대로 쓰면
+  // 한 줄의 구간이 바로 다음 줄까지 삼켜버리고 그게 연쇄적으로 이어져 문단 여러
+  // 개가 통째로 한 줄로 합쳐지는 문제가 있었다(실측). 대신 첨자 오프셋 실측치
+  // (~6~8px)에 맞춘 고정값을 쓴다 - 이 정도면 첨자는 여전히 같은 줄로 묶이면서도,
+  // 다음 실제 줄(보통 14px 이상 떨어짐)까지 삼키지는 않는다.
+  const LINE_ENVELOPE_REACH = 8;
   function groupSpansIntoLines(spansArr) {
     const byTop = [...spansArr].sort((a, b) => a.top - b.top);
     const lines = [];
     let current = [];
     let envelopeBottom = -Infinity;
     for (const s of byTop) {
-      const sBottom = s.top + (s.fontSize || 10);
+      const sBottom = s.top + LINE_ENVELOPE_REACH;
       if (current.length === 0 || s.top < envelopeBottom) {
         current.push(s);
         envelopeBottom = Math.max(envelopeBottom, sBottom);
@@ -5245,30 +5245,60 @@ function buildVirtualTextMap(container, pageNum) {
   }
 
   // 2단 레이아웃 감지
-  // 단순히 "중앙 좌우에 각각 30% 이상 스팬이 있는가"만 보면, 폭이 넓은 단일 컬럼
-  // 페이지(문장이나 수식이 페이지 중앙을 자연스럽게 가로지르는 경우)도 좌/우 양쪽에
-  // 스팬이 골고루 분포하므로 2단으로 오판된다. 실제 2단 레이아웃이라면 두 컬럼 사이에
-  // 텍스트가 거의 없는 "거터(gutter)"가 존재해야 하므로, 중앙 근처 좁은 띠에 시작하는
-  // 스팬 비율이 충분히 낮을 때만 2단으로 판정한다.
+  // "중앙 좌우에 각각 스팬이 있는가"나 "중앙 근처에 시작하는 스팬이 적은가" 같은
+  // 집계 기반 판정은 판별력이 낮다 - 폭 넓은 단일 컬럼도, 실제 2단 컬럼도(전체 폭
+  // 제목/캡션이 섞여 있으면) 중앙 근처 스팬 비율이 비슷하게 나올 수 있다(실측: 두
+  // 경우 모두 약 13~15%). "줄 안에 큰 가로 간격이 있는가"만 보는 것도 부족하다 -
+  // 수식 번호(예: "... = f(x)      (1)")도 한 줄 안에 큰 간격을 만들기 때문에
+  // 단일 컬럼 논문에서도 다수의 줄이 큰 간격을 갖는다(실측 40%+). 진짜 거터와
+  // 수식 번호 간격의 결정적 차이는: 거터는 페이지의 모든 줄에서 항상 같은 x좌표에
+  // 나타나지만, 수식 번호 간격은 수식마다 길이가 달라 x좌표가 줄마다 들쭉날쭉하다.
+  // 그래서 "중앙 부근"인지가 아니라 "큰 간격들이 하나의 x좌표에 얼마나 몰려있는지
+  // (일관성)"로 판정한다 - 실측상 거터의 x좌표는 페이지 정중앙(pageWidth/2)이
+  // 아닐 수 있다(여백이 좌우 비대칭인 논문들이 있음).
   const mid = pageWidth / 2;
-  const leftCount  = spans.filter(n => n.left < mid * 1.05).length;
-  const rightCount = spans.filter(n => n.left > mid * 0.95).length;
-  const gutterLo = mid - pageWidth * 0.04;
-  const gutterHi = mid + pageWidth * 0.04;
-  const gutterCount = spans.filter(n => n.left >= gutterLo && n.left <= gutterHi).length;
-  const isTwoColumn = spans.length > 5
-    && (leftCount  / spans.length > 0.3)
-    && (rightCount / spans.length > 0.3)
-    && (gutterCount / spans.length < 0.05);
-
-  let sortedSpans;
-  if (isTwoColumn) {
-    const leftLines  = groupSpansIntoLines(spans.filter(n => n.left < mid));
-    const rightLines = groupSpansIntoLines(spans.filter(n => n.left >= mid));
-    sortedSpans = leftLines.flat().concat(rightLines.flat());
-  } else {
-    sortedSpans = groupSpansIntoLines(spans).flat();
+  const probeLines = groupSpansIntoLines(spans);
+  const bigGapMids = [];
+  for (const line of probeLines) {
+    let biggest = null;
+    for (let i = 0; i < line.length - 1; i++) {
+      const gap = line[i + 1].left - line[i].left;
+      if (gap > pageWidth * 0.06 && (!biggest || gap > biggest.gap)) {
+        biggest = { gap, mid: (line[i + 1].left + line[i].left) / 2 };
+      }
+    }
+    if (biggest) bigGapMids.push(biggest.mid);
   }
+  let isTwoColumn = false;
+  let gutterX = mid;
+  if (bigGapMids.length > probeLines.length * 0.3) {
+    const sorted = [...bigGapMids].sort((a, b) => a - b);
+    const medianMid = sorted[Math.floor(sorted.length / 2)];
+    const consistentCount = bigGapMids.filter(m => Math.abs(m - medianMid) < pageWidth * 0.03).length;
+    isTwoColumn = spans.length > 5
+      && probeLines.length > 3
+      && (consistentCount / probeLines.length) > 0.3;
+    if (isTwoColumn) gutterX = medianMid;
+  }
+
+  // 2단 레이아웃에서는 좌단 전체를 다 훑은 뒤 우단으로 넘어가므로, 이어붙인 배열
+  // 안에서 top이 다시 페이지 상단 값으로 되돌아가는 지점(컬럼 경계)이 생긴다.
+  // findDisplayEquationsFromVTM처럼 top 값만으로 순차적으로 "같은 줄"을 재판정하는
+  // 코드가 있으면, 이 역행 지점에서 직전 줄의 늘어난 세로 구간(envelope) 안에
+  // 다음 컬럼의 첫 줄이 우연히 걸려 두 컬럼이 하나의 "줄"로 잘못 합쳐질 수 있다.
+  // 그래서 각 스팬에 실제로 몇 번째 줄에 속하는지(lineIndex)를 미리 기록해두고,
+  // 이후 단계는 top을 다시 비교하지 않고 이 lineIndex로만 줄 경계를 판정한다.
+  let sortedSpans;
+  let lineGroups;
+  if (isTwoColumn) {
+    const leftLines  = groupSpansIntoLines(spans.filter(n => n.left < gutterX));
+    const rightLines = groupSpansIntoLines(spans.filter(n => n.left >= gutterX));
+    lineGroups = leftLines.concat(rightLines);
+  } else {
+    lineGroups = groupSpansIntoLines(spans);
+  }
+  lineGroups.forEach((line, idx) => line.forEach(s => { s.lineIndex = idx; }));
+  sortedSpans = lineGroups.flat();
 
   // 줄간격 중앙값 및 폰트 크기 중앙값 계산
   const gaps = [];
@@ -5360,21 +5390,21 @@ function findDisplayEquationsFromVTM(vtm) {
   const lines = [];
   let currentLine = [];
 
-  // groupSpansIntoLines와 동일한 구간 병합(interval merging) 방식.
-  // spans는 이미 buildVirtualTextMap에서 줄 단위로 정렬되어 들어오므로 순차적으로
-  // 세로 구간이 겹치는 동안만 같은 줄로 묶는다.
-  let envelopeBottom = -Infinity;
+  // top 값으로 줄 경계를 다시 판정하지 않는다: 2단 레이아웃에서는 좌단을 다 훑은 뒤
+  // 우단으로 넘어가면서 top이 페이지 상단 값으로 되돌아가는데, 그 지점에서 직전 줄의
+  // 늘어난 세로 구간(envelope) 안에 다음 컬럼의 첫 줄이 우연히 걸려버리면 두 컬럼
+  //전체가 하나의 "줄"로 잘못 합쳐진다(실측: 문단 여러 개가 통째로 합쳐짐). 대신
+  // buildVirtualTextMap이 이미 정확히 판정해 둔 lineIndex가 바뀔 때만 줄을 나눈다.
+  let currentLineIndex = null;
   for (const spanInfo of spans) {
     if (spanInfo.charStart === undefined || spanInfo.charEnd === undefined) continue;
-    const sBottom = spanInfo.top + (spanInfo.fontSize || 10);
-    if (currentLine.length === 0 || spanInfo.top < envelopeBottom) {
+    if (currentLine.length === 0 || spanInfo.lineIndex === currentLineIndex) {
       currentLine.push(spanInfo);
-      envelopeBottom = Math.max(envelopeBottom, sBottom);
     } else {
       lines.push(currentLine);
       currentLine = [spanInfo];
-      envelopeBottom = sBottom;
     }
+    currentLineIndex = spanInfo.lineIndex;
   }
   if (currentLine.length > 0) lines.push(currentLine);
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5258,8 +5258,7 @@ function buildVirtualTextMap(container, pageNum) {
   // 아닐 수 있다(여백이 좌우 비대칭인 논문들이 있음).
   const mid = pageWidth / 2;
   const probeLines = groupSpansIntoLines(spans);
-  const bigGapMids = [];
-  for (const line of probeLines) {
+  function lineBiggestGap(line) {
     let biggest = null;
     for (let i = 0; i < line.length - 1; i++) {
       const gap = line[i + 1].left - line[i].left;
@@ -5267,18 +5266,37 @@ function buildVirtualTextMap(container, pageNum) {
         biggest = { gap, mid: (line[i + 1].left + line[i].left) / 2 };
       }
     }
+    return biggest;
+  }
+  const bigGapMids = [];
+  for (const line of probeLines) {
+    const biggest = lineBiggestGap(line);
     if (biggest) bigGapMids.push(biggest.mid);
   }
-  let isTwoColumn = false;
-  let gutterX = mid;
-  if (bigGapMids.length > probeLines.length * 0.3) {
-    const sorted = [...bigGapMids].sort((a, b) => a - b);
-    const medianMid = sorted[Math.floor(sorted.length / 2)];
-    const consistentCount = bigGapMids.filter(m => Math.abs(m - medianMid) < pageWidth * 0.03).length;
-    isTwoColumn = spans.length > 5
-      && probeLines.length > 3
-      && (consistentCount / probeLines.length) > 0.3;
-    if (isTwoColumn) gutterX = medianMid;
+  // 페이지 전체에서 "그럴듯한 거터 후보 x좌표"가 있는지만 우선 찾는다. 실제로 이
+  // 좌표를 기준으로 분할할지는 아래에서 줄(line) 단위로 별도 판정한다 - 제목/저자/
+  // 초록처럼 폭 넓은 단일 컬럼 블록과, 그 아래에 이어지는 진짜 2단 본문이 한
+  // 페이지에 섞여 있는 경우(혼합 레이아웃), 페이지 전체를 2단 여부 하나로만
+  // 판정하면 혼합 레이아웃에서 틀리기 때문이다.
+  // 페이지 전체 간격 위치들의 "전역 중앙값"을 거터 후보로 쓰면, 제목/저자/초록처럼
+  // 폭 넓은 단일 컬럼 블록이 페이지 대부분을 차지하는 혼합 레이아웃에서 틀릴 수
+  // 있다 - 그런 블록에서 생기는 잡음성 큰 간격들의 개수가 실제 거터 간격 개수보다
+  // 많아지면, 전역 중앙값이 잡음 쪽으로 쏠려 진짜 거터를 놓친다(실측: 진짜 거터는
+  // 12개 줄에서 x≈282에 뚜렷이 몰려 있었는데도, 잡음 22개가 더 낮은 값대에 퍼져
+  // 있어 전역 중앙값은 x≈194로 계산됨). 따라서 전역 중앙값 대신, 값들 중 가장
+  // 촘촘하게 몰려있는 군집(최빈 위치)을 찾아 그 군집을 거터 후보로 삼는다.
+  let gutterX = null;
+  if (spans.length > 5 && probeLines.length > 3 && bigGapMids.length >= 4) {
+    let bestMid = null;
+    let bestCount = 0;
+    for (const m of bigGapMids) {
+      const count = bigGapMids.filter(x => Math.abs(x - m) < pageWidth * 0.03).length;
+      if (count > bestCount) { bestCount = count; bestMid = m; }
+    }
+    if (bestCount >= 4) {
+      const cluster = bigGapMids.filter(x => Math.abs(x - bestMid) < pageWidth * 0.03);
+      gutterX = cluster.reduce((a, b) => a + b, 0) / cluster.length;
+    }
   }
 
   // 2단 레이아웃에서는 좌단 전체를 다 훑은 뒤 우단으로 넘어가므로, 이어붙인 배열
@@ -5290,10 +5308,42 @@ function buildVirtualTextMap(container, pageNum) {
   // 이후 단계는 top을 다시 비교하지 않고 이 lineIndex로만 줄 경계를 판정한다.
   let sortedSpans;
   let lineGroups;
-  if (isTwoColumn) {
-    const leftLines  = groupSpansIntoLines(spans.filter(n => n.left < gutterX));
-    const rightLines = groupSpansIntoLines(spans.filter(n => n.left >= gutterX));
-    lineGroups = leftLines.concat(rightLines);
+  if (gutterX !== null) {
+    // 줄 단위로 "이 줄이 실제로 좌/우로 갈라져야 하는가"를 개별 판정한다.
+    //  1) 줄 폭이 좁으면(페이지 폭의 55% 미만) 한쪽 컬럼의 내용만 담고 있을
+    //     가능성이 높다 - 반대쪽 컬럼과 세로 위치가 조금 어긋나 같은 줄로 묶이지
+    //     못한 경우(제목 폰트 크기 차이 등으로 기준선이 8px 이상 어긋나는 경우)다.
+    //     이미 찾아둔 gutterX를 기준으로 스팬 단위로 좌/우를 나눈다.
+    //  2) 줄 폭이 넓어도(제목/초록처럼 페이지 폭 대부분을 차지) 그 줄 내부에
+    //     gutterX 부근의 큰 간격이 있다면 좌/우 컬럼이 한 줄로 합쳐진 것이므로
+    //     역시 분할한다.
+    //  3) 그 외(폭이 넓고 gutterX 부근에 간격도 없음)는 페이지 폭을 그대로 쓰는
+    //     단일 컬럼 줄(제목/초록 등)이므로 분할하지 않고 원래 순서 그대로 둔다.
+    lineGroups = [];
+    let leftBuf = [];
+    let rightBuf = [];
+    const flushColumns = () => {
+      if (leftBuf.length) lineGroups.push(...groupSpansIntoLines(leftBuf));
+      if (rightBuf.length) lineGroups.push(...groupSpansIntoLines(rightBuf));
+      leftBuf = [];
+      rightBuf = [];
+    };
+    for (const line of probeLines) {
+      const lineLeft = line[0].left;
+      const lineRight = line[line.length - 1].left;
+      const isNarrow = (lineRight - lineLeft) < pageWidth * 0.55;
+      const gap = lineBiggestGap(line);
+      const hasGapAtGutter = gap && Math.abs(gap.mid - gutterX) < pageWidth * 0.05;
+      if (isNarrow || hasGapAtGutter) {
+        for (const s of line) {
+          if (s.left < gutterX) leftBuf.push(s); else rightBuf.push(s);
+        }
+      } else {
+        flushColumns();
+        lineGroups.push(line);
+      }
+    }
+    flushColumns();
   } else {
     lineGroups = groupSpansIntoLines(spans);
   }
@@ -5380,7 +5430,7 @@ function buildVirtualTextMap(container, pageNum) {
     prevFontSize = fontSize;
   }
 
-  return { fullText, spans: sortedSpans, nodeRanges, isTwoColumn, pageNum };
+  return { fullText, spans: sortedSpans, nodeRanges, isTwoColumn: gutterX !== null, pageNum };
 }
 
 // 독립 수식 검출 (VirtualTextMap 기반)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4704,8 +4704,26 @@ if (viewerScrollContainer) {
 
 window.addEventListener('resize', hideSelectionMenu);
 
+// 문장 중간에 섞여 있는 짧은 인라인 수식 조각인지 휴리스틱으로 판단.
+// findDisplayEquationsFromVTM은 줄 전체가 수식인 "독립 수식 줄"만 찾아내므로,
+// "The extracted representation Fenc(Φmodal(...)) will..." 처럼 영문 산문 문장
+// 한가운데에 끼어 있는 짧은 수식 조각은 isEquation으로 표시되지 않는다. 선택된
+// 조각 자체가 그리스 문자/수학 기호 위주이고 영단어가 거의 없으면 수식으로 간주한다.
+function looksLikeEquationFragment(text) {
+  const t = text.trim();
+  if (!t || t.length >= 100) return false;
+  const hasMathSymbol = /[=<>+−⋅Ͱ-Ͽ∀-⋿\-*/×÷_\^\\]/.test(t);
+  if (!hasMathSymbol) return false;
+  const words = t.split(/\s+/);
+  const engWordCount = words.filter(w => {
+    const c = w.replace(/[^a-zA-Z]/g, '');
+    return c.length >= 3 && !w.startsWith('\\');
+  }).length;
+  return engWordCount <= 2;
+}
+
 // 유니코드 수식 텍스트를 LaTeX 문법으로 변환하는 휴리스틱 헬퍼 함수
-function convertRawTextToLatex(text) {
+function convertRawTextToLatex(text, inline = false) {
   let clean = text.trim();
   
   // 그리스 문자 및 수학 기호 매핑
@@ -4748,7 +4766,7 @@ function convertRawTextToLatex(text) {
   // 아래첨자 자동 교정 (예: p\theta -> p_\theta)
   clean = clean.replace(/([a-zA-Z])(\\theta|\\phi|\\mu|\\sigma|\\alpha|\\beta|\\lambda)/g, '$1_$2');
   
-  return `$$ ${clean} $$`;
+  return inline ? `$ ${clean} $` : `$$ ${clean} $$`;
 }
 
 // ── LaTeX 스마트 클립보드 인터셉터 ────────────────────────────────────────
@@ -4844,12 +4862,26 @@ document.addEventListener('copy', (e) => {
     if (overlappingSentences.length === 0) return;
 
     // 3. 각 sentenceRange에 대해 선택된 텍스트 조각을 추출하고 수식 변환 적용
-    const parts = [];
-    for (const r of overlappingSentences) {
-      const partStart = Math.max(r.charStart, selCharStart);
-      const partEnd   = Math.min(r.charEnd,   selCharEnd);
-      if (partStart >= partEnd) continue;
+    // alignSentencesToText의 정렬 결과가 드물게 서로 겹치는 범위를 만들어낼 수 있는데
+    // (예: 전역 검색 폴백이 이미 다른 문장이 차지한 구간보다 앞쪽에서 매칭되는 경우),
+    // 그대로 두면 겹치는 부분의 텍스트가 두 번 복사된다. 겹치는 후보 중에서는 더
+    // 넓은(구체적인) 범위를 우선 채택한다 - 폭이 1~2자뿐인 잔여 조각이 먼저 선택되어
+    // 실제로 맞는 넓은 범위를 밀어내는 것을 방지하기 위함이다. 채택된 범위만 다시
+    // 위치 순으로 정렬해 읽는 순서대로 이어붙인다.
+    const candidates = overlappingSentences
+      .map(r => ({ r, partStart: Math.max(r.charStart, selCharStart), partEnd: Math.min(r.charEnd, selCharEnd) }))
+      .filter(c => c.partStart < c.partEnd)
+      .sort((a, b) => (b.partEnd - b.partStart) - (a.partEnd - a.partStart));
 
+    const kept = [];
+    for (const c of candidates) {
+      if (kept.some(k => c.partStart < k.partEnd && c.partEnd > k.partStart)) continue;
+      kept.push(c);
+    }
+    kept.sort((a, b) => a.partStart - b.partStart);
+
+    const parts = [];
+    for (const { r, partStart, partEnd } of kept) {
       let text = vtm.fullText.substring(partStart, partEnd);
 
       if (r.isEquation) {
@@ -4867,6 +4899,9 @@ document.addEventListener('copy', (e) => {
           if (!latex.startsWith('$')) latex = `$ ${latex.trim()} $`;
           parts.push(' ' + latex + ' ');
         }
+      } else if (looksLikeEquationFragment(text)) {
+        // 산문 문장 중간에 섞인 짧은 인라인 수식 조각 (독립 수식 줄 감지에는 걸리지 않음)
+        parts.push(' ' + convertRawTextToLatex(text, true) + ' ');
       } else {
         // 일반 텍스트: 그대로 사용
         parts.push(text);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5116,7 +5116,19 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
   }
 
   // 매칭 실패(길이 0)인 문장들의 범위를 주변 매칭 성공 문장들 사이의 간격으로 분할 보간(Gap Partitioning)
-  // 수식 등의 기호만 있는 문장들이 누락 없이 서로 겹치지 않고 PDF 텍스트 레이어에 균등 분할 마킹되도록 지원
+  // 수식 등의 기호만 있는 문장들이 누락 없이 서로 겹치지 않고 PDF 텍스트 레이어에 균등 분할 마킹되도록 지원.
+  //
+  // 실패한 문장들 사이의 간격을 "개수로 균등 분할"하면 위험하다 - 그림 캡션처럼 원문
+  // 추출 텍스트와 번역 문장 목록이 잘 안 맞는 구간에서 매칭이 연쇄적으로 실패하면,
+  // prevEnd와 nextStart 사이의 간격이 그림이 차지하는 공백이나 전혀 무관한 다른
+  // 단락까지 포함할 정도로 커질 수 있다(실측: 캡션 문장 하나가 수백 자 떨어진 다른
+  // 컬럼의 무관한 문단까지 하이라이트로 끌어옴). 그 큰 간격을 실패한 문장 "개수"로만
+  // 나누면 문장의 실제 길이와 무관하게 넓은 범위가 배정되므로, 대신 (1) 각 문장
+  // 원문(sText) 길이 비율로 나누고, (2) 간격이 실패한 문장들의 원문 길이 합보다
+  // 비정상적으로 크면(그림 등으로 인한 진짜 공백일 가능성) 간격 전체를 억지로 채우지
+  // 않고 prevEnd부터 필요한 만큼만 촘촘히 배정한 뒤 나머지는 어느 문장에도 배정하지
+  // 않고 비워 둔다.
+  const GAP_SAFETY_MULTIPLIER = 2.5;
   let walkIdx = 0;
   while (walkIdx < sentenceRanges.length) {
     if (sentenceRanges[walkIdx].start === sentenceRanges[walkIdx].end) {
@@ -5125,7 +5137,7 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
       while (k_end + 1 < sentenceRanges.length && sentenceRanges[k_end + 1].start === sentenceRanges[k_end + 1].end) {
         k_end++;
       }
-      
+
       let prevEnd = 0;
       for (let i = k_start - 1; i >= 0; i--) {
         if (sentenceRanges[i].end > sentenceRanges[i].start) {
@@ -5133,7 +5145,7 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
           break;
         }
       }
-      
+
       let nextStart = fullText.length;
       for (let i = k_end + 1; i < sentenceRanges.length; i++) {
         if (sentenceRanges[i].end > sentenceRanges[i].start) {
@@ -5141,22 +5153,33 @@ function alignSentencesToText(fullText, sentencesList, pageNum = '?') {
           break;
         }
       }
-      
+
       if (prevEnd < nextStart) {
-        const count = k_end - k_start + 1;
-        const chunkSize = (nextStart - prevEnd) / count;
+        const gapSize = nextStart - prevEnd;
+        const lens = [];
+        let totalLen = 0;
         for (let i = k_start; i <= k_end; i++) {
-          sentenceRanges[i].start = Math.round(prevEnd + (i - k_start) * chunkSize);
-          sentenceRanges[i].end = Math.round(prevEnd + (i - k_start + 1) * chunkSize);
+          const len = Math.max(1, (sentenceRanges[i].text || '').length);
+          lens.push(len);
+          totalLen += len;
+        }
+        const usedGap = Math.min(gapSize, totalLen * GAP_SAFETY_MULTIPLIER);
+        let cursor = prevEnd;
+        for (let idx = 0; idx < lens.length; idx++) {
+          const i = k_start + idx;
+          const share = Math.round((lens[idx] / totalLen) * usedGap);
+          sentenceRanges[i].start = cursor;
+          sentenceRanges[i].end = Math.min(nextStart, cursor + share);
+          cursor = sentenceRanges[i].end;
         }
       }
-      
+
       walkIdx = k_end + 1;
     } else {
       walkIdx++;
     }
   }
-  
+
   return sentenceRanges;
 }
 


### PR DESCRIPTION
# Summary 
## 1. 번역본/채팅 패널 수식 복사 버그 수정
- katex.renderToString()가 output: 'html'로 호출되어, 이미 로드돼 있던 copy-tex 확장이 LaTeX 원문을 찾는 데 필요한 MathML <annotation> 노드가 아예 생성되지 않던 문제 수정
- 번역 렌더링, pending 수식 하이드레이션, 채팅 렌더링 3곳의 katex.renderToString() 호출을 output: 'htmlAndMathml'로 변경
- 실제 브라우저에서 인라인/블록 수식 모두 정확한 LaTeX($...$/$$...$$)로 복사됨을 검증, 일반 텍스트 복사 회귀 없음, 렌더링 변화 없음

## 2. PDF 원문 패널 수식 복사 버그 수정
- buildVirtualTextMap의 2단 컬럼 감지가 폭 넓은 단일 컬럼 페이지(문장/수식이 자연스럽게 중앙을 가로지르는 경우)를 2단으로 오판해 페이지 중앙에서 잘라 좌/우를 따로 이어붙이는 바람에 중앙을 가로지르는 수식이 반토막나고 무관한 내용이 그 사이에 끼어드는 문제 수정 (중앙 거터가 비어있는지 추가로 확인하도록 변경)
- 줄 그룹핑 비교자("top차 4px 미만이면 left로, 아니면 top으로 비교")가 전이성이 없어 첨자가 섞인 수식에서 인접한 문자가 최종 문자 인덱스상 수백~수천자 떨어진 곳에 배치되던 문제 수정 (top 정렬 후 세로 구간이 겹치는 스팬을 하나의 줄로 묶는 구간 병합 방식으로 교체, buildVirtualTextMap과 findDisplayEquationsFromVTM 양쪽에 동일하게 적용)
- 복사 핸들러가 DOM 트리 순서 기반 range.intersectsNode()를 사용해, 콘텐츠 스트림 순서와 시각적 순서가 다른 수식에서 선택 범위 밖 노드를 끌어들이거나 안의 노드를 누락시키던 문제 수정 (선택 영역의 실제 화면 좌표(getClientRects)와 겹치는지로 판정하도록 변경)
- 기하학적으로 검출된 수식 범위와 번역 문장 정렬 범위가 서로 완전히 다른 알고리즘이라 대부분 부분적으로만 겹쳐 isEquation이 설정되지 않던 문제 수정 (겹치는 부분만 잘라내는 방식으로 일반화, 이미 수식으로 표시된 조각은 재처리하지 않도록 함)

## 3. 겹치는 문장 범위로 인한 중복 복사 및 인라인 수식 LaTeX 변환 확장
- alignSentencesToText가 드물게 서로 겹치는 두 문장 범위를 만들어내는 경우(전역 검색 폴백이 이미 다른 문장이 차지한 구간보다 앞쪽에서 매칭), 겹치는 텍스트가 두 번 복사되던 문제 수정 (겹치는 후보 중 더 넓은 범위를 우선 채택하고, 채택된 범위만 다시 읽는 순서로 정렬)
- findDisplayEquationsFromVTM은 줄 전체가 수식인 경우만 감지하므로, 산문 문장 중간에 섞인 짧은 인라인 수식(예: "The extracted representation Fenc(Φmodal(...)) will thus encode...")은 감지되지 않아 그대로 복사되던 문제 개선 (짧고 수학 기호 위주인 조각을 감지해 convertRawTextToLatex로 변환하는 휴리스틱 추가, 인라인 $...$ 출력 지원 추가)