### PR TITLE
feat: add viewer setting to disable hover-triggered selection tooltip

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -352,6 +352,15 @@
           </div>
           
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
+            <label>뷰어 편의 설정</label>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>데이터 및 용량 관리</label>
             <button type="button" id="clear-cache-btn" class="btn btn-secondary" style="width: 100%; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>브라우저 번역 캐시 비우기

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -55,7 +55,10 @@ const state = {
   isSelectionDragging: false,   // 마우스 드래그 선택 중인지 여부
   pdfPageSentences: {},        // pageNum → sentenceRanges 보관용
   pdfPageElements: {},         // pageNum → elRanges 보관용
-  cliAvailability: { antigravity: true, claude_code: true }
+  cliAvailability: { antigravity: true, claude_code: true },
+  // PDF 원문 위에 마우스를 올려두면(드래그 없이) 700ms 뒤 자동으로 문장을 선택하고
+  // 선택 메뉴(툴팁)를 띄우는 기능을 끌지 여부. true면 드래그로 직접 선택할 때만 뜬다.
+  disableHoverTooltip: localStorage.getItem('easypaper_disable_hover_tooltip') === 'true'
 }
 
 // ── DOM 참조 ──────────────────────────────────────
@@ -87,6 +90,7 @@ const settingIgnoreMath   = $('setting-ignore-math')
 const settingIgnoreTable  = $('setting-ignore-table')
 const settingIgnoreRefs   = $('setting-ignore-refs')
 const settingDefaultZoom  = $('setting-default-zoom')
+const settingDisableHoverTooltip = $('setting-disable-hover-tooltip')
 const clearCacheBtn       = $('clear-cache-btn')
 
 const systemSettingsForm  = $('system-settings-form')
@@ -1690,6 +1694,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingIgnoreTable.checked = localStorage.getItem('easypaper_ignore_table') !== 'false'
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
+  settingDisableHoverTooltip.checked = state.disableHoverTooltip
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
   await refreshSystemSettings()
@@ -1842,6 +1847,13 @@ generalSettingsForm.addEventListener('submit', async (e) => {
       }
     }
   }
+})
+
+// 뷰어 편의 설정: 번역 관련 설정이 아니므로 폼 제출(및 재번역 제안)과 무관하게
+// 체크 즉시 저장하고 바로 적용한다.
+settingDisableHoverTooltip.addEventListener('change', () => {
+  state.disableHoverTooltip = settingDisableHoverTooltip.checked
+  localStorage.setItem('easypaper_disable_hover_tooltip', state.disableHoverTooltip)
 })
 
 // 시스템 설정 폼 제출
@@ -6359,8 +6371,8 @@ if (viewerScrollContainer) {
 
     applyHoverHighlight(pageNum, sentenceRange);
 
-    // 700ms 드웰 선택 (수식 제외)
-    if (!annSpan && !state.hoverSelectionDisabled) {
+    // 700ms 드웰 선택 (수식 제외, 뷰어 설정에서 꺼져있지 않은 경우에만)
+    if (!annSpan && !state.hoverSelectionDisabled && !state.disableHoverTooltip) {
       if (!sentenceRange.isEquation) {
         startDwellSelection(pageNum, sentenceRange);
       }


### PR DESCRIPTION
# Summary
## 1. PDF 원문 호버 시 자동 선택/툴팁 끄기 설정 추가
- 뷰어에서 PDF 원문 위에 마우스를 올려두면(드래그 없이) 700ms 뒤 자동으로 문장이 선택되고 선택 메뉴(복사/메모/AI 질문 툴팁)가 뜨던 기존 동작(`startDwellSelection`)을 끌 수 있는 설정 추가
- 켜면 드래그로 직접 선택할 때만 툴팁이 뜨고, 마우스를 올려두기만 할 때는 기존의 은은한 하이라이트 표시(`applyHoverHighlight`)만 남음
- `frontend/index.html`: 일반 설정 탭에 "뷰어 편의 설정" 섹션 신설(체크박스 1개, 추후 다른 뷰어 편의 옵션도 이 아래에 추가할 수 있도록 구획)
- `frontend/src/main.js`: `state.disableHoverTooltip` 추가, PDF textLayer의 mousemove 핸들러에서 이 값이 true면 `startDwellSelection` 호출을 건너뜀

## 2. 저장 방식
- 번역 관련 설정(대상 언어/스타일/제외 요소 등)과 달리 이 설정은 번역 결과에 전혀 영향이 없으므로, 일반 설정 폼 제출 시 뜨는 "재번역하시겠습니까?" 확인창과 무관하게 체크 즉시 `localStorage`에 저장되고 바로 적용되도록 별도 `change` 리스너로 분리
