### PR TITLE
fix: setup.bat의 Windows Store python 별칭 스텁 오인 문제 수정

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -7,11 +7,28 @@ echo =========================================
 echo EasyPaper Auto Setup ^& Installation Script
 echo =========================================
 
-where python >nul 2>nul
+where python 2>nul | findstr /i "WindowsApps" >nul
+if not errorlevel 1 (
+    echo Error: 'python' currently points to the Windows Store app-execution-alias
+    echo stub, not a real Python installation ^(this stub only prints "Python" and
+    echo exits without doing anything^).
+    echo.
+    echo If you installed Python via Miniforge/Anaconda/Miniconda: run this script
+    echo from an "Anaconda Prompt" / "Miniforge Prompt" ^(where the base environment
+    echo is already activated^) instead of double-clicking it from Explorer.
+    echo.
+    echo Otherwise, disable the fake alias at:
+    echo   Settings ^> Apps ^> Advanced app settings ^> App execution aliases
+    echo   ^(turn off "python.exe" / "python3.exe"^)
+    goto :error
+)
+
+python --version >nul 2>nul
 if errorlevel 1 (
     echo Error: 'python' command not found.
     echo Please install Python 3.8+ from https://www.python.org/downloads/
     echo and make sure to check "Add python.exe to PATH" during installation.
+    echo ^(If you use Miniforge/Anaconda, run this from an Anaconda/Miniforge Prompt.^)
     goto :error
 )
 


### PR DESCRIPTION
# Summary
## 1. setup.bat이 Windows Store python 별칭 스텁을 진짜 설치로 오인하던 문제 수정
- 기존에는 `where python`으로 PATH 상에 `python.exe`가 "존재"하는지만 확인했는데, Windows의 앱 실행 별칭(App execution alias) 기능 때문에 실제 Python이 없어도 `%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe`라는 가짜 스텁이 항상 존재해서 이 사전 검사를 통과해버림
- 이 가짜 스텁은 실행하면 "Python"이라는 텍스트만 출력하고 아무 것도 하지 않은 채 종료되기 때문에, 사전 검사는 통과했지만 실제 venv 생성 단계에서 `Python` / `Setup failed. Please check the error message above.`라는 원인을 알 수 없는 메시지만 남기고 실패하는 문제가 있었음
- `where python` 결과에 `WindowsApps` 경로가 포함되어 있으면 이를 명시적으로 감지해서, Miniforge/Anaconda/Miniconda 사용자는 "Anaconda Prompt" / "Miniforge Prompt"(base 환경이 이미 activate된 상태)에서 실행해야 한다는 안내와, 필요 시 앱 실행 별칭을 끄는 설정 경로(`설정 > 앱 > 고급 앱 설정 > 앱 실행 별칭`)를 구체적으로 안내
- `python --version` 자체가 완전히 실패하는 경우(별칭조차 없는 경우)에 대한 안내도 별도로 유지

## 검증
- 실제 Windows 환경이 없어 재현 테스트는 못 했으나, 사용자가 겪은 정확한 증상(venv 생성 단계에서 "Python" 한 줄만 출력되고 실패)과 원인(Miniforge를 쓰지만 더블클릭 시 activate 안 된 새 cmd 창에서 Windows Store 스텁이 대신 실행됨)을 근거로 그 케이스를 정확히 진단해 안내하도록 로직을 작성
