### PR TITLE
fix: 아이디 변경 시 논문 라이브러리가 사라지던 문제 수정

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -139,6 +139,19 @@ def update_user_credentials(old_username: str, new_username: str, new_password_h
                 "UPDATE users SET username = ?, password_hash = ? WHERE username = ?",
                 (new_username, new_password_hash, old_username)
             )
+            # documents.username은 users.username을 참조하는 외래키로 선언돼
+            # 있지만, SQLite는 연결마다 별도로 PRAGMA foreign_keys를 켜주지
+            # 않는 한 이 외래키 제약(및 ON UPDATE CASCADE)을 전혀 강제하지
+            # 않는다. 이 프로젝트는 그 PRAGMA를 켜지 않으므로, 아이디를
+            # 바꾸면 documents 테이블은 예전 아이디를 그대로 가리킨 채 남아
+            # 라이브러리 목록 조회(WHERE username = 새 아이디)에서 전부
+            # 빠져버려 문서가 사라진 것처럼 보이는 문제가 있었다. 같은
+            # 트랜잭션 안에서 명시적으로 함께 갱신한다.
+            if new_username != old_username:
+                cursor.execute(
+                    "UPDATE documents SET username = ? WHERE username = ?",
+                    (new_username, old_username)
+                )
             conn.commit()
             return True
     except Exception:


### PR DESCRIPTION
# Summary
## 1. 아이디 변경 시 기존 논문 라이브러리가 통째로 사라지던 문제 수정
- `documents.username`은 `users.username`을 참조하는 외래키(`ON UPDATE CASCADE`)로 선언돼 있지만, SQLite는 연결마다 `PRAGMA foreign_keys`를 켜주지 않는 한 이 제약을 강제하지 않는데, 이 프로젝트는 그 PRAGMA를 켜지 않고 있었음
- 그 결과 설정 화면에서 아이디를 바꾸면 `users` 테이블만 갱신되고 `documents` 테이블은 예전 아이디를 그대로 가리킨 채 남아, 라이브러리 목록 조회(`WHERE username = 새 아이디`)에서 기존에 업로드/번역했던 문서가 전부 빠져 화면에서 사라진 것처럼 보였음 (실제로는 DB에 그대로 남아있지만 새 아이디로는 영구히 조회 불가능한 상태가 됨)
- `update_user_credentials()`가 `users` 테이블을 갱신하는 것과 같은 트랜잭션 안에서 `documents.username`도 명시적으로 함께 갱신하도록 수정

## 검증
- 임시 DB로 `admin` 계정 문서 2개를 만들어둔 뒤 아이디를 `admin` → `myaccount`로 변경, 변경 전/후 `db_list_documents()` 결과를 확인 - 변경 후 새 아이디로 문서 2개가 정상 조회되고 예전 아이디로는 0개가 조회되는지 확인
- 백엔드(`main.py`) import 정상 동작 확인
