### PR TITLE
refactor: 라이브러리 카드에 카테고리 색 아이덴티티와 모던한 마이크로 인터랙션 추가

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BxNIhlzx.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-isdAa1jm.css">
+  <script type="module" crossorigin src="/assets/index-BV3iadQT.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CSEqljEM.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2644,12 +2644,34 @@ function createEmptyState(isHistory = false) {
 }
 
 // 카테고리 이름을 해시해 8가지 색상 중 하나로 결정론적 배정 (같은 카테고리는 항상 같은 색)
-function categoryColorClass(category) {
+function categoryColorIndex(category) {
   let hash = 0
   for (let i = 0; i < category.length; i++) {
     hash = (hash * 31 + category.charCodeAt(i)) | 0
   }
-  return `doc-card-tag-c${Math.abs(hash) % 8}`
+  return Math.abs(hash) % 8
+}
+function categoryColorClass(category) {
+  return `doc-card-tag-c${categoryColorIndex(category)}`
+}
+
+// 카드 전체의 색 아이덴티티(아이콘 뱃지·상단 바·호버 글로우)를 대표 카테고리 색으로
+// 통일해서 카드마다 개성이 드러나도록 함. 카테고리가 없으면 기본 브랜드 그라디언트.
+const CARD_ACCENT_PALETTE = [
+  { from: '#8b5cf6', to: '#a855f7', glow: 'rgba(139, 92, 246, 0.45)' },
+  { from: '#3b82f6', to: '#6366f1', glow: 'rgba(59, 130, 246, 0.45)' },
+  { from: '#10b981', to: '#14b8a6', glow: 'rgba(16, 185, 129, 0.45)' },
+  { from: '#f59e0b', to: '#f97316', glow: 'rgba(245, 158, 11, 0.45)' },
+  { from: '#ec4899', to: '#f43f5e', glow: 'rgba(236, 72, 153, 0.45)' },
+  { from: '#14b8a6', to: '#06b6d4', glow: 'rgba(20, 184, 166, 0.45)' },
+  { from: '#ef4444', to: '#f97316', glow: 'rgba(239, 68, 68, 0.45)' },
+  { from: '#6366f1', to: '#8b5cf6', glow: 'rgba(99, 102, 241, 0.45)' },
+]
+function getCardAccent(categories) {
+  if (categories && categories.length > 0) {
+    return CARD_ACCENT_PALETTE[categoryColorIndex(categories[0])]
+  }
+  return { from: 'var(--accent-from)', to: 'var(--accent-to)', glow: 'var(--accent-glow)' }
 }
 
 function createDocCard(doc) {
@@ -2670,10 +2692,10 @@ function createDocCard(doc) {
   const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
   const isRead = doc.metadata?.read === true
 
-  let dateHtml = `<span>${icon('calendar', 12, 'style="vertical-align:-2px;margin-right:2px"')}등록: ${date}</span>`
+  let dateHtml = `<span class="doc-meta-chip">${icon('calendar', 12)}등록 ${date}</span>`
   if (isRead && doc.metadata?.read_at) {
     const readDateStr = new Date(doc.metadata.read_at).toLocaleDateString('ko-KR', { year:'numeric', month:'short', day:'numeric' })
-    dateHtml = `<span>${icon('checkCircle', 12, 'style="vertical-align:-2px;margin-right:2px"')}완독: ${readDateStr}</span>`
+    dateHtml = `<span class="doc-meta-chip done">${icon('checkCircle', 12)}완독 ${readDateStr}</span>`
   }
 
   const checkBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
@@ -2688,7 +2710,7 @@ function createDocCard(doc) {
   if (!isDone) {
     progressHtml = `
       <div class="doc-card-progress">
-        <div class="doc-progress-bar-wrap"><div class="doc-progress-bar" style="width:${pct}%"></div></div>
+        <div class="doc-progress-bar-wrap"><div class="doc-progress-bar" style="width:${pct}%"><span class="doc-progress-shimmer"></span></div></div>
         <div class="doc-progress-label">
           <span>번역 중 (${translated}/${total}p)</span>
           <span class="doc-progress-pct">${pct}%</span>
@@ -2723,8 +2745,13 @@ function createDocCard(doc) {
     `
   }
 
+  const accent = getCardAccent(categories)
+
   const card = document.createElement('div')
   card.className = 'doc-card'
+  card.style.setProperty('--card-accent-from', accent.from)
+  card.style.setProperty('--card-accent-to', accent.to)
+  card.style.setProperty('--card-accent-glow', accent.glow)
   card.innerHTML = `
     ${checkBtnHtml}
     <div class="doc-card-header">
@@ -2733,7 +2760,7 @@ function createDocCard(doc) {
     </div>
     ${tagsHtml}
     <div class="doc-card-meta">
-      ${dateHtml}<span class="meta-dot"></span><span>${icon('layers', 12, 'style="vertical-align:-2px;margin-right:2px"')}${total}페이지</span>
+      ${dateHtml}<span class="doc-meta-chip">${icon('layers', 12)}${total}페이지</span>
     </div>
     ${progressHtml}
     <div class="doc-card-actions">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1204,8 +1204,13 @@ body:not(.light-theme) .pdf-page-inner canvas {
   font-weight: 500;
 }
 
-/* 문서 카드 */
+/* 문서 카드
+   --card-accent-from/to/glow는 JS(getCardAccent)가 대표 카테고리 색으로 채워주는
+   커스텀 프로퍼티 - 카드마다 아이콘/상단 바/호버 글로우가 그 색으로 통일된다 */
 .doc-card {
+  --card-accent-from: var(--accent-from);
+  --card-accent-to: var(--accent-to);
+  --card-accent-glow: var(--accent-glow);
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
@@ -1213,7 +1218,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.4s ease, background 0.4s ease;
   cursor: pointer;
   position: relative;
   overflow: hidden;
@@ -1225,17 +1230,30 @@ body:not(.light-theme) .pdf-page-inner canvas {
   position: absolute;
   top: 0; left: 0; right: 0;
   height: 3px;
-  background: linear-gradient(90deg, var(--accent-from), #c084fc, var(--accent-to));
-  opacity: 0;
+  background: linear-gradient(90deg, var(--card-accent-from), var(--card-accent-to));
+  opacity: 0.5;
   transition: opacity 0.3s ease;
 }
+/* 대각선으로 스치는 하이라이트("sheen") - 호버 시 카드를 가로질러 은은하게 훑고 지나감 */
+.doc-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, transparent 40%, rgba(255, 255, 255, 0.07) 50%, transparent 60%);
+  background-size: 250% 250%;
+  background-position: 120% 0%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, background-position 0.9s cubic-bezier(0.16, 1, 0.3, 1);
+}
 .doc-card:hover {
-  border-color: rgba(129, 140, 248, 0.2);
+  border-color: color-mix(in srgb, var(--card-accent-from) 35%, transparent);
   background: var(--bg-card-hover);
-  transform: translateY(-6px);
-  box-shadow: var(--shadow-hover);
+  transform: translateY(-7px) scale(1.012);
+  box-shadow: var(--shadow-hover), 0 0 32px -6px var(--card-accent-glow);
 }
 .doc-card:hover::before { opacity: 1; }
+.doc-card:hover::after { opacity: 1; background-position: -20% 0%; }
 
 /* 아이콘 뱃지 + 제목을 한 줄에 나란히 배치 */
 .doc-card-header {
@@ -1244,54 +1262,71 @@ body:not(.light-theme) .pdf-page-inner canvas {
   gap: 14px;
 }
 
-/* 아이콘을 은은한 그라디언트 뱃지로 감싸 "떠 있는 아이콘" 느낌 대신
-   앱 아이콘처럼 정돈된 인상을 준다 */
+/* 아이콘을 대표 카테고리 색 그라디언트 뱃지로 감싸 앱 아이콘처럼 정돈된 인상을 준다 */
 .doc-card-icon {
-  width: 46px;
-  height: 46px;
-  border-radius: var(--radius-md);
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
-  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
-  box-shadow: 0 6px 16px rgba(124, 58, 237, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  background: linear-gradient(135deg, var(--card-accent-from), var(--card-accent-to));
+  box-shadow: 0 8px 18px -4px var(--card-accent-glow), inset 0 1px 0 rgba(255, 255, 255, 0.25);
   flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.doc-card-icon svg { filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15)); }
+.doc-card-icon::after {
+  /* 유리 광택 하이라이트 */
+  content: '';
+  position: absolute;
+  top: -60%; left: -20%;
+  width: 70%; height: 140%;
+  background: rgba(255, 255, 255, 0.22);
+  transform: rotate(20deg);
+}
+.doc-card-icon svg { filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15)); position: relative; z-index: 1; }
+.doc-card:hover .doc-card-icon { transform: rotate(-4deg) scale(1.08); }
 
 .doc-card-title {
-  font-size: 15.5px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 750;
   color: var(--text-primary);
-  line-height: 1.45;
+  line-height: 1.42;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
+  padding-top: 2px;
 }
 
 .doc-card-meta {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-secondary);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 5px 8px;
-  font-weight: 500;
+  gap: 6px;
+  font-weight: 600;
 }
-.doc-card-meta span {
+/* 메타 정보를 텍스트 나열 대신 작은 칩으로 묶어 시각적 무게감을 줌 */
+.doc-meta-chip {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   white-space: nowrap;
+  padding: 3px 9px 3px 7px;
+  border-radius: 100px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
 }
-.doc-card-meta .meta-dot {
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  flex-shrink: 0;
+.doc-meta-chip.done {
+  color: var(--success);
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.22);
 }
 
 /* 번역 진행률 */
@@ -1301,16 +1336,30 @@ body:not(.light-theme) .pdf-page-inner canvas {
   gap: 7px;
 }
 .doc-progress-bar-wrap {
-  height: 6px;
+  height: 7px;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 100px;
   overflow: hidden;
 }
 .doc-progress-bar {
   height: 100%;
-  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  background: linear-gradient(90deg, var(--card-accent-from, var(--accent-from)), var(--card-accent-to, var(--accent-to)));
   border-radius: 100px;
   transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+  position: relative;
+  overflow: hidden;
+}
+/* 진행 중인 항목이 정적으로 멈춰있지 않고 살아있는 느낌을 주는 은은한 반짝임 */
+.doc-progress-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+  width: 40%;
+  animation: docProgressShimmer 1.8s ease-in-out infinite;
+}
+@keyframes docProgressShimmer {
+  0%   { transform: translateX(-120%); }
+  100% { transform: translateX(280%); }
 }
 .doc-progress-label {
   display: flex;
@@ -1320,8 +1369,8 @@ body:not(.light-theme) .pdf-page-inner canvas {
   font-weight: 600;
 }
 .doc-progress-label .doc-progress-pct {
-  color: var(--accent-mid);
-  font-weight: 700;
+  color: var(--card-accent-from, var(--accent-mid));
+  font-weight: 800;
 }
 .doc-progress-label.done { color: var(--success); text-shadow: 0 0 8px rgba(16, 185, 129, 0.15); }
 
@@ -3822,13 +3871,15 @@ body.light-theme .library-tab-btn.active {
 /* ── Custom Checked Badge on Document Card ── */
 .doc-card-check-btn {
   position: absolute;
-  top: 18px;
-  right: 18px;
-  width: 24px;
-  height: 24px;
+  top: 16px;
+  right: 16px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   background: var(--bg-card);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
# Summary
## 1. 라이브러리 카드에 카테고리 색 아이덴티티와 모던한 마이크로 인터랙션 추가
- 이전 PR(#48)의 기본 리파인에서 한 단계 더 "모던하고 눈에 띄는" 방향으로 고도화
- 카드마다 대표 카테고리 색을 카드 전체의 색 아이덴티티(아이콘 뱃지, 상단 바, 호버 글로우, 진행률 바)로 통일 - `getCardAccent()`가 카테고리 해시로 8색 그라디언트 팔레트 중 하나를 결정론적으로 배정 (카테고리 없으면 기본 브랜드 그라디언트)
- 아이콘 뱃지에 유리 광택(shine) 오버레이와 호버 시 살짝 회전+확대되는 인터랙션 추가
- 카드 호버 시 대각선으로 스치는 하이라이트(sheen) 애니메이션 + 카테고리 색 글로우 섀도우 추가
- 번역 진행 중인 카드의 진행률 바에 은은한 shimmer 애니메이션을 넣어 "살아있는" 느낌을 줌
- 날짜/페이지 수 메타 정보를 텍스트 나열 대신 아이콘+배경이 있는 칩(chip) 형태로 변경
- 카드 상단 액센트 바를 호버 전에도 은은하게(50% opacity) 항상 보이도록 해 색 아이덴티티가 상시 드러나도록 함
- `frontend/src/main.js`: `categoryColorIndex()`, `CARD_ACCENT_PALETTE`, `getCardAccent()` 추가, `createDocCard`에서 카드 엘리먼트에 `--card-accent-from/to/glow` 커스텀 프로퍼티를 인라인으로 설정, 메타 정보를 칩 마크업으로 변경
- `frontend/src/style.css`: `.doc-card`/`.doc-card-icon`/`.doc-card::after`(sheen)/`.doc-meta-chip`/`.doc-progress-shimmer` 등 대거 리파인
- 검증: 로컬 미리보기 HTML + Playwright로 다크/라이트 테마, 기본 상태와 호버 상태 모두 스크린샷 확인. 실제 `createDocCard`/`getCardAccent`/`categoryColorClass` 함수를 추출해 마크업 구조와 색상 결정론성이 의도대로 동작하는지 확인
