### PR TITLE
fix: 문서 전환 시 PDF 렌더링 경쟁 조건으로 이전 문서가 섞여 보이던 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-MAneYPmi.js"></script>
+  <script type="module" crossorigin src="/assets/index-BKQk44H_.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -14,6 +14,15 @@ let currentScale = 1.5
 let pageObserver = null
 let pageVisibilityObserver = null
 let visiblePageHeights = {}
+// renderScrollView가 호출될 때마다(문서 전환, 줌 변경) 증가하는 세대 카운터.
+// pdf-page-wrapper DOM 노드는 문서를 바꿔도 새로 만들지 않고 재사용하는데,
+// 이전 문서/줌에 대한 _renderPage 호출이 비동기 대기 중일 때 사용자가 빠르게
+// 다른 문서를 열면, 그 이전 렌더링이 뒤늦게 끝나면서 이미 새 문서용으로
+// 재사용된 wrapper에 옛 canvas/textLayer를 덮어써버리는 경쟁 조건이 있었다.
+// 각 _renderPage 호출이 시작 시점의 세대를 기억해뒀다가, DOM을 건드리기 전에
+// 현재 세대와 비교해서 다르면(그 사이 새로 renderScrollView가 호출됐다면)
+// 조용히 중단한다.
+let renderGeneration = 0
 
 async function loadPDFJS() {
   if (pdfjsLib) return pdfjsLib
@@ -39,6 +48,8 @@ export async function loadPDF(url) {
 export async function renderScrollView(container, zoom, { onPageVisible } = {}) {
   if (!pdfDoc) return
   currentScale = zoom
+  renderGeneration++
+  const myGeneration = renderGeneration
 
   if (pageObserver) { pageObserver.disconnect(); pageObserver = null }
 
@@ -88,7 +99,7 @@ export async function renderScrollView(container, zoom, { onPageVisible } = {}) 
       if (entry.isIntersecting) {
         if (!rendered.has(pageNum)) {
           rendered.add(pageNum)
-          _renderPage(entry.target, pageNum)
+          _renderPage(entry.target, pageNum, myGeneration)
         }
       }
     })
@@ -137,7 +148,7 @@ export async function renderScrollView(container, zoom, { onPageVisible } = {}) 
       const targetWrapper = container.querySelector(`.pdf-page-wrapper[data-page="${pNum}"]`)
       if (targetWrapper) {
         rendered.add(pNum)
-        _renderPage(targetWrapper, pNum)
+        _renderPage(targetWrapper, pNum, myGeneration)
       }
     }
   }
@@ -148,12 +159,14 @@ export async function renderScrollView(container, zoom, { onPageVisible } = {}) 
   })
 }
 
-async function _renderPage(wrapper, pageNum) {
+async function _renderPage(wrapper, pageNum, generation) {
+  if (generation !== renderGeneration) return
   const inner = wrapper.querySelector('.pdf-page-inner')
   inner.innerHTML = ''
 
   try {
     const page = await pdfDoc.getPage(pageNum)
+    if (generation !== renderGeneration) return
     const viewport = page.getViewport({ scale: currentScale })
     const dpr = window.devicePixelRatio || 1
 
@@ -186,6 +199,7 @@ async function _renderPage(wrapper, pageNum) {
 
     // 캔버스 렌더링 (먼저 실행)
     await page.render({ canvasContext: ctx, viewport }).promise
+    if (generation !== renderGeneration) return
 
     // 텍스트 레이어 렌더링
     try {
@@ -220,7 +234,7 @@ async function _renderPage(wrapper, pageNum) {
       }
 
       // 텍스트 레이어 렌더 완료 콜백 호출
-      if (window.onTextLayerRendered) {
+      if (generation === renderGeneration && window.onTextLayerRendered) {
         window.onTextLayerRendered(textLayerDiv, pageNum)
       }
     } catch (e) {
@@ -228,6 +242,7 @@ async function _renderPage(wrapper, pageNum) {
     }
 
   } catch (e) {
+    if (generation !== renderGeneration) return
     inner.innerHTML = `<div class="page-render-error">페이지 ${pageNum} 오류</div>`
     console.error(`Render p.${pageNum}:`, e)
   }


### PR DESCRIPTION
# Summary
## 1. 문서를 빠르게 전환하면 이전 문서의 PDF 렌더링이 새 문서 화면에 섞여 들어가던 경쟁 조건 수정
- `pdf-page-wrapper` DOM 노드는 문서를 전환해도 새로 만들지 않고 재사용하는데, 이전 문서에 대한 `_renderPage()` 호출이 `pdfDoc.getPage()`/`page.render()` 등을 비동기로 기다리는 동안 사용자가 다른 문서로 빠르게 전환하면(예: 브라우저 뒤로가기 연타), 그 이전 렌더링이 뒤늦게 끝나면서 이미 새 문서용으로 재사용된 wrapper에 옛 canvas/textLayer를 덮어써버리는 문제가 있었음
- `renderScrollView`가 호출될 때마다(문서 전환, 줌 변경) 증가하는 `renderGeneration` 카운터를 추가. 각 `_renderPage` 호출이 시작 시점의 세대를 기억해뒀다가, DOM을 건드리는 시점마다(`getPage` 이후, `render` 이후, 에러 처리 시) 현재 세대와 비교해서 다르면 조용히 중단하도록 함
- 줌 변경(`reRenderAll`)도 내부적으로 `renderScrollView`를 다시 호출하므로, 문서 전환뿐 아니라 렌더링 도중 줌을 빠르게 바꾸는 경우의 동일한 경쟁 조건도 함께 방지됨

## 검증
- Playwright로 문서 A를 정상 로드해 캔버스가 올바르게 렌더링되는지 회귀 확인
- `#viewer?id=doc-A` → `doc-B` → `doc-A` → `doc-B`로 짧은 간격을 두고 연속 전환한 뒤, 최종 상태가 문서 B의 제목과 정확히 1개의 페이지 wrapper로 정리되고 콘솔 에러 없이 안정적으로 수렴하는지 확인
- 코드 경로 추적으로 `getPage()` 직후의 첫 세대 체크가 `appendChild` 이전에 위치해(그 사이 `await` 없음) 원래 버그가 발생하던 정확한 지점을 완전히 차단함을 확인
