### PR TITLE
feat: 버전 표시에 커밋 날짜 추가

### DIFF
--- a/backend/services/update_checker.py
+++ b/backend/services/update_checker.py
@@ -18,6 +18,7 @@ VALID_INTERVALS = ("daily", "weekly", "never")
 DEFAULT_INTERVAL = "weekly"
 
 _current_version_cache: Optional[str] = None
+_current_version_date_cache: Optional[str] = None
 
 
 async def _run_git(*args: str, timeout: float = 30.0) -> tuple[int, str, str]:
@@ -58,21 +59,41 @@ async def get_current_version() -> str:
     return _current_version_cache
 
 
+async def get_current_version_date() -> Optional[str]:
+    """현재 실행 중인 커밋의 날짜(YYYY-MM-DD)를 반환합니다. 버전 해시 자체는 그대로
+    두고, 화면에 표시할 때 사람이 읽기 쉽도록 날짜를 함께 보여주기 위한 값이다."""
+    global _current_version_date_cache
+    if _current_version_date_cache:
+        return _current_version_date_cache
+    _current_version_date_cache = await _get_commit_date("HEAD")
+    return _current_version_date_cache
+
+
+async def _get_commit_date(ref: str) -> Optional[str]:
+    code, out, _ = await _run_git("log", "-1", "--format=%cd", "--date=format:%Y-%m-%d", ref)
+    return out if code == 0 and out else None
+
+
 async def check_for_update() -> dict:
     """원격 origin/main을 fetch해 현재 버전과 비교합니다.
 
-    반환값: {ok, current_version, latest_version, update_available, changelog, error?}
+    반환값: {ok, current_version, current_version_date, latest_version,
+    latest_version_date, update_available, changelog, error?}
     changelog는 현재 버전에는 없고 최신 버전에는 있는 커밋들의 {sha, subject} 목록
-    (오래된 순 → 최신 순).
+    (오래된 순 → 최신 순). *_version_date는 해시 자체는 그대로 두고 화면에 표시할
+    때 사람이 읽기 쉽도록 덧붙이는 커밋 날짜(YYYY-MM-DD)다.
     """
     current_version = await get_current_version()
+    current_version_date = await get_current_version_date()
 
     fetch_code, _, fetch_err = await _run_git("fetch", "origin", "main")
     if fetch_code != 0:
         return {
             "ok": False,
             "current_version": current_version,
+            "current_version_date": current_version_date,
             "latest_version": current_version,
+            "latest_version_date": current_version_date,
             "update_available": False,
             "changelog": [],
             "error": f"원격 저장소 확인 실패: {fetch_err or '알 수 없는 오류'}",
@@ -83,7 +104,9 @@ async def check_for_update() -> dict:
         return {
             "ok": False,
             "current_version": current_version,
+            "current_version_date": current_version_date,
             "latest_version": current_version,
+            "latest_version_date": current_version_date,
             "update_available": False,
             "changelog": [],
             "error": f"최신 버전 확인 실패: {latest_err or '알 수 없는 오류'}",
@@ -96,16 +119,21 @@ async def check_for_update() -> dict:
         return {
             "ok": True,
             "current_version": current_version,
+            "current_version_date": current_version_date,
             "latest_version": latest_version,
+            "latest_version_date": current_version_date,
             "update_available": False,
             "changelog": [],
         }
 
+    latest_version_date = await _get_commit_date("origin/main")
     changelog = await _get_changelog(current_version, "origin/main")
     return {
         "ok": True,
         "current_version": current_version,
+        "current_version_date": current_version_date,
         "latest_version": latest_version,
+        "latest_version_date": latest_version_date,
         "update_available": True,
         "changelog": changelog,
     }
@@ -157,15 +185,16 @@ async def get_post_update_notice() -> dict:
     (업데이트된 게 아니라 그냥 처음 뜬 것이므로).
     """
     current_version = await get_current_version()
+    current_version_date = await get_current_version_date()
     last_shown = db_get_meta("last_shown_update_version")
 
     if last_shown is None:
         db_set_meta("last_shown_update_version", current_version)
-        return {"show": False, "version": current_version, "changelog": []}
+        return {"show": False, "version": current_version, "version_date": current_version_date, "changelog": []}
 
     if last_shown == current_version:
-        return {"show": False, "version": current_version, "changelog": []}
+        return {"show": False, "version": current_version, "version_date": current_version_date, "changelog": []}
 
     changelog = await _get_changelog(last_shown, "HEAD")
     db_set_meta("last_shown_update_version", current_version)
-    return {"show": True, "version": current_version, "changelog": changelog}
+    return {"show": True, "version": current_version, "version_date": current_version_date, "changelog": changelog}

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-fUWR84i5.js"></script>
+  <script type="module" crossorigin src="/assets/index-QjtQQT1p.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2449,6 +2449,12 @@ const UPDATE_CHECK_INTERVAL_MS = {
   weekly: 7 * 24 * 60 * 60 * 1000,
 }
 
+// 버전 해시 자체는 그대로 두고, 화면에는 날짜를 함께 보여줘 더 읽기 쉽게 함
+function formatVersionLabel(sha, date) {
+  if (!sha) return ''
+  return date ? `${date} · ${sha}` : sha
+}
+
 function renderChangelogList(ulEl, changelog) {
   if (!ulEl) return
   if (!changelog || changelog.length === 0) {
@@ -2574,12 +2580,12 @@ async function maybeAutoCheckForUpdate() {
 
     const result = await checkForUpdateAPI()
     if (currentVersionLabel && result.current_version) {
-      currentVersionLabel.textContent = `현재 버전: ${result.current_version}`
+      currentVersionLabel.textContent = `현재 버전: ${formatVersionLabel(result.current_version, result.current_version_date)}`
     }
     if (!result.ok || !result.update_available) return
 
     if (updateAvailableVersionLine) {
-      updateAvailableVersionLine.textContent = `${result.current_version} → ${result.latest_version}`
+      updateAvailableVersionLine.textContent = `${formatVersionLabel(result.current_version, result.current_version_date)} → ${formatVersionLabel(result.latest_version, result.latest_version_date)}`
     }
     renderChangelogList(updateAvailableChangelog, result.changelog)
     if (updateAvailableProgressArea) updateAvailableProgressArea.classList.add('hidden')
@@ -2599,12 +2605,12 @@ async function checkPostUpdateNoticeOnce() {
   try {
     const notice = await getPostUpdateNoticeAPI()
     if (currentVersionLabel && notice.version) {
-      currentVersionLabel.textContent = `현재 버전: ${notice.version}`
+      currentVersionLabel.textContent = `현재 버전: ${formatVersionLabel(notice.version, notice.version_date)}`
     }
     if (!notice.show) return false
 
     if (updateCompleteVersionLine) {
-      updateCompleteVersionLine.textContent = `버전 ${notice.version}로 업데이트되었습니다.`
+      updateCompleteVersionLine.textContent = `버전 ${formatVersionLabel(notice.version, notice.version_date)}로 업데이트되었습니다.`
     }
     renderChangelogList(updateCompleteChangelog, notice.changelog)
     if (updateCompleteModal) updateCompleteModal.classList.remove('hidden')


### PR DESCRIPTION
# Summary
## 1. 버전 표시에 커밋 해시와 함께 날짜를 붙여 가독성 개선
- 버전 식별자 자체(git 짧은 커밋 해시)는 그대로 유지 - 태그 기반 버전으로 바꾸면 릴리즈마다 태그를 붙이는 수동 절차가 필요한데, 이 프로젝트는 PR을 바로 main에 머지하는 방식이라 태그를 챙기지 않으면 업데이트 감지 자체가 깨질 위험이 있어 그대로 둠
- 대신 화면에 표시할 때만 `2026-07-21 · abc1234`처럼 커밋 날짜를 함께 보여줘 사람이 읽기 쉽게 함 (설정 화면의 현재 버전 라벨, 새 업데이트 안내 팝업의 버전 변화, 업데이트 완료 안내 모두 적용)
- `update_checker.py`에 `get_current_version_date()`/`_get_commit_date()` 추가, `check_for_update()`/`get_post_update_notice()` 응답에 `*_version_date` 필드 추가

## 검증
- 실제 저장소 히스토리로 `get_current_version_date()`/`check_for_update()`/`get_post_update_notice()`를 직접 호출해 날짜 필드가 정상적으로 채워지는지 확인
- Playwright로 새 업데이트 안내 팝업의 버전 라인이 `2026-07-15 · abc1234 → 2026-07-21 · def5678` 형식으로, 설정 화면의 현재 버전 라벨이 `현재 버전: 2026-07-15 · abc1234` 형식으로 정상 표시되는지 확인
