### PR TITLE
test: 백엔드 pytest 테스트 스위트 신규 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ npm run dev # 개발 서버 시작 (http://localhost:5173)
 
 ---
 
+## 테스트
+
+백엔드 테스트는 pytest로 작성되어 있으며, 실제 프로젝트 데이터(DB/업로드/라이브러리)는 건드리지 않고 임시 디렉터리에서 격리 실행됩니다.
+
+```bash
+cd backend
+.venv/bin/pip install -r requirements-dev.txt   # 최초 1회
+.venv/bin/python -m pytest tests/ -v
+```
+
+---
+
 ## 상시 구동 — systemd 서비스 등록 (선택 사항)
 
 Linux 서버에서 EasyPaper를 백그라운드 데몬으로 상시 실행하려면 제공된 `easypaper.service` 파일을 활용하세요.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==9.1.1
+pytest-asyncio==1.4.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,67 @@
+"""
+pytest 공용 fixture.
+
+이 프로젝트는 UPLOAD_DIR/LIBRARY_DIR/CACHE_DIR/DB_PATH 등을 각 모듈이 import
+시점에 자기 네임스페이스로 직접 바인딩해두는 구조라(`from config import
+LIBRARY_DIR` 등), 테스트에서 실제 데이터를 건드리지 않으려면 config.py가
+아니라 그 값을 실제로 사용하는 모듈(services.db/services.cache/
+services.library)의 속성을 직접 monkeypatch해야 한다. 함수 본문은 그 값을
+매 호출 시 모듈 전역에서 다시 읽으므로(재로드 불필요) 이 방식으로 충분하다.
+"""
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path, monkeypatch):
+    """UPLOAD_DIR/LIBRARY_DIR/CACHE_DIR/DB_PATH를 임시 디렉터리로 격리한다."""
+    import services.db as db
+    import services.cache as cache
+    import services.library as library
+
+    upload_dir = tmp_path / "uploads"
+    library_dir = tmp_path / "library"
+    cache_dir = tmp_path / "cache"
+    db_path = tmp_path / "test_easypaper.db"
+
+    upload_dir.mkdir()
+    library_dir.mkdir()
+    cache_dir.mkdir()
+
+    monkeypatch.setattr(db, "DB_PATH", str(db_path))
+    monkeypatch.setattr(cache, "CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr(library, "LIBRARY_DIR", str(library_dir))
+    monkeypatch.setattr(library, "UPLOAD_DIR", str(upload_dir))
+
+    db.init_db()
+
+    return {
+        "upload_dir": upload_dir,
+        "library_dir": library_dir,
+        "cache_dir": cache_dir,
+        "db_path": db_path,
+        "db": db,
+        "cache": cache,
+        "library": library,
+    }
+
+
+@pytest.fixture()
+def test_client(isolated_dirs, monkeypatch):
+    """격리된 DB 위에서 FastAPI 앱을 띄우고, 인증은 dependency override로
+    우회한 TestClient를 반환한다 (실제 로그인 플로우 없이 라우터 로직만 검증)."""
+    from fastapi.testclient import TestClient
+    from main import app
+    from services.auth import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: "testuser"
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.pop(get_current_user, None)

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,59 @@
+"""services/auth.py 단위 테스트 (비밀번호 해시, 세션 토큰 발급/검증)."""
+
+import time
+
+from services.auth import (
+    hash_password,
+    verify_password,
+    create_session_token,
+    verify_session_token,
+)
+
+
+def test_hash_password_produces_verifiable_hash():
+    h = hash_password("my-secret-pw")
+    assert ":" in h
+    assert verify_password(h, "my-secret-pw") is True
+
+
+def test_verify_password_rejects_wrong_password():
+    h = hash_password("correct-password")
+    assert verify_password(h, "wrong-password") is False
+
+
+def test_verify_password_rejects_malformed_hash():
+    assert verify_password("not-a-valid-hash", "anything") is False
+
+
+def test_hash_password_uses_random_salt():
+    h1 = hash_password("same-password")
+    h2 = hash_password("same-password")
+    assert h1 != h2, "매번 다른 salt를 써야 같은 비밀번호도 다른 해시가 나온다"
+
+
+def test_session_token_round_trip():
+    token = create_session_token("admin")
+    assert verify_session_token(token) is True
+    assert token.split(":")[0] == "admin"
+
+
+def test_session_token_rejects_tampered_username():
+    token = create_session_token("admin")
+    _, expires, sig = token.split(":")
+    forged = f"attacker:{expires}:{sig}"
+    assert verify_session_token(forged) is False, \
+        "서명은 원래 username에 대해 계산된 것이므로 username을 바꾸면 검증에 실패해야 한다"
+
+
+def test_session_token_rejects_expired_token():
+    payload = "admin:" + str(int(time.time()) - 10)  # 이미 만료된 시각
+    import hmac, hashlib
+    from config import SECRET_KEY
+    sig = hmac.new(SECRET_KEY.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    expired_token = f"{payload}:{sig}"
+    assert verify_session_token(expired_token) is False
+
+
+def test_session_token_rejects_malformed_token():
+    assert verify_session_token("not-enough-parts") is False
+    assert verify_session_token("") is False

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -1,0 +1,120 @@
+"""config.py의 크로스플랫폼/보안 관련 로직 회귀 테스트.
+
+이번 세션에서 실제로 발견·수정된 버그들(Windows CLI 실행, 하드코딩된 개발
+서버 경로, PROJECT_ROOT 검증, SECRET_KEY 공유 기본값)이 다시 재발하지
+않도록 각 수정의 핵심 동작을 고정한다.
+
+windows_safe_exec_args/_resolve_cli_path는 platform/shutil을 함수 내부에서
+지역으로 import하는데, 이는 sys.modules에 캐시된 동일한 모듈 객체를 가져오는
+것이므로, 이 테스트 파일에서 직접 import한 platform/shutil을 monkeypatch해도
+동일하게 적용된다.
+"""
+
+import os
+import platform
+import shutil
+
+import config
+
+
+def test_windows_safe_exec_args_wraps_with_cmd_on_windows(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    result = config.windows_safe_exec_args(["claude", "--print", "hello"])
+    assert result == ["cmd", "/c", "claude", "--print", "hello"]
+
+
+def test_windows_safe_exec_args_passthrough_on_posix(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    result = config.windows_safe_exec_args(["claude", "--print", "hello"])
+    assert result == ["claude", "--print", "hello"]
+
+
+def test_resolve_cli_path_prefers_existing_configured_path(tmp_path):
+    real_binary = tmp_path / "claude"
+    real_binary.write_text("#!/bin/sh\n")
+    resolved = config._resolve_cli_path(str(real_binary), "claude")
+    assert resolved == str(real_binary)
+
+
+def test_resolve_cli_path_falls_back_to_path_search(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/claude")
+    resolved = config._resolve_cli_path("/nonexistent/dev-server/only/claude", "claude")
+    assert resolved == "/usr/local/bin/claude"
+
+
+def test_resolve_cli_path_returns_bare_command_as_last_resort(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    resolved = config._resolve_cli_path("/nonexistent/claude", "claude")
+    assert resolved == "claude"
+
+
+def test_get_agy_env_never_hardcodes_dev_server_home(monkeypatch):
+    """HOME/USER가 비어있으면 이 개발 서버 전용 경로(/home/ubuntu)를 하드코딩해
+    반환하는 대신, 실제 현재 사용자의 홈 디렉터리를 동적으로 구해야 한다 - macOS
+    등 다른 환경에서는 하드코딩된 값이 존재하지 않는 디렉터리라 CLI 서브프로세스가
+    [Errno 45]로 실패하던 버그의 재발 방지 테스트.
+
+    이 테스트 자체는 우연히 이 서버(사용자명 ubuntu)에서 돌아서 결과값이
+    "/home/ubuntu"와 같을 수 있으므로, 고정 문자열과 비교하는 대신 매커니즘
+    (os.path.expanduser("~")를 실제로 호출하는지)을 검증한다.
+    """
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("USER", raising=False)
+    env = config.get_agy_env()
+    assert env["HOME"] == os.path.expanduser("~"), \
+        "하드코딩된 값이 아니라 실제 현재 사용자의 홈 디렉터리를 동적으로 반환해야 한다"
+    assert os.path.isdir(env["HOME"]), "생성된 HOME은 실제로 존재하는 디렉터리여야 한다"
+
+
+def test_project_root_falls_back_when_configured_path_missing():
+    """PROJECT_ROOT가 .env.example을 그대로 복사해 존재하지 않는 경로를 가리켜도,
+    CLI 서브프로세스의 cwd로 그대로 써서 [Errno 2]가 나던 버그의 재발 방지 테스트.
+
+    PROJECT_ROOT는 config.py가 처음 import될 때 딱 한 번만 계산되는 모듈 전역
+    이라, 이미 로드된 프로세스 안에서는 재현할 수 없다 - 별도 파이썬
+    프로세스를 띄워 env var를 존재하지 않는 경로로 지정한 뒤 실제로 폴백
+    되는지 확인한다.
+    """
+    import subprocess
+    import sys
+
+    backend_dir = os.path.dirname(os.path.abspath(config.__file__))
+    expected_project_root = os.path.dirname(backend_dir)
+    env = os.environ.copy()
+    env["PROJECT_ROOT"] = "/definitely/does/not/exist/on/this/machine"
+    result = subprocess.run(
+        [sys.executable, "-c", "import config; print(config.get_project_root())"],
+        cwd=backend_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    resolved = result.stdout.strip()
+    assert os.path.isdir(resolved), f"폴백된 PROJECT_ROOT({resolved!r})가 존재해야 한다 (stderr: {result.stderr})"
+    assert resolved == expected_project_root
+
+
+def test_secret_key_never_equals_known_insecure_default():
+    """SECRET_KEY는 모든 설치본이 공유하는 고정 문자열이면 안 된다 - 세션 토큰
+    위조로 이어지는 취약점의 재발 방지 테스트."""
+    assert config.SECRET_KEY not in config._INSECURE_DEFAULT_SECRET_KEYS
+    assert len(config.SECRET_KEY) >= 32
+
+
+def test_get_or_create_secret_key_persists_across_calls(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        config, "_persist_secret_key_to_env",
+        lambda key: env_path.write_text(f"SECRET_KEY={key}\n")
+    )
+    monkeypatch.setenv("SECRET_KEY", "")
+
+    first = config._get_or_create_secret_key()
+    assert first not in config._INSECURE_DEFAULT_SECRET_KEYS
+
+    # 두 번째 호출도 같은 (영속화된) 값을 재사용해야 한다 - 재시작마다 새로
+    # 만들면 기존 로그인 세션이 계속 끊긴다
+    monkeypatch.setenv("SECRET_KEY", first)
+    second = config._get_or_create_secret_key()
+    assert second == first

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -1,0 +1,80 @@
+"""services/db.py CRUD 및 app_meta 테스트 (격리된 임시 DB 사용)."""
+
+
+def test_document_crud_round_trip(isolated_dirs):
+    db = isolated_dirs["db"]
+    doc = db.db_save_document("doc-1", "admin", "paper.pdf", "/x/paper.pdf", 10, {"title": "T"})
+    assert doc["id"] == "doc-1"
+
+    fetched = db.db_get_document("doc-1")
+    assert fetched["username"] == "admin"
+    assert fetched["metadata"]["title"] == "T"
+
+    assert db.db_get_document("nonexistent") is None
+
+
+def test_list_documents_filters_by_username(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-a1", "alice", "a1.pdf", "/x", 1, {})
+    db.db_save_document("doc-a2", "alice", "a2.pdf", "/x", 1, {})
+    db.db_save_document("doc-b1", "bob", "b1.pdf", "/x", 1, {})
+
+    alice_docs = db.db_list_documents("alice")
+    bob_docs = db.db_list_documents("bob")
+    assert {d["id"] for d in alice_docs} == {"doc-a1", "doc-a2"}
+    assert {d["id"] for d in bob_docs} == {"doc-b1"}
+
+
+def test_soft_delete_and_restore(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p.pdf", "/x", 1, {})
+
+    assert db.db_soft_delete_document("doc-1") is True
+    assert db.db_list_documents("admin") == []
+    assert len(db.db_list_documents("admin", only_trash=True)) == 1
+
+    assert db.db_restore_document("doc-1") is True
+    assert len(db.db_list_documents("admin")) == 1
+    assert db.db_list_documents("admin", only_trash=True) == []
+
+
+def test_soft_delete_nonexistent_document_returns_false(isolated_dirs):
+    db = isolated_dirs["db"]
+    assert db.db_soft_delete_document("no-such-doc") is False
+
+
+def test_update_user_credentials_propagates_username_to_documents(isolated_dirs):
+    """지난 세션에서 수정한 버그(아이디 변경 시 문서가 사라지던 문제)의 회귀 테스트."""
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {})
+    db.db_save_document("doc-2", "admin", "p2.pdf", "/x", 1, {})
+    assert len(db.db_list_documents("admin")) == 2
+
+    ok = db.update_user_credentials("admin", "newname", "newhash:abcd")
+    assert ok is True
+
+    assert len(db.db_list_documents("newname")) == 2, \
+        "아이디를 바꾸면 documents.username도 함께 갱신되어야 한다"
+    assert db.db_list_documents("admin") == [], \
+        "예전 아이디로는 더 이상 문서가 조회되지 않아야 한다"
+
+
+def test_update_user_credentials_same_username_is_noop_for_documents(isolated_dirs):
+    """비밀번호만 바꾸고 아이디는 그대로인 경우, 불필요한 UPDATE가 안전하게 스킵된다."""
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {})
+    ok = db.update_user_credentials("admin", "admin", "newhash:xyz")
+    assert ok is True
+    assert len(db.db_list_documents("admin")) == 1
+
+
+def test_app_meta_get_set_round_trip(isolated_dirs):
+    db = isolated_dirs["db"]
+    assert db.db_get_meta("some_key") is None
+
+    db.db_set_meta("some_key", "value1")
+    assert db.db_get_meta("some_key") == "value1"
+
+    # 같은 키를 다시 쓰면 덮어써야 한다 (INSERT가 아니라 upsert)
+    db.db_set_meta("some_key", "value2")
+    assert db.db_get_meta("some_key") == "value2"

--- a/backend/tests/test_library_ownership_api.py
+++ b/backend/tests/test_library_ownership_api.py
@@ -1,0 +1,72 @@
+"""라이브러리 엔드포인트의 문서 소유자 확인(IDOR 수정) 회귀 테스트.
+
+get_current_user를 "testuser"로 고정하는 test_client fixture 위에서, 다른
+사용자("otheruser") 소유의 문서에 접근을 시도해 전부 404로 막히는지 확인한다.
+"""
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "Other's Paper"})
+
+
+def test_get_document_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-other-1", "otheruser")
+    res = test_client.get("/api/library/doc-other-1")
+    assert res.status_code == 404
+
+
+def test_get_own_document_succeeds(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-mine-1", "testuser")
+    res = test_client.get("/api/library/doc-mine-1")
+    assert res.status_code == 200
+    assert res.json()["id"] == "doc-mine-1"
+
+
+def test_delete_document_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-other-2", "otheruser")
+    res = test_client.delete("/api/library/doc-other-2")
+    assert res.status_code == 404
+
+    # 실제로 지워지지 않았어야 한다
+    db = isolated_dirs["db"]
+    assert db.db_get_document("doc-other-2") is not None
+
+
+def test_permanently_delete_document_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-other-3", "otheruser")
+    res = test_client.delete("/api/library/doc-other-3/permanent")
+    assert res.status_code == 404
+
+    db = isolated_dirs["db"]
+    assert db.db_get_document("doc-other-3") is not None, "다른 사용자 문서는 영구삭제도 막혀야 한다"
+
+
+def test_restore_document_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-other-4", "otheruser")
+    isolated_dirs["db"].db_soft_delete_document("doc-other-4")
+    res = test_client.post("/api/library/doc-other-4/restore")
+    assert res.status_code == 404
+
+
+def test_update_metadata_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-other-5", "otheruser")
+    res = test_client.put("/api/library/doc-other-5/metadata", json={"title": "Hijacked"})
+    assert res.status_code == 404
+
+
+def test_update_metadata_owned_by_self_succeeds(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-mine-2", "testuser")
+    res = test_client.put("/api/library/doc-mine-2/metadata", json={"title": "My New Title"})
+    assert res.status_code == 200
+    assert res.json()["metadata"]["title"] == "My New Title"
+
+
+def test_library_list_only_returns_own_documents(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-mine-3", "testuser")
+    _create_doc_owned_by(isolated_dirs, "doc-other-6", "otheruser")
+
+    res = test_client.get("/api/library")
+    assert res.status_code == 200
+    ids = {d["id"] for d in res.json()["documents"]}
+    assert ids == {"doc-mine-3"}

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -1,0 +1,48 @@
+"""services/library.py 테스트 - 특히 문서 영구삭제 시 관련 파일이 전부
+정리되는지(지난 세션 버그 수정)를 확인한다."""
+
+import os
+
+
+def test_permanently_delete_document_cleans_up_all_locations(isolated_dirs):
+    db = isolated_dirs["db"]
+    cache = isolated_dirs["cache"]
+    library = isolated_dirs["library"]
+    doc_id = "doc-cleanup-test"
+
+    upload_dir = os.path.join(str(isolated_dirs["upload_dir"]), doc_id)
+    os.makedirs(upload_dir, exist_ok=True)
+    with open(os.path.join(upload_dir, "document.pdf"), "w") as f:
+        f.write("original upload")
+
+    lib_dir = os.path.join(str(isolated_dirs["library_dir"]), doc_id)
+    os.makedirs(lib_dir, exist_ok=True)
+    with open(os.path.join(lib_dir, "document.pdf"), "w") as f:
+        f.write("library copy")
+
+    with open(os.path.join(str(isolated_dirs["cache_dir"]), f"{doc_id}_page_1.json"), "w") as f:
+        f.write("{}")
+    with open(os.path.join(str(isolated_dirs["cache_dir"]), f"{doc_id}_page_2.json"), "w") as f:
+        f.write("{}")
+
+    db.db_save_document(doc_id, "admin", "test.pdf", "/x", 1, {})
+
+    # 삭제 전 사전 조건 확인
+    assert os.path.exists(upload_dir)
+    assert os.path.exists(lib_dir)
+    assert len([f for f in os.listdir(str(isolated_dirs["cache_dir"])) if f.startswith(doc_id)]) == 2
+    assert db.db_get_document(doc_id) is not None
+
+    result = library.permanently_delete_document(doc_id)
+
+    assert result is True
+    assert not os.path.exists(upload_dir), "업로드 원본 디렉터리가 삭제되어야 한다"
+    assert not os.path.exists(lib_dir), "라이브러리 보관 디렉터리가 삭제되어야 한다"
+    assert len([f for f in os.listdir(str(isolated_dirs["cache_dir"])) if f.startswith(doc_id)]) == 0, \
+        "페이지별 번역 캐시 파일이 모두 삭제되어야 한다"
+    assert db.db_get_document(doc_id) is None, "DB 레코드도 삭제되어야 한다"
+
+
+def test_permanently_delete_nonexistent_document_returns_false(isolated_dirs):
+    library = isolated_dirs["library"]
+    assert library.permanently_delete_document("no-such-doc") is False

--- a/backend/tests/test_update_checker.py
+++ b/backend/tests/test_update_checker.py
@@ -1,0 +1,178 @@
+"""services/update_checker.py 테스트.
+
+실제 git 저장소(읽기 전용 명령만 사용: rev-parse/log/fetch)를 대상으로 동작을
+확인한다 - fetch는 원격에서 받아오기만 하고 로컬 브랜치를 바꾸지 않으므로
+테스트 실행 중에도 안전하다.
+"""
+
+import pytest
+
+from services.update_checker import (
+    get_current_version,
+    get_current_version_date,
+    check_for_update,
+    get_update_check_config,
+    set_update_check_interval,
+    get_post_update_notice,
+    _get_changelog,
+    VALID_INTERVALS,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_current_version_returns_short_sha():
+    version = await get_current_version()
+    assert version != "unknown"
+    assert len(version) >= 7  # git 짧은 해시는 보통 7자 이상
+
+
+@pytest.mark.asyncio
+async def test_get_current_version_is_cached(monkeypatch):
+    first = await get_current_version()
+    # 캐시되어 있으므로, git 명령이 실패하도록 망가뜨려도 캐시된 값을 그대로 반환해야 한다
+    import services.update_checker as uc
+    monkeypatch.setattr(uc, "_run_git", None)  # 호출되면 TypeError로 즉시 드러남
+    second = await get_current_version()
+    assert second == first
+
+
+@pytest.mark.asyncio
+async def test_get_current_version_date_returns_iso_date():
+    date = await get_current_version_date()
+    assert date is not None
+    assert len(date) == 10 and date[4] == "-" and date[7] == "-"  # YYYY-MM-DD
+
+
+@pytest.mark.asyncio
+async def test_check_for_update_reports_no_update_when_up_to_date(monkeypatch):
+    import services.update_checker as uc
+
+    async def fake_run_git(*args, timeout=30.0):
+        if args[0] == "fetch":
+            return 0, "", ""
+        if args == ("rev-parse", "--short", "origin/main"):
+            return 0, await get_current_version(), ""
+        if args[0] == "log" and args[1] == "-1":
+            return 0, "2026-01-01", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(uc, "_run_git", fake_run_git)
+    monkeypatch.setattr(uc, "db_set_meta", lambda k, v: None)
+
+    result = await check_for_update()
+    assert result["ok"] is True
+    assert result["update_available"] is False
+    assert result["changelog"] == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_update_reports_available_with_changelog(monkeypatch):
+    import services.update_checker as uc
+    current = await get_current_version()
+
+    async def fake_run_git(*args, timeout=30.0):
+        if args[0] == "fetch":
+            return 0, "", ""
+        if args == ("rev-parse", "--short", "origin/main"):
+            return 0, "def5678", ""
+        if args[0] == "log" and args[1] == "-1":
+            return 0, "2026-07-21", ""
+        if args[0] == "log" and "--no-merges" in args:
+            return 0, "aaa1111|feat: something new\nbbb2222|fix: a bug", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(uc, "_run_git", fake_run_git)
+    monkeypatch.setattr(uc, "db_set_meta", lambda k, v: None)
+
+    result = await check_for_update()
+    assert result["ok"] is True
+    assert result["update_available"] is True
+    assert result["latest_version"] == "def5678"
+    assert result["current_version"] == current
+    # _get_changelog는 오래된 순으로 반환해야 한다 (log는 최신이 먼저 나오므로 뒤집힘)
+    assert result["changelog"][0]["subject"] == "fix: a bug"
+    assert result["changelog"][1]["subject"] == "feat: something new"
+
+
+@pytest.mark.asyncio
+async def test_check_for_update_handles_fetch_failure_gracefully(monkeypatch):
+    import services.update_checker as uc
+
+    async def failing_fetch(*args, timeout=30.0):
+        return 1, "", "네트워크 연결 실패"
+
+    monkeypatch.setattr(uc, "_run_git", failing_fetch)
+
+    result = await check_for_update()
+    assert result["ok"] is False
+    assert result["update_available"] is False
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_get_changelog_excludes_merge_commits(monkeypatch):
+    import services.update_checker as uc
+
+    async def fake_run_git(*args, timeout=30.0):
+        assert "--no-merges" in args
+        return 0, "aaa|feat: real change", ""
+
+    monkeypatch.setattr(uc, "_run_git", fake_run_git)
+    entries = await _get_changelog("abc1234", "HEAD")
+    assert entries == [{"sha": "aaa", "subject": "feat: real change"}]
+
+
+def test_update_check_config_default_and_validation(isolated_dirs):
+    cfg = get_update_check_config()
+    assert cfg["interval"] == "weekly"
+    assert cfg["last_checked_at"] is None
+
+    updated = set_update_check_interval("daily")
+    assert updated["interval"] == "daily"
+    assert get_update_check_config()["interval"] == "daily"
+
+    with pytest.raises(ValueError):
+        set_update_check_interval("hourly")
+
+    assert set(VALID_INTERVALS) == {"daily", "weekly", "never"}
+
+
+@pytest.mark.asyncio
+async def test_post_update_notice_bootstraps_silently_on_first_run(isolated_dirs):
+    """안내 기록이 아예 없는 최초 실행에서는, "방금 설치한 것"을 업데이트로
+    오인해 팝업을 띄우면 안 된다 - 기준값만 저장하고 조용히 넘어가야 한다."""
+    notice = await get_post_update_notice()
+    assert notice["show"] is False
+
+    # 같은 버전으로 다시 확인해도 여전히 안 떠야 한다
+    notice2 = await get_post_update_notice()
+    assert notice2["show"] is False
+
+
+@pytest.mark.asyncio
+async def test_post_update_notice_shows_once_after_version_change(isolated_dirs, monkeypatch):
+    import services.update_checker as uc
+
+    # 최초 부팅으로 기준값(old-version) 저장
+    monkeypatch.setattr(uc, "get_current_version", lambda: _async_return("old-version"))
+    monkeypatch.setattr(uc, "get_current_version_date", lambda: _async_return("2026-01-01"))
+    first = await get_post_update_notice()
+    assert first["show"] is False
+
+    # 버전이 바뀐 뒤(=업데이트 적용되어 재시작됨) 첫 확인 -> 딱 1번 show=True
+    monkeypatch.setattr(uc, "get_current_version", lambda: _async_return("new-version"))
+    monkeypatch.setattr(uc, "get_current_version_date", lambda: _async_return("2026-07-21"))
+    monkeypatch.setattr(uc, "_get_changelog", lambda a, b: _async_return([{"sha": "x", "subject": "fix: something"}]))
+
+    second = await get_post_update_notice()
+    assert second["show"] is True
+    assert second["version"] == "new-version"
+    assert len(second["changelog"]) == 1
+
+    # 같은 버전으로 다시 확인하면 더 이상 뜨면 안 된다 (1회 한정)
+    third = await get_post_update_notice()
+    assert third["show"] is False
+
+
+async def _async_return(value):
+    return value


### PR DESCRIPTION
# Summary
## 1. 백엔드 pytest 테스트 스위트 신규 추가
- 이 프로젝트에는 자동화된 테스트가 전혀 없어서, 최근 세션에서 고친 버그 20여 개도 전부 즉석 스크립트로 수동 검증하고 끝났음 - 회귀 방지를 위한 최소한의 안전망으로 pytest 스위트를 새로 구축
- `tests/conftest.py`: `UPLOAD_DIR`/`LIBRARY_DIR`/`CACHE_DIR`/`DB_PATH`를 각 모듈(`services.db`/`cache`/`library`)의 속성을 직접 monkeypatch해 임시 디렉터리로 격리하는 `isolated_dirs` fixture, `get_current_user`를 오버라이드해 실제 로그인 없이 라우터를 검증하는 `test_client` fixture 추가
- `test_auth_service.py`: 비밀번호 해시/검증, 세션 토큰 발급·검증(변조·만료 거부) 단위 테스트
- `test_config_cross_platform.py`: 최근 세션에 실제로 수정한 버그들(Windows CLI 실행, 하드코딩된 개발서버 경로, `PROJECT_ROOT` 검증, `SECRET_KEY` 공유 기본값)의 회귀 방지 테스트
- `test_db_service.py`: 문서 CRUD, 소프트 삭제/복원, 아이디 변경 시 `documents.username` 전파(지난 버그 수정), `app_meta` 키-값 저장
- `test_library_service.py`: 문서 영구삭제 시 업로드 원본/라이브러리 사본/캐시 파일이 전부 정리되는지(지난 버그 수정)
- `test_library_ownership_api.py`: FastAPI `TestClient`로 실제 HTTP 요청을 보내, 다른 사용자 소유 문서에 대한 조회/수정/삭제/복원이 전부 404로 막히는지 확인 (IDOR 취약점 수정의 회귀 테스트)
- `test_update_checker.py`: 버전/날짜 조회, 변경 로그 생성(머지 커밋 제외), 업데이트 확인 주기 설정, 업데이트 완료 안내가 1회만 뜨는지 검증
- `backend/requirements-dev.txt`, `backend/pytest.ini` 추가, README에 테스트 실행 방법 안내 추가

## 검증
- 44개 테스트 전부 격리된 임시 디렉터리/DB에서 실행되어 실제 프로젝트 데이터를 전혀 건드리지 않으며, 전체 스위트가 2초 내외로 통과하는 것을 확인
- 개별 파일 실행과 전체 스위트 실행 모두에서 통과해 테스트 간 상태 간섭이 없는지 확인
