### PR TITLE
fix: 모든 설치본이 공유하는 고정 SECRET_KEY 기본값으로 인한 세션 위조 취약점 수정

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -188,7 +188,52 @@ APP_USERNAME = os.getenv("APP_USERNAME", "admin")
 DEFAULT_PASSWORD_HASH = "0102030405060708090a0b0c0d0e0f10:c8c17b1c61732cde577461e36b682deab2dda5cd72797d2517526dfcbc39d6b3"
 APP_PASSWORD_HASH = os.getenv("APP_PASSWORD_HASH", DEFAULT_PASSWORD_HASH)
 APP_PASSWORD = os.getenv("APP_PASSWORD", "")
-SECRET_KEY = os.getenv("SECRET_KEY", "easypaper_secret_key_change_me_in_production_1234567890")
+
+# 모든 설치본이 동일한 고정 문자열을 SECRET_KEY로 공유하면, 이 리포지토리를
+# 본 사람은 누구나 그 값으로 세션 토큰(HMAC 서명)을 위조해 로그인 없이도
+# 관리자 세션을 만들 수 있다 - 비밀번호를 바꿔도 세션 서명 키와는 무관해
+# 막히지 않는다. .env에 값이 없거나 예전에 쓰이던 고정 기본값 그대로면,
+# 안전한 난수 키를 새로 만들어 .env에 영구 저장한다(재시작마다 새로 만들면
+# 기존 로그인이 매번 끊기므로 반드시 영속화가 필요함).
+_INSECURE_DEFAULT_SECRET_KEYS = {
+    "",
+    "easypaper_secret_key_change_me_in_production_1234567890",
+}
+
+def _persist_secret_key_to_env(new_key: str):
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    if not os.path.exists(env_path):
+        with open(env_path, "w", encoding="utf-8") as f:
+            f.write(f"SECRET_KEY={new_key}\n")
+        return
+    with open(env_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    new_lines = []
+    found = False
+    for line in lines:
+        if line.strip().startswith("SECRET_KEY="):
+            new_lines.append(f"SECRET_KEY={new_key}\n")
+            found = True
+        else:
+            new_lines.append(line)
+    if not found:
+        new_lines.append(f"SECRET_KEY={new_key}\n")
+    with open(env_path, "w", encoding="utf-8") as f:
+        f.writelines(new_lines)
+
+def _get_or_create_secret_key() -> str:
+    existing = os.getenv("SECRET_KEY", "")
+    if existing not in _INSECURE_DEFAULT_SECRET_KEYS:
+        return existing
+    import secrets
+    new_key = secrets.token_hex(32)
+    try:
+        _persist_secret_key_to_env(new_key)
+    except Exception:
+        pass
+    return new_key
+
+SECRET_KEY = _get_or_create_secret_key()
 
 def get_app_username() -> str:
     return APP_USERNAME


### PR DESCRIPTION
# Summary
## 1. 세션 토큰 서명 키(SECRET_KEY)가 모든 설치본이 공유하는 고정 기본값이던 취약점 수정
- `config.py`의 `SECRET_KEY`가 `.env`에 없으면 리포지토리에 하드코딩된 고정 문자열(`easypaper_secret_key_change_me_in_production_1234567890`)로 폴백하고 있었음
- 이 값은 오픈소스 리포지토리를 클론한 모든 설치본이 동일하게 공유하는 값이라, 소스를 본 사람은 누구나 이 키로 세션 토큰(HMAC 서명)을 직접 계산해 로그인 절차 없이 관리자 세션 쿠키를 위조할 수 있는 완전한 인증 우회 취약점이었음
- 비밀번호 해시(`APP_PASSWORD_HASH`)를 변경해도 세션 서명 키와는 무관한 별개의 값이라 막히지 않는 문제였음
- `.env`에 `SECRET_KEY`가 없거나, 예전에 쓰이던 고정 기본값 그대로인 경우 안전한 난수 키(`secrets.token_hex(32)`)를 새로 생성해 `.env`에 영구 저장하도록 수정 - 매 재시작마다 새로 생성하면 기존 로그인이 계속 끊기므로, 최초 1회만 생성한 뒤 파일에 저장해 재사용

## 검증
- 기존에 고정 기본값이 저장돼 있던 `.env` 사본으로 실행 시, 새 난수 키가 생성되어 `.env`의 `SECRET_KEY` 라인이 안전하게 교체되는지 확인 (중복 라인 생성 없음)
- 같은 `.env`로 재실행 시 이미 저장된 키를 그대로 재사용하고 다시 생성하지 않는지 확인 (재시작 시 기존 로그인 세션이 매번 끊기지 않도록)
- 백엔드(`main.py`) import 정상 동작 확인

## 배포 시 주의
- 이 배포가 적용되는 순간, 이 서버에 저장돼 있던 취약한 고정 SECRET_KEY가 새 난수 키로 교체되면서 **기존에 로그인돼 있던 모든 세션이 즉시 무효화**됩니다. 재배포 후 다시 로그인해야 합니다.
