### PR TITLE
fix: CLI 실행 실패가 조용히 삼켜져 빈 번역/오분류가 캐시되던 문제 수정

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -945,10 +945,17 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
                     continue
 
                 print(f"[Claude Code CLI Error] code={process.returncode} stderr={stderr_out}")
-                return
+                # 실패를 조용히 삼키고 그냥 return하면, 호출부는 빈 결과를 "정상
+                # 번역 완료"로 착각해 빈 문자열을 캐시에 영구 저장해버린다.
+                # 예외를 던져서 라우터/job 쪽의 기존 실패 처리 로직(에러 응답,
+                # failed_pages 기록 등)이 실제로 작동하게 한다.
+                raise RuntimeError(
+                    f"Claude Code CLI 실행 실패 (code={process.returncode}): "
+                    f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
+                )
             except Exception as e:
                 print(f"[Claude Code CLI Exec Error] {e}")
-                return
+                raise
 
 
 _codex_session_locks = {}
@@ -1101,10 +1108,17 @@ async def stream_codex(prompt: str, model: str = None, session_id: str = None, i
                     continue
 
                 print(f"[Codex CLI Error] code={process.returncode} stderr={stderr_out}")
-                return
+                # 실패를 조용히 삼키고 그냥 return하면, 호출부는 빈 결과를 "정상
+                # 번역 완료"로 착각해 빈 문자열을 캐시에 영구 저장해버린다.
+                # 예외를 던져서 라우터/job 쪽의 기존 실패 처리 로직(에러 응답,
+                # failed_pages 기록 등)이 실제로 작동하게 한다.
+                raise RuntimeError(
+                    f"Codex CLI 실행 실패 (code={process.returncode}): "
+                    f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
+                )
             except Exception as e:
                 print(f"[Codex CLI Exec Error] {e}")
-                return
+                raise
 
 
 def _ai_session_meta_path(session_id: str) -> str:
@@ -1408,13 +1422,25 @@ async def stream_antigravity(
 
         await process.wait()
 
-        # stderr 코드가 0이 아닌 경우 stderr 내용을 로그
+        # stderr 코드가 0이 아닌 경우 실패로 처리한다. 예전에는 로그만 남기고
+        # 넘어가서 호출부가 빈 결과를 "정상 번역 완료"로 착각해 캐시에 영구
+        # 저장해버렸다. 예외를 던져서 라우터/job 쪽의 기존 실패 처리 로직
+        # (에러 응답, failed_pages 기록 등)이 실제로 작동하게 한다.
         if process.returncode and process.returncode != 0:
-            stderr_out = await process.stderr.read()
-            print(f"[Antigravity stderr]: {stderr_out.decode('utf-8', errors='ignore')[:500]}", flush=True)
+            stderr_out = (await process.stderr.read()).decode("utf-8", errors="replace")
+            print(f"[Antigravity CLI Error] code={process.returncode} stderr={stderr_out[:500]}", flush=True)
+            raise RuntimeError(
+                f"Antigravity CLI 실행 실패 (code={process.returncode}): "
+                f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
+            )
 
     except Exception as e:
-        yield f"\n[Antigravity CLI 실행 에러: {str(e)}]"
+        # 에러 문자열을 그대로 yield하면 그 문자열 자체가 번역/분류 결과인 것처럼
+        # 캐시에 영구 저장되는 버그가 있었다(실제로 "[Antigravity CLI 실행
+        # 에러: ...]"라는 문자열이 논문 카테고리로 분류된 사례가 있었음).
+        # 반드시 예외로 전파해 호출부가 실패로 인식하게 해야 한다.
+        print(f"[Antigravity CLI Exec Error] {e}", flush=True)
+        raise
 
 from typing import List
 


### PR DESCRIPTION
# Summary
## 1. CLI(Claude Code/Codex/Antigravity) 실행 실패가 조용히 삼켜져 빈 번역이 캐시되던 문제 수정
- `stream_claude_code`/`stream_codex`는 서브프로세스가 0이 아닌 종료 코드로 끝나거나 실행 자체가 예외로 실패해도 `print`만 하고 그냥 `return`해서, 호출부(`routers/translate.py`의 SSE 스트림, `translation_job.py`의 백그라운드 번역 job)는 빈 결과를 "정상 번역 완료"로 착각해 빈 문자열을 캐시(`save_translation_cache`/`lib_save_translation`)에 영구 저장하고 있었음 - 페이지가 빈 채로 영구히 "번역됨" 상태가 되고 사용자는 원인을 알 수 없었음
- `stream_antigravity`는 한 술 더 떠서, 실행 예외 발생 시 에러 메시지 문자열 자체를 번역/분류 결과인 것처럼 `yield`해버려서, 실제로 `"[Antigravity CLI 실행 에러: ...]"`라는 문자열이 그대로 논문 카테고리로 분류되어 저장되는 사례까지 있었음 (이번에 실제로 리포트된 버그)
- 세 provider 모두 실패 시 조용히 `return`/가짜 `yield`하는 대신 예외(`RuntimeError`)를 던지도록 통일
- 이미 존재하던 예외 처리 로직들이 실제로 작동하도록 함: `routers/translate.py`의 SSE 에러 응답(캐시 저장 스킵), `routers/chat.py`의 채팅 기록 미저장, `routers/insight.py`의 인사이트 캐시 미저장, `translation_job.py`의 `failed_pages` 기록, `classify_paper_category`의 빈 배열 반환 - 모두 별도 수정 없이 이번 fix만으로 정상 동작하는 것을 코드 추적으로 확인

## 검증
- 세 provider 함수 모두 코드 추적으로 실패 경로가 예외를 던지도록 수정됐는지, 그 예외가 각 호출부(번역 SSE/채팅/인사이트/백그라운드 job/분류)의 기존 `try/except`에 정상적으로 잡혀 캐시 저장을 건너뛰는지 확인
- 백엔드(`main.py`) import 및 `llm_client.py` 구문 정상 확인
