### PR TITLE
refactor: 라이브러리 카드/리스트/미리보기 팝업 디자인을 하나의 언어로 통일

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-yTxVsxrq.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BPUppcOA.css">
+  <script type="module" crossorigin src="/assets/index-CfUkrnLa.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-D3W6MYQf.css">
 </head>
 <body>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2675,23 +2675,6 @@ function createEmptyState(isHistory = false) {
   return el
 }
 
-// 카테고리 이름을 해시해 8가지 색상 중 하나로 결정론적 배정 (같은 카테고리는 항상 같은 색)
-function categoryColorIndex(category) {
-  let hash = 0
-  for (let i = 0; i < category.length; i++) {
-    hash = (hash * 31 + category.charCodeAt(i)) | 0
-  }
-  return Math.abs(hash) % 8
-}
-// 카드 컬러 존과 진행률 바 색을 대표 카테고리 색으로 통일해서 카드마다
-// 개성이 드러나도록 함. 카테고리가 없으면 기본 브랜드 색.
-const CARD_ACCENT_PALETTE = ['#8b5cf6', '#3b82f6', '#10b981', '#f59e0b', '#ec4899', '#14b8a6', '#ef4444', '#6366f1']
-function getCardAccent(categories) {
-  if (categories && categories.length > 0) {
-    return { from: CARD_ACCENT_PALETTE[categoryColorIndex(categories[0])] }
-  }
-  return { from: 'var(--accent-mid)' }
-}
 
 // 카드/리스트 뷰 공용: 문서 데이터로부터 두 뷰가 함께 쓰는 마크업 조각을 미리 계산한다.
 function prepareDocItemHtml(doc) {
@@ -2742,8 +2725,11 @@ function prepareDocItemHtml(doc) {
 
   const openIcon = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>'
 
+  // ctaBtnHtml: 리스트 뷰용 - 자리를 적게 차지하는 아이콘 전용 버튼
+  // ctaBtnFullHtml: 카드 뷰용 - 미리보기 팝업의 "열기" 버튼과 동일한 전체 너비 텍스트 버튼
   let iconActionsHtml = ''
   let ctaBtnHtml = ''
+  let ctaBtnFullHtml = ''
   if (state.currentLibraryTab === 'trash') {
     iconActionsHtml = `
       <button class="doc-permanent-delete-btn" data-id="${doc.id}" title="영구 삭제">
@@ -2753,7 +2739,8 @@ function prepareDocItemHtml(doc) {
         </svg>
       </button>
     `
-    ctaBtnHtml = `<button class="doc-restore-btn" data-id="${doc.id}" title="복원">${icon('refreshCw', 15)}</button>`
+    ctaBtnHtml = `<button class="doc-restore-btn doc-cta-compact" data-id="${doc.id}" title="복원">${icon('refreshCw', 15)}</button>`
+    ctaBtnFullHtml = `<button class="doc-restore-btn" data-id="${doc.id}"><span>복원</span>${icon('refreshCw', 15)}</button>`
   } else {
     iconActionsHtml = `
       <button class="doc-edit-btn" data-id="${doc.id}" title="제목 수정">
@@ -2766,12 +2753,11 @@ function prepareDocItemHtml(doc) {
         </svg>
       </button>
     `
-    ctaBtnHtml = `<button class="doc-open-btn" data-id="${doc.id}" title="열기">${openIcon}</button>`
+    ctaBtnHtml = `<button class="doc-open-btn doc-cta-compact" data-id="${doc.id}" title="열기">${openIcon}</button>`
+    ctaBtnFullHtml = `<button class="doc-open-btn" data-id="${doc.id}"><span>열기</span>${openIcon}</button>`
   }
 
-  const accent = getCardAccent(categories)
-
-  return { translated, total, pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, accent }
+  return { translated, total, pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, ctaBtnFullHtml }
 }
 
 // 카드/리스트 뷰 공용: 위임 없이 각 아이템 컨테이너에 직접 붙는 이벤트 리스너를 등록한다.
@@ -2938,7 +2924,6 @@ function createDocCard(doc) {
   const d = prepareDocItemHtml(doc)
   const card = document.createElement('div')
   card.className = 'doc-card'
-  card.style.setProperty('--card-accent-from', d.accent.from)
   card.innerHTML = `
     <div class="doc-card-zone">
       <div class="doc-card-zone-actions">
@@ -2947,18 +2932,14 @@ function createDocCard(doc) {
       </div>
       <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
       ${d.tagsHtml}
+      <div class="doc-card-meta">
+        ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${d.total}p</span>
+      </div>
+      ${d.progressHtml}
     </div>
     <div class="doc-card-footer">
-      <div class="doc-card-footer-info">
-        <div class="doc-card-meta">
-          ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${d.total}p</span>
-        </div>
-        ${d.progressHtml}
-      </div>
-      <div class="doc-card-cta">
-        <div class="doc-icon-actions">${d.iconActionsHtml}</div>
-        ${d.ctaBtnHtml}
-      </div>
+      ${d.ctaBtnFullHtml}
+      <div class="doc-icon-actions">${d.iconActionsHtml}</div>
     </div>`
   wireDocItemEvents(card, doc, d.displayTitle)
   const expandBtn = card.querySelector('.doc-card-expand-btn')
@@ -2988,7 +2969,6 @@ function createDocListRow(doc) {
 
   const row = document.createElement('div')
   row.className = 'doc-list-row'
-  row.style.setProperty('--card-accent-from', d.accent.from)
   row.innerHTML = `
     ${d.checkBtnHtml}
     <div class="doc-list-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
@@ -3013,15 +2993,14 @@ function showDocPreview(doc) {
   const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
   docPreviewTitle.textContent = displayTitle
 
-  // 표지 이미지 생성 실패(손상된 PDF 등) 시 깨진 이미지 아이콘 대신 카드와 같은
-  // 카테고리 색 그라디언트로 자연스럽게 대체한다.
-  const accent = getCardAccent(doc.metadata?.categories || [])
+  // 표지 이미지 생성 실패(손상된 PDF 등) 시 깨진 이미지 아이콘 대신 중립 그라디언트로
+  // 자연스럽게 대체한다 (카테고리 색을 쓰지 않아 다른 곳과 톤이 일관됨).
   const hero = docPreviewCoverImg.closest('.doc-preview-hero')
   docPreviewCoverImg.classList.remove('hidden')
   if (hero) hero.style.background = ''
   docPreviewCoverImg.onerror = () => {
     docPreviewCoverImg.classList.add('hidden')
-    if (hero) hero.style.background = `linear-gradient(160deg, color-mix(in srgb, ${accent.from} 35%, var(--bg-elevated)), var(--bg-elevated))`
+    if (hero) hero.style.background = 'linear-gradient(160deg, var(--bg-elevated), var(--bg-card))'
   }
   docPreviewCoverImg.src = `/api/library/${doc.id}/cover`
   docPreviewPages.textContent = `${doc.total_pages || 1}p`

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1204,11 +1204,9 @@ body:not(.light-theme) .pdf-page-inner canvas {
   font-weight: 500;
 }
 
-/* 문서 카드 - 파스텔 투톤 색인 카드 컨셉: 위쪽은 대표 카테고리 색을 옅게 입힌
-   "컬러 존", 아래쪽은 중립색 "푸터"로 나뉜다. --card-accent-from은 JS(getCardAccent)가
-   대표 카테고리 색으로 채워주는 커스텀 프로퍼티. */
+/* 문서 카드 - 미리보기 팝업과 동일한 톤(중립 배경, 굵은 산세리프 제목, 단일 브랜드
+   색만 사용)으로 통일. 카테고리별로 색이 달라지는 장식은 쓰지 않는다. */
 .doc-card {
-  --card-accent-from: var(--accent-mid);
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 20px;
@@ -1227,18 +1225,16 @@ body:not(.light-theme) .pdf-page-inner canvas {
   box-shadow: 0 16px 32px -16px rgba(0, 0, 0, 0.5);
 }
 
-/* 컬러 존: 카테고리 색을 옅게 섞어 테마(다크/라이트) 양쪽에서 자연스럽게 어울리도록 함 */
 .doc-card-zone {
-  background: color-mix(in srgb, var(--card-accent-from) 16%, var(--bg-card));
-  padding: 22px 22px 20px;
+  padding: 20px 22px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   position: relative;
 }
 
 .doc-card-title {
-  font-size: 19px;
+  font-size: 17px;
   font-weight: 800;
   color: var(--text-primary);
   line-height: 1.3;
@@ -1251,26 +1247,17 @@ body:not(.light-theme) .pdf-page-inner canvas {
   padding-right: 34px;
 }
 
-/* 푸터: 메타 정보 + 진행률(좌) / 액션 버튼(우) */
+/* 푸터: 미리보기 팝업의 "열기" 버튼과 동일한 전체 너비 버튼 + 편집/삭제 아이콘 */
 .doc-card-footer {
-  background: var(--bg-card);
-  padding: 15px 16px 15px 22px;
+  padding: 0 20px 20px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  gap: 8px;
   margin-top: auto;
-}
-.doc-card-footer-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
 }
 
 .doc-card-meta {
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-muted);
   display: flex;
   align-items: center;
@@ -1287,15 +1274,14 @@ body:not(.light-theme) .pdf-page-inner canvas {
   flex-shrink: 0;
 }
 
-/* 번역 진행률 - 푸터 좌측에 작은 바 + 텍스트로 압축 표기 */
+/* 번역 진행률 - 작은 바 + 텍스트로 압축 표기. 브랜드 색 하나로 통일 */
 .doc-card-progress-row {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 600;
-  color: var(--card-accent-from);
+  color: var(--accent-mid);
 }
 .doc-card-progress-row .doc-progress-bar-wrap {
   width: 44px;
@@ -1308,11 +1294,11 @@ body:not(.light-theme) .pdf-page-inner canvas {
 .doc-card-progress-row .doc-progress-bar {
   height: 100%;
   border-radius: 4px;
-  background: var(--card-accent-from);
+  background: var(--accent-mid);
   transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* 카드 액션 버튼 */
+/* 카드 액션 버튼 - 미리보기 팝업의 "열기" 버튼과 동일한 색/모양(흑백 반전) 사용 */
 .doc-card-cta {
   display: flex;
   align-items: center;
@@ -1322,36 +1308,47 @@ body:not(.light-theme) .pdf-page-inner canvas {
 .doc-icon-actions {
   display: flex;
   gap: 2px;
+  flex-shrink: 0;
 }
 .doc-open-btn, .doc-restore-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 14px;
+  background: #fff;
+  color: #14141a;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 800;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+body.light-theme .doc-open-btn,
+body.light-theme .doc-restore-btn {
+  background: #14141a;
+  color: #fff;
+}
+.doc-open-btn:hover, .doc-restore-btn:hover { filter: brightness(0.96); }
+.doc-open-btn:active, .doc-restore-btn:active { transform: scale(0.98); }
+
+/* 리스트 뷰용 컴팩트 변형 - 텍스트 없이 아이콘만, 원형으로 축소 */
+.doc-open-btn.doc-cta-compact, .doc-restore-btn.doc-cta-compact {
+  flex: none;
   width: 34px;
   height: 34px;
   padding: 0;
   border-radius: 50%;
-  background: var(--card-accent-from);
-  color: white;
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: filter 0.2s ease, transform 0.2s ease;
 }
-.doc-open-btn:hover, .doc-restore-btn:hover {
-  filter: brightness(1.1);
-  transform: scale(1.06);
-}
-.doc-open-btn:active, .doc-restore-btn:active {
-  filter: brightness(0.95);
-  transform: scale(1);
-}
+.doc-cta-compact span { display: none; }
 
 .doc-delete-btn, .doc-permanent-delete-btn, .doc-edit-btn {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  border: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -1364,10 +1361,12 @@ body:not(.light-theme) .pdf-page-inner canvas {
 .doc-delete-btn:hover, .doc-permanent-delete-btn:hover {
   color: #fca5a5;
   background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
 }
 .doc-edit-btn:hover {
-  color: var(--card-accent-from);
-  background: color-mix(in srgb, var(--card-accent-from) 14%, transparent);
+  color: var(--accent-mid);
+  background: color-mix(in srgb, var(--accent-mid) 14%, transparent);
+  border-color: var(--accent-mid);
 }
 
 /* ── 카드/리스트 보기 전환 토글 ── */
@@ -1407,11 +1406,9 @@ body:not(.light-theme) .pdf-page-inner canvas {
   gap: 10px;
 }
 .doc-list-row {
-  --card-accent-from: var(--accent-mid);
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-left: 4px solid var(--card-accent-from);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 12px 16px;
   display: flex;
   align-items: center;
@@ -1422,6 +1419,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
 }
 .doc-list-row:hover {
   background: var(--bg-card-hover);
+  border-color: var(--border-strong);
   transform: translateX(2px);
 }
 .doc-list-row .doc-card-check-btn {
@@ -1455,7 +1453,6 @@ body:not(.light-theme) .pdf-page-inner canvas {
   width: 120px;
 }
 .doc-list-progress-slot:empty { width: 0; }
-.doc-list-row .doc-card-progress-row { color: var(--card-accent-from); }
 .doc-list-row .doc-card-cta {
   flex-shrink: 0;
   margin-left: auto;
@@ -1594,7 +1591,6 @@ body:not(.light-theme) .pdf-page-inner canvas {
 .doc-preview-meta {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.65);
-  font-family: var(--font-mono);
 }
 
 .doc-preview-open-btn {
@@ -2725,8 +2721,8 @@ body.light-theme .provider-picker-panel {
   box-shadow: 0 4px 12px var(--accent-glow);
 }
 
-/* Card Category Tag - 카드의 컬러 존과 같은 색 계열의 필(pill) 태그로,
-   한 카드 안의 모든 태그는 그 카드의 대표 카테고리 색(--card-accent-from)을 공유한다. */
+/* Card Category Tag - 미리보기 팝업 태그와 톤을 맞춘 중립 필(pill). 카테고리마다
+   색이 달라지지 않고 모두 동일한 스타일을 공유해 카드 전체의 통일성을 유지한다. */
 .doc-card-tags {
   display: flex;
   gap: 8px;
@@ -2737,8 +2733,9 @@ body.light-theme .provider-picker-panel {
   font-weight: 700;
   padding: 4px 11px;
   border-radius: 100px;
-  background: color-mix(in srgb, var(--card-accent-from) 28%, var(--bg-card));
-  color: color-mix(in srgb, var(--card-accent-from) 80%, var(--text-primary));
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
 }
 
 /* ── Google Drive Style Upload Popup ── */
@@ -4025,8 +4022,8 @@ body.light-theme .library-tab-btn.active {
   width: 26px;
   height: 26px;
   border-radius: 8px;
-  border: none;
-  background: color-mix(in srgb, var(--card-accent-from) 22%, var(--bg-card));
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
   color: var(--text-muted);
   display: flex;
   align-items: center;
@@ -4042,16 +4039,17 @@ body.light-theme .library-tab-btn.active {
   transform: scale(1);
 }
 .doc-card-expand-btn:hover {
-  color: var(--card-accent-from);
-  background: color-mix(in srgb, var(--card-accent-from) 32%, var(--bg-card));
+  color: var(--accent-mid);
+  background: color-mix(in srgb, var(--accent-mid) 14%, var(--bg-elevated));
+  border-color: var(--accent-mid);
 }
 
 .doc-card-check-btn {
   width: 26px;
   height: 26px;
   border-radius: 8px;
-  border: none;
-  background: color-mix(in srgb, var(--card-accent-from) 22%, var(--bg-card));
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
# Summary
## 1. 카드/리스트/미리보기 팝업의 디자인 언어를 미리보기 팝업 기준으로 통일
- 카드·리스트 뷰가 "카테고리별로 색이 달라지는" 파스텔/레인보우 장식 시스템(컬러 존 배경, 모노스페이스 폰트, 카테고리별 색 태그, 원형 색상 열기 버튼, 색 책등)을 쓰고 있어서, 중립적이고 절제된 미리보기 팝업과 톤이 맞지 않았음
- 미리보기 팝업의 "정갈하고 심플한" 언어(중립 배경, 굵은 산세리프 타이포그래피, 단일 브랜드 색만 포인트로 사용, 흑백 반전 "열기" 버튼)를 기준으로 카드·리스트를 재설계
- 카테고리별 색상 배정 시스템(`getCardAccent`/`categoryColorIndex`/`CARD_ACCENT_PALETTE`) 전체 제거 - 카드 배경은 항상 중립(`--bg-card`), 진행률 바는 항상 브랜드 색(`--accent-mid`) 하나로 통일
- 카테고리 태그를 카테고리마다 색이 바뀌는 필(pill)에서, 팝업 태그와 같은 톤의 중립 회색 필로 변경
- 메타 정보(날짜/페이지) 폰트를 모노스페이스에서 기본 산세리프로 변경해 팝업과 통일
- "열기" 버튼을 원형 색상 아이콘 버튼에서, 팝업의 "열기" 버튼과 동일한 흑백 반전(다크 테마: 흰 배경/검정 글자, 라이트 테마: 반전) 전체 너비 버튼으로 교체 - 카드 푸터를 2행 구조(메타+진행률 / 버튼+편집·삭제 아이콘)로 재구성
- 리스트 뷰는 공간 제약상 같은 색/모양의 컴팩트(아이콘 전용, 원형) 버전을 사용 (`.doc-cta-compact` 수정자)
- 읽음 표시·확장 버튼, 편집/삭제 버튼도 카테고리 색 대신 중립 색상으로 통일
- 미리보기 팝업의 메타 텍스트도 모노스페이스를 제거해 완전히 통일

## 검증
- Playwright로 실제 `createDocCard`/`createDocListRow`/`showDocPreview`/`prepareDocItemHtml`/`wireDocItemEvents` 함수를 추출해 다크/라이트 테마로 카드·리스트·팝업을 함께 스크린샷 확인 - 세 요소가 동일한 색/타이포그래피 언어를 공유하는지 육안 확인
- 확장 버튼 → 팝업 열기/닫기, "열기" 버튼 클릭 → 뷰어 진입 등 기존 상호작용 시나리오가 리팩터링 이후에도 회귀 없이 동작하는지 재확인
