### PR TITLE
fix: 키워드 클릭 하이라이트 실패 시 무반응 대신 오류를 표시하도록 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BYkKzKGu.js"></script>
+  <script type="module" crossorigin src="/assets/index-vIfZMpe2.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DTcTdqER.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -503,7 +503,14 @@ function createTransBlock(pageNum) {
   if (keywordsContentEl) {
     keywordsContentEl.addEventListener('click', (e) => {
       const termEl = e.target.closest('.insight-keyword-term')
-      if (termEl) locateTermInPdf(pageNum, termEl.textContent)
+      if (!termEl) return
+      locateTermInPdf(pageNum, termEl.textContent).catch(err => {
+        // async 함수 내부에서 예상 못한 예외가 나면 토스트 없이 조용히
+        // 아무 반응도 없는 것처럼 보일 수 있으므로, 항상 사용자에게 알리고
+        // 콘솔에도 원인을 남긴다.
+        console.error('locateTermInPdf failed:', err)
+        showToast('원문 위치를 찾는 중 오류가 발생했습니다.', 'warning')
+      })
     })
   }
   return block


### PR DESCRIPTION
# Summary
## 1. 키워드 클릭 하이라이트 실패 시 무반응 대신 오류 노출
- 이전 수정(줌 후 stale virtualTextMaps 대응)에도 불구하고 사용자가 "단어를 클릭해도 아무 토스트도 뜨지 않고, 스크롤도 안 되고, 하이라이트도 안 보인다"고 재보고
- `locateTermInPdf`가 `async` 함수인데, 클릭 핸들러에서 `.catch()` 없이 호출되고 있어 함수 내부에서 예상 못한 예외가 발생하면 아무 토스트도 뜨지 않고 콘솔에도 흔적이 남지 않는 완전한 무반응(unhandled promise rejection)이 될 수 있는 상태였음
- `frontend/src/main.js`의 키워드 컨테이너 클릭 델리게이션 핸들러를 수정: `locateTermInPdf(...).catch(err => { console.error(...); showToast(...) })`로 예외를 항상 사용자에게 노출하고 콘솔에도 기록하도록 변경
- 이 변경으로 이후에도 같은 문제가 재현되면, 사용자가 브라우저 콘솔의 에러 메시지 또는 새로 뜨는 토스트 문구를 통해 정확한 실패 지점을 알려줄 수 있어 근본 원인 진단이 가능해짐
