### PR TITLE
feat: click a keyword term to locate and highlight it in the PDF

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -496,6 +496,16 @@ function createTransBlock(pageNum) {
     const tab = e.currentTarget.dataset.tab
     if (tab) loadPageInsight(pageNum, tab, true)
   })
+  // 키워드/단어 탭에서 용어 클릭 시 PDF 원문 해당 위치로 스크롤 + 하이라이트
+  // (콘텐츠는 renderInsightContent가 반복적으로 innerHTML을 교체하므로, 개별
+  // 용어 엘리먼트가 아니라 컨테이너에 위임 방식으로 한 번만 등록한다)
+  const keywordsContentEl = block.querySelector(`#keywords-content-${pageNum}`)
+  if (keywordsContentEl) {
+    keywordsContentEl.addEventListener('click', (e) => {
+      const termEl = e.target.closest('.insight-keyword-term')
+      if (termEl) locateTermInPdf(pageNum, termEl.textContent)
+    })
+  }
   return block
 }
 
@@ -599,7 +609,7 @@ function renderInsightContent(contentEl, kind, text) {
       }
       return `
         <div class="insight-keyword-item">
-          <span class="insight-keyword-term">${escapeHtml(it.term)}</span>
+          <span class="insight-keyword-term" title="클릭하면 원문에서 위치를 찾아줍니다">${escapeHtml(it.term)}</span>
           <span class="insight-keyword-def">${formatTranslationHtml(it.def)}</span>
         </div>`
     }).join('')}</div>`
@@ -5946,6 +5956,33 @@ function getOrCreateOverlay(pageWrapper) {
     inner.appendChild(overlay);
   }
   return overlay;
+}
+
+// 키워드/단어 탭에서 용어를 클릭하면 PDF 원문에서 그 단어를 찾아 스크롤 + 펄스
+// 하이라이트(citation 클릭 시 사용하는 것과 동일한 패턴 재사용)
+function locateTermInPdf(pageNum, term) {
+  const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+  const pw = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
+  if (!vtm || !pw) {
+    showToast('원문 위치를 찾을 수 없습니다.', 'warning')
+    return
+  }
+
+  const idx = vtm.fullText.toLowerCase().indexOf(term.trim().toLowerCase())
+  if (idx === -1) {
+    showToast('원문에서 해당 단어를 찾지 못했습니다.', 'warning')
+    return
+  }
+
+  const textLayer = pw.querySelector('.textLayer')
+  if (!textLayer) return
+  const rects = getSentenceRects({ charStart: idx, charEnd: idx + term.trim().length }, vtm, textLayer)
+  if (rects.length === 0) return
+
+  pw.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const overlay = getOrCreateOverlay(pw)
+  renderSentenceOverlay(overlay, rects, 'sentence-pulse-box')
+  setTimeout(() => clearOverlayBoxes(overlay, 'sentence-pulse-box'), 900)
 }
 
 // 메인 진입점: buildVirtualTextMap → alignSentencesToText → state 저장 → 메모 오버레이 렌더링

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -943,6 +943,15 @@ body:not(.light-theme) .pdf-page-inner canvas {
   font-weight: 700;
   color: var(--accent-mid);
   letter-spacing: -0.01em;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: rgba(124, 58, 237, 0.35);
+  text-underline-offset: 3px;
+  width: fit-content;
+}
+.insight-keyword-term:hover {
+  color: var(--accent-to, var(--accent-mid));
+  text-decoration-color: var(--accent-mid);
 }
 
 .insight-keyword-def {


### PR DESCRIPTION
# Summary
## 1. 키워드/단어 탭에서 용어 클릭 시 PDF 원문 위치로 이동
- 키워드/단어 탭의 각 용어를 클릭하면 PDF 원문에서 해당 단어를 찾아 스크롤 후 펄스(깜빡임) 하이라이트로 위치를 보여줌
- 인용문(citation) 클릭 시 이미 쓰고 있던 것과 동일한 메커니즘(`getSentenceRects`/`renderSentenceOverlay`/`sentence-pulse-box`)을 그대로 재사용해 시각적 일관성 확보
- `locateTermInPdf()`: 해당 페이지의 `virtualTextMap`에서 용어를 대소문자 구분 없이 검색해 문자 범위를 계산. 페이지 정보가 없거나 원문에서 못 찾으면 안내 토스트 표시

## 2. UX
- `.insight-keyword-term`에 포인터 커서 + 밑줄 스타일을 추가해 클릭 가능함을 시각적으로 표시, `title` 툴팁으로 안내
- 클릭 리스너는 `keywords-content` 컨테이너에 한 번만 위임 등록 - 탭 재방문/재생성으로 내용이 반복 교체돼도 중복 등록되지 않음
