### PR TITLE
refactor: 라이브러리 논문 카드 시각 디자인 리파인

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BvNfe2LK.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-D3SxXu79.css">
+  <script type="module" crossorigin src="/assets/index-BxNIhlzx.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-isdAa1jm.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2643,6 +2643,15 @@ function createEmptyState(isHistory = false) {
   return el
 }
 
+// 카테고리 이름을 해시해 8가지 색상 중 하나로 결정론적 배정 (같은 카테고리는 항상 같은 색)
+function categoryColorClass(category) {
+  let hash = 0
+  for (let i = 0; i < category.length; i++) {
+    hash = (hash * 31 + category.charCodeAt(i)) | 0
+  }
+  return `doc-card-tag-c${Math.abs(hash) % 8}`
+}
+
 function createDocCard(doc) {
   const translated = doc.translated_pages?.length || 0
   const total = doc.total_pages || 1
@@ -2654,7 +2663,7 @@ function createDocCard(doc) {
   let tagsHtml = ''
   if (categories.length > 0) {
     tagsHtml = `<div class="doc-card-tags">` +
-      categories.map(cat => `<span class="doc-card-tag">${escapeHtml(cat)}</span>`).join('') +
+      categories.map(cat => `<span class="doc-card-tag ${categoryColorClass(cat)}">${escapeHtml(cat)}</span>`).join('') +
       `</div>`
   }
 
@@ -2682,7 +2691,7 @@ function createDocCard(doc) {
         <div class="doc-progress-bar-wrap"><div class="doc-progress-bar" style="width:${pct}%"></div></div>
         <div class="doc-progress-label">
           <span>번역 중 (${translated}/${total}p)</span>
-          <span>${pct}%</span>
+          <span class="doc-progress-pct">${pct}%</span>
         </div>
       </div>
     `
@@ -2718,11 +2727,13 @@ function createDocCard(doc) {
   card.className = 'doc-card'
   card.innerHTML = `
     ${checkBtnHtml}
-    <div class="doc-card-icon">${icon('fileText', 28)}</div>
-    <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(displayTitle)}</div>
+    <div class="doc-card-header">
+      <div class="doc-card-icon">${icon('fileText', 22)}</div>
+      <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(displayTitle)}</div>
+    </div>
     ${tagsHtml}
     <div class="doc-card-meta">
-      ${dateHtml}<span>${icon('layers', 12, 'style="vertical-align:-2px;margin-right:2px"')}${total}페이지</span>
+      ${dateHtml}<span class="meta-dot"></span><span>${icon('layers', 12, 'style="vertical-align:-2px;margin-right:2px"')}${total}페이지</span>
     </div>
     ${progressHtml}
     <div class="doc-card-actions">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1209,10 +1209,10 @@ body:not(.light-theme) .pdf-page-inner canvas {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: 22px 22px 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   cursor: pointer;
   position: relative;
@@ -1237,17 +1237,34 @@ body:not(.light-theme) .pdf-page-inner canvas {
 }
 .doc-card:hover::before { opacity: 1; }
 
-.doc-card-icon {
-  font-size: 34px;
-  line-height: 1;
-  filter: drop-shadow(0 0 10px rgba(124, 58, 237, 0.15));
+/* 아이콘 뱃지 + 제목을 한 줄에 나란히 배치 */
+.doc-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
 }
 
+/* 아이콘을 은은한 그라디언트 뱃지로 감싸 "떠 있는 아이콘" 느낌 대신
+   앱 아이콘처럼 정돈된 인상을 준다 */
+.doc-card-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
+  box-shadow: 0 6px 16px rgba(124, 58, 237, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+}
+.doc-card-icon svg { filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15)); }
+
 .doc-card-title {
-  font-size: 15px;
+  font-size: 15.5px;
   font-weight: 700;
   color: var(--text-primary);
-  line-height: 1.5;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -1259,19 +1276,32 @@ body:not(.light-theme) .pdf-page-inner canvas {
   font-size: 12px;
   color: var(--text-secondary);
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px 8px;
   font-weight: 500;
+}
+.doc-card-meta span {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+.doc-card-meta .meta-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
 }
 
 /* 번역 진행률 */
 .doc-card-progress {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 7px;
 }
 .doc-progress-bar-wrap {
-  height: 5px;
+  height: 6px;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 100px;
   overflow: hidden;
@@ -1289,13 +1319,18 @@ body:not(.light-theme) .pdf-page-inner canvas {
   color: var(--text-muted);
   font-weight: 600;
 }
+.doc-progress-label .doc-progress-pct {
+  color: var(--accent-mid);
+  font-weight: 700;
+}
 .doc-progress-label.done { color: var(--success); text-shadow: 0 0 8px rgba(16, 185, 129, 0.15); }
 
 /* 카드 액션 버튼 */
 .doc-card-actions {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   margin-top: auto;
+  padding-top: 4px;
 }
 .doc-open-btn, .doc-restore-btn {
   flex: 1;
@@ -1314,6 +1349,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
 }
 .doc-open-btn:hover, .doc-restore-btn:hover {
   transform: translateY(-1px);
@@ -1324,7 +1360,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
 }
 
 .doc-delete-btn, .doc-permanent-delete-btn {
-  width: 36px; height: 36px;
+  width: 38px; height: 38px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.02);
@@ -1347,7 +1383,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
 }
 
 .doc-edit-btn {
-  width: 36px; height: 36px;
+  width: 38px; height: 38px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.02);
@@ -2493,6 +2529,24 @@ body.light-theme .provider-picker-panel {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+/* 카테고리별로 색을 달리 주어 한눈에 구분되도록 함 (이름 해시로 결정론적 배정) */
+.doc-card-tag-c0 { background: rgba(139, 92, 246, 0.12); color: #a78bfa; border-color: rgba(139, 92, 246, 0.22); }
+.doc-card-tag-c1 { background: rgba(59, 130, 246, 0.12);  color: #60a5fa; border-color: rgba(59, 130, 246, 0.22); }
+.doc-card-tag-c2 { background: rgba(16, 185, 129, 0.12);  color: #34d399; border-color: rgba(16, 185, 129, 0.22); }
+.doc-card-tag-c3 { background: rgba(245, 158, 11, 0.14);  color: #fbbf24; border-color: rgba(245, 158, 11, 0.25); }
+.doc-card-tag-c4 { background: rgba(236, 72, 153, 0.12);  color: #f472b6; border-color: rgba(236, 72, 153, 0.22); }
+.doc-card-tag-c5 { background: rgba(20, 184, 166, 0.12);  color: #2dd4bf; border-color: rgba(20, 184, 166, 0.22); }
+.doc-card-tag-c6 { background: rgba(239, 68, 68, 0.12);   color: #f87171; border-color: rgba(239, 68, 68, 0.22); }
+.doc-card-tag-c7 { background: rgba(99, 102, 241, 0.12);  color: #818cf8; border-color: rgba(99, 102, 241, 0.22); }
+/* 라이트 테마에서는 파스텔 톤 대신 더 진한 색으로 대비를 확보 */
+body.light-theme .doc-card-tag-c0 { color: #7c3aed; }
+body.light-theme .doc-card-tag-c1 { color: #2563eb; }
+body.light-theme .doc-card-tag-c2 { color: #059669; }
+body.light-theme .doc-card-tag-c3 { color: #b45309; }
+body.light-theme .doc-card-tag-c4 { color: #db2777; }
+body.light-theme .doc-card-tag-c5 { color: #0d9488; }
+body.light-theme .doc-card-tag-c6 { color: #dc2626; }
+body.light-theme .doc-card-tag-c7 { color: #4f46e5; }
 
 /* ── Google Drive Style Upload Popup ── */
 .upload-popup {


### PR DESCRIPTION
# Summary
## 1. 라이브러리 논문 카드 시각 디자인 리파인
- 아이콘을 단순히 떠 있는 형태에서, 제목과 나란히 배치된 그라디언트 뱃지(`.doc-card-header` 행)로 변경해 앱 아이콘처럼 정돈된 인상을 주도록 함
- 카테고리 태그에 이름 해시 기반 8색 팔레트(`categoryColorClass`)를 적용해, 이전에는 모든 태그가 동일한 보라색이었던 것을 카테고리별로 시각적으로 구분되도록 함 (같은 카테고리는 항상 같은 색 - 결정론적 배정). 라이트 테마에서는 대비 확보를 위해 더 진한 색상으로 오버라이드
- 등록일/완독일과 페이지 수를 줄바꿈된 두 줄 대신 가운데 점(`·`)으로 구분된 한 줄로 정리해 더 컴팩트하게 표시
- 번역 진행률 퍼센트를 강조 색상(`--accent-mid`)으로 스타일링해 가독성 향상
- 진행바 두께, 액션 버튼 크기(36px→38px) 등 세부 여백/비율 조정
- `frontend/src/main.js`: `categoryColorClass(category)` 헬퍼 추가, `createDocCard`의 마크업을 새 구조(헤더 행, 태그 색상 클래스, 메타 구분점, 진행률 퍼센트 클래스)에 맞게 수정
- `frontend/src/style.css`: `.doc-card-header`, `.doc-card-icon`(뱃지 스타일), `.doc-card-tag-c0`~`c7`(+라이트 테마 대비 오버라이드), `.doc-card-meta .meta-dot`, `.doc-progress-pct` 등 추가/수정
- 검증: 로컬 미리보기 HTML + Playwright 스크린샷으로 다크/라이트 테마 양쪽에서 시각 확인, 실제 `createDocCard`/`categoryColorClass` 함수를 추출해 마크업 구조(헤더 안에 아이콘+제목, 태그 색상 클래스 부여, 메타 구분점, 진행률 퍼센트 클래스, 카테고리 색상 결정론성)가 의도대로 동작하는지 확인
