### PR TITLE
fix: 미리보기 이미지가 잘려서 크게 보이던 문제와 뷰어 진입이 느려지던 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Cpj-tlmM.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Dai2ntca.css">
+  <script type="module" crossorigin src="/assets/index-BU2Sr9VR.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BPUppcOA.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3055,20 +3055,21 @@ document.addEventListener('keydown', (e) => {
 })
 
 if (docPreviewOpenBtn) {
-  docPreviewOpenBtn.addEventListener('click', async () => {
+  docPreviewOpenBtn.addEventListener('click', () => {
     const doc = docPreviewCurrentDoc
     if (!doc) return
-    const enterViewer = async () => {
-      hideDocPreview()
-      await openFromLibrary(doc)
-    }
-    // View Transitions API를 지원하는 브라우저에서는 팝업 닫힘 → 뷰어 진입이
-    // 즉각적인 화면 전환이 아니라 부드러운 크로스페이드로 이어지도록 한다.
+    // 트랜지션 콜백에는 팝업을 닫는 즉각적인 DOM 변경만 넣는다 - openFromLibrary
+    // 전체(PDF 로드 + 페이지 렌더링)를 콜백 안에 넣고 기다리면, 뷰 트랜지션이
+    // "이후 상태" 스냅샷을 로딩이 다 끝날 때까지 못 찍어서 그 사이 화면이 멈춘
+    // 것처럼 보이고 뷰어 진입이 오히려 훨씬 느리게 느껴진다. 팝업 닫힘만 짧게
+    // 트랜지션으로 처리하고, 문서 로딩은 기존과 동일하게 곧장 진행해 원래의
+    // 점진적 로딩 표시(스피너 등)가 그대로 보이도록 한다.
     if (document.startViewTransition) {
-      document.startViewTransition(enterViewer)
+      document.startViewTransition(() => { hideDocPreview() })
     } else {
-      await enterViewer()
+      hideDocPreview()
     }
+    openFromLibrary(doc)
   })
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1530,9 +1530,12 @@ body:not(.light-theme) .pdf-page-inner canvas {
 .doc-preview-cover-img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   object-position: top center;
   display: block;
+  /* 논문 페이지 자체가 흰 배경이므로, contain으로 인해 생기는 여백도 흰색으로 채워
+     이질감 없이 자연스럽게 이어지도록 함 */
+  background: #fdfdfd;
 }
 .doc-preview-gradient {
   position: absolute;


### PR DESCRIPTION
# Summary
## 1. 미리보기 팝업 이미지가 잘려서 과도하게 확대되어 보이던 문제 수정
- 원인: `.doc-preview-cover-img`에 `object-fit: cover`를 써서, 캡쳐된 이미지(가로로 넓은 비율)를 세로로 긴 히어로 영역에 꽉 채우면서 좌우가 크게 잘려나감 - 제목은 보여도 abstract 본문 대부분이 화면 밖으로 잘려 보이지 않았음
- `object-fit: contain`으로 변경해 이미지 전체(제목+저자+abstract 전문)가 잘리지 않고 한눈에 들어오도록 하고, `contain`으로 인해 생기는 여백은 논문 페이지 자체의 흰 배경과 자연스럽게 이어지도록 흰색으로 채움

## 2. 미리보기 팝업의 "열기" 버튼을 눌렀을 때 뷰어 진입이 느려지던 문제 수정
- 원인: 직전 PR에서 "열기" 클릭 시 `document.startViewTransition(async () => { hideDocPreview(); await openFromLibrary(doc) })`처럼 PDF 로딩+렌더링 전체를 트랜지션 콜백 안에 넣고 기다렸음. View Transition은 콜백이 완전히 끝나야 "이후 상태" 스냅샷을 찍기 때문에, 로딩이 끝날 때까지 화면이 멈춘 것처럼 보이고 원래 있던 점진적 로딩 표시(스피너 등)도 전혀 보이지 않아 체감 속도가 크게 느려졌음
- 트랜지션 콜백에는 팝업을 닫는 즉각적인 DOM 변경(`hideDocPreview()`)만 넣고, `openFromLibrary(doc)`는 트랜지션과 무관하게 곧장(await 없이) 호출하도록 수정 - 팝업이 부드럽게 닫히는 연출은 유지하면서, 문서 로딩 자체는 기존과 동일한 속도로 즉시 시작됨

## 검증
- Playwright로 클릭 후 20ms 이내에 `openFromLibrary`가 실제로 호출되기 시작하는지 확인 (수정 전 로직으로는 트랜지션 콜백 전체가 끝나야 호출되므로 이 타이밍 안에 시작되지 않음을 대비 확인)
- 확장 버튼 → 팝업 오픈 → 닫기/배경 클릭 → "열기" 버튼 클릭 시 `openFromLibrary` 호출 및 팝업 닫힘까지 기존 시나리오 회귀 테스트 재확인
- 실제 논문 캡쳐 이미지로 다크 테마 스크린샷 확인 - abstract 전문이 잘리지 않고 전부 보이는지 확인
