### PR TITLE
fix: 키워드 클릭 하이라이트가 스크롤 중 사라지고 두 번 클릭해야 보이는 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-vIfZMpe2.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DTcTdqER.css">
+  <script type="module" crossorigin src="/assets/index-CIAmAvTv.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-D3SxXu79.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5987,6 +5987,32 @@ function isVtmFresh(vtm) {
   return !!(vtm && vtm.nodeRanges && vtm.nodeRanges.length > 0 && document.contains(vtm.nodeRanges[0].node))
 }
 
+// 요소가 스크롤 컨테이너 뷰포트 안에 이미 충분히 들어와 있는지 확인 - 이미 보이는
+// 위치라면 scrollIntoView가 사실상 아무것도 하지 않으므로 굳이 스크롤 완료를 기다릴
+// 필요가 없다(불필요한 지연 방지).
+function isElementReasonablyInView(el, container, marginPx = 40) {
+  const elRect = el.getBoundingClientRect()
+  const contRect = container.getBoundingClientRect()
+  return elRect.top >= contRect.top - marginPx && elRect.bottom <= contRect.bottom + marginPx
+}
+
+// 'scrollend' 이벤트로 부드러운 스크롤이 실제로 끝나는 시점을 기다린다. 브라우저 지원이
+// 없거나 스크롤이 예상보다 오래 걸리는 경우를 대비해 최대 대기 시간을 둔다.
+function waitForScrollSettle(container, timeoutMs = 1000) {
+  return new Promise(resolve => {
+    let done = false
+    const finish = () => {
+      if (done) return
+      done = true
+      container.removeEventListener('scrollend', finish)
+      clearTimeout(timer)
+      resolve()
+    }
+    container.addEventListener('scrollend', finish, { once: true })
+    const timer = setTimeout(finish, timeoutMs)
+  })
+}
+
 async function locateTermInPdf(pageNum, term) {
   const pw = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
   if (!pw) {
@@ -6048,10 +6074,18 @@ async function locateTermInPdf(pageNum, term) {
     return
   }
 
+  // 스크롤이 실제로 필요한 경우, 부드러운 스크롤 애니메이션이 끝나기 전에 하이라이트가
+  // 먼저 그려져서 화면 밖에 있는 동안 다 사라져버리는 문제(그래서 두 번 클릭해야 겨우
+  // 보이는 것처럼 느껴짐)를 막기 위해, 스크롤이 실제로 자리를 잡을 때까지 기다린 뒤에
+  // 하이라이트를 그린다. 이미 화면에 보이는 위치라면(스크롤이 사실상 필요 없다면) 바로 그린다.
+  const alreadyInView = isElementReasonablyInView(pw, viewerScrollContainer)
   pw.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  if (!alreadyInView) {
+    await waitForScrollSettle(viewerScrollContainer)
+  }
   const overlay = getOrCreateOverlay(pw)
-  renderSentenceOverlay(overlay, rects, 'sentence-pulse-box')
-  setTimeout(() => clearOverlayBoxes(overlay, 'sentence-pulse-box'), 900)
+  renderSentenceOverlay(overlay, rects, 'sentence-locate-pulse-box')
+  setTimeout(() => clearOverlayBoxes(overlay, 'sentence-locate-pulse-box'), 1800)
 }
 
 // 메인 진입점: buildVirtualTextMap → alignSentencesToText → state 저장 → 메모 오버레이 렌더링

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3981,6 +3981,21 @@ body.light-theme .sentence-memo-box {
   animation: overlayPulse 0.8s cubic-bezier(0.25, 1, 0.5, 1) forwards;
 }
 
+/* 키워드/단어 탭 용어 클릭 시 원문 위치 하이라이트 - 스크롤이 끝난 뒤에 표시되므로
+   citation 클릭용 pulse보다 오래 보이도록 별도 애니메이션을 둔다(일정 시간 유지 후 페이드) */
+@keyframes locateHighlightPulse {
+  0%   { background-color: rgba(124, 58, 237, 0.55); }
+  65%  { background-color: rgba(124, 58, 237, 0.55); }
+  100% { background-color: transparent; }
+}
+.sentence-locate-pulse-box {
+  position: absolute;
+  pointer-events: none !important;
+  border-radius: 2px;
+  outline: 2px solid rgba(124, 58, 237, 0.45);
+  animation: locateHighlightPulse 1.8s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
 /* 좌측 마진 줄 번호 노이즈 스팬 (선택/포인터 이벤트 비활성) */
 .pdf-line-number-noise {
   user-select: none !important;


### PR DESCRIPTION
# Summary
## 1. 키워드 클릭 하이라이트가 스크롤 중 사라지고 두 번 클릭해야 보이는 문제 수정
- 원인: `locateTermInPdf`가 `pw.scrollIntoView({ behavior: 'smooth', ... })`를 호출한 직후 곧바로 펄스 하이라이트(0.8~0.9초 페이드 애니메이션)를 그리고 있어, 대상 페이지가 현재 화면 밖에 있어 실제 스크롤 거리가 있는 경우 스크롤 애니메이션이 채 끝나기도 전에 하이라이트가 다 사라져버림
  - 첫 클릭: 스크롤이 진행되는 동안 하이라이트가 이미 다 사라진 뒤에야 화면에 도착 → 아무것도 안 보이는 것처럼 느껴짐
  - 두 번째 클릭: 이미 해당 위치로 스크롤된 상태라 `scrollIntoView`가 사실상 아무것도 안 하므로, 하이라이트가 스크롤과 경쟁하지 않고 정상적으로 보임(다만 지속 시간이 0.9초로 짧음)
- `frontend/src/main.js`
  - `isElementReasonablyInView(el, container, marginPx)` 추가: 대상이 이미 스크롤 컨테이너 뷰포트 안에 충분히 들어와 있는지 확인 (이미 보이면 대기 없이 즉시 렌더링해 불필요한 지연 방지)
  - `waitForScrollSettle(container, timeoutMs)` 추가: `scrollend` 이벤트로 부드러운 스크롤이 실제로 끝나는 시점을 기다리고, 브라우저 미지원/예상보다 오래 걸리는 경우를 대비해 최대 대기 시간(기본 1초)을 둠
  - `locateTermInPdf`: 스크롤이 실제로 필요한 경우에만 `waitForScrollSettle`로 대기한 뒤 하이라이트를 그리도록 변경
- `frontend/src/style.css`
  - 키워드 클릭 전용 `.sentence-locate-pulse-box` + `locateHighlightPulse` 애니메이션 추가 (citation 클릭 등 기존 `.sentence-pulse-box`(0.8초)와는 별도로, 완전히 사라지기까지 1.8초 유지 - 스크롤 대기 후 표시되므로 사용자가 충분히 인지할 시간을 줌). 기존 `.sentence-pulse-box`를 쓰는 다른 기능(문장 클릭 이동 등)은 변경하지 않음
- 검증: Playwright로 (1) 스크롤이 실제로 필요한 원거리 타겟에서 스크롤 완료 후 새 하이라이트 클래스가 정상 렌더링되는지, (2) 이미 뷰포트 안에 있는 타겟은 대기 없이(수 ms 내) 즉시 렌더링되는지, (3) 기존 stale-vtm/줄바꿈 매칭 회귀 테스트가 새 클래스명 기준으로도 여전히 통과하는지 확인
