### PR TITLE
perf: 뷰어 진입 시 순차 실행되던 무관한 비동기 작업들을 병렬화

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BU2Sr9VR.js"></script>
+  <script type="module" crossorigin src="/assets/index-BRrfiipF.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BPUppcOA.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3116,24 +3116,16 @@ async function openFromLibrary(doc, shouldPushState = true) {
   // 번역이 완료된 페이지 번호만 기록하고 번역본 로드는 lazy-load에 위임
   state.translatedPages  = new Set(doc.translated_pages || [])
 
-  // 채팅 내역 초기화 및 복원
+  // 채팅 내역 초기화
   state.chatHistory = []
   chatMessages.innerHTML = `<div class="chat-message assistant"><div class="message-bubble">안녕하세요! 이 논문의 내용에 대해 궁금한 점을 질문하시면 해당 분야의 전문가로서 답변해 드립니다.<br><br><strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong><ul><li>이 논문의 핵심 연구 내용과 기여도를 요약해줘.</li><li>본문에서 제안하는 알고리즘/방법론의 상세 과정을 설명해줘.</li><li>실험 결과에서 제시된 주요 수치와 의의는 무엇이야?</li></ul></div></div>`
-  
-  try {
-    const res = await getChatHistoryAPI(doc.id)
-    const history = res.history || []
-    if (history && history.length > 0) {
-      for (const msg of history) {
-        state.chatHistory.push({ role: msg.role, content: msg.content })
-        const isAssistant = msg.role === 'assistant'
-        const renderedContent = isAssistant ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content)
-        appendChatMessage(msg.role, renderedContent, true)
-      }
-    }
-  } catch (err) {
+
+  // 채팅 기록 조회는 PDF 로딩과 서로 무관한 별개의 요청이므로, 기다리지 않고
+  // 병렬로 시작해 전체 대기 시간을 줄인다 (완료되면 아래에서 반영).
+  const chatHistoryPromise = getChatHistoryAPI(doc.id).catch(err => {
     console.error('채팅 기록 로드 실패:', err)
-  }
+    return null
+  })
 
   await loadPDF(`/api/library/${doc.id}/pdf`)
   docTitle.textContent  = displayTitle
@@ -3151,12 +3143,31 @@ async function openFromLibrary(doc, shouldPushState = true) {
   state.currentPage = restorePage
 
   showViewer()
-  await initScrollViewer()
-  if (restorePage > 1) {
-    scrollToPage(viewerScrollContainer, restorePage, { instant: true })
-  }
   hideOutlineSidebar()
-  await loadPDFOutline()
+
+  // PDF가 로드된 뒤에만 가능한 두 작업(페이지 렌더링, 목차 조회)은 서로 무관하므로
+  // 병렬로 실행한다 - 이전에는 순차 실행이라 두 작업 시간이 그대로 더해졌었다.
+  await Promise.all([
+    (async () => {
+      await initScrollViewer()
+      if (restorePage > 1) {
+        scrollToPage(viewerScrollContainer, restorePage, { instant: true })
+      }
+    })(),
+    loadPDFOutline(),
+  ])
+
+  // 채팅 기록 반영 (PDF 로딩과 병렬로 이미 완료됐을 가능성이 높음)
+  const chatRes = await chatHistoryPromise
+  const history = chatRes?.history || []
+  if (history.length > 0) {
+    for (const msg of history) {
+      state.chatHistory.push({ role: msg.role, content: msg.content })
+      const isAssistant = msg.role === 'assistant'
+      const renderedContent = isAssistant ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content)
+      appendChatMessage(msg.role, renderedContent, true)
+    }
+  }
 }
 
 function escapeHtml(str) {


### PR DESCRIPTION
# Summary
## 1. 뷰어 진입(`openFromLibrary`) 시 순차 실행되던 무관한 비동기 작업들을 병렬화
- 미리보기 팝업을 거치지 않는 일반 카드뷰 "열기"도 느리다는 피드백 확인 - 직전 PR(뷰 트랜지션 관련 수정)과 무관한, `openFromLibrary` 자체의 구조적 문제였음
- 기존에는 채팅 기록 조회 → PDF 로드 → 페이지 렌더링(`initScrollViewer`) → 목차 조회(`loadPDFOutline`)가 전부 순차적으로 `await` 되고 있었음. 이 중 채팅 기록 조회는 PDF 로딩과 완전히 무관하고, 페이지 렌더링과 목차 조회는 둘 다 "PDF가 로드된 뒤"라는 조건만 공유할 뿐 서로 무관해서 병렬 실행이 가능했는데도 계속 순서대로 기다리고 있었음
- `frontend/src/main.js`의 `openFromLibrary`를 재구성:
  - 채팅 기록 조회(`getChatHistoryAPI`)를 PDF 로드와 동시에 시작하고(await하지 않고 Promise만 보관), PDF 로드/렌더링이 끝난 뒤에 결과를 반영
  - PDF 로드 완료 후 `initScrollViewer()`(+ 책갈피 위치 복원)와 `loadPDFOutline()`을 `Promise.all`로 병렬 실행
- 기존 에러 처리(채팅 기록 조회 실패 시 콘솔 로그만 남기고 나머지는 정상 진행)는 `.catch()`로 그대로 유지

## 검증
- Playwright로 각 비동기 단계를 인위적 지연(채팅 150ms, PDF 300ms, 렌더링 200ms, 목차 200ms)으로 흉내낸 뒤 실제 `openFromLibrary` 함수를 추출해 실행 - 순차 실행이었다면 약 850ms가 걸릴 시나리오가 병렬화 후 약 500ms로 단축됨을 확인 (약 40% 단축)
- 채팅 기록이 정상적으로 있는 경우 메시지가 올바르게 화면에 반영되는지, 채팅 기록 조회가 실패하는 경우에도 나머지 로딩이 에러 없이 정상 완료되는지 별도 테스트로 확인
