### PR TITLE
refactor: bat/sh 스크립트를 scripts/ 상위 디렉터리로 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ EasyPaper는 학술 PDF 논문을 AI로 번역하고 논문 내용을 기반으�
 
 ## 빠른 시작
 
-명령어 세 줄로 바로 실행이 가능합니다. macOS·Linux용 스크립트는 `sh/`, Windows용 스크립트는 `bat/` 폴더에 모여 있습니다.
+설치와 실행에 필요한 모든 스크립트는 `scripts/` 폴더에 모여 있습니다 — macOS·Linux용은 `scripts/sh/`, Windows용은 `scripts/bat/`에 있습니다.
 
 **macOS / Linux**
 ```bash
@@ -32,28 +32,28 @@ cd EasyPaper
 
 # 2. 설치 스크립트 실행
 # (Python 가상환경 생성, 의존성 패키지 설치, .env 파일 생성, 프론트엔드 빌드 포함)
-./sh/setup.sh
+./scripts/sh/setup.sh
 
 # 3. 서버 시작
-./sh/start.sh
+./scripts/sh/start.sh
 ```
 
 **Windows**
 
-`bat\setup.bat` 파일을 더블클릭하거나(또는 명령 프롬프트에서 실행), 완료 후 `bat\start.bat`을 실행하면 됩니다.
+`scripts\bat\setup.bat` 파일을 더블클릭하거나(또는 명령 프롬프트에서 실행), 완료 후 `scripts\bat\start.bat`을 실행하면 됩니다.
 ```bat
 git clone https://github.com/orion-gz/EasyPaper.git
 cd EasyPaper
-bat\setup.bat
-bat\start.bat
+scripts\bat\setup.bat
+scripts\bat\start.bat
 ```
 
 서버 구동 후 브라우저에서 `http://localhost:8000` 에 접속합니다.
 
 설치 및 생성된 모든 가상 환경과 빌드 데이터, systemd 서비스(Linux)를 완전히 지우고 원복하려면 다음 삭제 스크립트를 실행합니다:
 ```bash
-./sh/cleanup.sh      # macOS / Linux
-bat\cleanup.bat      # Windows
+./scripts/sh/cleanup.sh      # macOS / Linux
+scripts\bat\cleanup.bat      # Windows
 ```
 
 ---

--- a/scripts/bat/cleanup.bat
+++ b/scripts/bat/cleanup.bat
@@ -1,8 +1,8 @@
 @echo off
 setlocal
 
-REM 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 bat\ 하위에 있음)
-cd /d "%~dp0.."
+REM 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts\bat\ 하위에 있음)
+cd /d "%~dp0..\.."
 
 echo =========================================
 echo EasyPaper Uninstall ^& Clean up Script

--- a/scripts/bat/setup.bat
+++ b/scripts/bat/setup.bat
@@ -1,8 +1,8 @@
 @echo off
 setlocal
 
-REM 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 bat\ 하위에 있음)
-cd /d "%~dp0.."
+REM 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts\bat\ 하위에 있음)
+cd /d "%~dp0..\.."
 
 echo =========================================
 echo EasyPaper Auto Setup ^& Installation Script
@@ -77,10 +77,10 @@ echo =========================================
 echo EasyPaper Setup Complete!
 echo =========================================
 echo To start the development servers concurrently, run:
-echo    bat\start-dev.bat
+echo    scripts\bat\start-dev.bat
 echo.
 echo To run the production-ready server serving both frontend ^& backend, run:
-echo    bat\start.bat
+echo    scripts\bat\start.bat
 echo    Then open: http://localhost:8000
 echo =========================================
 echo.

--- a/scripts/bat/start-dev.bat
+++ b/scripts/bat/start-dev.bat
@@ -1,10 +1,10 @@
 @echo off
 setlocal
 
-cd /d "%~dp0.."
+cd /d "%~dp0..\.."
 
 if not exist "backend\.venv" (
-    echo Error: Python virtual environment not found. Please run bat\setup.bat first.
+    echo Error: Python virtual environment not found. Please run scripts\bat\setup.bat first.
     echo.
     pause
     exit /b 1
@@ -12,10 +12,10 @@ if not exist "backend\.venv" (
 
 echo EasyPaper development servers starting...
 
-cd /d "%~dp0..\backend"
+cd /d "%~dp0..\..\backend"
 start "EasyPaper Backend" cmd /k .venv\Scripts\python.exe main.py
 
-cd /d "%~dp0..\frontend"
+cd /d "%~dp0..\..\frontend"
 start "EasyPaper Frontend" cmd /k npm run dev
 
 echo.

--- a/scripts/bat/start.bat
+++ b/scripts/bat/start.bat
@@ -1,10 +1,10 @@
 @echo off
 setlocal
 
-cd /d "%~dp0..\backend"
+cd /d "%~dp0..\..\backend"
 
 if not exist ".venv" (
-    echo Error: Python virtual environment not found. Please run bat\setup.bat first.
+    echo Error: Python virtual environment not found. Please run scripts\bat\setup.bat first.
     echo.
     pause
     exit /b 1

--- a/scripts/sh/cleanup.sh
+++ b/scripts/sh/cleanup.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-# 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 sh/ 하위에 있음)
-cd "$(dirname "$0")/.."
+# 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts/sh/ 하위에 있음)
+cd "$(dirname "$0")/../.."
 
 echo "========================================="
 echo "🧹 EasyPaper Uninstall & Clean up Script"

--- a/scripts/sh/setup.sh
+++ b/scripts/sh/setup.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-# 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 sh/ 하위에 있음)
-cd "$(dirname "$0")/.."
+# 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts/sh/ 하위에 있음)
+cd "$(dirname "$0")/../.."
 
 echo "========================================="
 echo "⚙️  EasyPaper Auto Setup & Installation Script"
@@ -39,9 +39,9 @@ echo "========================================="
 echo "✅ EasyPaper Setup Complete!"
 echo "========================================="
 echo "To start the development servers concurrently, run:"
-echo "   ./sh/start-dev.sh"
+echo "   ./scripts/sh/start-dev.sh"
 echo ""
 echo "To run the production-ready server serving both frontend & backend, run:"
-echo "   ./sh/start.sh"
+echo "   ./scripts/sh/start.sh"
 echo "   Then open: http://localhost:8000"
 echo "========================================="

--- a/scripts/sh/start-dev.sh
+++ b/scripts/sh/start-dev.sh
@@ -7,7 +7,7 @@ echo "🚀 EasyPaper 개발 서버 시작..."
 
 # 백엔드 시작
 echo "📡 FastAPI 백엔드 시작 중 (포트 8000)..."
-cd "$(dirname "$0")/../backend"
+cd "$(dirname "$0")/../../backend"
 .venv/bin/python main.py &
 BACKEND_PID=$!
 echo "   백엔드 PID: $BACKEND_PID"
@@ -17,7 +17,7 @@ sleep 2
 
 # 프론트엔드 시작
 echo "🌐 Vite 프론트엔드 시작 중 (포트 5173)..."
-cd "$(dirname "$0")/../frontend"
+cd "$(dirname "$0")/../../frontend"
 npm run dev &
 FRONTEND_PID=$!
 echo "   프론트엔드 PID: $FRONTEND_PID"

--- a/scripts/sh/start.sh
+++ b/scripts/sh/start.sh
@@ -5,11 +5,11 @@ set -e
 
 echo "📡 EasyPaper 서버 시작 중..."
 
-# Ensure we run from backend folder with .venv python (이 스크립트는 sh/ 하위에 있음)
-cd "$(dirname "$0")/../backend"
+# Ensure we run from backend folder with .venv python (이 스크립트는 scripts/sh/ 하위에 있음)
+cd "$(dirname "$0")/../../backend"
 
 if [ ! -d ".venv" ]; then
-    echo "❌ Error: Python 가상환경이 존재하지 않습니다. 먼저 './sh/setup.sh'를 실행해주세요."
+    echo "❌ Error: Python 가상환경이 존재하지 않습니다. 먼저 './scripts/sh/setup.sh'를 실행해주세요."
     exit 1
 fi
 


### PR DESCRIPTION
# Summary
## 1. bat/, sh/를 scripts/ 상위 디렉터리로 통합
- 저장소 루트에 `bat/`, `sh/`가 나란히 있으면 용도가 바로 와닿지 않는다는 피드백을 반영해, `scripts/bat/`, `scripts/sh/`로 한 단계 더 묶음 - "scripts 폴더 = 설치/실행 스크립트 모음"이라는 게 폴더명만 보고도 직관적으로 드러나도록 정리
- 각 스크립트의 저장소 루트 이동 로직을 새 깊이(저장소 루트 기준 2단계 하위)에 맞게 수정 - `./scripts/sh/setup.sh`처럼 루트에서 실행하든, `scripts/sh/` 안으로 들어가서 직접 실행하든 항상 올바르게 동작
- README와 스크립트 자체의 안내 메시지(다음에 실행할 스크립트 경로 등)를 `scripts/sh/*.sh`, `scripts\bat\*.bat` 새 경로로 갱신

## 검증
- `bash -n`으로 이동된 모든 `.sh` 스크립트 구문 오류 없음 확인, 실행 권한(+x) 유지 확인
- README/스크립트 내 예전 `sh/`·`bat/`(1단계) 경로 잔재가 없는지 grep으로 확인
