### PR TITLE
fix: CLI 채팅 사용량 이중 카운트 수정

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -605,11 +605,9 @@ async def stream_chat(
             yield token
         return
     elif provider == "antigravity":
-        try:
-            from services.usage_tracker import record_call
-            record_call("chat")
-        except Exception:
-            pass
+        # 사용량 기록(record_call)은 stream_antigravity 내부에서 usage_label에
+        # 맞춰 이미 처리한다 - 여기서 한 번 더 기록하면 채팅 1회가 2번으로
+        # 집계되는 이중 카운트 버그가 있었다.
         # agy CLI가 자체적으로 --conversation 세션 내에 이전 대화 히스토리(우리가 보낸
         # 논문 원문+가이드라인 포함)를 그대로 갖고 있으므로, 같은 세션에 이미 한 번
         # 보냈다면 매 질문마다 논문 원문 전체를 다시 붙일 필요가 없다 - 최초 1회만
@@ -629,11 +627,9 @@ async def stream_chat(
             _mark_chat_context_sent(session_id, "antigravity")
         return
     elif provider == "claude_code":
-        try:
-            from services.usage_tracker import record_call
-            record_call("chat")
-        except Exception:
-            pass
+        # 사용량 기록(record_call)은 stream_claude_code 내부에서 usage_label에
+        # 맞춰 이미 처리한다 - 여기서 한 번 더 기록하면 채팅 1회가 2번으로
+        # 집계되는 이중 카운트 버그가 있었다.
         # claude CLI가 자체적으로 --resume 세션 내에 이전 대화 히스토리(논문 원문+
         # 가이드라인 포함)를 그대로 갖고 있으므로, 같은 세션에 이미 한 번 보냈다면
         # 매 질문마다 논문 원문 전체를 다시 붙일 필요가 없다 - 최초 1회만 붙이고
@@ -653,11 +649,9 @@ async def stream_chat(
             _mark_chat_context_sent(session_id, "claude_code")
         return
     elif provider == "codex":
-        try:
-            from services.usage_tracker import record_call
-            record_call("chat")
-        except Exception:
-            pass
+        # 사용량 기록(record_call)은 stream_codex 내부에서 usage_label에 맞춰
+        # 이미 처리한다 - 여기서 한 번 더 기록하면 채팅 1회가 2번으로 집계되는
+        # 이중 카운트 버그가 있었다.
         # codex CLI가 자체적으로 resume 세션(thread) 내에 이전 대화 히스토리(논문 원문+
         # 가이드라인 포함)를 그대로 갖고 있으므로, 같은 세션에 이미 한 번 보냈다면
         # 매 질문마다 논문 원문 전체를 다시 붙일 필요가 없다 - 최초 1회만 붙이고


### PR DESCRIPTION
# Summary
## 1. CLI 채팅 사용량이 2배로 이중 카운트되던 문제 수정
- `stream_chat()`이 antigravity/claude_code/codex 분기에서 `record_call("chat")`을 직접 호출한 뒤, 각 `stream_antigravity`/`stream_claude_code`/`stream_codex` 내부에서도 `usage_label`(또는 `is_chat` 여부)에 맞춰 다시 한 번 `record_call`을 호출하고 있었음
- 그 결과 CLI 기반 채팅 메시지 1건이 사용량 통계(`/agy/usage` 등, 설정 화면의 Antigravity 사용량 표시에 쓰임)에 2건으로 집계되고 있었음 - 번역/인사이트 호출은 프로바이더 함수 내부의 기록만으로 이미 정상 동작(외부에서 별도로 `record_call`하지 않음)해서, 채팅 경로에서만 나타나는 불일치였음
- `stream_chat`의 중복 `record_call` 호출 3곳을 제거해, 세 provider 모두 프로바이더 함수 내부 기록 한 곳으로 통일

## 검증
- `grep`으로 파일 전체에서 실제 `record_call(...)` 호출이 정확히 3곳(각 프로바이더 함수 내부에 1곳씩)만 남고, `stream_chat`의 분기에는 더 이상 호출이 없는지 확인
- 백엔드(`main.py`) import 및 `llm_client.py` 구문 정상 확인
