### PR TITLE
test: 프론트엔드 Playwright E2E 테스트 스위트 신규 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,8 @@ pyrightconfig.json
 *.xhtml
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,python,node,web
+
+# Playwright
+frontend/playwright-report/
+frontend/test-results/
+frontend/blob-report/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ cd backend
 .venv/bin/python -m pytest tests/ -v
 ```
 
+프론트엔드 E2E 테스트는 Playwright로 작성되어 있으며, 실제 백엔드 없이 `/api/**` 응답을 목(mock)으로 대체해 빌드된 `dist/`를 대상으로 실행됩니다.
+
+```bash
+cd frontend
+npm install                # 최초 1회
+npm run build               # dist/ 생성
+npx playwright install chromium   # 최초 1회, 브라우저 바이너리 설치
+npm run test:e2e
+```
+
 ---
 
 ## 상시 구동 — systemd 서비스 등록 (선택 사항)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "marked": "^18.0.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "vite": "^5.3.1"
       }
     },
@@ -403,6 +404,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -892,6 +909,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "vite": "^5.3.1"
   },
   "allowScripts": {

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// EasyPaper E2E 테스트 설정
+// 실제 백엔드에 의존하지 않고, 각 테스트가 page.route()로 /api/** 응답을
+// 모킹해 프론트엔드 로직만 독립적으로 검증한다 (dist 빌드를 정적 서빙).
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:8934',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'python3 -m http.server 8934 --directory dist',
+    url: 'http://localhost:8934',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+})

--- a/frontend/tests/e2e/auth-and-library.spec.js
+++ b/frontend/tests/e2e/auth-and-library.spec.js
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('로그인 상태에서 라이브러리 화면이 정상적으로 뜬다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await gotoApp(page)
+
+  await expect(page.locator('#library-screen')).toHaveClass(/active/)
+  await expect(page.getByText('보관함에 저장된 논문이 없습니다')).toBeVisible()
+})
+
+test('라이브러리에 저장된 문서 카드가 표시된다', async ({ page }) => {
+  const doc = { id: 'doc-1', filename: 'Paper.pdf', total_pages: 5, metadata: { title: 'A Great Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [doc] })
+  await gotoApp(page)
+
+  await expect(page.getByText('A Great Paper')).toBeVisible()
+})

--- a/frontend/tests/e2e/chat-quote.spec.js
+++ b/frontend/tests/e2e/chat-quote.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+// AI 채팅 답변에서 텍스트를 선택하면 "Ask AI"로 후속 질문을 인용할 수 있어야 한다
+// (PDF/번역본 인용 기능을 채팅 답변에도 확장한 기능의 회귀 테스트)
+test('AI 채팅 답변 텍스트를 선택하면 Ask AI로 인용할 수 있다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docA] })
+
+  await page.route('**/api/library/doc-A/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+  await page.route('**/api/chat/stream', route =>
+    route.fulfill({ status: 200, contentType: 'text/plain', body: '트랜스포머 아키텍처는 셀프 어텐션 메커니즘을 핵심으로 사용하는 딥러닝 모델입니다.' }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1200)
+
+  await page.click('#chat-toggle-btn')
+  await page.fill('#chat-input', '트랜스포머 아키텍처가 뭐야?')
+  await page.click('#chat-send-btn')
+  await page.waitForTimeout(800)
+
+  const bubbleSelector = '.chat-message.assistant:not(.temp-typing) .message-bubble'
+  await page.waitForSelector(bubbleSelector)
+
+  const selection = await page.evaluate((sel) => {
+    const bubbles = document.querySelectorAll(sel)
+    const bubble = bubbles[bubbles.length - 1]
+    const text = bubble.textContent
+    const target = '셀프 어텐션'
+    const start = text.indexOf(target)
+    if (start === -1) return null
+
+    const walker = document.createTreeWalker(bubble, NodeFilter.SHOW_TEXT)
+    let node, offset = 0, startNode = null, startOffset = 0, endNode = null, endOffset = 0
+    while ((node = walker.nextNode())) {
+      const len = node.textContent.length
+      if (startNode === null && start >= offset && start < offset + len) {
+        startNode = node; startOffset = start - offset
+      }
+      const end = start + target.length
+      if (end >= offset && end <= offset + len) {
+        endNode = node; endOffset = end - offset
+      }
+      offset += len
+    }
+    if (!startNode || !endNode) return null
+
+    const sel_ = window.getSelection()
+    sel_.removeAllRanges()
+    const r = document.createRange()
+    r.setStart(startNode, startOffset)
+    r.setEnd(endNode, endOffset)
+    sel_.addRange(r)
+    const rect = r.getBoundingClientRect()
+    return { text: sel_.toString(), rect: { x: rect.left, y: rect.top } }
+  }, bubbleSelector)
+
+  expect(selection).not.toBeNull()
+  expect(selection.text).toBe('셀프 어텐션')
+
+  await page.mouse.move(selection.rect.x + 5, selection.rect.y + 5)
+  await page.mouse.up()
+
+  await expect(page.locator('.selection-menu .ask-ai-btn')).toBeVisible()
+
+  await page.click('.selection-menu .ask-ai-btn')
+
+  await expect(page.locator('#chat-quote-area')).not.toHaveClass(/hidden/)
+  await expect(page.locator('#chat-quote-text')).toHaveText('셀프 어텐션')
+})
+
+// 사용자 자신이 보낸 메시지는 인용 대상에서 제외되어야 한다
+test('사용자 자신의 채팅 메시지는 Ask AI 인용 대상이 아니다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docA] })
+  await page.route('**/api/library/doc-A/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+  await page.route('**/api/chat/stream', route =>
+    route.fulfill({ status: 200, contentType: 'text/plain', body: '답변입니다.' }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1200)
+  await page.click('#chat-toggle-btn')
+  await page.fill('#chat-input', '이것은 사용자 질문 텍스트')
+  await page.click('#chat-send-btn')
+  await page.waitForTimeout(500)
+
+  const userBubbleFound = await page.evaluate(() => {
+    const bubble = document.querySelector('.chat-message.user .message-bubble')
+    if (!bubble) return false
+    const range = document.createRange()
+    range.selectNodeContents(bubble)
+    window.getSelection().removeAllRanges()
+    window.getSelection().addRange(range)
+    return true
+  })
+  expect(userBubbleFound).toBe(true)
+
+  await page.mouse.move(200, 200)
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+
+  // 사용자 메시지 선택으로는 Ask AI 메뉴가 뜨지 않아야 한다
+  const menuHidden = await page.evaluate(() => {
+    const menu = document.querySelector('.selection-menu')
+    return !menu || menu.classList.contains('hidden')
+  })
+  expect(menuHidden).toBe(true)
+})

--- a/frontend/tests/e2e/chat-stream-race.spec.js
+++ b/frontend/tests/e2e/chat-stream-race.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A, SAMPLE_PDF_B } from './helpers.js'
+
+// 문서 A에서 스트리밍 중이던 채팅 응답이, 문서 B로 전환한 뒤 뒤늦게 도착해도
+// 문서 B의 채팅창에 섞여 들어가면 안 된다 (openFromLibrary가 이전 스트림을
+// 취소하지 않던 경쟁 조건의 회귀 테스트)
+test('문서 전환 시 이전 문서의 채팅 스트림이 새 문서에 섞이지 않는다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  const docB = { id: 'doc-B', filename: 'DocB.pdf', total_pages: 1, metadata: { title: 'Document B' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docA, docB] })
+
+  await page.route('**/api/library/doc-A/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+  await page.route('**/api/library/doc-B/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_B }))
+
+  let streamARoute = null
+  await page.route('**/api/chat/stream', async route => {
+    streamARoute = route // 응답을 보류해 "아직 진행 중인 스트림" 상태를 만든다
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1000)
+
+  await page.click('#chat-toggle-btn')
+  await page.fill('#chat-input', '문서 A에 대한 질문')
+  await page.click('#chat-send-btn')
+  await page.waitForTimeout(400)
+
+  // 스트림이 아직 pending인 상태에서 문서 B로 전환 (뒤로가기 라우팅과 동일 경로)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-B' })
+  await page.waitForTimeout(1000)
+
+  await expect(page.locator('#doc-title')).toHaveText('Document B')
+
+  // 이제서야 문서 A의 스트림 응답이 뒤늦게 도착했다고 가정
+  if (streamARoute) {
+    await streamARoute.fulfill({ status: 200, contentType: 'text/plain', body: '이것은 문서 A에 대한 뒤늦은 응답입니다.' }).catch(() => {})
+  }
+  await page.waitForTimeout(500)
+
+  const chatText = await page.locator('#chat-messages').textContent()
+  expect(chatText).not.toContain('문서 A에 대한 뒤늦은 응답')
+})

--- a/frontend/tests/e2e/fixtures/sample-a.pdf
+++ b/frontend/tests/e2e/fixtures/sample-a.pdf
@@ -1,0 +1,52 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 200 200]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 90>>
+stream
+
+q
+BT
+1 0 0 1 20 100 Tm
+/helv 11 Tf [<53616d706c65205044462041202d20706167652031>]TJ
+ET
+Q
+
+endstream
+endobj
+
+xref
+0 7
+0000000000 00001 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<52C394C28EC385C3B4462D221E484CC3><67954C49760DEDF19E115E8807FDCF12>]>>
+startxref
+490
+%%EOF

--- a/frontend/tests/e2e/fixtures/sample-b.pdf
+++ b/frontend/tests/e2e/fixtures/sample-b.pdf
@@ -1,0 +1,52 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 200 200]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 90>>
+stream
+
+q
+BT
+1 0 0 1 20 100 Tm
+/helv 11 Tf [<53616d706c65205044462042202d20706167652031>]TJ
+ET
+Q
+
+endstream
+endobj
+
+xref
+0 7
+0000000000 00001 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<C29F34C38A582B6150C3B8C3AFC398C2><FF77B28D04CE2AD66870613FBC233EDE>]>>
+startxref
+490
+%%EOF

--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -1,0 +1,75 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export const SAMPLE_PDF_A = fs.readFileSync(path.join(__dirname, 'fixtures/sample-a.pdf'))
+export const SAMPLE_PDF_B = fs.readFileSync(path.join(__dirname, 'fixtures/sample-b.pdf'))
+
+/**
+ * 로그인 이후의 기본 화면(라이브러리)까지 도달하는 데 필요한 최소한의
+ * /api/** 목(mock) 응답을 등록한다. 개별 테스트는 이 기반 위에
+ * page.route()를 추가로 덮어써서 시나리오별 응답을 얹는다.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {object} [overrides] - { documents, onRoute } 등 확장 옵션
+ */
+export async function mockBaseRoutes(page, { documents = [] } = {}) {
+  await page.route('**/api/**', async route => {
+    const url = route.request().url()
+
+    if (url.includes('/api/auth/check')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'authenticated', username: 'admin' }) })
+    }
+    if (url.includes('/api/settings/system')) {
+      return route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          ollama_host: 'http://localhost:11434', available_models: [],
+          trans_provider: 'ollama', trans_model: '', chat_provider: 'ollama', chat_model: '',
+          openai_api_key: '', gemini_api_key: '', claude_api_key: '', translation_prompt_template: '',
+        }),
+      })
+    }
+    if (url.includes('/api/availability')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ antigravity: false, claude_code: false, codex: false }) })
+    }
+    if (url.includes('/api/settings/update-check-config')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ interval: 'never', last_checked_at: null }) })
+    }
+    if (url.includes('/api/settings/post-update-notice')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ show: false, version: 'test0000', version_date: '2026-01-01', changelog: [] }) })
+    }
+    if (url.includes('/api/library/trash')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents: [], total: 0 }) })
+    }
+    if (url.includes('/api/library') && !url.includes('/pdf') && !url.includes('/images') && !url.includes('/history')) {
+      const idMatch = url.match(/\/api\/library\/([^/?]+)$/)
+      if (idMatch) {
+        const doc = documents.find(d => d.id === idMatch[1])
+        if (doc) return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(doc) })
+        return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: '문서를 찾을 수 없습니다.' }) })
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents, total: documents.length }) })
+    }
+    if (url.match(/\/api\/library\/[^/]+\/images/)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ images: [] }) })
+    }
+    if (url.match(/\/api\/chat\/[^/]+\/history/)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ history: [] }) })
+    }
+    if (url.includes('/outline')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ outline: [] }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+  })
+}
+
+/** 로그인 상태로 앱을 열고(온보딩은 건너뜀) 라이브러리 화면이 뜰 때까지 기다린다. */
+export async function gotoApp(page) {
+  await page.goto('/index.html')
+  await page.evaluate(() => localStorage.setItem('easypaper_onboarding_seen', '1'))
+  await page.reload()
+  await page.waitForTimeout(600)
+}

--- a/frontend/tests/e2e/pdf-viewer-race.spec.js
+++ b/frontend/tests/e2e/pdf-viewer-race.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A, SAMPLE_PDF_B } from './helpers.js'
+
+// pdf-page-wrapper DOM은 문서 전환 시 재사용되는데, 이전 문서의 비동기
+// _renderPage()가 뒤늦게 끝나며 새 문서용으로 이미 정리된 wrapper에 옛
+// canvas를 덮어쓰던 경쟁 조건의 회귀 테스트 (renderGeneration 카운터로 방지)
+test('문서를 빠르게 연속 전환해도 최종적으로 올바른 문서 상태로 수렴한다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  const docB = { id: 'doc-B', filename: 'DocB.pdf', total_pages: 1, metadata: { title: 'Document B' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docA, docB] })
+  await page.route('**/api/library/doc-A/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+  await page.route('**/api/library/doc-B/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_B }))
+
+  const consoleErrors = []
+  page.on('console', msg => {
+    if (msg.type() === 'error' && !msg.text().includes('katex') && !msg.text().includes('jsdelivr')) {
+      consoleErrors.push(msg.text())
+    }
+  })
+
+  await gotoApp(page)
+
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1500)
+
+  const initialCanvas = await page.evaluate(() => {
+    const wrapper = document.querySelector('.pdf-page-wrapper[data-page="1"]')
+    const canvas = wrapper?.querySelector('canvas')
+    return canvas ? { width: canvas.width, height: canvas.height } : null
+  })
+  expect(initialCanvas).not.toBeNull()
+  expect(initialCanvas.width).toBeGreaterThan(0)
+
+  // 문서를 빠르게 연속 전환 (경쟁 조건 유발 시도)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-B' })
+  await page.waitForTimeout(50)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(50)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-B' })
+  await page.waitForTimeout(1500)
+
+  await expect(page.locator('#doc-title')).toHaveText('Document B')
+
+  const finalState = await page.evaluate(() => {
+    const wrappers = document.querySelectorAll('.pdf-page-wrapper')
+    const canvas = wrappers[0]?.querySelector('canvas')
+    return { wrapperCount: wrappers.length, hasCanvas: !!canvas }
+  })
+  expect(finalState.wrapperCount).toBe(1)
+  expect(finalState.hasCanvas).toBe(true)
+
+  expect(consoleErrors, `예상치 못한 콘솔 에러: ${consoleErrors.join(', ')}`).toHaveLength(0)
+})

--- a/frontend/tests/e2e/update-notifications.spec.js
+++ b/frontend/tests/e2e/update-notifications.spec.js
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+async function mockUpdateEndpoints(page, { postUpdateShow, updateAvailable }) {
+  await page.route('**/api/settings/update-check-config', async route => {
+    if (route.request().method() === 'POST') {
+      const body = route.request().postDataJSON()
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ interval: body.interval, last_checked_at: null }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ interval: 'weekly', last_checked_at: null }) })
+  })
+  await page.route('**/api/settings/update-check', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({
+      ok: true, current_version: 'abc1234', current_version_date: '2026-07-15',
+      latest_version: 'def5678', latest_version_date: '2026-07-21', update_available: updateAvailable,
+      changelog: updateAvailable ? [
+        { sha: 'def5678', subject: 'feat: 새 기능 추가' },
+        { sha: 'aaa1111', subject: 'fix: 버그 수정' },
+      ] : [],
+    }),
+  }))
+  await page.route('**/api/settings/post-update-notice', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({
+      show: postUpdateShow, version: 'abc1234', version_date: '2026-07-15',
+      changelog: postUpdateShow ? [{ sha: 'aaa', subject: 'fix: 세션 토큰 서명 키 취약점 수정' }] : [],
+    }),
+  }))
+}
+
+test('방금 업데이트된 직후에는 완료 안내만 뜨고, 새 업데이트 확인 팝업과 겹치지 않는다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: true, updateAvailable: true })
+  await gotoApp(page)
+  await page.waitForTimeout(1000)
+
+  await expect(page.locator('#update-complete-modal')).not.toHaveClass(/hidden/)
+  await expect(page.locator('#update-available-modal')).toHaveClass(/hidden/)
+  await expect(page.locator('#update-complete-version-line')).toHaveText('버전 2026-07-15 · abc1234로 업데이트되었습니다.')
+
+  await page.click('#update-complete-confirm-btn')
+  await expect(page.locator('#update-complete-modal')).toHaveClass(/hidden/)
+})
+
+test('방금 업데이트되지 않았고 새 업데이트가 있으면 변경 로그 팝업이 뜬다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: true })
+  await gotoApp(page)
+  await page.waitForTimeout(1000)
+
+  await expect(page.locator('#update-complete-modal')).toHaveClass(/hidden/)
+  await expect(page.locator('#update-available-modal')).not.toHaveClass(/hidden/)
+  await expect(page.locator('#update-available-version-line')).toHaveText('2026-07-15 · abc1234 → 2026-07-21 · def5678')
+  await expect(page.locator('#update-available-changelog')).toContainText('feat: 새 기능 추가')
+  await expect(page.locator('#update-available-changelog')).toContainText('fix: 버그 수정')
+
+  await page.click('#update-available-later-btn')
+  await expect(page.locator('#update-available-modal')).toHaveClass(/hidden/)
+})
+
+test('업데이트도 없고 방금 업데이트되지도 않았으면 아무 팝업도 뜨지 않는다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
+  await gotoApp(page)
+  await page.waitForTimeout(1000)
+
+  await expect(page.locator('#update-complete-modal')).toHaveClass(/hidden/)
+  await expect(page.locator('#update-available-modal')).toHaveClass(/hidden/)
+})
+
+test('설정 화면에서 업데이트 확인 주기를 변경하면 저장된다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
+
+  let savedInterval = null
+  await page.route('**/api/settings/update-check-config', async route => {
+    if (route.request().method() === 'POST') {
+      savedInterval = route.request().postDataJSON().interval
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ interval: savedInterval, last_checked_at: null }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ interval: 'weekly', last_checked_at: null }) })
+  })
+
+  await gotoApp(page)
+  await page.waitForTimeout(600)
+  await page.click('#global-settings-btn')
+  await page.waitForTimeout(400)
+
+  await expect(page.locator('#setting-update-check-interval')).toHaveValue('weekly')
+  await page.selectOption('#setting-update-check-interval', 'never')
+  await page.waitForTimeout(300)
+
+  expect(savedInterval).toBe('never')
+})


### PR DESCRIPTION
# Summary
## 1. 프론트엔드 Playwright E2E 테스트 스위트 신규 추가
- `@playwright/test`를 devDependency로 추가하고, 실제 백엔드 없이 `/api/**` 응답을 목(mock)으로 대체해 빌드된 `dist/`를 정적 서빙하는 방식으로 테스트 실행 (`frontend/playwright.config.js`)
- `tests/e2e/helpers.js`: 로그인/라이브러리 화면까지 도달하는 데 필요한 공용 mock 라우트(`mockBaseRoutes`)와 앱 진입 헬퍼(`gotoApp`), 테스트용 샘플 PDF 픽스처 로더 제공
- `auth-and-library.spec.js`: 로그인 후 라이브러리 화면 및 문서 카드 표시
- `chat-quote.spec.js`: AI 채팅 답변 텍스트 선택 시 Ask AI로 인용 가능(사용자 자신의 메시지는 인용 대상 제외) - 최근 추가한 기능의 회귀 테스트
- `chat-stream-race.spec.js`: 문서 전환 시 이전 문서의 채팅 스트림이 새 문서에 섞이지 않는지 - 최근 수정한 경쟁 조건의 회귀 테스트
- `pdf-viewer-race.spec.js`: 문서를 빠르게 연속 전환해도 PDF 렌더링이 최종적으로 올바른 문서로 수렴하는지 - 최근 수정한 경쟁 조건의 회귀 테스트
- `update-notifications.spec.js`: 업데이트 완료 안내/새 업데이트 안내 팝업이 동시에 겹치지 않는지, 설정 화면의 확인 주기 저장까지 4가지 시나리오 검증
- README에 프론트엔드 E2E 테스트 실행 방법 안내 추가, `.gitignore`에 `playwright-report`/`test-results` 추가

## 검증
- 10개 테스트 전부 통과 확인 (약 21초)
- 의도적으로 실패하는 더미 테스트를 임시로 추가해 실패 감지가 실제로 정확히 동작하는지(종료 코드, 에러 메시지) 확인한 뒤 제거
