### PR TITLE
fix: 문서 영구삭제 시 업로드 원본/캐시 파일이 남던 문제 수정

### DIFF
--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import json
 from typing import Optional, List
-from config import LIBRARY_DIR
+from config import LIBRARY_DIR, UPLOAD_DIR
+from services.cache import clear_session_cache
 from services.db import (
     db_save_document,
     db_get_document,
@@ -195,14 +196,35 @@ def delete_chat_sessions(doc_id: str) -> None:
 
 
 def permanently_delete_document(doc_id: str) -> bool:
-    """라이브러리에서 문서 파일 및 데이터베이스 레코드를 영구히 삭제합니다."""
+    """라이브러리에서 문서 파일 및 데이터베이스 레코드를 영구히 삭제합니다.
+
+    doc_id는 업로드 당시의 session_id와 동일한 값이다 - 업로드 시
+    UPLOAD_DIR/{doc_id}/document.pdf에 원본이 저장되고, 라이브러리에 저장될
+    때 LIBRARY_DIR/{doc_id}/document.pdf로 "복사"만 될 뿐 원본은 그대로
+    남는다. 예전에는 LIBRARY_DIR만 지우고 UPLOAD_DIR의 원본과 CACHE_DIR의
+    페이지별 번역 캐시 파일은 전혀 지우지 않아, 문서를 영구 삭제해도 그
+    파일들이 디스크에 계속 쌓이는 문제가 있었다.
+    """
     doc_dir = os.path.join(LIBRARY_DIR, doc_id)
+    upload_dir = os.path.join(UPLOAD_DIR, doc_id)
+
     # 1. 채팅 세션 삭제
     delete_chat_sessions(doc_id)
-    # 2. 파일 삭제
+    # 2. 라이브러리 보관 파일 삭제 (PDF 사본, 커버 이미지, MD 등)
     if os.path.exists(doc_dir):
         shutil.rmtree(doc_dir, ignore_errors=True)
-    # 3. DB 삭제
+    # 3. 업로드 당시 원본 파일 삭제
+    if os.path.exists(upload_dir):
+        shutil.rmtree(upload_dir, ignore_errors=True)
+    # 4. 페이지별 번역 캐시 파일 삭제
+    clear_session_cache(doc_id)
+    # 5. 메모리에 남아있는 활성 업로드 세션도 정리 (있다면)
+    try:
+        from routers.upload import sessions
+        sessions.pop(doc_id, None)
+    except Exception:
+        pass
+    # 6. DB 삭제
     return db_delete_document(doc_id)
 
 def soft_delete_document(doc_id: str) -> bool:


### PR DESCRIPTION
# Summary
## 1. 문서 영구삭제 시 업로드 원본/번역 캐시 파일이 지워지지 않고 남던 문제 수정
- `permanently_delete_document()`는 `LIBRARY_DIR/{doc_id}`(라이브러리 보관용 사본)만 지우고 DB 레코드를 삭제했음. `doc_id`는 업로드 당시의 `session_id`와 동일한 값인데, `UPLOAD_DIR/{doc_id}`에 남아있는 업로드 원본 PDF와 `CACHE_DIR`에 쌓인 페이지별 번역 캐시 파일들은 전혀 정리 대상이 아니었음
- 결과적으로 사용자가 "영구 삭제"를 눌러도 실제로는 디스크에 원본 PDF와 캐시 파일이 계속 남아 쌓이는 문제였음 - 이 정리 로직이 있던 유일한 코드(`DELETE /api/session/{session_id}`)는 프론트엔드에서 아무도 호출하지 않는 죽은 엔드포인트였음
- `permanently_delete_document()`에 `UPLOAD_DIR/{doc_id}` 삭제, `clear_session_cache(doc_id)`로 페이지별 캐시 파일 삭제, 메모리에 남아있을 수 있는 활성 업로드 세션(`routers.upload.sessions`) 정리를 추가

## 검증
- 임시 디렉토리로 `UPLOAD_DIR`/`LIBRARY_DIR`/`CACHE_DIR`를 오버라이드해 업로드 원본, 라이브러리 사본, 페이지 캐시 파일 2개, DB 레코드를 모두 만들어둔 뒤 `permanently_delete_document()`를 직접 호출 - 삭제 전 모두 존재함을 확인, 삭제 후 네 가지(업로드 디렉터리/라이브러리 디렉터리/캐시 파일/DB 레코드) 모두 정상적으로 제거됐는지 확인
- 백엔드(`main.py`) import 시 순환 참조 없이 정상 동작 확인
