### PR TITLE
fix: PROJECT_ROOT 하드코딩으로 인한 CLI 서브프로세스 [Errno 2] 실행 오류 수정

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,9 +26,9 @@ CLAUDE_API_KEY=
 APP_HOST=0.0.0.0
 APP_PORT=8000
 
-# Antigravity CLI (agy) 절대 경로 설정 (선택 사항)
-AGY_PATH=/home/ubuntu/.local/bin/agy
+# Antigravity CLI (agy) 절대 경로 설정 (선택 사항 - 비워두면 PATH에서 자동으로 찾음)
+# AGY_PATH=/path/to/agy
 
-# 프로젝트 루트 절대 경로 설정 (CLI 세션 격리 및 CWD 일관성 확보용)
-PROJECT_ROOT=/home/ubuntu/programming/projects/EasyPaper
+# 프로젝트 루트 절대 경로 설정 (선택 사항 - 비워두면 자동으로 감지됨)
+# PROJECT_ROOT=/path/to/EasyPaper
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,7 +20,13 @@ CACHE_DIR = os.getenv("CACHE_DIR", "./cache")
 LIBRARY_DIR = os.getenv("LIBRARY_DIR", "./library")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:5173").split(",")
 PROJECT_ROOT = os.getenv("PROJECT_ROOT", "")
-if not PROJECT_ROOT:
+# .env.example에 이 프로젝트를 개발한 서버 전용 절대경로가 예시로 박혀 있어서,
+# 사용자가 .env.example을 그대로 복사해 .env를 만들면 자기 기기에는 존재하지
+# 않는 PROJECT_ROOT를 그대로 신뢰하게 된다. 이 값은 CLI(Claude Code/Codex/
+# Antigravity) 서브프로세스의 cwd로 바로 쓰이기 때문에, 존재하지 않는 경로면
+# 서브프로세스 실행 자체가 [Errno 2] No such file or directory로 즉시 실패한다.
+# 실제로 존재하는 디렉터리인지 검증하고, 아니면 코드 위치 기준으로 다시 계산한다.
+if not PROJECT_ROOT or not os.path.isdir(PROJECT_ROOT):
     PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def get_project_root() -> str:


### PR DESCRIPTION
# Summary
## 1. PROJECT_ROOT가 존재하지 않는 경로일 때 CLI 서브프로세스가 [Errno 2]로 실패하던 문제 수정
- `.env.example`의 `PROJECT_ROOT`/`AGY_PATH`가 이 프로젝트를 개발한 서버 전용 절대경로(`/home/ubuntu/...`)로, 주석/예시가 아니라 그대로 값처럼 박혀 있었음
- 사용자가 일반적인 설치 절차대로 `.env.example`을 복사해 `.env`를 만들면, 자기 기기에는 존재하지 않는 `PROJECT_ROOT` 값을 그대로 물려받게 됨
- `PROJECT_ROOT`는 Claude Code/Codex/Antigravity CLI 서브프로세스를 띄울 때 `cwd`로 직접 쓰이는데, 존재하지 않는 디렉터리를 `cwd`로 넘기면 서브프로세스 생성 자체가 `[Errno 2] No such file or directory`로 즉시 실패함 - 세 CLI 프로바이더 모두 동일하게 영향받아 번역/채팅/문서 분류가 전부 실패
- `config.py`에서 `PROJECT_ROOT` 값이 실제 존재하는 디렉터리인지(`os.path.isdir`) 검증하고, 아니면 코드 파일 위치 기준으로 다시 계산하도록 방어 로직 추가 (기존에 CLI 경로들에 적용했던 `_resolve_cli_path()` 패턴과 동일한 접근)
- `.env.example`의 `PROJECT_ROOT`/`AGY_PATH`를 주석 처리된 예시로 바꿔, 앞으로 이 값을 그대로 복사해 새 환경에 전파되는 것 자체를 방지

## 검증
- `PROJECT_ROOT` 환경변수를 존재하지 않는 경로로 설정한 상태에서 `config.get_project_root()`가 실제 존재하는 프로젝트 루트로 정상 폴백하는지 확인
- 백엔드(`main.py`) import 정상 동작 확인
