### PR TITLE
fix: Windows에서 claude/codex/agy CLI [WinError 2] 실행 실패 수정

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -40,6 +40,23 @@ def is_ollama_host_local() -> bool:
     return hostname in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
 
+def windows_safe_exec_args(cmd):
+    """CLI 서브프로세스 실행용 argv를 만듭니다.
+
+    claude/codex/agy는 npm 등을 통해 설치되면 Windows에서 실제 실행 파일이
+    아니라 .cmd/.bat 래퍼 스크립트로 배포되는 경우가 많다. asyncio의
+    create_subprocess_exec(shell=False)는 Windows의 CreateProcess를 그대로
+    쓰는데, 이 API는 .cmd/.bat 파일을 이미지로 인식하지 못해 실제로는 정상
+    설치되어 있어도 "[WinError 2] 지정된 파일을 찾을 수 없습니다" 오류로
+    실행 자체가 실패한다. Windows에서는 cmd.exe를 경유해 PATHEXT 확장자
+    검색·해석을 맡기는 방식으로 이를 우회한다 (macOS/Linux는 기존과 동일).
+    """
+    import platform
+    if platform.system() == "Windows":
+        return ["cmd", "/c"] + list(cmd)
+    return list(cmd)
+
+
 def find_ollama_binary():
     # 반환값: 찾은 ollama 실행 파일의 경로(str) 또는 못 찾았을 때 None
     """이 서버에 Ollama CLI가 설치되어 있는지 확인합니다.

--- a/backend/routers/agy.py
+++ b/backend/routers/agy.py
@@ -26,13 +26,13 @@ async def get_agy_usage():
 async def get_agy_models():
     """agy models 명령으로 실제 지원 모델 목록 반환"""
     import os
-    from config import get_agy_path, get_agy_env
+    from config import get_agy_path, get_agy_env, windows_safe_exec_args
     agy_path = get_agy_path()
     if not os.path.exists(agy_path):
         agy_path = "agy"
     try:
         proc = await asyncio.create_subprocess_exec(
-            agy_path, "models",
+            *windows_safe_exec_args([agy_path, "models"]),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=get_agy_env()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -518,8 +518,9 @@ async def system_update(current_user: str = Depends(get_current_user)):
             frontend_dir = os.path.join(project_dir, "frontend")
             if os.path.exists(frontend_dir):
                 # npm install && npm run build
+                from config import windows_safe_exec_args
                 build_proc = await asyncio.create_subprocess_exec(
-                    "npm", "run", "build",
+                    *windows_safe_exec_args(["npm", "run", "build"]),
                     cwd=frontend_dir,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -16,7 +16,8 @@ from config import (
     get_claude_code_path,
     get_codex_path,
     get_translation_prompt_template,
-    get_project_root
+    get_project_root,
+    windows_safe_exec_args as _exec_args,
 )
 
 
@@ -889,7 +890,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
             cmd = base_cmd + session_flag
             try:
                 process = await asyncio.create_subprocess_exec(
-                    *cmd,
+                    *_exec_args(cmd),
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
@@ -1038,7 +1039,7 @@ async def stream_codex(prompt: str, model: str = None, session_id: str = None, i
             cmd = build_cmd(thread_id)
             try:
                 process = await asyncio.create_subprocess_exec(
-                    *cmd,
+                    *_exec_args(cmd),
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
@@ -1326,7 +1327,7 @@ async def stream_antigravity(
 
                 try:
                     init_proc = await asyncio.create_subprocess_exec(
-                        *init_cmd,
+                        *_exec_args(init_cmd),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                         env=get_agy_env(),
@@ -1383,7 +1384,7 @@ async def stream_antigravity(
 
     try:
         process = await asyncio.create_subprocess_exec(
-            *cmd,
+            *_exec_args(cmd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=get_agy_env(),


### PR DESCRIPTION
# Summary
## 1. Windows에서 claude/codex/agy CLI 실행 시 [WinError 2] 발생하던 문제 수정
- `claude`/`codex`/`agy`는 npm 등으로 설치되면 Windows에서 실제 실행 파일이 아니라 `.cmd`/`.bat` 래퍼 스크립트로 배포되는 경우가 많은데, `asyncio`의 `create_subprocess_exec(shell=False)`가 사용하는 Windows `CreateProcess`는 이런 스크립트 파일을 이미지로 인식하지 못해 실제로는 정상 설치되어 있어도 `[WinError 2] 지정된 파일을 찾을 수 없습니다` 오류로 번역/채팅 요청이 전부 실패하던 문제 수정 (사용자가 Windows에서 Claude Code로 번역 시도 중 실제로 겪은 오류)
- `config.py`에 `windows_safe_exec_args()` 공용 헬퍼 추가 - Windows에서는 `["cmd", "/c", ...]`로 감싸 cmd.exe가 PATHEXT 확장자 검색·해석을 맡도록 우회 (macOS/Linux는 기존과 동일하게 그대로 실행)

## 2. Antigravity/Codex를 포함해 같은 패턴의 서브프로세스 호출을 모두 점검
- `llm_client.py`의 claude_code/codex/antigravity 서브프로세스 실행 4곳(번역·채팅·세션 초기화), `agy.py`의 `agy models` 목록 조회, `auth.py`의 시스템 업데이트 기능 중 `npm run build` 단계까지 전부 이 헬퍼를 거치도록 적용
- Windows 설치 프로그램(.exe) 실행이나 `git pull`처럼 실제 실행 파일을 직접 가리키는 곳은 원래도 이 문제가 없어 그대로 둠

## 검증
- `windows_safe_exec_args()`가 POSIX에서는 원래 커맨드를 그대로 반환하고, Windows로 시뮬레이션했을 때 `["cmd", "/c", ...]`로 올바르게 감싸는지 확인
- 백엔드 전체 모듈 임포트 및 라우트 등록 정상 확인
- 실제 Windows 환경이 없어 재현 테스트는 못 했으나, 사용자가 보고한 정확한 오류 메시지와 원인(.cmd 래퍼 + create_subprocess_exec)에 근거해 수정
