### PR TITLE
fix: 설치 SSE 스트림 클라이언트 연결 끊김 시 좀비 프로세스 방지

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -29,14 +29,32 @@ from services.llm_client import check_ollama_health
 
 
 async def _stream_subprocess_lines(proc):
-    """서브프로세스의 stdout을 한 줄씩 비동기로 yield합니다 (설치 스크립트 진행 로그 스트리밍용)."""
-    while True:
-        line = await proc.stdout.readline()
-        if not line:
-            break
-        text = line.decode("utf-8", errors="replace").rstrip()
-        if text:
-            yield text
+    """서브프로세스의 stdout을 한 줄씩 비동기로 yield합니다 (설치 스크립트 진행 로그 스트리밍용).
+
+    클라이언트가 SSE 연결을 중간에 끊으면(설치 진행 중 브라우저 탭을 닫는 등)
+    FastAPI/Starlette가 이 async generator를 GeneratorExit로 강제 종료하는데,
+    그 시점에 설치 서브프로세스가 아직 살아있으면 아무도 기다려주지 않는
+    좀비/유령 프로세스로 남는다. finally에서 아직 살아있으면 항상 죽이고
+    회수해, 취소된 설치가 반복될 때마다 프로세스가 계속 쌓이지 않게 한다.
+    """
+    try:
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                yield text
+    finally:
+        if proc.returncode is None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                await proc.wait()
+            except Exception:
+                pass
 
 router = APIRouter()
 


### PR DESCRIPTION
# Summary
## 1. 설치 SSE 스트림 중 클라이언트 연결이 끊기면 서브프로세스가 좀비로 남던 문제 수정
- Ollama/Claude Code/Codex/Antigravity 설치 SSE 엔드포인트들은 모두 공용 헬퍼 `_stream_subprocess_lines()`로 설치 서브프로세스의 stdout을 스트리밍하는데, 클라이언트가 설치 진행 중 브라우저 탭을 닫는 등으로 SSE 연결을 끊으면 FastAPI/Starlette가 이 async generator를 `GeneratorExit`로 강제 종료함
- 그 시점에 설치 서브프로세스(`curl | sh`, `npm install -g`, 설치 프로그램 실행 등)가 아직 살아있어도 아무도 죽이거나 회수(`wait`)하지 않아 좀비/유령 프로세스로 남고, 설치를 시작했다가 취소하는 걸 반복하면 계속 쌓일 수 있었음
- `_stream_subprocess_lines()`의 읽기 루프를 `try/finally`로 감싸, 제너레이터가 어떤 이유로든(정상 종료/`GeneratorExit`) 빠져나갈 때 프로세스가 아직 살아있으면 항상 강제 종료 후 회수하도록 수정 - 공용 헬퍼 한 곳만 고쳐서 이 헬퍼를 쓰는 모든 설치 엔드포인트(Ollama 3개 OS 분기, Claude Code/Codex npm 설치, Antigravity 설치)에 동일하게 적용됨
- `system_update`(깃허브 pull + 프론트엔드 빌드 + 서비스 재기동)는 SSE 스트림이 아니라 `communicate()`로 완결하는 일반 엔드포인트라 이 버그의 영향을 받지 않아 그대로 둠

## 검증
- 실제로 오래 실행되는 더미 프로세스(`sleep 10`)를 `_stream_subprocess_lines`로 스트리밍하다가 제너레이터를 중간에 `aclose()`(Starlette가 클라이언트 연결 끊김을 처리할 때와 동일한 신호)한 뒤, 프로세스가 실제로 강제 종료(`returncode == -9`, SIGKILL)됐는지 확인
- 백엔드(`main.py`) import 및 `auth.py` 구문 정상 확인
