### PR TITLE
fix: 문서 전환 시 채팅 스트림 미취소로 인한 경쟁 조건 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CAeESSxu.js"></script>
+  <script type="module" crossorigin src="/assets/index-MAneYPmi.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3136,6 +3136,13 @@ async function loadDocumentImages(docId) {
 }
 
 async function openFromLibrary(doc, shouldPushState = true) {
+  // 이전 문서에서 진행 중이던 채팅 스트림이 있으면 반드시 먼저 취소한다.
+  // 이 함수는 popstate/hashchange 라우팅(handleRouting)에서 resetState()를
+  // 거치지 않고 직접 호출될 수 있어서, 취소하지 않으면 이전 문서의 스트림
+  // 응답이 뒤늦게 도착해 방금 초기화한 새 문서의 state.chatHistory/DOM에
+  // 섞여 들어가는 경쟁 조건이 있었다.
+  if (state.chatActiveStream) { state.chatActiveStream(); state.chatActiveStream = null }
+
   if (shouldPushState) {
     history.pushState({ screen: 'viewer', docId: doc.id }, '', `#viewer?id=${doc.id}`)
   }


### PR DESCRIPTION
# Summary
## 1. 문서 전환 시 이전 문서의 채팅 스트림이 취소되지 않던 경쟁 조건 수정
- `openFromLibrary()`는 문서를 열 때 `state.chatHistory`와 `chatMessages` DOM을 초기화하지만, 진행 중이던 `state.chatActiveStream`은 취소하지 않고 있었음
- `resetState()`에는 이 취소 로직(`if (state.chatActiveStream) { state.chatActiveStream(); state.chatActiveStream = null }`)이 있지만, `popstate`/`hashchange` 라우팅(`handleRouting`)이 `openFromLibrary`를 직접 호출하는 경로는 `resetState()`를 거치지 않아 취소가 누락됨
- 재현 시나리오: 문서 A에서 채팅 응답을 스트리밍 중에 브라우저 뒤로가기로 문서 B로 전환하면, 문서 A의 스트림 콜백이 클로저로 캡처한 전역 `state`를 계속 참조해 뒤늦게 도착한 응답이 문서 B의 채팅 기록/DOM에 섞여 들어감
- `openFromLibrary()` 맨 앞에서 `resetState()`와 동일하게 기존 `state.chatActiveStream`을 취소하도록 추가

## 검증
- Playwright로 재현: 문서 A를 열고 채팅 메시지를 전송해 `/api/chat/stream` 요청을 응답하지 않은 채로 pending 상태로 유지, 그 상태에서 해시 라우팅으로 문서 B로 전환한 뒤 문서 A의 스트림 응답을 뒤늦게 흘려보내는 시나리오로 확인
- 수정 전: 문서 A의 뒤늦은 응답이 문서 B의 채팅창에 그대로 나타남 / 수정 후: `AbortController`로 취소되어 문서 B의 채팅창은 새 문서의 초기 안내 메시지만 깨끗하게 유지됨 (스크린샷으로 확인)
