### PR TITLE
feat: support pinch-to-zoom in viewer (trackpad + touchscreen)

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -796,10 +796,18 @@ pageInput.addEventListener('blur', (e) => {
 })
 
 // ── 줌 ────────────────────────────────────────────
-async function setZoom(newZoom) {
+// 클램핑 + 라벨 갱신만 즉시 수행하는 가벼운 버전. 핀치/휠 제스처처럼 짧은 시간에
+// 값이 계속 바뀌는 상황에서, 매번 무거운 캔버스 재렌더링(reRenderAll)을 부르지
+// 않고도 숫자 표시는 실시간으로 따라오게 하기 위해 분리했다.
+function previewZoom(newZoom) {
   newZoom = Math.max(0.5, Math.min(3.0, newZoom))
   state.zoom = newZoom
   zoomLabel.textContent = `${Math.round(newZoom / 1.5 * 100)}%`
+  return newZoom
+}
+
+async function setZoom(newZoom) {
+  newZoom = previewZoom(newZoom)
   if (!state.sessionId) return
   await reRenderAll(viewerScrollContainer, newZoom, {
     onPageVisible: (pageNum) => updatePageDisplay(pageNum)
@@ -808,6 +816,54 @@ async function setZoom(newZoom) {
 
 zoomInBtn.addEventListener('click',  () => setZoom(state.zoom + 0.2))
 zoomOutBtn.addEventListener('click', () => setZoom(state.zoom - 0.2))
+
+// 제스처 중에는 previewZoom으로 라벨만 계속 갱신하다가, 제스처가 잠시 멈추면
+// (디바운스) 그 시점의 최종 값으로 실제 재렌더링을 한 번만 실행한다.
+let zoomGestureTimer = null
+function requestZoomFromGesture(newZoom) {
+  previewZoom(newZoom)
+  if (zoomGestureTimer) clearTimeout(zoomGestureTimer)
+  zoomGestureTimer = setTimeout(() => setZoom(state.zoom), 200)
+}
+
+// 트랙패드 핀치: 브라우저가 Ctrl+wheel 이벤트로 합성해서 보낸다(맥/윈도우 공통).
+// 기본 동작(브라우저 페이지 전체 확대)을 막고 대신 뷰어 줌으로 처리한다.
+viewerScrollContainer.addEventListener('wheel', (e) => {
+  if (!e.ctrlKey) return
+  e.preventDefault()
+  // 지수 스케일링 사용 - 매끄러운 트랙패드 핀치(작은 deltaY가 연속으로 여러 번)와
+  // 마우스 휠 한 칸(±100 안팎의 큰 deltaY가 단발성으로) 양쪽 모두에서 한 번에
+  // 과도하게 확대/축소되지 않도록 함
+  requestZoomFromGesture(state.zoom * Math.exp(-e.deltaY * 0.002))
+}, { passive: false })
+
+// 터치스크린 핀치: 두 손가락 사이 거리 변화 비율만큼 확대/축소
+let pinchStartDist = null
+let pinchStartZoom = null
+function getTouchDistance(touches) {
+  const dx = touches[0].clientX - touches[1].clientX
+  const dy = touches[0].clientY - touches[1].clientY
+  return Math.hypot(dx, dy)
+}
+viewerScrollContainer.addEventListener('touchstart', (e) => {
+  if (e.touches.length === 2) {
+    pinchStartDist = getTouchDistance(e.touches)
+    pinchStartZoom = state.zoom
+  }
+}, { passive: true })
+viewerScrollContainer.addEventListener('touchmove', (e) => {
+  if (e.touches.length === 2 && pinchStartDist) {
+    e.preventDefault()
+    const scale = getTouchDistance(e.touches) / pinchStartDist
+    requestZoomFromGesture(pinchStartZoom * scale)
+  }
+}, { passive: false })
+viewerScrollContainer.addEventListener('touchend', (e) => {
+  if (e.touches.length < 2) {
+    pinchStartDist = null
+    pinchStartZoom = null
+  }
+})
 
 // ── 내보내기 ──────────────────────────────────────
 exportBtn.addEventListener('click', async () => {


### PR DESCRIPTION
# Summary
## 1. 트랙패드/터치스크린 핀치 줌 지원
- `frontend/src/main.js`: 트랙패드 핀치 제스처(브라우저가 Ctrl+wheel 이벤트로 합성해서 전달)를 감지해 브라우저의 기본 동작(페이지 전체 확대)을 막고 뷰어 자체 줌으로 처리
- 터치스크린 핀치(두 손가락 터치)도 `touchstart`/`touchmove`/`touchend`로 감지해 손가락 사이 거리 변화 비율만큼 확대/축소
- 마우스 휠 한 칸(큰 deltaY 단발성 값)과 트랙패드의 매끄러운 연속 제스처(작은 deltaY가 여러 번) 양쪽에서 자연스러운 줌 단계가 되도록 지수 스케일링(`Math.exp(-deltaY * 0.002)`) 사용

## 2. 성능: 제스처 중 재렌더링 분리
- 기존 `setZoom()`을 "클램핑 + 숫자 라벨 갱신"만 즉시 수행하는 `previewZoom()`과, 실제 PDF 캔버스 재렌더링까지 수행하는 `setZoom()`으로 분리
- 핀치/휠처럼 짧은 시간에 값이 계속 바뀌는 입력에서 이벤트마다 무거운 캔버스 재렌더링을 부르지 않도록, 제스처 중에는 `previewZoom`으로 숫자만 실시간 갱신하고 200ms 동안 추가 입력이 없을 때(디바운스) 그 시점 값으로 실제 재렌더링을 한 번만 실행(`requestZoomFromGesture`)
- 기존 확대/축소 버튼 클릭은 변경 없이 그대로 `setZoom` 즉시 호출 유지

## 검증
- Playwright로 합성 `WheelEvent`(ctrlKey 유무, 큰/작은 deltaY)와 합성 `TouchEvent`(2-포인트 핀치 인/아웃) 발생시켜 줌 라벨이 기대한 비율로 정확히 반응하는지, 일반 wheel(ctrlKey 없음)은 영향을 주지 않는지 확인
- 디바운스 이후 실제 `setZoom` 경로가 호출돼도 콘솔 에러가 없는지 확인
