### PR TITLE
fix: 줌 변경 후 키워드 클릭 하이라이트가 동작하지 않는 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Buil2O4O.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BQT0TNUd.css">
+  <script type="module" crossorigin src="/assets/index-BYkKzKGu.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DTcTdqER.css">
 </head>
 <body>
 
@@ -30,7 +30,7 @@
     </div>
     <div class="upload-container">
       <div class="logo">
-        <span class="logo-icon">⚗️</span>
+        <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></span>
         <span class="logo-text">EasyPaper</span>
       </div>
       <h1 class="upload-title">학술 논문 번역 서비스<br /><span class="gradient-text">보안 로그인</span></h1>
@@ -62,7 +62,7 @@
     <div class="library-container">
       <div class="library-header">
         <div class="logo">
-          <span class="logo-icon">⚗️</span>
+          <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></span>
           <span class="logo-text">내 라이브러리</span>
         </div>
         <button id="lib-upload-btn" class="file-btn">
@@ -72,8 +72,8 @@
 
       <!-- 탭 영역 -->
       <div class="library-tabs-container">
-        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive">📥 보관함</button>
-        <button id="lib-tab-history" class="library-tab-btn" data-tab="history">✅ 히스토리</button>
+        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>보관함</button>
+        <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
@@ -84,12 +84,16 @@
 
       <div id="library-grid" class="library-grid">
         <div class="lib-empty" id="lib-empty">
-          <div style="font-size:48px;margin-bottom:16px">📚</div>
+          <div style="margin-bottom:16px;color:var(--text-muted)"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg></div>
           <p>저장된 논문이 없습니다</p>
           <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>
         </div>
       </div>
     </div>
+    <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
+    <button id="lib-empty-trash-btn" class="file-btn hidden">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
+    </button>
   </div>
 
   <!-- 뷰어 화면 -->
@@ -101,17 +105,17 @@
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
-        <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기">⚗️ EasyPaper</button>
+        <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:4px"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>EasyPaper</button>
         <!-- 독서 완료 토글 버튼 -->
         <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글" style="margin-left: 8px;">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-            <polyline points="22 4 12 14.01 9 11.01"></polyline>
+            <circle cx="12" cy="12" r="10"></circle>
+            <path d="m9 12 2 2 4-4"></path>
           </svg>
           <span class="read-btn-text">독서 완료</span>
         </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
@@ -157,9 +161,9 @@
         <div class="toolbar-group tool-group">
           <button id="capture-area-btn" class="icon-btn" title="영역 캡처하여 질문하기">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-              <circle cx="8.5" cy="8.5" r="1.5"/>
-              <polyline points="21 15 16 10 5 21"/>
+              <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+              <circle cx="9" cy="9" r="2"/>
+              <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
             </svg>
           </button>
           <button id="chat-toggle-btn" class="icon-btn" title="AI 어시스턴트 토글">
@@ -184,7 +188,7 @@
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
           </button>
           <button id="export-btn" class="icon-btn" title="번역본 내보내기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
           </button>
         </div>
 
@@ -203,7 +207,7 @@
     <!-- 좌측 목차 사이드바 -->
     <aside class="outline-sidebar hidden" id="outline-sidebar">
       <div class="outline-header">
-        <span class="outline-title">📌 논문 목차</span>
+        <span class="outline-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>논문 목차</span>
         <button id="outline-close-btn" class="outline-close-btn" title="목차 닫기">&times;</button>
       </div>
       <div class="outline-content" id="outline-content">
@@ -225,7 +229,7 @@
       <aside class="chat-sidebar hidden" id="chat-sidebar">
         <div class="chat-header" style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
           <div class="chat-title-area" style="display: flex; align-items: center; gap: 4px;">
-            <span class="chat-header-icon">💬</span>
+            <span class="chat-header-icon"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg></span>
             <span class="chat-title">AI 어시스턴트</span>
           </div>
           <button id="chat-close-btn" class="chat-close-btn" title="닫기">&times;</button>
@@ -236,7 +240,7 @@
         </div>
         <div class="chat-messages" id="chat-messages">
           <div class="chat-message assistant">
-            <div class="message-bubble">안녕하세요! 이 논문의 내용에 대해 궁금한 점을 질문하시면 해당 분야의 전문가로서 답변해 드립니다.<br><br><strong>💡 질문 예시:</strong><ul><li>이 논문의 핵심 연구 내용과 기여도를 요약해줘.</li><li>본문에서 제안하는 알고리즘/방법론의 상세 과정을 설명해줘.</li><li>실험 결과에서 제시된 주요 수치와 의의는 무엇이야?</li></ul></div>
+            <div class="message-bubble">안녕하세요! 이 논문의 내용에 대해 궁금한 점을 질문하시면 해당 분야의 전문가로서 답변해 드립니다.<br><br><strong><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>질문 예시:</strong><ul><li>이 논문의 핵심 연구 내용과 기여도를 요약해줘.</li><li>본문에서 제안하는 알고리즘/방법론의 상세 과정을 설명해줘.</li><li>실험 결과에서 제시된 주요 수치와 의의는 무엇이야?</li></ul></div>
           </div>
         </div>
         <div class="chat-input-area">
@@ -270,12 +274,15 @@
 
   <!-- 공통 테마 토글 버튼 (업로드 & 라이브러리 화면용) -->
   <div class="global-theme-toggle" id="global-theme-toggle">
+    <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash" title="휴지통">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+    </button>
     <button id="global-theme-toggle-btn" title="화이트/다크 모드 전환">
       <svg class="sun-icon hidden" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       <svg class="moon-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     </button>
     <button id="global-settings-btn" title="비밀번호 변경" class="hidden">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"/><circle cx="12" cy="12" r="3"/></svg>
     </button>
     <button id="global-logout-btn" title="로그아웃" class="hidden">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
@@ -286,7 +293,7 @@
   <div id="settings-modal" class="modal-overlay hidden">
     <div class="modal-content" style="max-width: 500px;">
       <div class="modal-header">
-        <h2>⚙️ EasyPaper 설정</h2>
+        <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"/><circle cx="12" cy="12" r="3"/></svg>EasyPaper 설정</h2>
         <button id="close-settings-btn" class="close-btn">&times;</button>
       </div>
       
@@ -346,22 +353,37 @@
           </div>
           
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
+            <label>뷰어 편의 설정</label>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>데이터 및 용량 관리</label>
             <button type="button" id="clear-cache-btn" class="btn btn-secondary" style="width: 100%; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
-              🗑️ 브라우저 번역 캐시 비우기
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>브라우저 번역 캐시 비우기
             </button>
           </div>
           
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>시스템 업데이트 (System Update)</label>
             <div style="background: rgba(139, 92, 246, 0.1); border-left: 4px solid var(--accent-mid); padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
-              💡 <strong>GitHub 최신 업데이트 확인 및 자동 빌드:</strong><br>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>GitHub 최신 업데이트 확인 및 자동 빌드:</strong><br>
               아래 버튼을 누르면 GitHub 저장소로부터 최신 코드를 풀(Pull) 받고,<br>
               변경된 내용이 있을 경우 프론트엔드를 자동 빌드한 뒤 EasyPaper 데몬 서비스를 즉시 재기동합니다.
             </div>
             <div style="display: flex; gap: 10px; align-items: center;">
               <button type="button" id="system-update-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
-                🚀 최신 업데이트 실행
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>최신 업데이트 실행
               </button>
               <span id="system-update-status" style="font-size: 12.5px; color: var(--text-secondary);"></span>
             </div>
@@ -377,7 +399,7 @@
       <div id="tab-model" class="tab-pane">
         <!-- 시스템 설정 폼 (Ollama, OpenAI, Gemini, Claude 통합 및 번역/대화 분리) -->
         <form id="system-settings-form" class="modal-form" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px;">
-          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;">🤖 AI 엔진 및 서버 설정</h3>
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20v2"/><path d="M12 2v2"/><path d="M17 20v2"/><path d="M17 2v2"/><path d="M2 12h2"/><path d="M2 17h2"/><path d="M2 7h2"/><path d="M20 12h2"/><path d="M20 17h2"/><path d="M20 7h2"/><path d="M7 20v2"/><path d="M7 2v2"/><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="8" y="8" width="8" height="8" rx="1"/></svg>AI 엔진 및 서버 설정</h3>
           
           <!-- 공통 Ollama 주소 -->
           <div class="form-group" id="setting-ollama-host-group" style="display: none;">
@@ -387,7 +409,7 @@
 
           <!-- API Key 관리 -->
           <div id="setting-apikeys-section" style="border-top: 1px solid var(--border); padding-top: 15px; margin-top: 15px; display: none;">
-            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;">🔑 클라우드 API Key 설정</h4>
+            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/></svg>클라우드 API Key 설정</h4>
             <div class="form-group" id="setting-openai-key-group" style="display: none;">
               <label for="setting-openai-key">OpenAI API Key</label>
               <input type="password" id="setting-openai-key" placeholder="sk-..." style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-md); color: var(--text-primary); outline: none; font-size: 14px;" />
@@ -404,7 +426,7 @@
 
           <!-- 번역 AI 설정 -->
           <div style="border-top: 1px solid var(--border); padding-top: 15px; margin-top: 15px;">
-            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;">📖 논문 번역 (Translation) 설정</h4>
+            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>논문 번역 (Translation) 설정</h4>
             <div class="form-group">
               <label>번역 AI 제공업체 및 모델</label>
               <div id="setting-trans-provider"></div>
@@ -413,7 +435,7 @@
 
           <!-- AI 어시스턴트 설정 -->
           <div style="border-top: 1px solid var(--border); padding-top: 15px; margin-top: 15px;">
-            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;">💬 AI 어시스턴트 (Chat) 설정</h4>
+            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>AI 어시스턴트 (Chat) 설정</h4>
             <div class="form-group">
               <label>어시스턴트 AI 제공업체 및 모델</label>
               <div id="setting-chat-provider"></div>
@@ -427,10 +449,10 @@
 
         <!-- 모델 다운로드 섹션 (Ollama 전용) -->
         <div id="pull-model-section" class="modal-form hidden" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px; padding-top: 10px;">
-          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;">📥 새 모델 다운로드 (Pull)</h3>
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>새 모델 다운로드 (Pull)</h3>
           
           <div class="form-group" style="margin-bottom: 12px;">
-            <label style="margin-bottom: 6px;">💡 추천 번역 모델 (클릭하여 즉시 다운로드)</label>
+            <label style="margin-bottom: 6px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>추천 번역 모델 (클릭하여 즉시 다운로드)</label>
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="qwen3.5:9b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Qwen 3.5 9B (qwen3.5:9b)</button>
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="llama3.1:8b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Llama 3.1 8B (llama3.1:8b)</button>
@@ -461,7 +483,7 @@
       <div id="tab-account" class="tab-pane">
         <!-- 계정 변경 폼 -->
         <form id="change-credentials-form" class="modal-form" style="padding-top: 10px;">
-          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;">🔐 계정 비밀번호 변경</h3>
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>계정 비밀번호 변경</h3>
           <div class="form-group">
             <label for="change-current-password">현재 비밀번호</label>
             <input type="password" id="change-current-password" placeholder="현재 비밀번호 입력" required />
@@ -490,7 +512,7 @@
           <div class="form-group">
             <label for="setting-prompt-template">번역 프롬프트 템플릿 (Prompt Template)</label>
             <div style="background: rgba(139, 92, 246, 0.1); border-left: 4px solid var(--accent-mid); padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
-              💡 <strong>직관적인 번역 어투 및 스타일 수정 방법:</strong><br>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>직관적인 번역 어투 및 스타일 수정 방법:</strong><br>
               아래 프롬프트 입력창 내부의 원하는 위치(예: <strong>번역 규칙</strong> 목록 밑에 직접 줄을 추가)에<br>
               <code style="background: rgba(255,255,255,0.08); padding: 2px 4px; border-radius: 3px; font-weight: bold; color: var(--accent-mid);">- 번역 시 어미는 무조건 경어체(~합니다, ~입니다)로 일관되게 끝맺으세요.</code><br>
               또는 특정 전문 용어 번역 강제 등 <strong>원하는 번역 지시사항을 직접 입력한 후 하단의 저장 버튼</strong>을 누르시면 됩니다.<br>
@@ -537,7 +559,7 @@
     </div>
     <div class="upload-popup-body" id="upload-popup-body">
       <div class="upload-item-row">
-        <div class="upload-item-icon">📄</div>
+        <div class="upload-item-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></div>
         <div class="upload-item-info">
           <div class="upload-item-name" id="upload-item-name">filename.pdf</div>
           <div class="upload-item-status" id="upload-item-status">준비 중...</div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5972,10 +5972,35 @@ function getOrCreateOverlay(pageWrapper) {
 // (alignSentencesToText와 동일한 방식) 순수 문자만 비교해야 안정적으로 매칭된다.
 const INSIGHT_MATCH_CHAR_RE = /[a-zA-Z0-9ㄱ-힝一-鿿Ͱ-Ͽ]/
 
-function locateTermInPdf(pageNum, term) {
-  const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+// 줌 변경 시 모든 페이지의 캔버스/텍스트 레이어가 파괴되고 뷰포트에 들어온
+// 페이지만 지연 재렌더링되므로, 화면 밖으로 스크롤되어 있던 페이지의
+// virtualTextMaps는 이미 DOM에서 제거된(detached) 노드를 계속 참조하게 된다.
+// 그 상태로는 하이라이트 좌표를 계산할 수 없으므로 유효성을 먼저 확인한다.
+function isVtmFresh(vtm) {
+  return !!(vtm && vtm.nodeRanges && vtm.nodeRanges.length > 0 && document.contains(vtm.nodeRanges[0].node))
+}
+
+async function locateTermInPdf(pageNum, term) {
   const pw = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
-  if (!vtm || !pw) {
+  if (!pw) {
+    showToast('원문 위치를 찾을 수 없습니다.', 'warning')
+    return
+  }
+
+  let vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+  if (!isVtmFresh(vtm)) {
+    // 페이지로 스크롤해 지연 렌더링을 트리거한 뒤, 텍스트 레이어 재생성 및
+    // 재세그멘테이션이 끝나 virtualTextMaps가 갱신될 때까지 잠시 대기한다.
+    pw.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    const deadline = Date.now() + 3000
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 100))
+      vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+      if (isVtmFresh(vtm)) break
+    }
+  }
+
+  if (!isVtmFresh(vtm)) {
     showToast('원문 위치를 찾을 수 없습니다.', 'warning')
     return
   }
@@ -6006,7 +6031,10 @@ function locateTermInPdf(pageNum, term) {
   const rawEnd = cleanToRaw[cleanIdx + cleanTerm.length - 1] + 1
 
   const textLayer = pw.querySelector('.textLayer')
-  if (!textLayer) return
+  if (!textLayer) {
+    showToast('원문 위치를 찾을 수 없습니다.', 'warning')
+    return
+  }
   const rects = getSentenceRects({ charStart: rawStart, charEnd: rawEnd }, vtm, textLayer)
   if (rects.length === 0) {
     showToast('원문 위치를 하이라이트하지 못했습니다.', 'warning')


### PR DESCRIPTION
# Summary
## 1. 줌 변경 후 키워드/단어 클릭 하이라이트가 동작하지 않는 문제 수정
- 원인: `setZoom`/`requestZoomFromGesture`(휠 Ctrl, 핀치, +/- 버튼)로 줌이 바뀌면 `reRenderAll` → `renderScrollView`가 **모든 페이지**의 캔버스·텍스트 레이어 DOM을 파괴하고, 뷰포트 근처 페이지만 `IntersectionObserver`로 지연 재렌더링함
- 이때 화면 밖으로 스크롤되어 있던 페이지는 재렌더링(및 재세그멘테이션)되지 않아 `state.virtualTextMaps[pageNum]`가 이미 DOM에서 제거된(detached) 옛 노드를 계속 참조하는 상태(stale)로 남음
- 이 상태에서 키워드/단어를 클릭하면 `locateTermInPdf`가 stale한 `nodeRanges`로 `Range`를 생성하려다 조용히 실패하거나, `.textLayer`가 아예 없어 아무 반응도 없이 종료됨(에러/토스트 없음)
- `frontend/src/main.js`
  - `isVtmFresh(vtm)` 헬퍼 추가: `vtm.nodeRanges[0].node`가 현재 문서에 연결(`document.contains`)되어 있는지로 신선도 판별
  - `locateTermInPdf`를 async로 전환: vtm이 stale하면 해당 페이지로 먼저 스크롤해 지연 렌더링을 트리거하고, 최대 3초간 100ms 간격으로 재세그멘테이션 완료(신선한 vtm 갱신)를 대기한 뒤 하이라이트 로직을 이어감
  - 재렌더링이 끝내 완료되지 않거나 `.textLayer`를 찾을 수 없는 경우, 조용히 종료하는 대신 명시적으로 "원문 위치를 찾을 수 없습니다." 토스트를 표시
- 재현/검증: Playwright로 (1) detached 노드를 참조하는 stale vtm 상태에서 클릭 → 500ms 뒤 실제 재렌더링을 시뮬레이션했을 때 정상적으로 하이라이트가 나타나는지, (2) 한 번도 렌더링되지 않은 페이지에서 끝내 갱신되지 않을 때 타임아웃 후 토스트가 뜨는지, (3) 기존 하이픈 줄바꿈 매칭 등 정상 케이스가 회귀 없이 동작하는지 확인
## 2. 프론트엔드 빌드 산출물 갱신
- `frontend/dist/index.html` 재빌드 반영
