### PR TITLE
fix: 뷰어 진입 시 history 변수명 충돌로 열기 버튼이 응답 없이 실패하던 심각한 버그 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BRrfiipF.js"></script>
+  <script type="module" crossorigin src="/assets/index-yTxVsxrq.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BPUppcOA.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3158,10 +3158,13 @@ async function openFromLibrary(doc, shouldPushState = true) {
   ])
 
   // 채팅 기록 반영 (PDF 로딩과 병렬로 이미 완료됐을 가능성이 높음)
+  // 주의: 변수명을 "history"로 쓰면 이 함수 맨 위에서 쓰는 전역 history(window.history)
+  // 객체를 가려버려("Cannot access 'history' before initialization") 함수 전체가
+  // 조용히 실패하므로 반드시 다른 이름을 사용해야 한다.
   const chatRes = await chatHistoryPromise
-  const history = chatRes?.history || []
-  if (history.length > 0) {
-    for (const msg of history) {
+  const chatHistoryList = chatRes?.history || []
+  if (chatHistoryList.length > 0) {
+    for (const msg of chatHistoryList) {
       state.chatHistory.push({ role: msg.role, content: msg.content })
       const isAssistant = msg.role === 'assistant'
       const renderedContent = isAssistant ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content)


### PR DESCRIPTION
# Summary
## 1. 뷰어 진입 시 열기 버튼이 응답 없이 실패하던 심각한 버그 수정
- 직전 PR(뷰어 진입 병렬화)에서 채팅 기록을 반영하는 부분에 `const history = chatRes?.history || []`를 추가했는데, 이 함수 맨 위에서 `history.pushState(...)`로 이미 쓰고 있던 전역 `window.history` 객체와 이름이 겹침
- JS의 `const`/`let`은 선언 지점 이전에 접근하면 "Temporal Dead Zone" 규칙에 의해 `ReferenceError: Cannot access 'history' before initialization`가 발생하는데, 이 지역 변수 선언이 함수 전체 스코프에 적용되면서 함수 맨 위의 `history.pushState(...)` 호출이 이 에러로 즉시 실패 - 결과적으로 `openFromLibrary` 함수 전체가 아무 것도 하지 못하고 조용히 중단되어, "열기" 버튼을 눌러도 화면이 전혀 바뀌지 않는 것처럼 보였음
- 변수명을 `chatHistoryList`로 변경해 충돌을 제거

## 검증
- 실제로 배포되어 있던 버그 버전(`bf63b85`)의 `openFromLibrary`를 그대로 추출해 실행 → `"Cannot access 'history' before initialization"` 에러가 실제로 발생하고 `history.pushState`가 전혀 호출되지 않음을 재현 확인
- 수정된 버전으로 동일 테스트 실행 → 에러 없이 정상적으로 `pushState`가 호출되고 URL이 바뀜을 확인
- 직전 PR에서 검증했던 병렬화 타이밍(약 500ms) 및 채팅 기록 반영 로직도 회귀 없이 정상 동작함을 재확인
