### PR TITLE
feat: add keywords/vocabulary and summary tabs to translation panel

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from routers import library as library_router
 from routers import jobs as jobs_router
 from routers import auth as auth_router
 from routers import agy as agy_router
+from routers import insight as insight_router
 from services.auth import get_current_user
 
 app = FastAPI(
@@ -35,6 +36,7 @@ app.include_router(chat.router, prefix="/api", dependencies=[Depends(get_current
 app.include_router(library_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Library"])
 app.include_router(jobs_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Jobs"])
 app.include_router(agy_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["AGY"])
+app.include_router(insight_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Insight"])
 
 
 @app.on_event("startup")

--- a/backend/routers/insight.py
+++ b/backend/routers/insight.py
@@ -1,0 +1,89 @@
+import json
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+
+from routers.upload import sessions, ensure_session
+from services.llm_client import stream_page_insight
+from services.library import save_page_insight, get_page_insight
+
+router = APIRouter()
+
+VALID_KINDS = ("keywords", "summary")
+
+
+@router.get("/insight/{session_id}/{page_num}")
+async def get_page_insight_stream(
+    session_id: str,
+    page_num: int,
+    kind: str,
+    target_lang: str = "한국어",
+    force: bool = False
+):
+    """
+    특정 페이지의 키워드/단어 설명(kind=keywords) 또는 요약(kind=summary)을
+    SSE 스트리밍으로 반환합니다. 이미 생성된 적이 있으면 캐시에서 즉시 반환하고,
+    force=true면 캐시를 무시하고 새로 생성합니다.
+    """
+    if kind not in VALID_KINDS:
+        raise HTTPException(status_code=400, detail=f"kind는 {VALID_KINDS} 중 하나여야 합니다.")
+
+    if not ensure_session(session_id):
+        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+
+    session = sessions[session_id]
+    total_pages = session["total_pages"]
+
+    if page_num < 1 or page_num > total_pages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"페이지 번호는 1~{total_pages} 사이여야 합니다."
+        )
+
+    pages = session["pages"]
+    page_data = next((p for p in pages if p["page_num"] == page_num), None)
+    if not page_data:
+        raise HTTPException(status_code=404, detail="페이지를 찾을 수 없습니다.")
+
+    page_text = page_data.get("text", "").strip()
+    suffix = target_lang
+    doc_title = session.get("metadata", {}).get("title") or session.get("filename", "")
+
+    async def event_stream():
+        if not force:
+            cached = get_page_insight(session_id, page_num, kind, suffix)
+            if cached:
+                chunk_size = 100
+                for i in range(0, len(cached), chunk_size):
+                    data = json.dumps({"content": cached[i:i + chunk_size], "done": False, "cached": True}, ensure_ascii=False)
+                    yield f"data: {data}\n\n"
+                yield f"data: {json.dumps({'content': '', 'done': True, 'cached': True}, ensure_ascii=False)}\n\n"
+                return
+
+        if not page_text:
+            msg = "이 페이지에는 분석할 텍스트가 없습니다."
+            yield f"data: {json.dumps({'content': msg, 'done': False, 'cached': False}, ensure_ascii=False)}\n\n"
+            yield f"data: {json.dumps({'content': '', 'done': True, 'cached': False}, ensure_ascii=False)}\n\n"
+            return
+
+        full_result = []
+        try:
+            async for token in stream_page_insight(
+                kind,
+                page_text,
+                target_lang=target_lang,
+                doc_title=doc_title,
+                session_id=session_id
+            ):
+                full_result.append(token)
+                data = json.dumps({"content": token, "done": False, "cached": False}, ensure_ascii=False)
+                yield f"data: {data}\n\n"
+
+            complete_result = "".join(full_result).strip()
+            save_page_insight(session_id, page_num, kind, complete_result, suffix)
+            yield f"data: {json.dumps({'content': '', 'done': True, 'cached': False}, ensure_ascii=False)}\n\n"
+        except Exception as e:
+            error_data = json.dumps({"error": str(e), "done": True})
+            yield f"data: {error_data}\n\n"
+            return
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -66,7 +66,22 @@ def init_db():
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
         )
         """)
-        
+
+        # 5. page_insights 테이블 (페이지별 키워드/단어 설명, 요약 캐시)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS page_insights (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            doc_id TEXT NOT NULL,
+            page_num INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            suffix TEXT NOT NULL,
+            content TEXT NOT NULL,
+            saved_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+            UNIQUE(doc_id, page_num, kind, suffix)
+        )
+        """)
+
         # documents 테이블 동적 스키마 마이그레이션 (is_deleted 컬럼 추가)
         try:
             cursor.execute("ALTER TABLE documents ADD COLUMN is_deleted INTEGER DEFAULT 0")
@@ -305,6 +320,38 @@ def db_clear_chat_history(doc_id: str) -> None:
         cursor = conn.cursor()
         cursor.execute("DELETE FROM chats WHERE doc_id = ?", (doc_id,))
         conn.commit()
+
+# ── 페이지 인사이트 (키워드/단어, 요약) ─────────────────────────────────────────
+
+def db_save_page_insight(doc_id: str, page_num: int, kind: str, content: str, suffix: str = "") -> None:
+    saved_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO page_insights (doc_id, page_num, kind, suffix, content, saved_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (doc_id, page_num, kind, suffix, content, saved_at)
+        )
+        conn.commit()
+
+def db_get_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "") -> Optional[str]:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT content FROM page_insights WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?",
+            (doc_id, page_num, kind, suffix)
+        )
+        row = cursor.fetchone()
+        return row["content"] if row else None
+
+def db_clear_page_insights(doc_id: str) -> None:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM page_insights WHERE doc_id = ?", (doc_id,))
+        conn.commit()
+
 
 def db_clear_translations(doc_id: str) -> None:
     with get_db() as conn:

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -13,6 +13,9 @@ from services.db import (
     db_save_translation,
     db_get_translation,
     db_clear_translations,
+    db_save_page_insight,
+    db_get_page_insight,
+    db_clear_page_insights,
     db_update_document_metadata,
     get_db
 )
@@ -251,6 +254,23 @@ def get_translation_full(doc_id: str, page_num: int, suffix: str = "", fallback:
 def clear_translations(doc_id: str) -> None:
     """데이터베이스에서 모든 번역 데이터를 지웁니다."""
     db_clear_translations(doc_id)
+
+
+# ── 페이지 인사이트 (키워드/단어, 요약) ─────────────────────────────────────────
+
+def save_page_insight(doc_id: str, page_num: int, kind: str, content: str, suffix: str = "") -> None:
+    """키워드/단어 설명 또는 요약 결과를 데이터베이스에 저장합니다."""
+    db_save_page_insight(doc_id, page_num, kind, content, suffix)
+
+
+def get_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "") -> Optional[str]:
+    """데이터베이스에서 키워드/단어 설명 또는 요약 결과를 가져옵니다."""
+    return db_get_page_insight(doc_id, page_num, kind, suffix)
+
+
+def clear_page_insights(doc_id: str) -> None:
+    """데이터베이스에서 모든 페이지 인사이트(키워드/요약) 데이터를 지웁니다."""
+    db_clear_page_insights(doc_id)
 
 
 def get_pdf_path(doc_id: str) -> Optional[str]:

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -600,6 +600,95 @@ async def stream_chat(
 
 
 
+async def stream_page_insight(
+    kind: str,
+    text: str,
+    target_lang: str,
+    doc_title: str = "",
+    session_id: str = None
+) -> AsyncGenerator[str, None]:
+    """
+    페이지 원문에서 키워드/전문용어 설명(kind='keywords') 또는 요약(kind='summary')을
+    생성합니다. 어시스턴트(Chat) 프로바이더/모델 설정을 그대로 재사용한다 - 번역보다는
+    "분석/설명" 작업에 가깝고, antigravity/claude_code처럼 세션이 지속되는 provider라면
+    이미 채팅에서 쓰고 있는 문서당 공유 세션을 그대로 활용해 별도 세션을 만들지 않는다.
+    단, 대화창에 노출되는 채팅 기록(chats 테이블)에는 남기지 않고 사용량 통계도
+    "insight"로 별도 기록한다.
+    """
+    if kind == "keywords":
+        instruction = (
+            f"다음은 학술 논문 '{doc_title}'의 한 페이지 원문입니다. 이 텍스트에서 "
+            f"고급 어휘(GRE 수준 이상의 영단어) 또는 이 분야의 전문용어·고유명사를 "
+            f"중요도 순으로 최대 10개까지 골라주세요. 각 항목은 \"- **원어 용어**: {target_lang} 뜻풀이\" "
+            f"형식의 마크다운 목록으로만 출력하고, 서론이나 부연 설명은 절대 추가하지 마세요. "
+            f"본문에 그런 용어가 거의 없다면 목록 개수를 줄이거나, 정말 하나도 없으면 "
+            f"\"이 페이지에는 특별히 짚을 전문용어/고급 어휘가 없습니다.\"라고만 답하세요."
+        )
+    else:  # "summary"
+        instruction = (
+            f"다음은 학술 논문 '{doc_title}'의 한 페이지 원문입니다. 이 페이지의 핵심 내용을 "
+            f"{target_lang}로 3~5문장 이내로 간결하게 요약해주세요. 서론이나 부연 설명 없이 "
+            f"요약 내용만 즉시 출력하세요."
+        )
+
+    prompt = f"{instruction}\n\n원문:\n{text}"
+
+    provider = get_chat_provider()
+    model = get_chat_model()
+
+    if provider == "antigravity":
+        async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="insight"):
+            yield token
+        return
+    elif provider == "claude_code":
+        async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="insight"):
+            yield token
+        return
+
+    messages = [{"role": "user", "content": prompt}]
+    if provider == "openai":
+        async for token in stream_openai(messages, model=model, temperature=0.3):
+            yield token
+        return
+    elif provider == "gemini":
+        async for token in stream_gemini(messages, model=model, temperature=0.3):
+            yield token
+        return
+    elif provider == "claude":
+        async for token in stream_claude(messages, model=model, temperature=0.3):
+            yield token
+        return
+
+    # Ollama 폴백
+    payload = {
+        "model": model,
+        "messages": messages,
+        "stream": True,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            async with client.stream("POST", f"{get_ollama_host()}/api/chat", json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        token = data.get("message", {}).get("content", "")
+                        if token:
+                            yield token
+                        if data.get("done", False):
+                            break
+                    except json.JSONDecodeError:
+                        continue
+    except httpx.ConnectError:
+        raise RuntimeError(f"Ollama 서버에 연결할 수 없습니다. ({get_ollama_host()})")
+    except httpx.TimeoutException:
+        raise RuntimeError("답변 생성 시간이 초과되었습니다.")
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(f"Ollama HTTP 오류: {e.response.status_code}")
+
+
 async def check_ollama_health() -> dict:
     """Ollama 서버 상태를 확인합니다."""
     try:
@@ -634,7 +723,7 @@ def _get_claude_code_session_lock(session_id: str):
     return _claude_code_session_locks[session_id]
 
 
-async def stream_claude_code(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False) -> AsyncGenerator[str, None]:
+async def stream_claude_code(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False, usage_label: str = None) -> AsyncGenerator[str, None]:
     import asyncio
     import os
     import codecs
@@ -705,7 +794,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
 
     try:
         from services.usage_tracker import record_call
-        record_call("translate" if not is_chat else "chat")
+        record_call(usage_label or ("translate" if not is_chat else "chat"))
     except Exception:
         pass
 
@@ -940,7 +1029,8 @@ async def stream_antigravity(
     prompt: str,
     model: str = None,
     session_id: str = None,
-    is_chat: bool = False
+    is_chat: bool = False,
+    usage_label: str = None
 ) -> AsyncGenerator[str, None]:
     import asyncio
     import os
@@ -1052,7 +1142,7 @@ async def stream_antigravity(
     # 사용량 기록
     try:
         from services.usage_tracker import record_call
-        record_call("translate" if not is_chat else "chat")
+        record_call(usage_label or ("translate" if not is_chat else "chat"))
     except Exception:
         pass
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -360,6 +360,9 @@
               <label class="checkbox-label">
                 <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
               </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
+              </label>
             </div>
           </div>
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -126,6 +126,77 @@ export function streamTranslation(sessionId, pageNum, onToken, onDone, onError) 
 }
 
 /**
+ * SSE 스트리밍으로 페이지 키워드/단어 설명(kind='keywords') 또는 요약(kind='summary')을 수신합니다.
+ * @param {string} sessionId
+ * @param {number} pageNum
+ * @param {string} kind - 'keywords' | 'summary'
+ * @param {string} targetLang
+ * @param {boolean} force - true면 캐시를 무시하고 새로 생성
+ * @param {function} onToken
+ * @param {function} onDone
+ * @param {function} onError
+ * @returns {function} abort
+ */
+export function streamPageInsightAPI(sessionId, pageNum, kind, targetLang, force, onToken, onDone, onError) {
+  const controller = new AbortController()
+  const query = `?kind=${encodeURIComponent(kind)}&target_lang=${encodeURIComponent(targetLang)}&force=${force ? 'true' : 'false'}`
+
+  fetch(`${API_BASE}/insight/${sessionId}/${pageNum}${query}`, {
+    signal: controller.signal,
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const err = await res.json()
+        onError(new Error(err.detail || '생성 실패'))
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop()
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const jsonStr = line.slice(6).trim()
+          if (!jsonStr) continue
+
+          try {
+            const data = JSON.parse(jsonStr)
+            if (data.error) {
+              onError(new Error(data.error))
+              return
+            }
+            if (data.content) {
+              onToken(data.content, data.cached || false)
+            }
+            if (data.done) {
+              onDone(data.cached || false)
+              return
+            }
+          } catch (e) {
+            console.warn('SSE 파싱 오류:', e)
+          }
+        }
+      }
+    })
+    .catch((err) => {
+      if (err.name !== 'AbortError') {
+        onError(err)
+      }
+    })
+
+  return () => controller.abort()
+}
+
+/**
  * 백그라운드 번역 잡 상태를 조회합니다.
  */
 export async function getJobStatus(sessionId) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently } from './library.js'
 import { icon } from './icons.js'
@@ -61,7 +61,12 @@ const state = {
   disableHoverTooltip: localStorage.getItem('easypaper_disable_hover_tooltip') === 'true',
   // 마지막으로 읽던 페이지를 자동 저장하고, 문서를 다시 열 때 그 위치로 이동하는
   // 책갈피 기능을 끌지 여부. true면 항상 1페이지부터 시작한다.
-  disableBookmark: localStorage.getItem('easypaper_disable_bookmark') === 'true'
+  disableBookmark: localStorage.getItem('easypaper_disable_bookmark') === 'true',
+  // 번역 패널의 "키워드/단어", "요약" 탭을 끌지 여부(기본값 켜짐 - 다른 편의
+  // 설정과 달리 토큰을 추가로 소모하는 기능이라 설정에서 끌 수 있게 함).
+  disableInsights: localStorage.getItem('easypaper_disable_insights') === 'true',
+  // pageNum_kind(예: "3_keywords") → 생성된 텍스트. 탭 재방문 시 재요청 방지용 캐시.
+  pageInsightCache: {}
 }
 
 // ── DOM 참조 ──────────────────────────────────────
@@ -95,6 +100,7 @@ const settingIgnoreRefs   = $('setting-ignore-refs')
 const settingDefaultZoom  = $('setting-default-zoom')
 const settingDisableHoverTooltip = $('setting-disable-hover-tooltip')
 const settingDisableBookmark = $('setting-disable-bookmark')
+const settingDisableInsights = $('setting-disable-insights')
 const clearCacheBtn       = $('clear-cache-btn')
 
 const systemSettingsForm  = $('system-settings-form')
@@ -469,12 +475,97 @@ function createTransBlock(pageNum) {
       <span>${icon('fileText', 13, 'style="vertical-align:-2px;margin-right:3px"')}${pageNum}페이지</span>
       <span class="trans-page-status" id="trans-status-${pageNum}">대기 중</span>
     </div>
+    <div class="trans-tabs${state.disableInsights ? ' insights-off' : ''}" id="trans-tabs-${pageNum}">
+      <button class="trans-tab-btn active" data-tab="translation">번역</button>
+      <button class="trans-tab-btn insight-tab-btn" data-tab="keywords">키워드·단어</button>
+      <button class="trans-tab-btn insight-tab-btn" data-tab="summary">요약</button>
+      <button class="trans-tab-refresh-btn insight-tab-btn hidden" title="다시 생성">${icon('refreshCw', 12)}</button>
+    </div>
     <div class="trans-page-content" id="trans-content-${pageNum}">
       <div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>
     </div>
+    <div class="trans-insight-content hidden" id="keywords-content-${pageNum}"></div>
+    <div class="trans-insight-content hidden" id="summary-content-${pageNum}"></div>
     <div class="trans-resizer-handle"></div>
     <button class="trans-collapse-btn" title="${btnTitle}">${chevron}</button>`
+
+  block.querySelectorAll('.trans-tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => switchTransTab(pageNum, btn.dataset.tab))
+  })
+  block.querySelector('.trans-tab-refresh-btn').addEventListener('click', (e) => {
+    const tab = e.currentTarget.dataset.tab
+    if (tab) loadPageInsight(pageNum, tab, true)
+  })
   return block
+}
+
+// ── 번역 패널 탭 (번역 / 키워드·단어 / 요약) ─────────
+function switchTransTab(pageNum, tab) {
+  const block = $(`trans-block-${pageNum}`)
+  if (!block) return
+  block.querySelectorAll('.trans-tab-btn').forEach(btn => btn.classList.toggle('active', btn.dataset.tab === tab))
+
+  const transContent = $(`trans-content-${pageNum}`)
+  const keywordsContent = $(`keywords-content-${pageNum}`)
+  const summaryContent = $(`summary-content-${pageNum}`)
+  if (transContent) transContent.classList.toggle('hidden', tab !== 'translation')
+  if (keywordsContent) keywordsContent.classList.toggle('hidden', tab !== 'keywords')
+  if (summaryContent) summaryContent.classList.toggle('hidden', tab !== 'summary')
+
+  const refreshBtn = block.querySelector('.trans-tab-refresh-btn')
+  if (refreshBtn) {
+    if (tab === 'translation') {
+      refreshBtn.classList.add('hidden')
+    } else {
+      refreshBtn.classList.remove('hidden')
+      refreshBtn.dataset.tab = tab
+    }
+  }
+
+  if (tab === 'keywords' || tab === 'summary') {
+    loadPageInsight(pageNum, tab, false)
+  }
+}
+
+// 설정에서 키워드/요약 탭을 켜고 끌 때, 이미 열려있는 뷰어의 탭 바에도 즉시 반영
+function applyInsightsTabVisibility() {
+  document.querySelectorAll('.trans-tabs').forEach(tabsEl => {
+    tabsEl.classList.toggle('insights-off', state.disableInsights)
+    if (state.disableInsights) {
+      const pageNum = tabsEl.id.replace('trans-tabs-', '')
+      const activeBtn = tabsEl.querySelector('.trans-tab-btn.active')
+      if (activeBtn && activeBtn.dataset.tab !== 'translation') {
+        switchTransTab(pageNum, 'translation')
+      }
+    }
+  })
+}
+
+function loadPageInsight(pageNum, kind, force) {
+  const contentEl = $(`${kind}-content-${pageNum}`)
+  if (!contentEl || !state.sessionId) return
+
+  const cacheKey = `${pageNum}_${kind}`
+  if (!force && state.pageInsightCache[cacheKey] !== undefined) {
+    contentEl.innerHTML = formatTranslationHtml(state.pageInsightCache[cacheKey])
+    return
+  }
+
+  contentEl.innerHTML = `<div class="trans-waiting"><div class="trans-wait-spinner"></div><span>${kind === 'keywords' ? '키워드' : '요약'} 생성 중...</span></div>`
+
+  let buffer = ''
+  const targetLang = getTranslationOptions().targetLang
+  streamPageInsightAPI(
+    state.sessionId, pageNum, kind, targetLang, force,
+    (token) => { buffer += token },
+    () => {
+      state.pageInsightCache[cacheKey] = buffer
+      contentEl.innerHTML = formatTranslationHtml(buffer)
+    },
+    (err) => {
+      contentEl.innerHTML = `<div class="trans-error">생성 실패: ${escapeHtml(err.message)}</div>`
+    }
+  )
 }
 
 // ── 페이지 번역 ───────────────────────────────────
@@ -1799,6 +1890,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
   settingDisableHoverTooltip.checked = state.disableHoverTooltip
   settingDisableBookmark.checked = state.disableBookmark
+  settingDisableInsights.checked = state.disableInsights
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
   await refreshSystemSettings()
@@ -1963,6 +2055,12 @@ settingDisableHoverTooltip.addEventListener('change', () => {
 settingDisableBookmark.addEventListener('change', () => {
   state.disableBookmark = settingDisableBookmark.checked
   localStorage.setItem('easypaper_disable_bookmark', state.disableBookmark)
+})
+
+settingDisableInsights.addEventListener('change', () => {
+  state.disableInsights = settingDisableInsights.checked
+  localStorage.setItem('easypaper_disable_insights', state.disableInsights)
+  applyInsightsTabVisibility()
 })
 
 // 시스템 설정 폼 제출
@@ -2677,6 +2775,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
   state.translationCache = {}
   state.translationSentences = {}
   state.translatingPages = new Set()
+  state.pageInsightCache = {}
   // 번역이 완료된 페이지 번호만 기록하고 번역본 로드는 lazy-load에 위임
   state.translatedPages  = new Set(doc.translated_pages || [])
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -868,6 +868,57 @@ body:not(.light-theme) .pdf-page-inner canvas {
   text-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
 }
 
+/* 번역 / 키워드·단어 / 요약 탭 바 */
+.trans-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 20px;
+  background: var(--bg-trans-label);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.trans-tab-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.trans-tab-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.trans-tab-btn.active { color: var(--accent-mid); background: var(--bg-hover); }
+
+.trans-tab-refresh-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: all 0.15s ease;
+}
+.trans-tab-refresh-btn:hover { color: var(--accent-mid); background: var(--bg-hover); }
+
+/* 설정에서 키워드/요약 탭을 껐을 때는 번역 탭바 자체를 숨긴다 */
+.trans-tabs.insights-off .insight-tab-btn { display: none; }
+
+.trans-insight-content {
+  padding: 28px;
+  min-height: 140px;
+  overflow-y: auto;
+  flex: 1;
+  box-sizing: border-box;
+}
+
 .trans-page-content {
   padding: 28px;
   min-height: 140px;
@@ -2906,7 +2957,9 @@ body.light-theme .message-quote-img {
 }
 
 .collapse-translation .trans-page-block .trans-page-label,
-.collapse-translation .trans-page-block .trans-page-content {
+.collapse-translation .trans-page-block .trans-tabs,
+.collapse-translation .trans-page-block .trans-page-content,
+.collapse-translation .trans-page-block .trans-insight-content {
   display: none !important;
 }
 


### PR DESCRIPTION
# Summary
## 1. 번역 패널에 키워드·단어 / 요약 탭 추가
- 페이지별 번역 패널에 "번역 | 키워드·단어 | 요약" 탭 바 추가. 각 탭은 페이지마다 독립적으로 동작
- 키워드/단어 탭: 해당 페이지의 GRE급 고급 어휘나 분야별 전문용어·고유명사를 최대 10개까지 뽑아 원어+뜻풀이(번역 대상 언어)로 설명
- 요약 탭: 해당 페이지 핵심 내용을 3~5문장으로 요약
- 각 탭에 재생성(새로고침) 버튼 포함

## 2. 토큰 절약 (lazy 생성 + 캐시)
- 번역은 스크롤 시 자동 생성되지만, 키워드/요약은 **탭을 처음 클릭할 때만** 생성 - 안 보는 페이지는 아예 호출하지 않음
- 한 번 생성되면 DB에 캐시되어 재방문 시 재생성하지 않음 (새로고침 버튼으로만 강제 재생성)
- 설정 > 뷰어 편의 설정에 "키워드·단어/요약 탭 끄기" 체크박스 추가 (기본값 켜짐) - 끄면 탭바 자체가 숨겨지고, 이미 그 탭을 보고 있었다면 번역 탭으로 자동 복귀

## 3. 어시스턴트(Chat) 프로바이더 재사용
- 키워드/요약 생성은 번역이 아닌 어시스턴트(Chat) 프로바이더/모델 설정을 사용 - 번역보다 "분석/설명" 작업에 가까움
- antigravity/claude_code처럼 세션이 지속되는 provider는 채팅에서 이미 쓰고 있는 문서당 공유 세션을 그대로 활용해 별도 세션을 만들지 않음
- 단, 대화창에 노출되는 채팅 기록(`chats` 테이블)에는 남기지 않고, 사용량 통계도 `record_call`에 `insight`로 별도 기록되도록 `usage_label` 파라미터 추가

## 백엔드
- `services/db.py`: `page_insights` 테이블 추가(`doc_id, page_num, kind, suffix, content`) + CRUD. `suffix`는 `target_lang`으로 언어별 캐시 분리
- `services/library.py`: `save_page_insight`/`get_page_insight`/`clear_page_insights` 래퍼
- `services/llm_client.py`: `stream_antigravity`/`stream_claude_code`에 `usage_label` 파라미터 추가, `stream_page_insight()` 신규(kind별 프롬프트 구성 + 어시스턴트 프로바이더 라우팅)
- `routers/insight.py` 신규: `GET /api/insight/{session_id}/{page_num}` (`kind`, `target_lang`, `force` 쿼리) - 캐시 확인 후 없으면 SSE로 생성+저장
- `main.py`: 새 라우터 등록

## 프론트엔드
- `api.js`: `streamPageInsightAPI()` 추가 (기존 `streamTranslation`과 동일한 SSE 파싱 패턴)
- `index.html`: 뷰어 편의 설정에 체크박스 추가
- `main.js`: `createTransBlock`에 탭 바 추가, `switchTransTab`/`loadPageInsight`/`applyInsightsTabVisibility` 구현
- `style.css`: 탭 바/인사이트 콘텐츠 스타일, 번역 패널 접기 규칙에도 새 요소 포함
