### PR TITLE
feat: 설정 화면에서 Ollama 미설치 시 원클릭 설치 기능 추가

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -29,6 +29,16 @@ def get_project_root() -> str:
 def get_ollama_host() -> str:
     return OLLAMA_HOST
 
+def is_ollama_host_local() -> bool:
+    """설정된 Ollama 호스트가 이 서버 자신(localhost)을 가리키는지 확인합니다.
+    원격 호스트를 가리키는 경우 이 서버에 설치 스크립트를 실행하는 것은 의미가 없습니다."""
+    from urllib.parse import urlparse
+    try:
+        hostname = urlparse(OLLAMA_HOST).hostname or ""
+    except Exception:
+        return False
+    return hostname in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
 def get_trans_provider() -> str:
     return TRANS_PROVIDER
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -9,6 +9,7 @@ from config import (
     get_app_password_hash,
     update_credentials_in_env,
     get_ollama_host,
+    is_ollama_host_local,
     update_system_settings,
     get_trans_provider,
     get_trans_model,
@@ -197,6 +198,69 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
     update_translation_prompt_template(data.translation_prompt_template)
     
     return {"message": "시스템 설정이 성공적으로 변경되었습니다."}
+
+@router.get("/settings/ollama-status")
+async def ollama_status(current_user: str = Depends(get_current_user)):
+    """Ollama CLI가 이 서버에 설치되어 있는지, 설정된 호스트가 로컬인지 확인합니다."""
+    import os
+    import shutil
+    installed = bool(shutil.which("ollama") or os.path.exists("/usr/local/bin/ollama"))
+    return {
+        "installed": installed,
+        "is_local": is_ollama_host_local(),
+    }
+
+
+@router.get("/settings/install-ollama")
+async def install_ollama_stream(current_user: str = Depends(get_current_user)):
+    """공식 설치 스크립트(https://ollama.com/install.sh)를 실행해 이 서버에 Ollama를
+    설치하고 진행 상황을 스트리밍합니다. 원격 호스트를 가리키고 있거나 이미 설치된
+    경우에는 실행하지 않습니다."""
+    import asyncio
+    import shutil
+
+    async def event_stream():
+        if not is_ollama_host_local():
+            yield f"data: {json.dumps({'status': 'error', 'message': 'Ollama 호스트가 이 서버(localhost)가 아니어서 여기서 설치할 수 없습니다.'})}\n\n"
+            return
+        if shutil.which("ollama"):
+            yield f"data: {json.dumps({'status': 'error', 'message': 'Ollama가 이미 설치되어 있습니다.'})}\n\n"
+            return
+
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                "curl -fsSL https://ollama.com/install.sh | sh",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                # sudo가 비밀번호를 요구하면 무한 대기하지 않고 즉시 실패하도록 stdin을 막는다
+                stdin=asyncio.subprocess.DEVNULL,
+            )
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                text = line.decode("utf-8", errors="replace").rstrip()
+                if text:
+                    yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+
+            await proc.wait()
+            if proc.returncode == 0 and shutil.which("ollama"):
+                yield f"data: {json.dumps({'status': 'success'})}\n\n"
+            else:
+                yield f"data: {json.dumps({'status': 'error', 'message': f'설치 스크립트가 오류 코드 {proc.returncode}로 종료되었습니다. sudo 권한이 필요할 수 있습니다.'})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'status': 'error', 'message': str(e)})}\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        }
+    )
+
 
 @router.get("/settings/pull-model")
 async def pull_model_stream(model_name: str, current_user: str = Depends(get_current_user)):

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-D1u7GfUO.js"></script>
+  <script type="module" crossorigin src="/assets/index-BvNfe2LK.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-D3SxXu79.css">
 </head>
 <body>
@@ -446,6 +446,25 @@
             <button type="submit" class="btn btn-primary" style="width: 100%; justify-content: center;">시스템 설정 저장</button>
           </div>
         </form>
+
+        <!-- Ollama 미설치 안내 및 설치 섹션 -->
+        <div id="ollama-install-section" class="modal-form hidden" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px; padding-top: 10px;">
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>Ollama 설치</h3>
+
+          <div id="ollama-install-not-local" class="hidden" style="font-size: 13px; color: var(--text-secondary); line-height: 1.6;">
+            현재 Ollama API 주소가 이 서버(localhost)가 아닌 원격 호스트를 가리키고 있어, 여기서 직접 설치할 수 없습니다. 해당 원격 서버에서 직접 설치해 주세요.
+          </div>
+
+          <div id="ollama-install-prompt">
+            <p style="font-size: 13px; color: var(--text-secondary); margin-bottom: 12px; line-height: 1.6;">이 서버에 Ollama가 설치되어 있지 않습니다. 아래 버튼을 누르면 공식 설치 스크립트를 실행합니다 (관리자 권한 필요, 다소 시간이 걸릴 수 있습니다).</p>
+            <button type="button" id="ollama-install-btn" class="btn btn-primary" style="padding: 10px 18px; font-size: 13px;">Ollama 설치하기</button>
+          </div>
+
+          <div id="ollama-install-progress-area" class="hidden" style="margin-top: 15px; background: var(--bg-elevated); border: 1px solid var(--border-strong); padding: 12px; border-radius: var(--radius-md);">
+            <div style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px;">설치 진행 중...</div>
+            <div id="ollama-install-log" style="max-height: 160px; overflow-y: auto; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-secondary); white-space: pre-wrap; line-height: 1.5;"></div>
+          </div>
+        </div>
 
         <!-- 모델 다운로드 섹션 (Ollama 전용) -->
         <div id="pull-model-section" class="modal-form hidden" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px; padding-top: 10px;">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -446,6 +446,25 @@
           </div>
         </form>
 
+        <!-- Ollama 미설치 안내 및 설치 섹션 -->
+        <div id="ollama-install-section" class="modal-form hidden" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px; padding-top: 10px;">
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>Ollama 설치</h3>
+
+          <div id="ollama-install-not-local" class="hidden" style="font-size: 13px; color: var(--text-secondary); line-height: 1.6;">
+            현재 Ollama API 주소가 이 서버(localhost)가 아닌 원격 호스트를 가리키고 있어, 여기서 직접 설치할 수 없습니다. 해당 원격 서버에서 직접 설치해 주세요.
+          </div>
+
+          <div id="ollama-install-prompt">
+            <p style="font-size: 13px; color: var(--text-secondary); margin-bottom: 12px; line-height: 1.6;">이 서버에 Ollama가 설치되어 있지 않습니다. 아래 버튼을 누르면 공식 설치 스크립트를 실행합니다 (관리자 권한 필요, 다소 시간이 걸릴 수 있습니다).</p>
+            <button type="button" id="ollama-install-btn" class="btn btn-primary" style="padding: 10px 18px; font-size: 13px;">Ollama 설치하기</button>
+          </div>
+
+          <div id="ollama-install-progress-area" class="hidden" style="margin-top: 15px; background: var(--bg-elevated); border: 1px solid var(--border-strong); padding: 12px; border-radius: var(--radius-md);">
+            <div style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px;">설치 진행 중...</div>
+            <div id="ollama-install-log" style="max-height: 160px; overflow-y: auto; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-secondary); white-space: pre-wrap; line-height: 1.5;"></div>
+          </div>
+        </div>
+
         <!-- 모델 다운로드 섹션 (Ollama 전용) -->
         <div id="pull-model-section" class="modal-form hidden" style="border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 10px; padding-top: 10px;">
           <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>새 모델 다운로드 (Pull)</h3>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -352,6 +352,45 @@ export async function cancelJobAPI(sessionId) {
 }
 
 /**
+ * 이 서버에 Ollama CLI가 설치되어 있는지, 설정된 호스트가 로컬인지 확인합니다.
+ */
+export async function getOllamaStatusAPI() {
+  const res = await fetch(`${API_BASE}/settings/ollama-status`)
+  return res.json()
+}
+
+/**
+ * 이 서버(localhost)에 Ollama를 설치하고 진행 상황을 스트리밍합니다.
+ */
+export function streamInstallOllamaAPI(onProgress, onDone, onError) {
+  const eventSource = new EventSource(`${API_BASE}/settings/install-ollama`)
+
+  eventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data)
+      if (data.status === 'error') {
+        onError(new Error(data.message || 'Ollama 설치 실패'))
+        eventSource.close()
+      } else if (data.status === 'success') {
+        onDone()
+        eventSource.close()
+      } else {
+        onProgress(data)
+      }
+    } catch (err) {
+      console.warn('Install ollama message parse error:', err)
+    }
+  }
+
+  eventSource.onerror = () => {
+    onError(new Error('네트워크 연결 끊김 또는 설치 실패'))
+    eventSource.close()
+  }
+
+  return () => eventSource.close()
+}
+
+/**
  * Ollama 서버에 새로운 모델 다운로드를 요청하고 상태를 스트리밍합니다.
  */
 export function streamPullModelAPI(modelName, onStatus, onDone, onError) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently } from './library.js'
 import { icon } from './icons.js'
@@ -118,6 +118,13 @@ const pullStatusText       = $('pull-status-text')
 const pullPctText          = $('pull-pct-text')
 const pullProgressBar      = $('pull-progress-bar')
 const pullModelSection     = $('pull-model-section')
+
+const ollamaInstallSection  = $('ollama-install-section')
+const ollamaInstallNotLocal = $('ollama-install-not-local')
+const ollamaInstallPrompt   = $('ollama-install-prompt')
+const ollamaInstallBtn      = $('ollama-install-btn')
+const ollamaInstallProgressArea = $('ollama-install-progress-area')
+const ollamaInstallLog      = $('ollama-install-log')
 
 const libraryScreen     = $('library-screen')
 const viewerScreen      = $('viewer-screen')
@@ -1846,13 +1853,14 @@ function updateSettingsUIVisibility() {
     hostGroup.style.display = providers.has('ollama') ? 'block' : 'none'
   }
   
-  // 2. Ollama 모델 다운로드 섹션 표시 여부
+  // 2. Ollama 모델 다운로드 섹션 표시 여부 (설치 여부에 따라 refreshOllamaInstallUI에서 최종 결정)
   if (providers.has('ollama')) {
-    pullModelSection.classList.remove('hidden')
+    refreshOllamaInstallUI()
   } else {
     pullModelSection.classList.add('hidden')
+    ollamaInstallSection.classList.add('hidden')
   }
-  
+
   // 3. API Keys 섹션 표시 여부
   const keysSection = $('setting-apikeys-section')
   const openaiGroup = $('setting-openai-key-group')
@@ -2014,6 +2022,60 @@ tabBtns.forEach(btn => {
 })
 
 // (provider+model event listeners are now handled inside ProviderModelPicker instances)
+
+// Ollama 미설치 시 설치 섹션과 모델 다운로드 섹션 중 무엇을 보여줄지 결정
+let ollamaStatusCheckInFlight = false
+async function refreshOllamaInstallUI() {
+  if (ollamaStatusCheckInFlight) return
+  ollamaStatusCheckInFlight = true
+  try {
+    const { installed, is_local } = await getOllamaStatusAPI()
+    if (installed) {
+      ollamaInstallSection.classList.add('hidden')
+      pullModelSection.classList.remove('hidden')
+    } else {
+      pullModelSection.classList.add('hidden')
+      ollamaInstallSection.classList.remove('hidden')
+      ollamaInstallNotLocal.classList.toggle('hidden', is_local)
+      ollamaInstallPrompt.classList.toggle('hidden', !is_local)
+    }
+  } catch (err) {
+    console.warn('Ollama 상태 확인 실패:', err)
+  } finally {
+    ollamaStatusCheckInFlight = false
+  }
+}
+
+// Ollama 설치
+ollamaInstallBtn.addEventListener('click', () => {
+  ollamaInstallBtn.disabled = true
+  ollamaInstallBtn.textContent = '설치 중...'
+  ollamaInstallProgressArea.classList.remove('hidden')
+  ollamaInstallLog.textContent = ''
+
+  showToast('Ollama 설치를 시작합니다. 다소 시간이 걸릴 수 있습니다.', 'info')
+
+  streamInstallOllamaAPI(
+    (data) => {
+      if (data.line) {
+        ollamaInstallLog.textContent += data.line + '\n'
+        ollamaInstallLog.scrollTop = ollamaInstallLog.scrollHeight
+      }
+    },
+    async () => {
+      showToast('Ollama 설치가 완료되었습니다!', 'success')
+      ollamaInstallBtn.disabled = false
+      ollamaInstallBtn.textContent = 'Ollama 설치하기'
+      ollamaInstallProgressArea.classList.add('hidden')
+      await refreshOllamaInstallUI()
+    },
+    (err) => {
+      showToast(`Ollama 설치 실패: ${err.message}`, 'error')
+      ollamaInstallBtn.disabled = false
+      ollamaInstallBtn.textContent = 'Ollama 설치하기'
+    }
+  )
+})
 
 // Ollama 모델 다운로드 (Pull)
 settingPullModelBtn.addEventListener('click', () => {


### PR DESCRIPTION
# Summary
## 1. 설정 화면에서 Ollama 미설치 시 원클릭 설치 기능 추가
- 번역/어시스턴트 provider로 Ollama를 선택했는데 이 서버에 Ollama CLI가 설치되어 있지 않은 경우, 기존 "모델 다운로드(Pull)" 섹션 대신 "Ollama 설치" 안내 섹션을 보여주고 버튼 클릭으로 공식 설치 스크립트(`https://ollama.com/install.sh`)를 실행해 설치할 수 있도록 함
- 단, Ollama 호스트(`OLLAMA_HOST`)가 원격 서버를 가리키는 경우는 이 서버에 설치해도 의미가 없으므로 설치 버튼 대신 "원격 서버에서 직접 설치해달라"는 안내만 표시
- `backend/config.py`: `is_ollama_host_local()` 추가 - `OLLAMA_HOST`가 localhost/127.0.0.1/::1/0.0.0.0을 가리키는지 확인
- `backend/routers/auth.py`
  - `GET /api/settings/ollama-status`: Ollama CLI 설치 여부(`shutil.which`) + 호스트가 로컬인지 반환
  - `GET /api/settings/install-ollama`: SSE로 설치 스크립트 실행 진행 상황 스트리밍 (`/settings/pull-model`과 동일한 SSE 패턴 재사용)
    - 원격 호스트이거나 이미 설치되어 있으면 스크립트를 실행하지 않고 즉시 에러 이벤트로 안내
    - `stdin=DEVNULL`로 실행해, sudo가 비밀번호를 요구하는 환경(비밀번호 없는 sudo 미설정)에서 무한 대기 없이 즉시 실패하도록 방지
    - 설치 스크립트 자체는 내부적으로 필요한 곳에만 `sudo`를 호출하는 공식 스크립트 구조를 그대로 사용 (전체를 sudo로 감싸지 않음)
- `frontend/index.html`: 모델 설정 탭에 `#ollama-install-section` 추가 (설치 안내 + 버튼 + 실시간 로그 영역)
- `frontend/src/api.js`: `getOllamaStatusAPI()`, `streamInstallOllamaAPI()` 추가
- `frontend/src/main.js`: `refreshOllamaInstallUI()`로 설치 여부에 따라 "설치 섹션"과 "모델 다운로드 섹션"을 전환 표시, 설치 버튼 클릭 시 진행 로그를 실시간으로 표시하고 완료되면 자동으로 모델 다운로드 섹션으로 전환
- 검증: 실제 시스템에는 이미 Ollama가 설치되어 있어(운영 중인 서비스) 설치 스크립트를 실제로 재실행하는 위험한 테스트는 피하고,
  - 백엔드: "이미 설치됨"/"원격 호스트" 두 가드레일이 실제 스크립트를 실행하지 않고 올바르게 즉시 에러를 반환하는지 확인
  - 서브프로세스 스트리밍 메커니즘 자체(멀티라인 출력, 실패 종료 코드, `stdin=DEVNULL`로 인해 비밀번호 프롬프트 상황에서도 멈추지 않고 즉시 진행되는지)는 안전한 대체 셸 명령으로 별도 검증
  - 프론트엔드: Playwright로 설치됨/미설치+로컬/미설치+원격 3가지 상태에서 UI 섹션 전환이 올바른지, 설치 버튼 클릭 시 진행 로그 누적과 성공/실패 처리(버튼 상태, 토스트)가 올바른지 확인
