### PR TITLE
fix: resolve AI assistant session persistence and history redundancy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,3 +29,6 @@ APP_PORT=8000
 # Antigravity CLI (agy) 절대 경로 설정 (선택 사항)
 AGY_PATH=/home/ubuntu/.local/bin/agy
 
+# 프로젝트 루트 절대 경로 설정 (CLI 세션 격리 및 CWD 일관성 확보용)
+PROJECT_ROOT=/home/ubuntu/programming/projects/EasyPaper
+

--- a/backend/config.py
+++ b/backend/config.py
@@ -19,6 +19,12 @@ UPLOAD_DIR = os.getenv("UPLOAD_DIR", "./uploads")
 CACHE_DIR = os.getenv("CACHE_DIR", "./cache")
 LIBRARY_DIR = os.getenv("LIBRARY_DIR", "./library")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:5173").split(",")
+PROJECT_ROOT = os.getenv("PROJECT_ROOT", "")
+if not PROJECT_ROOT:
+    PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+def get_project_root() -> str:
+    return PROJECT_ROOT
 
 def get_ollama_host() -> str:
     return OLLAMA_HOST

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -443,12 +443,11 @@ async def stream_chat(
             pass
         formatted_prompt = []
         formatted_prompt.append(f"System instructions:\n{system_prompt}\n")
-        formatted_prompt.append("Conversation history:")
-        for msg in history_messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            role_label = "User" if role == "user" else "Assistant"
-            formatted_prompt.append(f"[{role_label}]: {content}")
+        # agy CLI가 자체적으로 --conversation 세션 내에 이전 대화 히스토리를 가지고 있으므로,
+        # 프롬프트에 중복해서 이전 대화 이력을 문자열로 덧붙이지 않고 최신 질문만 전달합니다.
+        if history_messages:
+            latest_msg = history_messages[-1]
+            formatted_prompt.append(f"User Question:\n{latest_msg.get('content', '')}")
         
         chat_prompt = "\n".join(formatted_prompt)
         async for token in stream_antigravity(chat_prompt, model=model, session_id=session_id):
@@ -462,12 +461,11 @@ async def stream_chat(
             pass
         formatted_prompt = []
         formatted_prompt.append(f"System instructions:\n{system_prompt}\n")
-        formatted_prompt.append("Conversation history:")
-        for msg in history_messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            role_label = "User" if role == "user" else "Assistant"
-            formatted_prompt.append(f"[{role_label}]: {content}")
+        # claude CLI가 자체적으로 --resume 세션 내에 이전 대화 히스토리를 가지고 있으므로,
+        # 프롬프트에 중복해서 이전 대화 이력을 문자열로 덧붙이지 않고 최신 질문만 전달합니다.
+        if history_messages:
+            latest_msg = history_messages[-1]
+            formatted_prompt.append(f"User Question:\n{latest_msg.get('content', '')}")
         
         chat_prompt = "\n".join(formatted_prompt)
         async for token in stream_claude_code(chat_prompt, model=model, session_id=session_id):

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -13,7 +13,8 @@ from config import (
     get_agy_path,
     get_agy_env,
     get_claude_code_path,
-    get_translation_prompt_template
+    get_translation_prompt_template,
+    get_project_root
 )
 
 
@@ -580,7 +581,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
     env = get_agy_env()
     if session_id:
         import shutil
-        cache_dir = "/home/ubuntu/programming/projects/EasyPaper/cache"
+        cache_dir = os.path.join(get_project_root(), "cache")
         home_dir = os.path.join(cache_dir, f"claude_home_{session_id}")
         claude_dir = os.path.join(home_dir, ".claude")
         os.makedirs(claude_dir, exist_ok=True)
@@ -650,7 +651,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
-                    cwd="/home/ubuntu/programming/projects/EasyPaper"
+                    cwd=get_project_root()
                 )
 
                 process.stdin.write(encoded_prompt)
@@ -781,7 +782,7 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=get_agy_env(),
-            cwd="/home/ubuntu/programming/projects/EasyPaper"
+            cwd=get_project_root()
         )
         
         # 새 대화 ID를 비동기적으로 감지하여 매핑 테이블에 저장하는 백그라운드 태스크 기동

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -651,7 +651,8 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
-                    env=env
+                    env=env,
+                    cwd="/home/ubuntu/programming/projects/EasyPaper"
                 )
 
                 process.stdin.write(encoded_prompt)
@@ -781,14 +782,19 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=get_agy_env()
+            env=get_agy_env(),
+            cwd="/home/ubuntu/programming/projects/EasyPaper"
         )
         
         # 새 대화 ID를 비동기적으로 감지하여 매핑 테이블에 저장하는 백그라운드 태스크 기동
+        # 타임아웃을 60초(120회)로 대폭 늘려 생성 지연에 강인하게 함
         if session_id and not mapped_conv_id:
             async def detect_and_save():
-                for _ in range(20): # 최대 10초 대기
+                for _ in range(120): # 최대 60초 대기
                     await asyncio.sleep(0.5)
+                    # 만약 아래 wait() 이후의 최종 Sync에서 매핑에 성공했다면 조기 종료
+                    if get_mapped_conversation_id(session_id):
+                        break
                     current_set = get_existing_conversations()
                     new_ids = current_set - before_set
                     if new_ids:
@@ -814,6 +820,15 @@ async def stream_antigravity(prompt: str, model: str = None, session_id: str = N
             yield final_decoded
             
         await process.wait()
+
+        # 프로세스가 종료되었으므로 혹시 백그라운드 루프가 아직 감지하지 못했을 때를 위한 동기식 최종 Sync 및 저장
+        if session_id and not get_mapped_conversation_id(session_id):
+            current_set = get_existing_conversations()
+            new_ids = current_set - before_set
+            if new_ids:
+                new_id = list(new_ids)[0]
+                save_mapped_conversation_id(session_id, new_id)
+                print(f"[stream_antigravity] [Final Sync] Mapped session {session_id} to new Antigravity conversation {new_id}")
         
         # stderr 코드가 0이 아닌 경우 stderr 내용을 로그
         if process.returncode and process.returncode != 0:


### PR DESCRIPTION
# Summary
## 1. CLI AI 어시스턴트 세션 유실 오류 수정함
- `stream_claude_code` 실행 시 `cwd`를 프로젝트 루트 `/home/ubuntu/programming/projects/EasyPaper`로 고정하여 작업 공간 변경에 따른 세션 캐시 분리 문제를 방지함.
- `stream_antigravity` 실행 시 신규 세션 ID 감지 루프 대기 횟수를 20회(10초)에서 120회(60초)로 증가시켜 네트워크 및 모델 대기 시간에 유연하도록 조치함.
- `stream_antigravity` 프로세스가 종료(`process.wait()`)되는 시점에, 백그라운드 감지 루프가 아직 동작하지 못했을 때를 대비한 동기식 최종 세션 매핑 동기화(Final Sync) 보완 로직을 추가함.
## 2. CLI 어시스턴트 질문 시 중복 대화 히스토리 전송 낭비 제거함
- `stream_chat` 함수에서 `antigravity` 및 `claude_code`에 대해 이전 질답 전체를 합쳐 전달하던 `Conversation history` 포맷팅 로직을 제거함.
- 세션 자체에서 이전 대화(번역 텍스트 포함)를 기억하므로, 질문 시에는 시스템 가이드라인과 유저의 최신 질문(`history_messages[-1]`)만 프롬프트에 실어 전달하도록 로직을 최적화함.
