### PR TITLE
fix: 번역 job 재시작 시 _running_tasks 추적 경쟁 조건 수정

### DIFF
--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -267,7 +267,13 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
         job["error"] = str(e)
         _save_job(session_id, job)
     finally:
-        _running_tasks.pop(session_id, None)
+        # 취소된 이전 잡(Restart로 대체된 구 태스크)이 뒤늦게 여기 도달하면,
+        # 이미 새로 등록된 최신 태스크의 항목을 그냥 pop(key)로 지워버려서
+        # cancel_job()이나 진행 상태 확인이 "실행 중인 잡 없음"으로 잘못
+        # 판단하게 되는 문제가 있었다. 지금 _running_tasks에 등록된 태스크가
+        # 정확히 "나 자신"일 때만 제거한다.
+        if _running_tasks.get(session_id) is asyncio.current_task():
+            _running_tasks.pop(session_id, None)
 
 
 async def _translate_page(


### PR DESCRIPTION
# Summary
## 1. 번역 job 재시작 시 _running_tasks 추적이 새 태스크를 지워버리던 경쟁 조건 수정
- `start_job()`은 이미 실행 중인 태스크가 있으면 취소만 하고(await 없이) 곧바로 같은 세션 키에 새 태스크를 등록하는데, `_run_job()`의 `finally` 블록은 무조건 `_running_tasks.pop(session_id)`를 호출하고 있었음
- 취소된 구 태스크가 뒤늦게 그 `finally`에 도달하면, 그 사이 이미 등록된 새 태스크의 항목을 그대로 지워버려서 `cancel_job()`이나 진행 상태 확인(`routers/translate.py`의 캐시 삭제 엔드포인트 등)이 "실행 중인 잡 없음"으로 잘못 판단하는 문제가 있었음
- `finally`에서 지금 `_running_tasks`에 등록된 태스크가 정확히 `asyncio.current_task()`(자기 자신)일 때만 `pop`하도록 수정 - 취소된 구 태스크가 이후에 등록된 새 태스크의 항목을 건드리지 않게 함

## 검증
- 느린 페이지 번역(5초 sleep)으로 태스크 A를 시작 → 짧게 대기해 A가 진행 중인 상태를 만든 뒤, 같은 세션으로 다시 `start_job()`을 호출해 A를 취소하고 태스크 B를 새로 등록 → A의 취소 전파와 `finally` 실행이 끝난 뒤에도 `_running_tasks[session_id]`가 여전히 정확히 B를 가리키는지 확인 (제거되지 않음)
- 백엔드(`main.py`) import 정상 동작 확인
