### PR TITLE
fix: 라이브러리 엔드포인트 문서 소유자 확인 누락(IDOR) 수정

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -14,6 +14,20 @@ router = APIRouter()
 
 from typing import Optional
 
+
+def _require_owned_document(doc_id: str, current_user: str, doc: Optional[dict] = None) -> dict:
+    """문서가 존재하고 현재 로그인한 사용자 소유인지 확인한다.
+
+    다른 사용자의 문서는 존재 여부조차 알려주지 않도록, 존재하지 않는 경우와
+    동일하게 404로 응답한다(문서는 있지만 권한이 없다는 403은 doc_id가
+    실제로 존재한다는 사실 자체를 노출하게 됨).
+    """
+    if doc is None:
+        doc = get_document(doc_id)
+    if not doc or doc.get("username") != current_user:
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    return doc
+
 @router.get("/library")
 async def get_library(
     target_lang: Optional[str] = None,
@@ -57,12 +71,12 @@ async def get_library_document(
     style: Optional[str] = None,
     ignore_math: Optional[bool] = None,
     ignore_table: Optional[bool] = None,
-    ignore_refs: Optional[bool] = None
+    ignore_refs: Optional[bool] = None,
+    current_user: str = Depends(get_current_user)
 ):
     """특정 문서의 메타데이터와 번역 완료 페이지 목록을 반환합니다."""
     doc = get_document(doc_id, target_lang, style, ignore_math, ignore_table, ignore_refs)
-    if not doc:
-        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    _require_owned_document(doc_id, current_user, doc)
     return doc
 
 
@@ -74,9 +88,11 @@ async def get_library_translation(
     style: Optional[str] = None,
     ignore_math: Optional[bool] = None,
     ignore_table: Optional[bool] = None,
-    ignore_refs: Optional[bool] = None
+    ignore_refs: Optional[bool] = None,
+    current_user: str = Depends(get_current_user)
 ):
     """라이브러리에서 특정 페이지 번역을 가져옵니다."""
+    _require_owned_document(doc_id, current_user)
     suffix = ""
     if target_lang is not None and style is not None:
         suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
@@ -106,9 +122,11 @@ async def update_library_translation(
     style: Optional[str] = None,
     ignore_math: Optional[bool] = None,
     ignore_table: Optional[bool] = None,
-    ignore_refs: Optional[bool] = None
+    ignore_refs: Optional[bool] = None,
+    current_user: str = Depends(get_current_user)
 ):
     """라이브러리의 특정 페이지 번역 데이터를 수정하여 캐시 및 DB에 저장합니다."""
+    _require_owned_document(doc_id, current_user)
     suffix = ""
     if target_lang is not None and style is not None:
         suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
@@ -131,8 +149,9 @@ async def update_library_translation(
 
 
 @router.get("/library/{doc_id}/pdf")
-async def get_library_pdf(doc_id: str):
+async def get_library_pdf(doc_id: str, current_user: str = Depends(get_current_user)):
     """라이브러리 PDF 파일을 서빙합니다."""
+    _require_owned_document(doc_id, current_user)
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
@@ -140,8 +159,9 @@ async def get_library_pdf(doc_id: str):
 
 
 @router.get("/library/{doc_id}/cover")
-async def get_library_cover(doc_id: str):
+async def get_library_cover(doc_id: str, current_user: str = Depends(get_current_user)):
     """라이브러리 카드 미리보기용 1페이지 상단(제목+abstract) 캡쳐 이미지를 서빙합니다."""
+    _require_owned_document(doc_id, current_user)
     cover_path = get_cover_path(doc_id)
     if not cover_path:
         raise HTTPException(status_code=404, detail="미리보기 이미지를 생성할 수 없습니다.")
@@ -149,34 +169,38 @@ async def get_library_cover(doc_id: str):
 
 
 @router.delete("/library/{doc_id}")
-async def delete_library_document(doc_id: str):
+async def delete_library_document(doc_id: str, current_user: str = Depends(get_current_user)):
     """라이브러리 문서를 휴지통으로 이동(Soft Delete)합니다."""
+    _require_owned_document(doc_id, current_user)
     if not soft_delete_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 휴지통으로 이동되었습니다."}
 
 @router.post("/library/{doc_id}/restore")
-async def restore_library_document(doc_id: str):
+async def restore_library_document(doc_id: str, current_user: str = Depends(get_current_user)):
     """휴지통에서 문서를 복원합니다."""
+    _require_owned_document(doc_id, current_user)
     if not restore_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 성공적으로 복원되었습니다."}
 
 @router.delete("/library/{doc_id}/permanent")
-async def delete_library_document_permanently(doc_id: str):
+async def delete_library_document_permanently(doc_id: str, current_user: str = Depends(get_current_user)):
     """라이브러리에서 문서를 영구히 삭제(Hard Delete)합니다."""
+    _require_owned_document(doc_id, current_user)
     if not permanently_delete_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 영구적으로 삭제되었습니다."}
 
 
 @router.get("/library/{doc_id}/images")
-async def get_library_document_images(doc_id: str):
+async def get_library_document_images(doc_id: str, current_user: str = Depends(get_current_user)):
     """특정 문서의 모든 페이지에서 이미지/Figure 좌표 정보(백분율) 목록을 반환합니다."""
+    _require_owned_document(doc_id, current_user)
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
-    
+
     try:
         from services.pdf_parser import extract_pdf_images
         images = extract_pdf_images(pdf_path)
@@ -192,12 +216,8 @@ async def update_doc_metadata(
     current_user: str = Depends(get_current_user)
 ):
     """문서의 메타데이터(예: 제목 등)를 업데이트합니다."""
-    doc = get_document(doc_id)
-    if not doc:
-        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
-    if doc.get("username") != current_user:
-        raise HTTPException(status_code=403, detail="권한이 없습니다.")
-    
+    doc = _require_owned_document(doc_id, current_user)
+
     meta = doc.get("metadata") or {}
     meta.update(payload)
     


### PR DESCRIPTION
# Summary
## 1. 라이브러리 엔드포인트에 문서 소유자 확인 로직 누락된 문제 수정 (IDOR)
- `/api/library/*` 라우터는 로그인 자체는 라우터 레벨 `dependencies=[Depends(get_current_user)]`로 요구하고 있었지만, `doc_id`를 다루는 대부분의 엔드포인트(문서 조회, PDF/커버 이미지 서빙, 이미지 좌표 조회, 페이지 번역 조회/수정, 휴지통 이동/복원/영구삭제)는 그 문서가 실제로 요청한 사용자 소유인지는 전혀 확인하지 않았음
- 결과적으로 로그인만 되어 있으면 `doc_id`(UUID) 값만 알아낼 경우 다른 사용자의 문서를 열람·수정·삭제할 수 있는 상태였음 - `update_doc_metadata` 엔드포인트에만 소유자 확인 로직이 있었고 나머지 8개 엔드포인트에는 빠져 있어 파일 내에서도 일관성이 없었음
- `update_doc_metadata`에 있던 소유자 확인 패턴을 공용 헬퍼 `_require_owned_document()`로 뽑아 모든 `doc_id` 엔드포인트(`GET /library/{doc_id}`, `GET/PUT /library/{doc_id}/translation/{page_num}`, `GET /library/{doc_id}/pdf`, `GET /library/{doc_id}/cover`, `GET /library/{doc_id}/images`, `DELETE /library/{doc_id}`, `POST /library/{doc_id}/restore`, `DELETE /library/{doc_id}/permanent`)에 동일하게 적용
- 소유자가 아닌 경우 문서가 실제로 존재한다는 사실 자체를 노출하지 않도록, 기존 `update_doc_metadata`가 쓰던 403 대신 "문서를 찾을 수 없습니다" 404로 응답을 통일

## 검증
- `_require_owned_document()`를 단위 테스트로 직접 호출해 (1) 소유자가 일치하면 문서를 정상 반환, (2) 소유자가 다르면 404, (3) 문서가 아예 없으면 404를 반환하는지 확인
- 백엔드(`main.py`) import 정상 동작 확인
