### PR TITLE
fix: 배치 파일 더블클릭 시 창이 바로 닫히던 문제 수정

### DIFF
--- a/cleanup.bat
+++ b/cleanup.bat
@@ -48,3 +48,5 @@ if /i "%REPLY%"=="y" (
 echo =========================================
 echo EasyPaper Clean up Complete!
 echo =========================================
+echo.
+pause

--- a/setup.bat
+++ b/setup.bat
@@ -7,6 +7,21 @@ echo =========================================
 echo EasyPaper Auto Setup ^& Installation Script
 echo =========================================
 
+where python >nul 2>nul
+if errorlevel 1 (
+    echo Error: 'python' command not found.
+    echo Please install Python 3.8+ from https://www.python.org/downloads/
+    echo and make sure to check "Add python.exe to PATH" during installation.
+    goto :error
+)
+
+where npm >nul 2>nul
+if errorlevel 1 (
+    echo Error: 'npm' command not found.
+    echo Please install Node.js 16+ from https://nodejs.org/ ^(npm is included^).
+    goto :error
+)
+
 echo 1. Setting up Backend...
 cd backend
 
@@ -50,9 +65,13 @@ echo To run the production-ready server serving both frontend ^& backend, run:
 echo    start.bat
 echo    Then open: http://localhost:8000
 echo =========================================
+echo.
+pause
 goto :eof
 
 :error
 echo.
 echo Setup failed. Please check the error message above.
+echo.
+pause
 exit /b 1

--- a/start-dev.bat
+++ b/start-dev.bat
@@ -1,6 +1,15 @@
 @echo off
 setlocal
 
+cd /d "%~dp0"
+
+if not exist "backend\.venv" (
+    echo Error: Python virtual environment not found. Please run setup.bat first.
+    echo.
+    pause
+    exit /b 1
+)
+
 echo EasyPaper development servers starting...
 
 cd /d "%~dp0backend"
@@ -17,3 +26,5 @@ echo    API Docs:    http://localhost:8000/docs
 echo.
 echo Backend and frontend are each running in their own window.
 echo Close those windows (or Ctrl+C inside them) to stop the servers.
+echo.
+pause

--- a/start.bat
+++ b/start.bat
@@ -5,6 +5,8 @@ cd /d "%~dp0backend"
 
 if not exist ".venv" (
     echo Error: Python virtual environment not found. Please run setup.bat first.
+    echo.
+    pause
     exit /b 1
 )
 
@@ -13,3 +15,10 @@ if not exist ".env" (
 )
 
 .venv\Scripts\python.exe main.py
+
+if errorlevel 1 (
+    echo.
+    echo EasyPaper exited with an error. See the message above.
+    echo.
+    pause
+)


### PR DESCRIPTION
# Summary
## 1. 배치 파일 더블클릭 시 창이 바로 닫혀 오류를 확인할 수 없던 문제 수정
- 탐색기에서 `.bat` 파일을 더블클릭하면 새 `cmd` 창이 열리는데, 스크립트가 끝나자마자(성공이든 오류든) 그 창이 즉시 닫혀버려 무슨 일이 있었는지 전혀 알 수 없던 문제 수정
- `setup.bat`/`start.bat`/`start-dev.bat`/`cleanup.bat` 모두 정상 종료·오류 종료 각 경로 끝에 `pause`를 추가해, 사용자가 결과(또는 오류 메시지)를 읽고 키를 눌러야 창이 닫히도록 변경
- `setup.bat`에는 `python`/`npm` 명령이 PATH에 없는 경우를 스크립트 맨 앞에서 미리 감지해, cmd의 불친절한 "not recognized" 메시지 대신 설치 링크가 포함된 명확한 안내 메시지를 띄우도록 개선 (가장 흔한 실패 원인으로 추정)
- `start.bat`도 서버가 오류로 즉시 종료된 경우 창이 닫히지 않도록 처리

## 검증
- 각 배치 스크립트의 성공/실패 분기 모두에서 `pause`가 호출되는지 코드 리뷰로 확인
- PowerShell/cmd 실행 환경이 없어 실제 더블클릭 재현 테스트는 못 했으나, 표준 cmd.exe 문법만 사용
