### PR TITLE
fix: CLI 서브프로세스 HOME 환경변수 하드코딩으로 인한 macOS [Errno 45] 오류 수정

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -286,11 +286,25 @@ def get_codex_path() -> str:
     return _resolve_cli_path(CODEX_PATH, "codex")
 
 def get_agy_env() -> dict:
+    """CLI(Claude Code/Codex/Antigravity) 서브프로세스에 넘길 환경 변수를 만든다.
+
+    일부 실행 환경(예: 로그인 셸을 거치지 않는 서비스/데몬으로 백엔드를 띄운 경우)에서는
+    HOME/USER가 비어 있을 수 있는데, 예전에는 이 값을 이 프로젝트를 개발한 서버 전용
+    경로(/home/ubuntu)로 하드코딩해 다른 환경(특히 macOS)에서는 존재하지 않는 디렉터리를
+    가리키게 됐다. macOS의 posix_spawn은 존재하지 않는 디렉터리를 만나면 ENOENT 대신
+    [Errno 45] Operation not supported를 던지는 경우가 있어, CLI 실행이 알 수 없는 에러로
+    실패하는 원인이 됐다. os.path.expanduser("~")/getpass로 실제 현재 사용자의 홈 디렉터리를
+    구해 어떤 OS/계정에서도 항상 존재하는 경로를 쓰도록 수정.
+    """
     env = os.environ.copy()
     if "HOME" not in env or not env["HOME"]:
-        env["HOME"] = "/home/ubuntu"
+        env["HOME"] = os.path.expanduser("~")
     if "USER" not in env or not env["USER"]:
-        env["USER"] = "ubuntu"
+        try:
+            import getpass
+            env["USER"] = getpass.getuser()
+        except Exception:
+            pass
     return env
 
 # ── Dynamic Translation Prompt Template ─────────────────

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -181,12 +181,12 @@ def delete_chat_sessions(doc_id: str) -> None:
     if conv_id:
         try:
             # conversations/<conv_id>.db 파일 삭제
-            db_path = f"/home/ubuntu/.gemini/antigravity-cli/conversations/{conv_id}.db"
+            db_path = os.path.expanduser(f"~/.gemini/antigravity-cli/conversations/{conv_id}.db")
             if os.path.exists(db_path):
                 os.remove(db_path)
                 print(f"[delete_chat_sessions] Deleted Antigravity conversation db: {db_path}")
             # brain/<conv_id>/ 디렉터리 삭제
-            brain_dir = f"/home/ubuntu/.gemini/antigravity-cli/brain/{conv_id}"
+            brain_dir = os.path.expanduser(f"~/.gemini/antigravity-cli/brain/{conv_id}")
             if os.path.exists(brain_dir):
                 shutil.rmtree(brain_dir, ignore_errors=True)
                 print(f"[delete_chat_sessions] Deleted Antigravity brain directory: {brain_dir}")

--- a/backend/services/usage_tracker.py
+++ b/backend/services/usage_tracker.py
@@ -64,13 +64,18 @@ def _get_antigravity_cloud_quota(retry=True) -> dict:
         from config import get_agy_path, get_agy_env
     except ImportError:
         def get_agy_path():
-            return os.getenv("AGY_PATH", "/home/ubuntu/.local/bin/agy")
+            import shutil
+            return shutil.which("agy") or "agy"
         def get_agy_env():
             env = os.environ.copy()
             if "HOME" not in env or not env["HOME"]:
-                env["HOME"] = "/home/ubuntu"
+                env["HOME"] = os.path.expanduser("~")
             if "USER" not in env or not env["USER"]:
-                env["USER"] = "ubuntu"
+                try:
+                    import getpass
+                    env["USER"] = getpass.getuser()
+                except Exception:
+                    pass
             return env
 
     token_path = os.path.expanduser("~/.gemini/antigravity-cli/antigravity-oauth-token")


### PR DESCRIPTION
# Summary
## 1. CLI 서브프로세스 HOME 환경변수 하드코딩 수정 (macOS 등에서 [Errno 45] 발생 문제)
- `config.py`의 `get_agy_env()`가 Claude Code/Codex/Antigravity 서브프로세스 호출 시 공통으로 쓰이는데, 실행 환경에 `HOME`/`USER`가 비어있을 경우 이 프로젝트를 개발한 서버 전용 경로(`/home/ubuntu`, `ubuntu`)로 하드코딩되어 있었음
- macOS 등 다른 환경에서는 `/home/ubuntu`가 존재하지 않는 경로라, macOS의 `posix_spawn`이 이를 `ENOENT` 대신 `[Errno 45] Operation not supported`로 보고하면서 번역 페이지 처리 및 문서 분류(Classification)가 원인을 알기 어려운 에러로 실패하던 문제의 원인이었음 (Claude Code/Codex/Antigravity 모두 동일한 `get_agy_env()`를 공유해서 셋 다 영향받음)
- `os.path.expanduser("~")`/`getpass.getuser()`로 실제 현재 사용자의 홈 디렉터리·사용자명을 구하도록 수정해 Windows/macOS/Linux 어디서든 항상 존재하는 경로를 쓰도록 함
- `usage_tracker.py`의 `config` import 실패 시 폴백 정의에도 동일한 하드코딩이 중복되어 있어 같이 수정
- `library.py`의 Antigravity 대화 삭제 로직(`delete_chat_sessions`)에서도 대화 DB/브레인 디렉터리 경로가 `/home/ubuntu/.gemini/...`로 하드코딩되어 있던 것을 `os.path.expanduser` 기반으로 수정

## 검증
- `get_agy_env()`를 HOME/USER 환경변수가 없는 상태로 호출해도 실제 존재하는 현재 사용자 홈 디렉터리를 반환하는지 확인
- 백엔드(`main.py`) import 정상 동작 확인
