### PR TITLE
fix: 번역문 볼드 구간으로 문장이 쪼개질 때 호버/클릭 하이라이트가 일부만 표시되는 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-D8pv_c_4.js"></script>
+  <script type="module" crossorigin src="/assets/index-D1u7GfUO.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-D3SxXu79.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6820,8 +6820,12 @@ if (viewerScrollContainer) {
       if (isNaN(sentenceIdx)) return;
 
       // 번역 패널 호버 → PDF 오버레이 하이라이트
+      // 볼드(**...**) 등으로 한 문장이 여러 DOM 노드에 걸쳐 쪼개진 경우, 같은
+      // sentenceIdx를 가진 .trans-sentence 조각이 여러 개 존재한다 - 커서 아래
+      // 조각 하나만 하이라이트하면 문장의 나머지 조각이 하이라이트되지 않으므로,
+      // 같은 문장에 속한 조각을 전부 찾아 함께 하이라이트한다.
       viewerScrollContainer.querySelectorAll('.sentence-highlight').forEach(el => el.classList.remove('sentence-highlight'));
-      transSent.classList.add('sentence-highlight');
+      pageWrapper.querySelectorAll(`.trans-sentence[data-sentence-idx="${sentenceIdx}"]`).forEach(el => el.classList.add('sentence-highlight'));
 
       const sentenceRanges = state.pdfPageSentences && state.pdfPageSentences[pageNum];
       if (sentenceRanges) {
@@ -6944,15 +6948,19 @@ if (viewerScrollContainer) {
       activeHighlightSentenceIdx = sentenceRange.sentenceIdx;
 
       // 번역 패널로 스크롤
+      // 볼드 등으로 문장이 여러 조각으로 쪼개져 있을 수 있으므로 같은
+      // sentenceIdx를 가진 조각을 모두 찾아 함께 펄스 처리한다.
       const transIdx = sentenceRange.sentenceIdx >= 10000 ? (sentenceRange.originalSentenceIdx ?? -1) : sentenceRange.sentenceIdx;
       if (transIdx >= 0) {
-        const match = viewerScrollContainer.querySelector(
+        const matches = viewerScrollContainer.querySelectorAll(
           `.trans-sentence[data-page="${pageNum}"][data-sentence-idx="${transIdx}"]`
         );
-        if (match) {
-          match.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          match.classList.add('sentence-pulse');
-          setTimeout(() => match.classList.remove('sentence-pulse'), 1000);
+        if (matches.length > 0) {
+          matches[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+          matches.forEach(match => {
+            match.classList.add('sentence-pulse');
+            setTimeout(() => match.classList.remove('sentence-pulse'), 1000);
+          });
         }
       }
     } catch (err) {


### PR DESCRIPTION
# Summary
## 1. 번역문 볼드 구간으로 문장이 쪼개질 때 호버/클릭 하이라이트가 일부만 표시되는 문제 수정
- 원인: `segmentTransElements`는 번역 문장을 감쌀 때 실제 DOM 텍스트 노드 단위로 `.trans-sentence` span을 씌우는데, 볼드(`**...**` → `<strong>`) 등으로 한 문장의 텍스트가 여러 형제 DOM 노드(일반 텍스트 → `<strong>` 내부 텍스트 → 다시 일반 텍스트)로 나뉘어 있으면, 같은 `data-sentence-idx`를 가진 `.trans-sentence` 조각이 여러 개 생김
  - PDF 쪽 하이라이트는 좌표 기반 가상 오버레이 시스템(`getSentenceRects`)을 쓰기 때문에 문장이 몇 개의 DOM 노드에 걸쳐 있든 항상 문장 전체를 정확히 하이라이트함
  - 반면 번역문 자체의 호버/클릭 하이라이트는 `e.target.closest('.trans-sentence')`로 찾은 "커서 아래 조각 하나"에만 `.sentence-highlight`/`.sentence-pulse` 클래스를 적용하고 있어서, 볼드가 포함된 문장은 마우스가 올라간 한 조각만 하이라이트되고 나머지 조각(볼드 부분 등)은 하이라이트되지 않아 문장이 "쪼개져" 보임
- `frontend/src/main.js`
  - `mouseover` 핸들러(번역 패널 호버): `transSent.classList.add(...)` 대신, 같은 페이지의 `.trans-sentence[data-sentence-idx="N"]`에 해당하는 모든 조각을 찾아 함께 `.sentence-highlight`를 적용하도록 수정
  - `click` 핸들러(PDF 클릭 → 번역 패널로 스크롤 + pulse): 동일하게 `querySelector` 단일 매칭 대신 `querySelectorAll`로 같은 문장의 모든 조각을 찾아 함께 pulse 처리하도록 수정 (스크롤은 첫 번째 조각 기준)
- 검증: Playwright로 "일반 텍스트 + `<strong>`볼드 부분 + 일반 텍스트"로 3조각 분리된 실제 DOM 구조를 재현해, 첫 조각에 마우스오버 시 3조각 모두 `.sentence-highlight`가 적용되는지 확인 (수정 전 로직으로는 1개 조각만 하이라이트됨을 확인 후 수정)
