### PR TITLE
feat: AI 채팅 답변에서도 텍스트 선택 인용(Ask AI) 기능 추가

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BKQk44H_.js"></script>
+  <script type="module" crossorigin src="/assets/index-BqanXNwC.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4881,8 +4881,11 @@ document.addEventListener('mouseup', (e) => {
       
       const isTextLayer = container && container.nodeType === 1 && container.closest('.textLayer')
       const isTransContent = container && container.nodeType === 1 && container.closest('.trans-page-content')
+      // AI가 답변한 채팅 메시지(assistant)에서 선택한 내용도 인용해 후속 질문을
+      // 할 수 있도록, 사용자 자신의 메시지는 제외하고 assistant 말풍선만 대상으로 함
+      const isChatAssistantMsg = container && container.nodeType === 1 && container.closest('.chat-message.assistant .message-bubble')
 
-      if (!isTextLayer && !isTransContent) {
+      if (!isTextLayer && !isTransContent && !isChatAssistantMsg) {
         hideSelectionMenu()
         return
       }


### PR DESCRIPTION
# Summary
## 1. AI 채팅 답변에서도 텍스트를 선택해 인용 후속 질문(Ask AI)을 할 수 있도록 추가
- 기존에는 PDF 원문/번역본에서 텍스트를 드래그 선택하면 "Ask AI" 버튼이 뜨는 인용 질문 기능이 있었는데, 채팅창에서 AI가 이미 답변한 내용은 같은 방식으로 인용해 후속 질문을 할 수 없었음
- 통합 텍스트 선택 감지 핸들러(전역 `mouseup`)가 `.textLayer`/`.trans-page-content`뿐 아니라 `.chat-message.assistant .message-bubble`(AI 답변 말풍선) 안의 선택도 인식하도록 확장 - 사용자 자신이 보낸 메시지(`.chat-message.user`)는 대상에서 제외해, AI가 답변한 내용만 인용 가능
- 기존 `ask-ai-btn` 클릭 핸들러와 `askAIAssistant()`가 선택 출처와 무관하게 이미 범용으로 동작하도록 짜여 있어서 그대로 재사용됨 - 인용 영역 표시, 채팅 사이드바 활성화, 입력창 포커스까지 PDF/번역본 인용과 완전히 동일하게 작동

## 검증
- Playwright로 실제 채팅 흐름 재현: 질문 전송 → AI 응답 도착 → 응답 텍스트 일부 드래그 선택 → "Ask AI" 플로팅 버튼이 뜨는지 확인 → 클릭 시 채팅 입력창 위 인용 영역에 선택한 텍스트가 정확히 표시되는지 확인 (스크린샷으로 확인)
