### PR TITLE
feat: auto-save and restore last reading position in viewer

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -357,6 +357,9 @@
               <label class="checkbox-label">
                 <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
               </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
+              </label>
             </div>
           </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -683,6 +683,18 @@ function updatePageDisplay(pageNum) {
   if (pageNum === state.currentPage) return
   state.currentPage = pageNum
   pageInput.value = pageNum
+  scheduleSaveLastReadPage(pageNum)
+}
+
+// ── 마지막으로 읽던 위치(책갈피) 자동 저장 ─────────
+// 스크롤 중 페이지가 바뀔 때마다 API를 호출하지 않도록 디바운스한다.
+let saveLastReadPageTimer = null
+function scheduleSaveLastReadPage(pageNum) {
+  if (!state.currentDocId) return
+  if (saveLastReadPageTimer) clearTimeout(saveLastReadPageTimer)
+  saveLastReadPageTimer = setTimeout(() => {
+    updateLibraryDocMetadata(state.currentDocId, { last_page: pageNum }).catch(() => {})
+  }, 1500)
 }
 
 function updateProgressMini() {
@@ -2595,10 +2607,20 @@ async function openFromLibrary(doc, shouldPushState = true) {
   docTitle.title        = doc.filename
   pageTotal.textContent = `/ ${doc.total_pages}`
   pageInput.max   = doc.total_pages
-  pageInput.value = 1
+
+  // 책갈피: 마지막으로 읽던 위치가 저장되어 있으면 그 페이지로, 없으면 1페이지로
+  const savedLastPage = doc.metadata?.last_page
+  const restorePage = (Number.isInteger(savedLastPage) && savedLastPage >= 1 && savedLastPage <= doc.total_pages)
+    ? savedLastPage
+    : 1
+  pageInput.value = restorePage
+  state.currentPage = restorePage
 
   showViewer()
   await initScrollViewer()
+  if (restorePage > 1) {
+    scrollToPage(viewerScrollContainer, restorePage, { instant: true })
+  }
   hideOutlineSidebar()
   await loadPDFOutline()
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -58,7 +58,10 @@ const state = {
   cliAvailability: { antigravity: true, claude_code: true },
   // PDF 원문 위에 마우스를 올려두면(드래그 없이) 700ms 뒤 자동으로 문장을 선택하고
   // 선택 메뉴(툴팁)를 띄우는 기능을 끌지 여부. true면 드래그로 직접 선택할 때만 뜬다.
-  disableHoverTooltip: localStorage.getItem('easypaper_disable_hover_tooltip') === 'true'
+  disableHoverTooltip: localStorage.getItem('easypaper_disable_hover_tooltip') === 'true',
+  // 마지막으로 읽던 페이지를 자동 저장하고, 문서를 다시 열 때 그 위치로 이동하는
+  // 책갈피 기능을 끌지 여부. true면 항상 1페이지부터 시작한다.
+  disableBookmark: localStorage.getItem('easypaper_disable_bookmark') === 'true'
 }
 
 // ── DOM 참조 ──────────────────────────────────────
@@ -91,6 +94,7 @@ const settingIgnoreTable  = $('setting-ignore-table')
 const settingIgnoreRefs   = $('setting-ignore-refs')
 const settingDefaultZoom  = $('setting-default-zoom')
 const settingDisableHoverTooltip = $('setting-disable-hover-tooltip')
+const settingDisableBookmark = $('setting-disable-bookmark')
 const clearCacheBtn       = $('clear-cache-btn')
 
 const systemSettingsForm  = $('system-settings-form')
@@ -690,7 +694,7 @@ function updatePageDisplay(pageNum) {
 // 스크롤 중 페이지가 바뀔 때마다 API를 호출하지 않도록 디바운스한다.
 let saveLastReadPageTimer = null
 function scheduleSaveLastReadPage(pageNum) {
-  if (!state.currentDocId) return
+  if (!state.currentDocId || state.disableBookmark) return
   if (saveLastReadPageTimer) clearTimeout(saveLastReadPageTimer)
   saveLastReadPageTimer = setTimeout(() => {
     updateLibraryDocMetadata(state.currentDocId, { last_page: pageNum }).catch(() => {})
@@ -1707,6 +1711,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
   settingDisableHoverTooltip.checked = state.disableHoverTooltip
+  settingDisableBookmark.checked = state.disableBookmark
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
   await refreshSystemSettings()
@@ -1866,6 +1871,11 @@ generalSettingsForm.addEventListener('submit', async (e) => {
 settingDisableHoverTooltip.addEventListener('change', () => {
   state.disableHoverTooltip = settingDisableHoverTooltip.checked
   localStorage.setItem('easypaper_disable_hover_tooltip', state.disableHoverTooltip)
+})
+
+settingDisableBookmark.addEventListener('change', () => {
+  state.disableBookmark = settingDisableBookmark.checked
+  localStorage.setItem('easypaper_disable_bookmark', state.disableBookmark)
 })
 
 // 시스템 설정 폼 제출
@@ -2608,8 +2618,9 @@ async function openFromLibrary(doc, shouldPushState = true) {
   pageTotal.textContent = `/ ${doc.total_pages}`
   pageInput.max   = doc.total_pages
 
-  // 책갈피: 마지막으로 읽던 위치가 저장되어 있으면 그 페이지로, 없으면 1페이지로
-  const savedLastPage = doc.metadata?.last_page
+  // 책갈피: 설정에서 끄지 않았고 마지막으로 읽던 위치가 저장되어 있으면 그 페이지로,
+  // 아니면 1페이지로
+  const savedLastPage = state.disableBookmark ? null : doc.metadata?.last_page
   const restorePage = (Number.isInteger(savedLastPage) && savedLastPage >= 1 && savedLastPage <= doc.total_pages)
     ? savedLastPage
     : 1

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -234,9 +234,9 @@ async function _renderPage(wrapper, pageNum) {
 }
 
 /** 특정 페이지 wrapper로 스크롤 */
-export function scrollToPage(container, pageNum) {
+export function scrollToPage(container, pageNum, { instant = false } = {}) {
   const el = container.querySelector(`[data-page="${pageNum}"]`)
-  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  if (el) el.scrollIntoView({ behavior: instant ? 'auto' : 'smooth', block: 'start' })
 }
 
 /** 줌 변경 후 전체 재렌더링 */


### PR DESCRIPTION
# Summary
## 1. 마지막으로 읽던 위치 자동 저장 (책갈피)
- `frontend/src/main.js`의 `updatePageDisplay()`에서 페이지가 바뀔 때마다 `scheduleSaveLastReadPage()`를 호출해 현재 페이지 번호를 문서 메타데이터(`last_page`)에 저장
- 스크롤 중 페이지가 빠르게 바뀔 때 매번 API를 호출하지 않도록 1.5초 디바운스 적용
- 저장은 "읽음" 상태 저장에 이미 쓰이던 `updateLibraryDocMetadata()`(PUT `/library/{doc_id}/metadata`)를 그대로 재사용 - 백엔드가 메타데이터를 부분 병합(`meta.update(payload)`) 방식으로 저장하기 때문에 새 필드를 추가해도 백엔드 변경이 전혀 필요 없음

## 2. 문서를 다시 열 때 마지막 위치로 점프
- `openFromLibrary()`에서 문서를 열 때 저장된 `last_page`가 유효한 범위(1~총 페이지 수)인지 검증
- 유효하면 `pageInput`/`state.currentPage`를 그 값으로 맞추고, 스크롤 뷰어 초기화 직후 해당 페이지로 즉시 이동
- 값이 없거나 범위를 벗어나면(예: 이전에 저장된 페이지 수보다 문서 페이지 수가 줄어든 경우) 기존처럼 1페이지로 시작
- `pdfViewer.js`의 `scrollToPage()`에 `instant` 옵션 추가 - 문서를 처음 열 때 저장된 위치로 점프하는 경우는 여러 페이지를 애니메이션으로 훑고 지나가지 않도록 즉시 이동시키고, 기존 페이지 번호 입력창 이동/목차 클릭 등은 그대로 부드러운 스크롤 유지

## 3. 책갈피 기능 끄기 설정 추가
- 일반 설정 > 뷰어 편의 설정에 "마지막으로 읽던 위치 자동 저장/이동 끄기" 체크박스 추가
- 켜면 저장(`scheduleSaveLastReadPage`)과 복원(`openFromLibrary`의 `last_page` 조회) 모두 건너뛰고 항상 1페이지부터 시작
- 다른 뷰어 편의 설정과 동일하게 폼 제출 없이 체크 즉시 localStorage에 저장/적용

## 검증
- 복원 위치 계산 로직(유효 범위 검증)을 11개 엣지 케이스(정상값, 범위 초과, 0/음수, 정수 아님, 문자열, 필드 없음, metadata 자체가 없음)로 검증
- `scrollToPage` 기존 호출부(페이지 입력, 목차 클릭)가 새 파라미터 추가 후에도 그대로 동작하는지 확인(3-arg 옵션은 기본값 처리로 하위 호환)
- Playwright로 설정 UI 렌더링 및 체크 즉시 저장 동작 확인
