### PR TITLE
feat: 자동 업데이트 확인 주기 설정 + 변경 로그 팝업 + 업데이트 완료 안내 추가

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -642,4 +642,41 @@ async def system_update(current_user: str = Depends(get_current_user)):
         }
 
 
+class UpdateCheckConfigRequest(BaseModel):
+    interval: str
+
+
+@router.get("/settings/update-check-config")
+async def get_update_check_config_endpoint(current_user: str = Depends(get_current_user)):
+    """자동 업데이트 확인 주기 설정과 마지막 확인 시각을 반환합니다."""
+    from services.update_checker import get_update_check_config
+    return get_update_check_config()
+
+
+@router.post("/settings/update-check-config")
+async def set_update_check_config_endpoint(
+    data: UpdateCheckConfigRequest,
+    current_user: str = Depends(get_current_user)
+):
+    """자동 업데이트 확인 주기를 저장합니다 (daily/weekly/never)."""
+    from services.update_checker import set_update_check_interval
+    try:
+        return set_update_check_interval(data.interval)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/settings/update-check")
+async def check_for_update_endpoint(current_user: str = Depends(get_current_user)):
+    """원격 저장소를 확인해 새 버전이 있는지, 있다면 변경 로그를 반환합니다."""
+    from services.update_checker import check_for_update
+    return await check_for_update()
+
+
+@router.get("/settings/post-update-notice")
+async def post_update_notice_endpoint(current_user: str = Depends(get_current_user)):
+    """직전 재시작으로 버전이 바뀌었다면(방금 업데이트 완료) 1회에 한해 안내 정보를 반환합니다."""
+    from services.update_checker import get_post_update_notice
+    return await get_post_update_notice()
+
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -87,7 +87,17 @@ def init_db():
             cursor.execute("ALTER TABLE documents ADD COLUMN is_deleted INTEGER DEFAULT 0")
         except sqlite3.OperationalError:
             pass
-            
+
+        # 6. app_meta 테이블 (자동 업데이트 확인 주기/마지막 확인 시각/마지막으로
+        #    "업데이트 완료" 알림을 보여준 버전 등, 자주 바뀌는 앱 내부 상태를
+        #    저장하는 범용 key-value 테이블)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS app_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """)
+
         conn.commit()
         
     # 기본 관리자 계정 초기 생성
@@ -379,5 +389,26 @@ def db_update_document_metadata(doc_id: str, metadata: dict) -> None:
         cursor.execute(
             "UPDATE documents SET metadata = ? WHERE id = ?",
             (meta_str, doc_id)
+        )
+        conn.commit()
+
+
+# ── 앱 내부 상태 (app_meta) ───────────────────────────────────────────────────
+
+def db_get_meta(key: str) -> Optional[str]:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT value FROM app_meta WHERE key = ?", (key,))
+        row = cursor.fetchone()
+        return row["value"] if row else None
+
+
+def db_set_meta(key: str, value: str) -> None:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO app_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value)
         )
         conn.commit()

--- a/backend/services/update_checker.py
+++ b/backend/services/update_checker.py
@@ -1,0 +1,171 @@
+"""
+자동 업데이트 확인 서비스
+- 현재 실행 중인 커밋(버전) 조회
+- 원격(origin/main)과 비교해 새 버전 존재 여부 및 변경 로그(커밋 목록) 조회
+- 업데이트 확인 주기 설정 및 마지막 확인 시각, 마지막으로 안내한 버전을
+  app_meta 테이블에 저장/조회
+"""
+
+import asyncio
+import subprocess
+from datetime import datetime, timezone
+from typing import Optional
+
+from config import get_project_root
+from services.db import db_get_meta, db_set_meta
+
+VALID_INTERVALS = ("daily", "weekly", "never")
+DEFAULT_INTERVAL = "weekly"
+
+_current_version_cache: Optional[str] = None
+
+
+async def _run_git(*args: str, timeout: float = 30.0) -> tuple[int, str, str]:
+    """git 명령을 프로젝트 루트에서 실행하고 (returncode, stdout, stderr)를 반환합니다."""
+    proc = await asyncio.create_subprocess_exec(
+        "git", *args,
+        cwd=get_project_root(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        await proc.wait()
+        return 1, "", "git 명령이 시간 초과되었습니다."
+    return (
+        proc.returncode,
+        stdout.decode("utf-8", errors="replace").strip(),
+        stderr.decode("utf-8", errors="replace").strip(),
+    )
+
+
+async def get_current_version() -> str:
+    """이 프로세스가 현재 실행 중인 커밋의 짧은 해시를 반환합니다.
+
+    실행 중에는 바뀌지 않는 값이라(재시작해야 새 버전이 반영됨) 최초 1회만
+    계산해 캐시한다.
+    """
+    global _current_version_cache
+    if _current_version_cache:
+        return _current_version_cache
+    code, out, _ = await _run_git("rev-parse", "--short", "HEAD")
+    _current_version_cache = out if code == 0 and out else "unknown"
+    return _current_version_cache
+
+
+async def check_for_update() -> dict:
+    """원격 origin/main을 fetch해 현재 버전과 비교합니다.
+
+    반환값: {ok, current_version, latest_version, update_available, changelog, error?}
+    changelog는 현재 버전에는 없고 최신 버전에는 있는 커밋들의 {sha, subject} 목록
+    (오래된 순 → 최신 순).
+    """
+    current_version = await get_current_version()
+
+    fetch_code, _, fetch_err = await _run_git("fetch", "origin", "main")
+    if fetch_code != 0:
+        return {
+            "ok": False,
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+            "changelog": [],
+            "error": f"원격 저장소 확인 실패: {fetch_err or '알 수 없는 오류'}",
+        }
+
+    latest_code, latest_out, latest_err = await _run_git("rev-parse", "--short", "origin/main")
+    if latest_code != 0 or not latest_out:
+        return {
+            "ok": False,
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+            "changelog": [],
+            "error": f"최신 버전 확인 실패: {latest_err or '알 수 없는 오류'}",
+        }
+    latest_version = latest_out
+
+    db_set_meta("last_update_checked_at", datetime.now(timezone.utc).isoformat())
+
+    if latest_version == current_version:
+        return {
+            "ok": True,
+            "current_version": current_version,
+            "latest_version": latest_version,
+            "update_available": False,
+            "changelog": [],
+        }
+
+    changelog = await _get_changelog(current_version, "origin/main")
+    return {
+        "ok": True,
+        "current_version": current_version,
+        "latest_version": latest_version,
+        "update_available": True,
+        "changelog": changelog,
+    }
+
+
+async def _get_changelog(from_ref: str, to_ref: str) -> list[dict]:
+    """from_ref(제외)부터 to_ref(포함)까지의 커밋 목록을 오래된 순으로 반환합니다.
+
+    머지 커밋("Merge pull request ...")은 실제 작업 내용이 아니라 노이즈이므로
+    --no-merges로 제외한다.
+    """
+    code, out, _ = await _run_git(
+        "log", "--no-merges", "--pretty=format:%h|%s", f"{from_ref}..{to_ref}"
+    )
+    if code != 0 or not out:
+        return []
+    entries = []
+    for line in reversed(out.splitlines()):
+        if "|" not in line:
+            continue
+        sha, _, subject = line.partition("|")
+        subject = subject.strip()
+        if subject:
+            entries.append({"sha": sha.strip(), "subject": subject})
+    return entries
+
+
+def get_update_check_config() -> dict:
+    interval = db_get_meta("update_check_interval") or DEFAULT_INTERVAL
+    if interval not in VALID_INTERVALS:
+        interval = DEFAULT_INTERVAL
+    return {
+        "interval": interval,
+        "last_checked_at": db_get_meta("last_update_checked_at"),
+    }
+
+
+def set_update_check_interval(interval: str) -> dict:
+    if interval not in VALID_INTERVALS:
+        raise ValueError(f"잘못된 확인 주기입니다: {interval}")
+    db_set_meta("update_check_interval", interval)
+    return get_update_check_config()
+
+
+async def get_post_update_notice() -> dict:
+    """직전 재시작으로 버전이 바뀌었다면(=방금 업데이트됨) 딱 한 번만 안내 정보를
+    반환합니다. 이미 안내한 버전이면 show=False를 반환하고, 최초 실행(기록이
+    아예 없는 경우)에는 지금 버전을 기준값으로만 저장해두고 안내하지 않습니다
+    (업데이트된 게 아니라 그냥 처음 뜬 것이므로).
+    """
+    current_version = await get_current_version()
+    last_shown = db_get_meta("last_shown_update_version")
+
+    if last_shown is None:
+        db_set_meta("last_shown_update_version", current_version)
+        return {"show": False, "version": current_version, "changelog": []}
+
+    if last_shown == current_version:
+        return {"show": False, "version": current_version, "changelog": []}
+
+    changelog = await _get_changelog(last_shown, "HEAD")
+    db_set_meta("last_shown_update_version", current_version)
+    return {"show": True, "version": current_version, "changelog": changelog}

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BqanXNwC.js"></script>
+  <script type="module" crossorigin src="/assets/index-fUWR84i5.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>
@@ -397,6 +397,51 @@
     </div>
   </div>
 
+  <!-- 새 버전 업데이트 안내 모달 -->
+  <div id="update-available-modal" class="modal-overlay hidden">
+    <div class="modal-content" style="max-width: 440px;">
+      <div class="modal-header">
+        <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>새 업데이트가 있습니다</h2>
+        <button id="update-available-close-btn" class="close-btn">&times;</button>
+      </div>
+      <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
+        <p id="update-available-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
+        <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">변경 내용</div>
+        <ul id="update-available-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+
+        <div id="update-available-progress-area" class="hidden">
+          <div id="update-available-status" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 8px;">업데이트 진행 중...</div>
+          <div class="spinner" style="width: 20px; height: 20px; border-width: 2px; margin: 0 auto;"></div>
+        </div>
+
+        <div id="update-available-actions" style="display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px;">
+          <button type="button" id="update-available-later-btn" style="background: none; border: none; color: var(--text-muted); font-size: 12.5px; cursor: pointer; text-decoration: underline; padding: 9px 6px;">나중에</button>
+          <button type="button" id="update-available-now-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">지금 업데이트</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 업데이트 완료 안내 모달 (업데이트 직후 1회만 표시) -->
+  <div id="update-complete-modal" class="modal-overlay hidden">
+    <div class="modal-content" style="max-width: 440px;">
+      <div class="modal-header">
+        <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px; color: var(--success);"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>새 버전으로 업데이트되었습니다</h2>
+        <button id="update-complete-close-btn" class="close-btn">&times;</button>
+      </div>
+      <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
+        <p id="update-complete-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
+        <div id="update-complete-changelog-wrap">
+          <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">이번 업데이트에서 바뀐 점</div>
+          <ul id="update-complete-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        </div>
+        <div style="text-align: right;">
+          <button type="button" id="update-complete-confirm-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">확인</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- EasyPaper 통합 설정 모달 -->
   <div id="settings-modal" class="modal-overlay hidden">
     <div class="modal-content" style="max-width: 500px;">
@@ -501,6 +546,17 @@
               아래 버튼을 누르면 GitHub 저장소로부터 최신 코드를 풀(Pull) 받고,<br>
               변경된 내용이 있을 경우 프론트엔드를 자동 빌드한 뒤 EasyPaper 데몬 서비스를 즉시 재기동합니다.
             </div>
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="font-size: 12.5px; color: var(--text-secondary); white-space: nowrap;">자동 업데이트 확인</span>
+                <select id="setting-update-check-interval" class="form-select" style="width: auto; min-width: 110px;">
+                  <option value="daily">매일</option>
+                  <option value="weekly">매주</option>
+                  <option value="never">사용 안 함</option>
+                </select>
+              </div>
+              <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
+            </div>
             <div style="display: flex; gap: 10px; align-items: center;">
               <button type="button" id="system-update-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>최신 업데이트 실행
@@ -508,7 +564,7 @@
               <span id="system-update-status" style="font-size: 12.5px; color: var(--text-secondary);"></span>
             </div>
           </div>
-          
+
           <div class="form-actions" style="margin-top: 15px;">
             <button type="submit" class="btn btn-primary" style="width: 100%;">일반 설정 저장</button>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -396,6 +396,51 @@
     </div>
   </div>
 
+  <!-- 새 버전 업데이트 안내 모달 -->
+  <div id="update-available-modal" class="modal-overlay hidden">
+    <div class="modal-content" style="max-width: 440px;">
+      <div class="modal-header">
+        <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>새 업데이트가 있습니다</h2>
+        <button id="update-available-close-btn" class="close-btn">&times;</button>
+      </div>
+      <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
+        <p id="update-available-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
+        <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">변경 내용</div>
+        <ul id="update-available-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+
+        <div id="update-available-progress-area" class="hidden">
+          <div id="update-available-status" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 8px;">업데이트 진행 중...</div>
+          <div class="spinner" style="width: 20px; height: 20px; border-width: 2px; margin: 0 auto;"></div>
+        </div>
+
+        <div id="update-available-actions" style="display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px;">
+          <button type="button" id="update-available-later-btn" style="background: none; border: none; color: var(--text-muted); font-size: 12.5px; cursor: pointer; text-decoration: underline; padding: 9px 6px;">나중에</button>
+          <button type="button" id="update-available-now-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">지금 업데이트</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 업데이트 완료 안내 모달 (업데이트 직후 1회만 표시) -->
+  <div id="update-complete-modal" class="modal-overlay hidden">
+    <div class="modal-content" style="max-width: 440px;">
+      <div class="modal-header">
+        <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px; color: var(--success);"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>새 버전으로 업데이트되었습니다</h2>
+        <button id="update-complete-close-btn" class="close-btn">&times;</button>
+      </div>
+      <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
+        <p id="update-complete-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
+        <div id="update-complete-changelog-wrap">
+          <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">이번 업데이트에서 바뀐 점</div>
+          <ul id="update-complete-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        </div>
+        <div style="text-align: right;">
+          <button type="button" id="update-complete-confirm-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">확인</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- EasyPaper 통합 설정 모달 -->
   <div id="settings-modal" class="modal-overlay hidden">
     <div class="modal-content" style="max-width: 500px;">
@@ -500,6 +545,17 @@
               아래 버튼을 누르면 GitHub 저장소로부터 최신 코드를 풀(Pull) 받고,<br>
               변경된 내용이 있을 경우 프론트엔드를 자동 빌드한 뒤 EasyPaper 데몬 서비스를 즉시 재기동합니다.
             </div>
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="font-size: 12.5px; color: var(--text-secondary); white-space: nowrap;">자동 업데이트 확인</span>
+                <select id="setting-update-check-interval" class="form-select" style="width: auto; min-width: 110px;">
+                  <option value="daily">매일</option>
+                  <option value="weekly">매주</option>
+                  <option value="never">사용 안 함</option>
+                </select>
+              </div>
+              <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
+            </div>
             <div style="display: flex; gap: 10px; align-items: center;">
               <button type="button" id="system-update-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>최신 업데이트 실행
@@ -507,7 +563,7 @@
               <span id="system-update-status" style="font-size: 12.5px; color: var(--text-secondary);"></span>
             </div>
           </div>
-          
+
           <div class="form-actions" style="margin-top: 15px;">
             <button type="submit" class="btn btn-primary" style="width: 100%;">일반 설정 저장</button>
           </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -569,6 +569,43 @@ export async function triggerSystemUpdateAPI() {
   return res.json()
 }
 
+/**
+ * 자동 업데이트 확인 주기 설정을 조회/저장합니다.
+ */
+export async function getUpdateCheckConfigAPI() {
+  const res = await fetch(`${API_BASE}/settings/update-check-config`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('업데이트 확인 설정 조회 실패')
+  return res.json()
+}
+
+export async function setUpdateCheckConfigAPI(interval) {
+  const res = await fetch(`${API_BASE}/settings/update-check-config`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ interval })
+  })
+  if (!res.ok) throw new Error('업데이트 확인 설정 저장 실패')
+  return res.json()
+}
+
+/**
+ * 원격 저장소를 확인해 새 버전이 있는지 조회합니다 (변경 로그 포함).
+ */
+export async function checkForUpdateAPI() {
+  const res = await fetch(`${API_BASE}/settings/update-check`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('업데이트 확인 실패')
+  return res.json()
+}
+
+/**
+ * 방금 업데이트가 적용되어 재시작된 직후라면(1회 한정) 안내 정보를 조회합니다.
+ */
+export async function getPostUpdateNoticeAPI() {
+  const res = await fetch(`${API_BASE}/settings/post-update-notice`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('업데이트 완료 안내 조회 실패')
+  return res.json()
+}
+
 export async function fetchTrashAPI() {
   const res = await fetch(`${API_BASE}/library/trash`, { cache: 'no-store' })
   if (!res.ok) throw new Error('휴지통 목록 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently } from './library.js'
 import { icon } from './icons.js'
@@ -1378,6 +1378,11 @@ async function checkAuthentication() {
     await loadLibraryCount()
     await refreshSystemSettings()
     maybeShowOnboarding()
+    // 업데이트 직후(방금 재시작됨) 안내가 있으면 그것부터 먼저 보여주고, 없을
+    // 때만 "새 업데이트가 있는지" 확인 - 두 팝업이 동시에 겹쳐 뜨지 않도록 함
+    checkPostUpdateNoticeOnce().then((shown) => {
+      if (!shown) maybeAutoCheckForUpdate()
+    })
   } else {
     showLogin()
   }
@@ -2417,6 +2422,197 @@ if (systemUpdateBtn) {
       }, 5000)
     }
   })
+}
+
+// ── 자동 업데이트 확인 / 새 버전 안내 / 업데이트 완료 안내 ──────────────
+const settingUpdateCheckInterval = $('setting-update-check-interval')
+const currentVersionLabel = $('current-version-label')
+
+const updateAvailableModal = $('update-available-modal')
+const updateAvailableCloseBtn = $('update-available-close-btn')
+const updateAvailableVersionLine = $('update-available-version-line')
+const updateAvailableChangelog = $('update-available-changelog')
+const updateAvailableProgressArea = $('update-available-progress-area')
+const updateAvailableStatus = $('update-available-status')
+const updateAvailableActions = $('update-available-actions')
+const updateAvailableLaterBtn = $('update-available-later-btn')
+const updateAvailableNowBtn = $('update-available-now-btn')
+
+const updateCompleteModal = $('update-complete-modal')
+const updateCompleteCloseBtn = $('update-complete-close-btn')
+const updateCompleteVersionLine = $('update-complete-version-line')
+const updateCompleteChangelog = $('update-complete-changelog')
+const updateCompleteConfirmBtn = $('update-complete-confirm-btn')
+
+const UPDATE_CHECK_INTERVAL_MS = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+}
+
+function renderChangelogList(ulEl, changelog) {
+  if (!ulEl) return
+  if (!changelog || changelog.length === 0) {
+    ulEl.innerHTML = `<li style="font-size: 12.5px; color: var(--text-muted);">세부 변경 내역이 없습니다.</li>`
+    return
+  }
+  ulEl.innerHTML = changelog.map(c => `
+    <li style="display: flex; gap: 8px; font-size: 12.5px; color: var(--text-primary); line-height: 1.5;">
+      <span style="color: var(--control-accent); flex-shrink: 0;">•</span>
+      <span>${escapeHtml(c.subject)}</span>
+    </li>
+  `).join('')
+}
+
+// 설정 화면에서 자동 업데이트 확인 주기를 로드/저장
+async function initUpdateCheckSettingUI() {
+  if (!settingUpdateCheckInterval) return
+  try {
+    const cfg = await getUpdateCheckConfigAPI()
+    settingUpdateCheckInterval.value = cfg.interval || 'weekly'
+  } catch (err) {
+    console.warn('업데이트 확인 설정 로드 실패:', err)
+  }
+}
+globalSettingsBtn.addEventListener('click', initUpdateCheckSettingUI)
+
+if (settingUpdateCheckInterval) {
+  settingUpdateCheckInterval.addEventListener('change', async () => {
+    try {
+      await setUpdateCheckConfigAPI(settingUpdateCheckInterval.value)
+      showToast('자동 업데이트 확인 설정이 저장되었습니다.', 'success')
+    } catch (err) {
+      showToast(err.message || '설정 저장 실패', 'error')
+    }
+  })
+}
+
+function closeUpdateAvailableModal() {
+  if (updateAvailableModal) updateAvailableModal.classList.add('hidden')
+}
+
+function closeUpdateCompleteModal() {
+  if (updateCompleteModal) updateCompleteModal.classList.add('hidden')
+}
+
+if (updateAvailableCloseBtn) updateAvailableCloseBtn.addEventListener('click', closeUpdateAvailableModal)
+if (updateAvailableLaterBtn) updateAvailableLaterBtn.addEventListener('click', closeUpdateAvailableModal)
+if (updateAvailableModal) {
+  updateAvailableModal.addEventListener('click', (e) => {
+    if (e.target === updateAvailableModal) closeUpdateAvailableModal()
+  })
+}
+if (updateCompleteCloseBtn) updateCompleteCloseBtn.addEventListener('click', closeUpdateCompleteModal)
+if (updateCompleteConfirmBtn) updateCompleteConfirmBtn.addEventListener('click', closeUpdateCompleteModal)
+if (updateCompleteModal) {
+  updateCompleteModal.addEventListener('click', (e) => {
+    if (e.target === updateCompleteModal) closeUpdateCompleteModal()
+  })
+}
+
+// 서버가 재시작할 시간을 준 뒤, 응답이 돌아올 때까지 짧게 폴링하고 새로고침한다.
+// (git pull 직후 서버가 스스로 프로세스를 내렸다 올리는 구간이라, 그 사이의
+// 연결 실패는 실패가 아니라 재시작 중이라는 정상 신호로 취급해야 한다)
+async function waitForServerRestartAndReload() {
+  await new Promise(resolve => setTimeout(resolve, 2000))
+  const maxAttempts = 24 // 약 2초 + 24 * 1.5초 = 최대 약 38초 대기
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const auth = await checkAuthAPI()
+      if (auth) {
+        location.reload()
+        return
+      }
+    } catch (err) {
+      // 아직 재시작 중 - 계속 폴링
+    }
+    await new Promise(resolve => setTimeout(resolve, 1500))
+  }
+  // 시간이 오래 걸려도 일단 새로고침을 시도해본다
+  location.reload()
+}
+
+if (updateAvailableNowBtn) {
+  updateAvailableNowBtn.addEventListener('click', async () => {
+    updateAvailableNowBtn.disabled = true
+    if (updateAvailableLaterBtn) updateAvailableLaterBtn.disabled = true
+    if (updateAvailableProgressArea) updateAvailableProgressArea.classList.remove('hidden')
+    if (updateAvailableActions) updateAvailableActions.style.display = 'none'
+    if (updateAvailableStatus) updateAvailableStatus.textContent = 'GitHub 코드 가져오는 중...'
+
+    try {
+      const res = await triggerSystemUpdateAPI()
+      if (res.ok) {
+        if (updateAvailableStatus) updateAvailableStatus.textContent = '업데이트 성공! 서버 재시작을 기다리는 중...'
+        await waitForServerRestartAndReload()
+      } else {
+        if (updateAvailableStatus) updateAvailableStatus.textContent = res.message || '업데이트 실패'
+        showToast(res.message || '업데이트 실패', 'error')
+        updateAvailableNowBtn.disabled = false
+        if (updateAvailableLaterBtn) updateAvailableLaterBtn.disabled = false
+        if (updateAvailableActions) updateAvailableActions.style.display = 'flex'
+      }
+    } catch (err) {
+      // 요청 도중 서버가 이미 재시작을 시작해 연결이 끊겼을 가능성이 높다
+      if (updateAvailableStatus) updateAvailableStatus.textContent = '서버 재시작을 감지했습니다. 잠시 후 새로고침합니다...'
+      await waitForServerRestartAndReload()
+    }
+  })
+}
+
+// 설정된 주기(매일/매주)가 지났으면 원격 저장소를 확인해 새 버전이 있는지 확인하고,
+// 있으면 변경 로그와 함께 안내 팝업을 띄운다. "사용 안 함"이면 절대 확인하지 않는다.
+async function maybeAutoCheckForUpdate() {
+  try {
+    const cfg = await getUpdateCheckConfigAPI()
+    if (settingUpdateCheckInterval) settingUpdateCheckInterval.value = cfg.interval || 'weekly'
+    if (cfg.interval === 'never') return
+
+    const intervalMs = UPDATE_CHECK_INTERVAL_MS[cfg.interval] || UPDATE_CHECK_INTERVAL_MS.weekly
+    const lastCheckedAt = cfg.last_checked_at ? new Date(cfg.last_checked_at).getTime() : 0
+    const dueNow = !lastCheckedAt || (Date.now() - lastCheckedAt) >= intervalMs
+    if (!dueNow) return
+
+    const result = await checkForUpdateAPI()
+    if (currentVersionLabel && result.current_version) {
+      currentVersionLabel.textContent = `현재 버전: ${result.current_version}`
+    }
+    if (!result.ok || !result.update_available) return
+
+    if (updateAvailableVersionLine) {
+      updateAvailableVersionLine.textContent = `${result.current_version} → ${result.latest_version}`
+    }
+    renderChangelogList(updateAvailableChangelog, result.changelog)
+    if (updateAvailableProgressArea) updateAvailableProgressArea.classList.add('hidden')
+    if (updateAvailableActions) updateAvailableActions.style.display = 'flex'
+    if (updateAvailableNowBtn) updateAvailableNowBtn.disabled = false
+    if (updateAvailableLaterBtn) updateAvailableLaterBtn.disabled = false
+    if (updateAvailableModal) updateAvailableModal.classList.remove('hidden')
+  } catch (err) {
+    console.warn('자동 업데이트 확인 실패:', err)
+  }
+}
+
+// 직전 재시작으로 버전이 바뀌었다면(=방금 업데이트 적용됨) 변경 로그와 함께
+// "업데이트 완료" 안내를 1회만 보여준다. 팝업을 실제로 띄웠는지(true/false)를
+// 반환해, 호출부가 "새 업데이트 확인" 팝업과 동시에 겹쳐 뜨지 않게 조율한다.
+async function checkPostUpdateNoticeOnce() {
+  try {
+    const notice = await getPostUpdateNoticeAPI()
+    if (currentVersionLabel && notice.version) {
+      currentVersionLabel.textContent = `현재 버전: ${notice.version}`
+    }
+    if (!notice.show) return false
+
+    if (updateCompleteVersionLine) {
+      updateCompleteVersionLine.textContent = `버전 ${notice.version}로 업데이트되었습니다.`
+    }
+    renderChangelogList(updateCompleteChangelog, notice.changelog)
+    if (updateCompleteModal) updateCompleteModal.classList.remove('hidden')
+    return true
+  } catch (err) {
+    console.warn('업데이트 완료 안내 조회 실패:', err)
+    return false
+  }
 }
 
 // 로컬 캐시 비우기


### PR DESCRIPTION
# Summary
## 1. 자동 업데이트 확인(주기 설정) 및 변경 로그 팝업 추가
- 설정 화면에서 "매일 / 매주 / 사용 안 함" 중 확인 주기를 선택할 수 있고, 설정한 주기가 지나면 앱 로드 시 원격 저장소(`origin/main`)를 자동으로 확인함
- 버전 식별은 git 짧은 커밋 해시를 사용 - 이 프로젝트는 별도의 semver/릴리즈 태깅을 쓰지 않아, 실제 배포 단위(커밋)와 정확히 일치하는 값을 그대로 활용
- 새 버전이 있으면 "abc1234 → def5678" 형태의 버전 변화와, 두 버전 사이 커밋 제목들을 모은 변경 로그(머지 커밋 제외)를 함께 보여주는 팝업을 띄움
- "지금 업데이트"를 누르면 기존 `/settings/update`(git pull + 프론트 빌드 + 재시작, 직전 PR에서 크로스플랫폼 대응 완료)를 그대로 실행하고, 재시작으로 연결이 잠깐 끊기는 구간은 실패가 아니라 정상 신호로 취급해 `/api/auth/check`가 다시 응답할 때까지 짧게 폴링한 뒤 자동으로 새로고침

## 2. 업데이트 완료 안내 (1회 한정)
- 업데이트가 실제로 적용되어 재시작된 직후(현재 버전이 마지막으로 안내했던 버전과 다르면), 그 사이의 변경 로그와 함께 "새 버전으로 업데이트되었습니다" 안내를 1회에 한해 표시
- `app_meta` 키-값 테이블(신규)에 마지막 확인 시각/마지막으로 안내한 버전을 저장해 추적. 최초 실행(안내 기록이 아예 없는 경우)에는 안내 없이 현재 버전만 기준값으로 저장해, "방금 설치한 것"을 업데이트로 오인하지 않도록 함
- 업데이트 완료 안내와 새 업데이트 안내 두 팝업이 동시에 겹쳐 뜨지 않도록, 완료 안내를 먼저 확인하고 뜨지 않았을 때만 새 업데이트 확인으로 넘어가도록 순서를 조정

## 3. 신규 백엔드 모듈
- `backend/services/update_checker.py`: `get_current_version`/`check_for_update`/`get_update_check_config`/`set_update_check_interval`/`get_post_update_notice` 등 버전·변경로그 조회 로직을 전담. git 명령 실패(네트워크 없음 등) 시에도 예외 없이 에러 필드와 함께 안전하게 반환
- `/api/settings/update-check-config` (GET/POST), `/api/settings/update-check` (GET), `/api/settings/post-update-notice` (GET) 엔드포인트 신규 추가

## 검증
- 실제 저장소 히스토리로 `get_current_version`/`check_for_update`/`_get_changelog`/`get_update_check_config`/`set_update_check_interval`/`get_post_update_notice`를 직접 호출해 정상 동작 확인 (오늘 세션에서 실제로 발생한 커밋 구간으로 변경 로그 포맷도 확인)
- Playwright로 3가지 시나리오 모두 확인: (1) 방금 업데이트됨 + 새 업데이트도 있음 → 완료 안내만 뜨고 새 업데이트 안내는 겹쳐 뜨지 않음, (2) 방금 업데이트 안 됨 + 새 업데이트 있음 → 새 업데이트 안내만 뜨고 변경 로그·버전 표시·"나중에" 버튼 정상 동작, (3) 둘 다 없음 → 아무 팝업도 뜨지 않음
- 설정 화면의 확인 주기 드롭다운이 서버 값을 정확히 불러오고, 변경 시 즉시 저장되는지 확인
