### PR TITLE
fix: setup.bat이 Miniforge/Anaconda 파이썬을 자동으로 탐색해 사용

### DIFF
--- a/scripts/bat/setup.bat
+++ b/scripts/bat/setup.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 REM 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts\bat\ 하위에 있음)
 cd /d "%~dp0..\.."
@@ -8,30 +8,51 @@ echo =========================================
 echo EasyPaper Auto Setup ^& Installation Script
 echo =========================================
 
+REM 1단계: 'python'이 PATH에서 바로 정상 동작하는지 확인.
+REM Windows Store 앱 실행 별칭 스텁이면 실제로는 아무 것도 하지 않으므로 걸러낸다.
+set "PYTHON_EXE="
 where python 2>nul | findstr /i "WindowsApps" >nul
-if not errorlevel 1 (
-    echo Error: 'python' currently points to the Windows Store app-execution-alias
-    echo stub, not a real Python installation ^(this stub only prints "Python" and
-    echo exits without doing anything^).
+if errorlevel 1 (
+    python --version >nul 2>nul
+    if not errorlevel 1 set "PYTHON_EXE=python"
+)
+
+REM 2단계: bare 'python'을 못 쓰면, 더블클릭 실행 시 activate되지 않는 Miniforge,
+REM Anaconda, Miniconda의 흔한 설치 경로들을 직접 찾아본다. 설치되어 있기만 하면
+REM activate 여부와 무관하게 전체 경로로 바로 실행 가능하다.
+if not defined PYTHON_EXE (
+    echo    'python' 명령을 바로 쓸 수 없어 Miniforge/Anaconda/Miniconda 설치를 찾는 중...
+    for %%P in (
+        "%USERPROFILE%\miniforge3\python.exe"
+        "%USERPROFILE%\anaconda3\python.exe"
+        "%USERPROFILE%\miniconda3\python.exe"
+        "%LOCALAPPDATA%\miniforge3\python.exe"
+        "%PROGRAMDATA%\miniforge3\python.exe"
+        "%PROGRAMDATA%\Anaconda3\python.exe"
+        "%PROGRAMDATA%\Miniconda3\python.exe"
+    ) do (
+        if not defined PYTHON_EXE (
+            if exist %%P (
+                set "PYTHON_EXE=%%P"
+                echo    Found: %%P
+            )
+        )
+    )
+)
+
+if not defined PYTHON_EXE (
+    echo Error: 'python' command not found, and no Miniforge/Anaconda/Miniconda
+    echo installation was found in the usual locations either.
     echo.
-    echo If you installed Python via Miniforge/Anaconda/Miniconda: run this script
-    echo from an "Anaconda Prompt" / "Miniforge Prompt" ^(where the base environment
-    echo is already activated^) instead of double-clicking it from Explorer.
+    echo Please install Python 3.8+ from https://www.python.org/downloads/
+    echo and make sure to check "Add python.exe to PATH" during installation.
     echo.
-    echo Otherwise, disable the fake alias at:
-    echo   Settings ^> Apps ^> Advanced app settings ^> App execution aliases
-    echo   ^(turn off "python.exe" / "python3.exe"^)
+    echo If you use Miniforge/Anaconda/Miniconda under a different path, run this
+    echo script from an "Anaconda Prompt" / "Miniforge Prompt" instead.
     goto :error
 )
 
-python --version >nul 2>nul
-if errorlevel 1 (
-    echo Error: 'python' command not found.
-    echo Please install Python 3.8+ from https://www.python.org/downloads/
-    echo and make sure to check "Add python.exe to PATH" during installation.
-    echo ^(If you use Miniforge/Anaconda, run this from an Anaconda/Miniforge Prompt.^)
-    goto :error
-)
+echo    Using Python: !PYTHON_EXE!
 
 where npm >nul 2>nul
 if errorlevel 1 (
@@ -45,7 +66,7 @@ cd backend
 
 if not exist ".venv" (
     echo    Creating Python virtual environment ^(.venv^)...
-    python -m venv .venv
+    "!PYTHON_EXE!" -m venv .venv
     if errorlevel 1 goto :error
 )
 


### PR DESCRIPTION
# Summary
## 1. setup.bat이 Miniforge/Anaconda 파이썬을 자동으로 찾아 쓰도록 개선
- 더블클릭 실행 시 열리는 새 `cmd` 창은 Miniforge/Anaconda의 activate 스크립트를 거치지 않아 PATH에 `python`이 없고, 결국 Windows Store 앱 실행 별칭 스텁만 잡혀 "Python"이라는 텍스트만 찍고 실패하던 문제를 실질적으로 해결 (이전 PR에서는 원인 진단 및 안내 메시지만 추가했고, 자동 대응은 하지 않았음)
- bare `python`을 바로 쓸 수 없으면, activate 여부와 무관하게 전체 경로로 그 자체로 완전히 동작하는 `miniforge3`/`anaconda3`/`miniconda3`의 흔한 설치 경로(사용자 프로필, `%LOCALAPPDATA%`, `%PROGRAMDATA%`)를 순서대로 탐색해, 발견되는 즉시 그 `python.exe`의 전체 경로를 사용
- 어디에서도 찾지 못했을 때만 기존처럼 Anaconda/Miniforge Prompt에서 실행하라는 안내와 함께 에러 처리

## 검증
- Python으로 파일 내 괄호를 (echo/REM 텍스트 안의 장식용 괄호는 제외하고) 실제 `if`/`for`/`do` 블록 단위로 다시 세어 중첩 구조가 정확히 닫혀 있는지 확인
- 실제 Windows/conda 환경이 없어 직접 실행 검증은 못 했으나, 표준 cmd.exe 배치 문법(`setlocal enabledelayedexpansion`, `for %%P in (...) do`, `if not defined`)만 사용
