### PR TITLE
fix: locate keyword terms in PDF using fuzzy text matching

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5960,6 +5960,11 @@ function getOrCreateOverlay(pageWrapper) {
 
 // 키워드/단어 탭에서 용어를 클릭하면 PDF 원문에서 그 단어를 찾아 스크롤 + 펄스
 // 하이라이트(citation 클릭 시 사용하는 것과 동일한 패턴 재사용)
+// 문자열에서 영숫자/한글/한자/그리스 문자만 남기고 소문자화 - PDF 원문 추출 텍스트는
+// 줄바꿈으로 끊긴 하이픈 단어, 공백 간격 등이 LLM이 본 정제된 텍스트와 다를 수 있어
+// (alignSentencesToText와 동일한 방식) 순수 문자만 비교해야 안정적으로 매칭된다.
+const INSIGHT_MATCH_CHAR_RE = /[a-zA-Z0-9ㄱ-힝一-鿿Ͱ-Ͽ]/
+
 function locateTermInPdf(pageNum, term) {
   const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
   const pw = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
@@ -5968,16 +5973,38 @@ function locateTermInPdf(pageNum, term) {
     return
   }
 
-  const idx = vtm.fullText.toLowerCase().indexOf(term.trim().toLowerCase())
-  if (idx === -1) {
+  const fullText = vtm.fullText
+  const cleanToRaw = []
+  let cleanText = ''
+  for (let i = 0; i < fullText.length; i++) {
+    const ch = fullText[i]
+    if (INSIGHT_MATCH_CHAR_RE.test(ch)) {
+      cleanToRaw.push(i)
+      cleanText += ch.toLowerCase()
+    }
+  }
+
+  let cleanTerm = ''
+  for (const ch of term.trim()) {
+    if (INSIGHT_MATCH_CHAR_RE.test(ch)) cleanTerm += ch.toLowerCase()
+  }
+
+  const cleanIdx = cleanTerm ? cleanText.indexOf(cleanTerm) : -1
+  if (cleanIdx === -1) {
     showToast('원문에서 해당 단어를 찾지 못했습니다.', 'warning')
     return
   }
 
+  const rawStart = cleanToRaw[cleanIdx]
+  const rawEnd = cleanToRaw[cleanIdx + cleanTerm.length - 1] + 1
+
   const textLayer = pw.querySelector('.textLayer')
   if (!textLayer) return
-  const rects = getSentenceRects({ charStart: idx, charEnd: idx + term.trim().length }, vtm, textLayer)
-  if (rects.length === 0) return
+  const rects = getSentenceRects({ charStart: rawStart, charEnd: rawEnd }, vtm, textLayer)
+  if (rects.length === 0) {
+    showToast('원문 위치를 하이라이트하지 못했습니다.', 'warning')
+    return
+  }
 
   pw.scrollIntoView({ behavior: 'smooth', block: 'center' })
   const overlay = getOrCreateOverlay(pw)


### PR DESCRIPTION
# Summary
## 1. 키워드 용어 클릭 시 하이라이트가 안 뜨던 문제 수정
- `locateTermInPdf()`가 PDF 원문 추출 텍스트(`vtm.fullText`)에서 용어를 순수 substring으로만 찾다 보니, PDF 레이아웃상 하이픈 줄바꿈으로 끊긴 단어(예: "cosine anneal-\ning scheduler")처럼 공백/하이픈 처리가 backend가 LLM에 넘긴 정제된 텍스트("cosine annealing scheduler")와 다르면 매칭에 실패해 클릭은 되지만 하이라이트가 전혀 안 뜨던 문제 수정
- 이 코드베이스에서 이미 같은 문제(PDF 원문 vs 정제된 텍스트 불일치)를 겪고 해결한 `alignSentencesToText`와 동일한 방식 적용 - 영숫자/한글/한자/그리스 문자만 남기고 소문자화한 뒤 비교하고, 매칭된 위치를 원본 문자 인덱스로 역매핑해서 정확한 하이라이트 좌표를 계산
- rect 계산 자체가 실패하는 극단적인 경우도 조용히 실패하지 않고 안내 토스트를 띄우도록 함

## 검증
- Playwright로 실제 `main.js`에서 함수를 추출해 하이픈 줄바꿈으로 끊긴 용어, 평범한 단일 단어, 대소문자가 다른 경우 모두 정상적으로 하이라이트가 뜨는지 확인. 존재하지 않는 용어/페이지 정보가 없는 경우 각각 올바른 안내 토스트가 뜨는 것도 재확인(회귀 없음)
