### PR TITLE
fix: Windows에서 셸 스크립트 CRLF 실행 오류 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# 셸 스크립트는 Windows(Git Bash 등)에서 체크아웃될 때도 항상 LF 개행을 사용해야 합니다.
+# core.autocrlf=true 환경에서 CRLF로 변환되면 "$'\r': command not found" 같은 오류가 발생합니다.
+*.sh text eol=lf
+
+# 이미지 등 바이너리 파일은 개행 변환 대상에서 제외합니다.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ cd EasyPaper
 ```
 
 > **Windows에서 실행하는 경우:** `git clone` 시 이미 설치된 **Git Bash**(Git for Windows 기본 포함)에서 위 명령을 그대로 실행하면 됩니다. 별도의 스크립트나 셸이 필요하지 않으며, 파이썬 가상환경 내부 경로(`bin/` vs `Scripts/`) 차이는 스크립트가 자동으로 감지해서 처리합니다.
+>
+> 만약 `setup.sh: line 3: $'\r': command not found` 같은 오류가 발생한다면, 클론 당시 Git의 `core.autocrlf` 설정으로 인해 스크립트 파일이 Windows 줄바꿈(CRLF)으로 변환되어 저장된 것입니다(현재 저장소에는 이를 방지하는 `.gitattributes`가 포함되어 있어 새로 클론하면 발생하지 않습니다). 이미 클론한 상태라면 저장소를 새로 클론하거나, 기존 폴더에서 다음 명령으로 파일을 다시 체크아웃하세요:
+> ```bash
+> git rm --cached -r .
+> git reset --hard
+> ```
 
 서버 구동 후 브라우저에서 `http://localhost:8000` 에 접속합니다.
 


### PR DESCRIPTION
# Summary
## 1. Windows에서 셸 스크립트가 CRLF로 체크아웃되어 실행되지 않던 문제 수정
- Windows의 Git 기본 설정(`core.autocrlf=true`)에서는 클론 시 저장소의 LF 개행이 로컬 워킹 디렉터리에서 CRLF로 자동 변환되는데, 이 상태의 `.sh` 파일을 Git Bash에서 실행하면 `setup.sh: line 3: $'\r': command not found` 같은 오류와 함께 스크립트 전체가 깨지는 문제가 있었음
- `.gitattributes`를 추가해 `*.sh` 파일은 `core.autocrlf` 설정과 무관하게 항상 LF로 체크아웃되도록 강제
- 이미지 파일(png/jpg/jpeg/gif/ico)도 개행 변환 대상에서 제외되도록 binary로 명시

## 2. README 안내 추가
- 이미 CRLF로 체크아웃된 기존 클론을 가진 사용자를 위해, 재클론하거나 `git rm --cached -r . && git reset --hard`로 복구하는 방법을 안내

## 검증
- `git add --renormalize .`로 저장소 내 모든 파일이 `.gitattributes` 규칙과 일치하는지 확인 (기존에 이미 LF였으므로 추가 변경 없음 확인)
