### PR TITLE
feat: implement document soft-delete, restore, and trash bin control

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import FileResponse
 from services.auth import get_current_user
 from services.library import (
-    list_documents, get_document, delete_document,
+    list_documents, get_document, permanently_delete_document,
+    soft_delete_document, restore_document, empty_trash,
     get_translation, get_pdf_path, update_document_metadata
 )
 from pydantic import BaseModel
@@ -118,10 +119,44 @@ async def get_library_pdf(doc_id: str):
 
 @router.delete("/library/{doc_id}")
 async def delete_library_document(doc_id: str):
-    """라이브러리에서 문서를 삭제합니다."""
-    if not delete_document(doc_id):
+    """라이브러리 문서를 휴지통으로 이동(Soft Delete)합니다."""
+    if not soft_delete_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
-    return {"message": "문서가 삭제되었습니다."}
+    return {"message": "문서가 휴지통으로 이동되었습니다."}
+
+@router.get("/library/trash")
+async def get_library_trash(
+    target_lang: Optional[str] = None,
+    style: Optional[str] = None,
+    ignore_math: Optional[bool] = None,
+    ignore_table: Optional[bool] = None,
+    ignore_refs: Optional[bool] = None,
+    current_user: str = Depends(get_current_user)
+):
+    """휴지통에 보관 중인 문서 목록을 반환합니다."""
+    docs = list_documents(current_user, target_lang, style, ignore_math, ignore_table, ignore_refs, only_trash=True)
+    return {"documents": docs, "total": len(docs)}
+
+@router.post("/library/{doc_id}/restore")
+async def restore_library_document(doc_id: str):
+    """휴지통에서 문서를 복원합니다."""
+    if not restore_document(doc_id):
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    return {"message": "문서가 성공적으로 복원되었습니다."}
+
+@router.delete("/library/trash/empty")
+async def empty_library_trash(current_user: str = Depends(get_current_user)):
+    """휴지통을 완전히 비웁니다(영구 삭제)."""
+    if not empty_trash(current_user):
+        raise HTTPException(status_code=500, detail="휴지통 비우기에 실패했습니다.")
+    return {"message": "휴지통이 비워졌습니다."}
+
+@router.delete("/library/{doc_id}/permanent")
+async def delete_library_document_permanently(doc_id: str):
+    """라이브러리에서 문서를 영구히 삭제(Hard Delete)합니다."""
+    if not permanently_delete_document(doc_id):
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    return {"message": "문서가 영구적으로 삭제되었습니다."}
 
 
 @router.get("/library/{doc_id}/images")

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -28,6 +28,28 @@ async def get_library(
     return {"documents": docs, "total": len(docs)}
 
 
+@router.get("/library/trash")
+async def get_library_trash(
+    target_lang: Optional[str] = None,
+    style: Optional[str] = None,
+    ignore_math: Optional[bool] = None,
+    ignore_table: Optional[bool] = None,
+    ignore_refs: Optional[bool] = None,
+    current_user: str = Depends(get_current_user)
+):
+    """휴지통에 보관 중인 문서 목록을 반환합니다."""
+    docs = list_documents(current_user, target_lang, style, ignore_math, ignore_table, ignore_refs, only_trash=True)
+    return {"documents": docs, "total": len(docs)}
+
+
+@router.delete("/library/trash/empty")
+async def empty_library_trash(current_user: str = Depends(get_current_user)):
+    """휴지통을 완전히 비웁니다(영구 삭제)."""
+    if not empty_trash(current_user):
+        raise HTTPException(status_code=500, detail="휴지통 비우기에 실패했습니다.")
+    return {"message": "휴지통이 비워졌습니다."}
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,
@@ -124,32 +146,12 @@ async def delete_library_document(doc_id: str):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 휴지통으로 이동되었습니다."}
 
-@router.get("/library/trash")
-async def get_library_trash(
-    target_lang: Optional[str] = None,
-    style: Optional[str] = None,
-    ignore_math: Optional[bool] = None,
-    ignore_table: Optional[bool] = None,
-    ignore_refs: Optional[bool] = None,
-    current_user: str = Depends(get_current_user)
-):
-    """휴지통에 보관 중인 문서 목록을 반환합니다."""
-    docs = list_documents(current_user, target_lang, style, ignore_math, ignore_table, ignore_refs, only_trash=True)
-    return {"documents": docs, "total": len(docs)}
-
 @router.post("/library/{doc_id}/restore")
 async def restore_library_document(doc_id: str):
     """휴지통에서 문서를 복원합니다."""
     if not restore_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 성공적으로 복원되었습니다."}
-
-@router.delete("/library/trash/empty")
-async def empty_library_trash(current_user: str = Depends(get_current_user)):
-    """휴지통을 완전히 비웁니다(영구 삭제)."""
-    if not empty_trash(current_user):
-        raise HTTPException(status_code=500, detail="휴지통 비우기에 실패했습니다.")
-    return {"message": "휴지통이 비워졌습니다."}
 
 @router.delete("/library/{doc_id}/permanent")
 async def delete_library_document_permanently(doc_id: str):

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -67,6 +67,12 @@ def init_db():
         )
         """)
         
+        # documents 테이블 동적 스키마 마이그레이션 (is_deleted 컬럼 추가)
+        try:
+            cursor.execute("ALTER TABLE documents ADD COLUMN is_deleted INTEGER DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass
+            
         conn.commit()
         
     # 기본 관리자 계정 초기 생성
@@ -153,7 +159,7 @@ def db_get_document(doc_id: str) -> Optional[dict]:
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, username, filename, pdf_path, total_pages, metadata, created_at FROM documents WHERE id = ?",
+            "SELECT id, username, filename, pdf_path, total_pages, metadata, is_deleted, created_at FROM documents WHERE id = ?",
             (doc_id,)
         )
         row = cursor.fetchone()
@@ -163,17 +169,19 @@ def db_get_document(doc_id: str) -> Optional[dict]:
             return doc
         return None
 
-def db_list_documents(username: Optional[str] = None) -> list:
+def db_list_documents(username: Optional[str] = None, only_trash: bool = False) -> list:
+    is_deleted_val = 1 if only_trash else 0
     with get_db() as conn:
         cursor = conn.cursor()
         if username:
             cursor.execute(
-                "SELECT id, username, filename, pdf_path, total_pages, metadata, created_at FROM documents WHERE username = ? ORDER BY created_at DESC",
-                (username,)
+                "SELECT id, username, filename, pdf_path, total_pages, metadata, is_deleted, created_at FROM documents WHERE username = ? AND is_deleted = ? ORDER BY created_at DESC",
+                (username, is_deleted_val)
             )
         else:
             cursor.execute(
-                "SELECT id, username, filename, pdf_path, total_pages, metadata, created_at FROM documents ORDER BY created_at DESC"
+                "SELECT id, username, filename, pdf_path, total_pages, metadata, is_deleted, created_at FROM documents WHERE is_deleted = ? ORDER BY created_at DESC",
+                (is_deleted_val,)
             )
         rows = cursor.fetchall()
         docs = []
@@ -190,6 +198,26 @@ def db_delete_document(doc_id: str) -> bool:
         if not cursor.fetchone():
             return False
         cursor.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+        conn.commit()
+        return True
+
+def db_soft_delete_document(doc_id: str) -> bool:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM documents WHERE id = ?", (doc_id,))
+        if not cursor.fetchone():
+            return False
+        cursor.execute("UPDATE documents SET is_deleted = 1 WHERE id = ?", (doc_id,))
+        conn.commit()
+        return True
+
+def db_restore_document(doc_id: str) -> bool:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM documents WHERE id = ?", (doc_id,))
+        if not cursor.fetchone():
+            return False
+        cursor.execute("UPDATE documents SET is_deleted = 0 WHERE id = ?", (doc_id,))
         conn.commit()
         return True
 

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -8,6 +8,8 @@ from services.db import (
     db_get_document,
     db_list_documents,
     db_delete_document,
+    db_soft_delete_document,
+    db_restore_document,
     db_save_translation,
     db_get_translation,
     db_clear_translations,
@@ -93,10 +95,11 @@ def list_documents(
     style: Optional[str] = None,
     ignore_math: Optional[bool] = None,
     ignore_table: Optional[bool] = None,
-    ignore_refs: Optional[bool] = None
+    ignore_refs: Optional[bool] = None,
+    only_trash: bool = False
 ) -> list:
     """라이브러리의 문서를 최신순으로 반환합니다 (필터링 가능)."""
-    docs = db_list_documents(username)
+    docs = db_list_documents(username, only_trash=only_trash)
     
     suffix = None
     if target_lang is not None and style is not None:
@@ -171,8 +174,8 @@ def delete_chat_sessions(doc_id: str) -> None:
             print(f"[delete_chat_sessions Antigravity Error] {e}")
 
 
-def delete_document(doc_id: str) -> bool:
-    """라이브러리에서 문서 파일 및 데이터베이스 레코드를 삭제합니다."""
+def permanently_delete_document(doc_id: str) -> bool:
+    """라이브러리에서 문서 파일 및 데이터베이스 레코드를 영구히 삭제합니다."""
     doc_dir = os.path.join(LIBRARY_DIR, doc_id)
     # 1. 채팅 세션 삭제
     delete_chat_sessions(doc_id)
@@ -181,6 +184,21 @@ def delete_document(doc_id: str) -> bool:
         shutil.rmtree(doc_dir, ignore_errors=True)
     # 3. DB 삭제
     return db_delete_document(doc_id)
+
+def soft_delete_document(doc_id: str) -> bool:
+    """라이브러리 문서를 휴지통으로 이동(Soft Delete)시킵니다."""
+    return db_soft_delete_document(doc_id)
+
+def restore_document(doc_id: str) -> bool:
+    """휴지통의 문서를 복원합니다."""
+    return db_restore_document(doc_id)
+
+def empty_trash(username: str = "admin") -> bool:
+    """휴지통에 있는 모든 문서를 영구 삭제(하드 딜리트)합니다."""
+    trashed_docs = db_list_documents(username, only_trash=True)
+    for doc in trashed_docs:
+        permanently_delete_document(doc["id"])
+    return True
 
 
 # ── 번역 저장/조회 ─────────────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,10 +69,16 @@
         </button>
       </div>
 
-      <!-- 탭 영역 -->
-      <div class="library-tabs-container">
-        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
-        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
+      <!-- 탭 영역 및 제어 도구 -->
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; flex-wrap: wrap; gap: 12px;">
+        <div class="library-tabs-container" style="margin-bottom: 0;">
+          <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
+          <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
+          <button id="lib-tab-trash" class="library-tab-btn" data-tab="trash">🗑️ 휴지통</button>
+        </div>
+        <button id="lib-empty-trash-btn" class="file-btn hidden">
+          🗑️ 휴지통 비우기
+        </button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,25 +64,18 @@
           <span class="logo-icon">⚗️</span>
           <span class="logo-text">내 라이브러리</span>
         </div>
+        <button id="lib-empty-trash-btn" class="file-btn hidden">
+          🗑️ 휴지통 비우기
+        </button>
         <button id="lib-upload-btn" class="file-btn">
           + 새 논문 추가
         </button>
       </div>
 
-      <!-- 탭 영역 및 제어 도구 -->
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; flex-wrap: wrap; gap: 12px;">
-        <div class="library-tabs-container" style="margin-bottom: 0;">
-          <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
-          <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
-        </div>
-        <div style="display: flex; gap: 8px; align-items: center;">
-          <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash">
-            🗑️ 휴지통
-          </button>
-          <button id="lib-empty-trash-btn" class="file-btn hidden">
-            🗑️ 휴지통 비우기
-          </button>
-        </div>
+      <!-- 탭 영역 -->
+      <div class="library-tabs-container">
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
@@ -99,6 +92,10 @@
         </div>
       </div>
     </div>
+    <!-- 좌하단 휴지통 플로팅 버튼 -->
+    <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash">
+      🗑️ 휴지통
+    </button>
   </div>
 
   <!-- 뷰어 화면 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,10 +92,6 @@
         </div>
       </div>
     </div>
-    <!-- 좌하단 휴지통 플로팅 버튼 -->
-    <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash">
-      🗑️ 휴지통
-    </button>
   </div>
 
   <!-- 뷰어 화면 -->
@@ -276,6 +272,9 @@
 
   <!-- 공통 테마 토글 버튼 (업로드 & 라이브러리 화면용) -->
   <div class="global-theme-toggle" id="global-theme-toggle">
+    <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash" title="휴지통">
+      🗑️
+    </button>
     <button id="global-theme-toggle-btn" title="화이트/다크 모드 전환">
       <svg class="sun-icon hidden" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       <svg class="moon-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,9 +64,6 @@
           <span class="logo-icon">⚗️</span>
           <span class="logo-text">내 라이브러리</span>
         </div>
-        <button id="lib-empty-trash-btn" class="file-btn hidden">
-          🗑️ 휴지통 비우기
-        </button>
         <button id="lib-upload-btn" class="file-btn">
           + 새 논문 추가
         </button>
@@ -92,6 +89,10 @@
         </div>
       </div>
     </div>
+    <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
+    <button id="lib-empty-trash-btn" class="file-btn hidden">
+      🗑️ 휴지통 비우기
+    </button>
   </div>
 
   <!-- 뷰어 화면 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,11 +74,15 @@
         <div class="library-tabs-container" style="margin-bottom: 0;">
           <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
           <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
-          <button id="lib-tab-trash" class="library-tab-btn" data-tab="trash">🗑️ 휴지통</button>
         </div>
-        <button id="lib-empty-trash-btn" class="file-btn hidden">
-          🗑️ 휴지통 비우기
-        </button>
+        <div style="display: flex; gap: 8px; align-items: center;">
+          <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash">
+            🗑️ 휴지통
+          </button>
+          <button id="lib-empty-trash-btn" class="file-btn hidden">
+            🗑️ 휴지통 비우기
+          </button>
+        </div>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -431,6 +431,24 @@ export async function triggerSystemUpdateAPI() {
   return res.json()
 }
 
+export async function fetchTrashAPI() {
+  const res = await fetch(`${API_BASE}/library/trash`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('휴지통 목록 조회 실패')
+  return res.json()
+}
+
+export async function restoreLibraryDocAPI(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/restore`, { method: 'POST' })
+  if (!res.ok) throw new Error('문서 복원 실패')
+  return res.json()
+}
+
+export async function emptyTrashAPI() {
+  const res = await fetch(`${API_BASE}/library/trash/empty`, { method: 'DELETE' })
+  if (!res.ok) throw new Error('휴지통 비우기 실패')
+  return res.json()
+}
+
 
 
 

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -59,4 +59,26 @@ export async function updateLibraryTranslation(docId, pageNum, payload, options 
   if (!res.ok) throw new Error('번역 수정 저장 실패')
   return res.json()
 }
+export async function fetchLibraryTrash(options = {}) {
+  const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
+  if (!res.ok) throw new Error('휴지통 조회 실패')
+  return res.json()
+}
 
+export async function restoreLibraryDoc(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/restore`, { method: 'POST' })
+  if (!res.ok) throw new Error('복원 실패')
+  return res.json()
+}
+
+export async function emptyLibraryTrash() {
+  const res = await fetch(`${API_BASE}/library/trash/empty`, { method: 'DELETE' })
+  if (!res.ok) throw new Error('휴지통 비우기 실패')
+  return res.json()
+}
+
+export async function deleteLibraryDocPermanently(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/permanent`, { method: 'DELETE' })
+  if (!res.ok) throw new Error('영구 삭제 실패')
+  return res.json()
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2304,8 +2304,8 @@ function createDocCard(doc) {
   let actionsHtml = ''
   if (state.currentLibraryTab === 'trash') {
     actionsHtml = `
-      <button class="doc-open-btn doc-restore-btn" data-id="${doc.id}">복원</button>
-      <button class="doc-delete-btn doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
+      <button class="doc-restore-btn" data-id="${doc.id}">복원</button>
+      <button class="doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
           <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2020,6 +2020,24 @@ async function loadLibraryCount() {
       libraryCountBadge.classList.add('hidden')
     }
   } catch {}
+
+  // 동적 휴지통 탭 노출 여부 및 배지 카운트 표시 처리
+  try {
+    const trashData = await fetchLibraryTrash(getTranslationOptions())
+    const trashDocs = trashData.documents || []
+    const trashCount = trashDocs.length
+
+    if (libTabTrash) {
+      if (trashCount > 0 || state.currentLibraryTab === 'trash') {
+        libTabTrash.classList.remove('hidden')
+        libTabTrash.innerHTML = `🗑️ 휴지통 (${trashCount})`
+      } else {
+        libTabTrash.classList.add('hidden')
+      }
+    }
+  } catch (err) {
+    console.error('휴지통 개수 조회 실패:', err)
+  }
 }
 
 // 탭 클릭 이벤트 리스너 등록

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -23,6 +23,7 @@ window.fetch = async function (...args) {
 // ── 상태 ──────────────────────────────────────────
 const state = {
   currentLibraryTab: 'archive', // 'archive' (보관함) 또는 'history' (히스토리)
+  previousLibraryTab: 'archive', // 휴지통 진입 전 이전 탭 기억용
   currentDocId: null,
   currentDocMetadata: {},
   sessionId: null,
@@ -2084,8 +2085,12 @@ if (libTabHistory) {
 }
 if (libTabTrash) {
   libTabTrash.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'trash') return
-    updateTabUI('trash')
+    if (state.currentLibraryTab === 'trash') {
+      updateTabUI(state.previousLibraryTab || 'archive')
+    } else {
+      state.previousLibraryTab = state.currentLibraryTab
+      updateTabUI('trash')
+    }
   })
 }
 
@@ -2299,8 +2304,8 @@ function createDocCard(doc) {
   let actionsHtml = ''
   if (state.currentLibraryTab === 'trash') {
     actionsHtml = `
-      <button class="doc-restore-btn" data-id="${doc.id}">복원</button>
-      <button class="doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
+      <button class="doc-open-btn doc-restore-btn" data-id="${doc.id}">복원</button>
+      <button class="doc-delete-btn doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
           <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,7 @@ import './style.css'
 import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently } from './library.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -112,6 +112,8 @@ const libraryCategoryFilters = $('library-category-filters')
 const libraryCountBadge = $('library-count-badge')
 const libTabArchive     = $('lib-tab-archive')
 const libTabHistory     = $('lib-tab-history')
+const libTabTrash       = $('lib-tab-trash')
+const libEmptyTrashBtn  = $('lib-empty-trash-btn')
 const libraryStatsContainer = $('library-stats-container')
 
 // Google Drive Style Upload Popup references
@@ -1077,6 +1079,26 @@ globalLogoutBtn.addEventListener('click', async () => {
   }
 })
 
+// 휴지통 비우기 버튼 클릭 이벤트
+if (libEmptyTrashBtn) {
+  libEmptyTrashBtn.addEventListener('click', async () => {
+    const ok = await showCustomConfirm('휴지통에 있는 모든 논문을 영구 삭제할까요?\n이 작업은 복구할 수 없습니다.', {
+      title: '휴지통 비우기',
+      confirmText: '휴지통 비우기',
+      danger: true
+    })
+    if (!ok) return
+    try {
+      await emptyLibraryTrash()
+      showToast('휴지통이 비워졌습니다.', 'success')
+      await renderLibrary()
+      await loadLibraryCount()
+    } catch (err) {
+      showToast('휴지통 비우기 실패: ' + err.message, 'error')
+    }
+  })
+}
+
 // ── 비밀번호 변경 모달 이벤트 ──────────────────────────
 // ── Ollama 설정 새로고침 헬퍼 ──────────────────────────
 // ── 시스템 설정 새로고침 헬퍼 ──────────────────────────
@@ -2001,22 +2023,50 @@ async function loadLibraryCount() {
 }
 
 // 탭 클릭 이벤트 리스너 등록
-if (libTabArchive && libTabHistory) {
+function updateTabUI(activeTab) {
+  state.currentLibraryTab = activeTab
+  activeCategoryFilter = 'ALL'
+  
+  if (libTabArchive) libTabArchive.classList.toggle('active', activeTab === 'archive')
+  if (libTabHistory) libTabHistory.classList.toggle('active', activeTab === 'history')
+  if (libTabTrash) libTabTrash.classList.toggle('active', activeTab === 'trash')
+  
+  if (libEmptyTrashBtn) {
+    if (activeTab === 'trash') {
+      libEmptyTrashBtn.classList.remove('hidden')
+    } else {
+      libEmptyTrashBtn.classList.add('hidden')
+    }
+  }
+
+  // 휴지통 탭인 경우 새 논문 추가 플로팅 버튼을 숨깁니다.
+  if (libUploadBtn) {
+    if (activeTab === 'trash') {
+      libUploadBtn.classList.add('hidden')
+    } else {
+      libUploadBtn.classList.remove('hidden')
+    }
+  }
+  
+  renderLibrary()
+}
+
+if (libTabArchive) {
   libTabArchive.addEventListener('click', () => {
     if (state.currentLibraryTab === 'archive') return
-    state.currentLibraryTab = 'archive'
-    libTabArchive.classList.add('active')
-    libTabHistory.classList.remove('active')
-    activeCategoryFilter = 'ALL'
-    renderLibrary()
+    updateTabUI('archive')
   })
+}
+if (libTabHistory) {
   libTabHistory.addEventListener('click', () => {
     if (state.currentLibraryTab === 'history') return
-    state.currentLibraryTab = 'history'
-    libTabHistory.classList.add('active')
-    libTabArchive.classList.remove('active')
-    activeCategoryFilter = 'ALL'
-    renderLibrary()
+    updateTabUI('history')
+  })
+}
+if (libTabTrash) {
+  libTabTrash.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'trash') return
+    updateTabUI('trash')
   })
 }
 
@@ -2044,12 +2094,17 @@ async function renderLibrary() {
   libraryGrid.innerHTML = ''
   libraryCategoryFilters.innerHTML = ''
   try {
-    const data = await fetchLibrary(getTranslationOptions())
+    let data
+    if (state.currentLibraryTab === 'trash') {
+      data = await fetchLibraryTrash(getTranslationOptions())
+    } else {
+      data = await fetchLibrary(getTranslationOptions())
+    }
     const allDocs = data.documents || []
 
-    // 보관함 뱃지에는 안읽은 논문 개수 표시
+    // 보관함 뱃지에는 안읽은 논문 개수 표시 (휴지통이 아닐 때만 적용하거나, archive 기준 개수 표시)
     const unreadCount = allDocs.filter(doc => doc.metadata?.read !== true).length
-    if (unreadCount > 0 && libraryCountBadge) {
+    if (unreadCount > 0 && libraryCountBadge && state.currentLibraryTab !== 'trash') {
       libraryCountBadge.textContent = unreadCount
       libraryCountBadge.classList.remove('hidden')
     } else if (libraryCountBadge) {
@@ -2058,6 +2113,7 @@ async function renderLibrary() {
 
     // 현재 선택된 탭에 따라 논문 목록 필터링
     const docs = allDocs.filter(doc => {
+      if (state.currentLibraryTab === 'trash') return true
       const isRead = doc.metadata?.read === true
       return state.currentLibraryTab === 'history' ? isRead : !isRead
     })
@@ -2200,7 +2256,7 @@ function createDocCard(doc) {
     dateHtml = `<span>✅ 완독: ${readDateStr}</span>`
   }
 
-  const checkBtnHtml = `
+  const checkBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
     <button class="doc-card-check-btn ${isRead ? 'checked' : ''}" data-id="${doc.id}" title="${isRead ? '읽지 않음으로 표시' : '읽음으로 표시'}">
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="20 6 9 17 4 12"></polyline>
@@ -2221,6 +2277,32 @@ function createDocCard(doc) {
     `
   }
 
+  let actionsHtml = ''
+  if (state.currentLibraryTab === 'trash') {
+    actionsHtml = `
+      <button class="doc-restore-btn" data-id="${doc.id}">복원</button>
+      <button class="doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
+          <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>
+        </svg>
+      </button>
+    `
+  } else {
+    actionsHtml = `
+      <button class="doc-open-btn" data-id="${doc.id}">열기</button>
+      <button class="doc-edit-btn" data-id="${doc.id}" title="제목 수정">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
+      </button>
+      <button class="doc-delete-btn" data-id="${doc.id}" title="삭제">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
+          <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>
+        </svg>
+      </button>
+    `
+  }
+
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.innerHTML = `
@@ -2233,55 +2315,100 @@ function createDocCard(doc) {
     </div>
     ${progressHtml}
     <div class="doc-card-actions">
-      <button class="doc-open-btn" data-id="${doc.id}">열기</button>
-      <button class="doc-edit-btn" data-id="${doc.id}" title="제목 수정">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
-      </button>
-      <button class="doc-delete-btn" data-id="${doc.id}" title="삭제">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
-          <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>
-        </svg>
-      </button>
+      ${actionsHtml}
     </div>`
 
-  card.querySelector('.doc-card-check-btn').addEventListener('click', async (e) => {
-    e.stopPropagation()
-    const currentReadState = doc.metadata?.read === true
-    const nextReadState = !currentReadState
-    const payload = { read: nextReadState }
-    if (nextReadState) {
-      payload.read_at = new Date().toISOString()
-    } else {
-      payload.read_at = null
-    }
-    
-    try {
-      await updateLibraryDocMetadata(doc.id, payload)
-      showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
-      await renderLibrary()
-      await loadLibraryCount()
-    } catch (err) {
-      showToast('상태 변경 실패: ' + err.message, 'error')
-    }
-  })
+  const checkBtn = card.querySelector('.doc-card-check-btn')
+  if (checkBtn) {
+    checkBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      const currentReadState = doc.metadata?.read === true
+      const nextReadState = !currentReadState
+      const payload = { read: nextReadState }
+      if (nextReadState) {
+        payload.read_at = new Date().toISOString()
+      } else {
+        payload.read_at = null
+      }
+      
+      try {
+        await updateLibraryDocMetadata(doc.id, payload)
+        showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
+        await renderLibrary()
+        await loadLibraryCount()
+      } catch (err) {
+        showToast('상태 변경 실패: ' + err.message, 'error')
+      }
+    })
+  }
 
-  card.querySelector('.doc-open-btn').addEventListener('click', (e) => { e.stopPropagation(); openFromLibrary(doc) })
-  card.querySelector('.doc-delete-btn').addEventListener('click', async (e) => {
-    e.stopPropagation()
-    const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
-    const ok = await showCustomConfirm(`"${displayTitle}"을 삭제할까요?`, { title: '논문 삭제', confirmText: '삭제', danger: true })
-    if (!ok) return
-    try { await deleteLibraryDoc(doc.id); showToast('삭제되었습니다', 'success'); await renderLibrary() }
-    catch { showToast('삭제 실패', 'error') }
-  })
+  const openBtn = card.querySelector('.doc-open-btn')
+  if (openBtn) {
+    openBtn.addEventListener('click', (e) => { e.stopPropagation(); openFromLibrary(doc) })
+  }
+
+  const deleteBtn = card.querySelector('.doc-delete-btn')
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+      const ok = await showCustomConfirm(`"${displayTitle}"을 삭제할까요? (휴지통으로 이동합니다)`, { title: '논문 삭제', confirmText: '삭제', danger: true })
+      if (!ok) return
+      try {
+        await deleteLibraryDoc(doc.id)
+        showToast('휴지통으로 이동되었습니다.', 'success')
+        await renderLibrary()
+        await loadLibraryCount()
+      } catch {
+        showToast('삭제 실패', 'error')
+      }
+    })
+  }
+
+  const restoreBtn = card.querySelector('.doc-restore-btn')
+  if (restoreBtn) {
+    restoreBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      try {
+        await restoreLibraryDoc(doc.id)
+        showToast('논문이 복원되었습니다.', 'success')
+        await renderLibrary()
+        await loadLibraryCount()
+      } catch (err) {
+        showToast('복원 실패: ' + err.message, 'error')
+      }
+    })
+  }
+
+  const permDeleteBtn = card.querySelector('.doc-permanent-delete-btn')
+  if (permDeleteBtn) {
+    permDeleteBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+      const ok = await showCustomConfirm(`"${displayTitle}"을 영구적으로 삭제할까요?\n이 작업은 되돌릴 수 없으며, 모든 번역 데이터 및 채팅 기록이 지워집니다.`, {
+        title: '논문 영구 삭제',
+        confirmText: '영구 삭제',
+        danger: true
+      })
+      if (!ok) return
+      try {
+        await deleteLibraryDocPermanently(doc.id)
+        showToast('영구 삭제되었습니다.', 'success')
+        await renderLibrary()
+      } catch (err) {
+        showToast('삭제 실패: ' + err.message, 'error')
+      }
+    })
+  }
   
-  card.querySelector('.doc-edit-btn').addEventListener('click', (e) => {
-    e.stopPropagation()
-    const titleEl = card.querySelector('.doc-card-title')
-    const oldTitle = displayTitle
-    
-    const input = document.createElement('input')
+  const editBtn = card.querySelector('.doc-edit-btn')
+  if (editBtn) {
+    editBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      const titleEl = card.querySelector('.doc-card-title')
+      const oldTitle = displayTitle
+      
+      const input = document.createElement('input')
     input.type = 'text'
     input.value = oldTitle
     input.style.width = '100%'
@@ -2337,7 +2464,14 @@ function createDocCard(doc) {
       }, 100)
     })
   })
-  card.addEventListener('click', () => openFromLibrary(doc))
+}
+  card.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'trash') {
+      showToast('휴지통에 있는 논문입니다. 복원 후 열 수 있습니다.', 'warning')
+      return
+    }
+    openFromLibrary(doc)
+  })
   return card
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2030,7 +2030,8 @@ async function loadLibraryCount() {
     if (libTabTrash) {
       if (trashCount > 0 || state.currentLibraryTab === 'trash') {
         libTabTrash.classList.remove('hidden')
-        libTabTrash.innerHTML = `🗑️ 휴지통 (${trashCount})`
+        libTabTrash.title = `휴지통 (${trashCount}개 문서)`
+        libTabTrash.innerHTML = '🗑️'
       } else {
         libTabTrash.classList.add('hidden')
       }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3896,33 +3896,35 @@ body.light-theme .sentence-memo-box {
   transform: translateY(-1px) scale(0.98);
 }
 
-/* 휴지통 비우기 버튼 스타일 */
-/* 휴지통 비우기 버튼 스타일 리파인 */
+/* 휴지통 비우기 우하단 플로팅 버튼 스타일 */
 #lib-empty-trash-btn {
-  background: rgba(239, 68, 68, 0.08);
-  color: #ef4444;
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  padding: 8px 20px;
-  font-size: 13px;
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  z-index: 999;
+  padding: 14px 28px;
+  font-size: 14px;
   font-weight: 600;
-  border-radius: 20px;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  border-radius: 50px;
+  background: linear-gradient(135deg, #ef4444, #f43f5e);
+  color: white;
+  border: none;
+  box-shadow: 0 10px 25px -5px rgba(239, 68, 68, 0.5), 0 8px 10px -6px rgba(239, 68, 68, 0.5);
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  cursor: pointer;
 }
 
 #lib-empty-trash-btn:hover {
-  background: #ef4444;
-  color: white;
-  border-color: #ef4444;
-  box-shadow: 0 6px 16px rgba(239, 68, 68, 0.35);
-  transform: translateY(-2px);
+  transform: translateY(-4px) scale(1.02);
+  background: linear-gradient(135deg, #dc2626, #e11d48);
+  box-shadow: 0 20px 30px -10px rgba(239, 68, 68, 0.7), 0 10px 15px -5px rgba(239, 68, 68, 0.5);
 }
 
 #lib-empty-trash-btn:active {
-  transform: translateY(0);
+  transform: translateY(-1px) scale(0.98);
 }
 
 /* 우측 상단 플로팅 패널 내 휴지통 버튼 스타일 */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3897,11 +3897,12 @@ body.light-theme .sentence-memo-box {
 }
 
 /* 휴지통 비우기 버튼 스타일 */
+/* 휴지통 비우기 버튼 스타일 리파인 */
 #lib-empty-trash-btn {
-  background: rgba(239, 68, 68, 0.12);
+  background: rgba(239, 68, 68, 0.08);
   color: #ef4444;
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  padding: 8px 18px;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  padding: 8px 20px;
   font-size: 13px;
   font-weight: 600;
   border-radius: 20px;
@@ -3916,39 +3917,54 @@ body.light-theme .sentence-memo-box {
   background: #ef4444;
   color: white;
   border-color: #ef4444;
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(239, 68, 68, 0.35);
+  transform: translateY(-2px);
 }
 
 #lib-empty-trash-btn:active {
   transform: translateY(0);
 }
 
-/* 독립된 휴지통 탭 버튼 스타일 */
+/* 좌하단 휴지통 플로팅 버튼 */
 #lib-tab-trash {
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
-  padding: 8px 18px;
-  font-size: 13px;
+  position: fixed;
+  bottom: 40px;
+  left: 40px;
+  z-index: 999;
+  padding: 14px 24px;
+  font-size: 14px;
   font-weight: 600;
-  border-radius: 20px;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  border-radius: 50px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.2), 0 8px 10px -6px rgba(0, 0, 0, 0.2);
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  cursor: pointer;
 }
 
 #lib-tab-trash:hover {
+  transform: translateY(-4px) scale(1.02);
   background: rgba(239, 68, 68, 0.08);
   color: #ef4444;
   border-color: rgba(239, 68, 68, 0.3);
+  box-shadow: 0 20px 30px -10px rgba(239, 68, 68, 0.2), 0 10px 15px -5px rgba(239, 68, 68, 0.1);
 }
 
 #lib-tab-trash.active {
-  background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
-  border-color: rgba(239, 68, 68, 0.4);
-  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.2);
+  background: linear-gradient(135deg, #ef4444, #f43f5e);
+  color: white;
+  border-color: transparent;
+  box-shadow: 0 10px 25px -5px rgba(239, 68, 68, 0.4), 0 8px 10px -6px rgba(239, 68, 68, 0.4);
+}
+
+#lib-tab-trash.active:hover {
+  background: linear-gradient(135deg, #dc2626, #e11d48);
+}
+
+#lib-tab-trash:active {
+  transform: translateY(-1px) scale(0.98);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3923,3 +3923,32 @@ body.light-theme .sentence-memo-box {
 #lib-empty-trash-btn:active {
   transform: translateY(0);
 }
+
+/* 독립된 휴지통 탭 버튼 스타일 */
+#lib-tab-trash {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#lib-tab-trash:hover {
+  background: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+#lib-tab-trash.active {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.4);
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.2);
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3895,3 +3895,31 @@ body.light-theme .sentence-memo-box {
 #lib-upload-btn:active {
   transform: translateY(-1px) scale(0.98);
 }
+
+/* 휴지통 비우기 버튼 스타일 */
+#lib-empty-trash-btn {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#lib-empty-trash-btn:hover {
+  background: #ef4444;
+  color: white;
+  border-color: #ef4444;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+  transform: translateY(-1px);
+}
+
+#lib-empty-trash-btn:active {
+  transform: translateY(0);
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3925,46 +3925,42 @@ body.light-theme .sentence-memo-box {
   transform: translateY(0);
 }
 
-/* 좌하단 휴지통 플로팅 버튼 */
+/* 우측 상단 플로팅 패널 내 휴지통 버튼 스타일 */
 #lib-tab-trash {
-  position: fixed;
-  bottom: 40px;
-  left: 40px;
-  z-index: 999;
-  padding: 14px 24px;
-  font-size: 14px;
-  font-weight: 600;
-  border-radius: 50px;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
   background: var(--bg-surface);
-  color: var(--text-secondary);
   border: 1px solid var(--border-strong);
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.2), 0 8px 10px -6px rgba(0, 0, 0, 0.2);
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  color: var(--text-secondary);
+  cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
-  cursor: pointer;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  font-size: 16px;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  padding: 0;
 }
 
 #lib-tab-trash:hover {
-  transform: translateY(-4px) scale(1.02);
+  transform: scale(1.08);
   background: rgba(239, 68, 68, 0.08);
   color: #ef4444;
   border-color: rgba(239, 68, 68, 0.3);
-  box-shadow: 0 20px 30px -10px rgba(239, 68, 68, 0.2), 0 10px 15px -5px rgba(239, 68, 68, 0.1);
 }
 
 #lib-tab-trash.active {
-  background: linear-gradient(135deg, #ef4444, #f43f5e);
+  background: #ef4444;
   color: white;
-  border-color: transparent;
-  box-shadow: 0 10px 25px -5px rgba(239, 68, 68, 0.4), 0 8px 10px -6px rgba(239, 68, 68, 0.4);
+  border-color: #ef4444;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.4);
 }
 
 #lib-tab-trash.active:hover {
-  background: linear-gradient(135deg, #dc2626, #e11d48);
+  background: #dc2626;
 }
 
 #lib-tab-trash:active {
-  transform: translateY(-1px) scale(0.98);
+  transform: scale(0.95);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1179,7 +1179,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
   gap: 10px;
   margin-top: auto;
 }
-.doc-open-btn {
+.doc-open-btn, .doc-restore-btn {
   flex: 1;
   padding: 10px 16px;
   border-radius: var(--radius-sm);
@@ -1192,16 +1192,20 @@ body:not(.light-theme) .pdf-page-inner canvas {
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   font-family: var(--font-body);
   box-shadow: 0 4px 12px rgba(124, 58, 237, 0.2);
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.doc-open-btn:hover {
+.doc-open-btn:hover, .doc-restore-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 16px rgba(124, 58, 237, 0.3);
 }
-.doc-open-btn:active {
+.doc-open-btn:active, .doc-restore-btn:active {
   transform: translateY(0);
 }
 
-.doc-delete-btn {
+.doc-delete-btn, .doc-permanent-delete-btn {
   width: 36px; height: 36px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
@@ -1214,7 +1218,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   flex-shrink: 0;
 }
-.doc-delete-btn:hover {
+.doc-delete-btn:hover, .doc-permanent-delete-btn:hover {
   border-color: rgba(239, 68, 68, 0.3);
   color: #fca5a5;
   background: rgba(239, 68, 68, 0.12);


### PR DESCRIPTION
# Summary
## 1. 데이터베이스 스키마 마이그레이션 및 서비스 레이어 구축함
- `backend/services/db.py`의 `documents` 테이블에 `is_deleted` 컬럼을 동적으로 추가하는 마이그레이션 코드를 적용함.
- `db_soft_delete_document`, `db_restore_document` 함수를 정의하여 소프트 딜리트 및 복구용 쿼리를 지원함.
- `backend/services/library.py`에 소프트 딜리트(`soft_delete_document`), 복구(`restore_document`), 및 휴지통 전체 영구 삭제(`empty_trash`) 비즈니스 로직을 구축함.

## 2. API 라우터 구현 및 신규 엔드포인트 연동함
- `backend/routers/library.py`의 `DELETE /api/library/{doc_id}`를 소프트 딜리트 형태로 전환함.
- `GET /api/library/trash` (휴지통 목록 조회), `POST /api/library/{doc_id}/restore` (복원), `DELETE /api/library/trash/empty` (휴지통 비우기) 및 `DELETE /api/library/{doc_id}/permanent` (개별 영구 삭제) 라우트를 신설함.

## 3. 프론트엔드 UI/UX 개편 및 모달 제어함
- `frontend/index.html`에 "🗑️ 휴지통" 탭 및 "🗑️ 휴지통 비우기" 제어 버튼을 신설함.
- `frontend/src/style.css`에 휴지통 비우기 버튼용 아웃라인 경고 컬러 테마 및 호버/액티브 애니메이션 효과를 정의함.
- `frontend/src/api.js` 및 `library.js`에 휴지통 제어용 API 통신 함수들을 추가함.
- `frontend/src/main.js`에서 휴지통 탭 전환 시 "새 논문 추가" 플로팅 버튼을 숨기고 "휴지통 비우기" 버튼이 출현하도록 제어함.
- 휴지통의 문서 카드는 "열기", "수정" 대신 "복원" 및 "영구 삭제" 전용 액션 버튼을 렌더링하고, 클릭 시 복원/영구 삭제 API 호출과 목록 리로드 피드백을 적용함.
- 휴지통 상태의 문서를 클릭하여 뷰어를 열지 못하도록 경고 안내(`showToast`) 로직을 추가함.
- 커스텀 다이얼로그 모달(`showCustomConfirm`)을 연동하여 영구 삭제 및 휴지통 비우기 시 안전 장치를 마련함.
