### PR TITLE
feat: 구조화된 로깅 도입 (콘솔+로테이팅 파일 핸들러, llm_client.py 우선 전환)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,3 +373,6 @@ pyrightconfig.json
 frontend/playwright-report/
 frontend/test-results/
 frontend/blob-report/
+
+# EasyPaper 로그 파일
+backend/logs/

--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,54 @@
+"""
+구조화된 로깅 설정.
+
+지금까지는 전부 print()로만 로그를 남겨서, 레벨별 필터링(에러만 보기 등)이나
+Windows/macOS처럼 systemd 저널이 없는 환경에서의 영속 저장이 불가능했다.
+표준 logging 모듈로 콘솔 + 파일(로테이션) 핸들러를 함께 등록해, 어떤
+운영체제/실행 방식에서도 backend/logs/easypaper.log에 로그가 남도록 한다.
+
+기존 print() 문들은 이번에는 건드리지 않는다 - 전체 일괄 치환은 200곳
+이상을 건드리는 큰 변경이라 회귀 위험이 크므로, 우선 이 설정을 쓰는 신규/
+전환 모듈부터 시작하고 나머지는 점진적으로 옮긴다. print() 출력은
+Linux(systemd) 환경에서는 기존처럼 저널에 그대로 남는다.
+"""
+
+import logging
+import logging.handlers
+import os
+
+LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+LOG_FILE = os.path.join(LOG_DIR, "easypaper.log")
+
+_configured = False
+
+
+def setup_logging(level: int = logging.INFO) -> logging.Logger:
+    """루트 로거에 콘솔 + 로테이팅 파일 핸들러를 등록한다. 여러 번 호출해도
+    핸들러가 중복 등록되지 않는다."""
+    global _configured
+    root = logging.getLogger()
+    if _configured:
+        return root
+
+    os.makedirs(LOG_DIR, exist_ok=True)
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    # 10MB x 5개 백업 - 무한정 커지지 않도록 로테이션
+    file_handler = logging.handlers.RotatingFileHandler(
+        LOG_FILE, maxBytes=10 * 1024 * 1024, backupCount=5, encoding="utf-8"
+    )
+    file_handler.setFormatter(formatter)
+
+    root.setLevel(level)
+    root.addHandler(console_handler)
+    root.addHandler(file_handler)
+
+    _configured = True
+    return root

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 import os
+import logging
+
+from logging_config import setup_logging
+setup_logging()
+logger = logging.getLogger(__name__)
 
 from config import CORS_ORIGINS, UPLOAD_DIR, APP_HOST, APP_PORT
 from routers import upload, translate, chat

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import httpx
 import json
+import logging
 from typing import AsyncGenerator
 from config import (
     get_ollama_host,
@@ -19,6 +20,8 @@ from config import (
     get_project_root,
     windows_safe_exec_args as _exec_args,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # CLI(Claude Code/Codex/Antigravity) 서브프로세스 출력이 이 시간(초) 동안
@@ -1013,7 +1016,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
                     session_flag = ["--session-id", session_id]
                     continue
 
-                print(f"[Claude Code CLI Error] code={process.returncode} stderr={stderr_out}")
+                logger.error(f"Claude Code CLI 실패: code={process.returncode} stderr={stderr_out}")
                 # 실패를 조용히 삼키고 그냥 return하면, 호출부는 빈 결과를 "정상
                 # 번역 완료"로 착각해 빈 문자열을 캐시에 영구 저장해버린다.
                 # 예외를 던져서 라우터/job 쪽의 기존 실패 처리 로직(에러 응답,
@@ -1023,7 +1026,7 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
                     f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
                 )
             except Exception as e:
-                print(f"[Claude Code CLI Exec Error] {e}")
+                logger.error(f"Claude Code CLI 실행 예외: {e}")
                 raise
 
 
@@ -1177,7 +1180,7 @@ async def stream_codex(prompt: str, model: str = None, session_id: str = None, i
                     thread_id = None
                     continue
 
-                print(f"[Codex CLI Error] code={process.returncode} stderr={stderr_out}")
+                logger.error(f"Codex CLI 실패: code={process.returncode} stderr={stderr_out}")
                 # 실패를 조용히 삼키고 그냥 return하면, 호출부는 빈 결과를 "정상
                 # 번역 완료"로 착각해 빈 문자열을 캐시에 영구 저장해버린다.
                 # 예외를 던져서 라우터/job 쪽의 기존 실패 처리 로직(에러 응답,
@@ -1187,7 +1190,7 @@ async def stream_codex(prompt: str, model: str = None, session_id: str = None, i
                     f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
                 )
             except Exception as e:
-                print(f"[Codex CLI Exec Error] {e}")
+                logger.error(f"Codex CLI 실행 예외: {e}")
                 raise
 
 
@@ -1242,7 +1245,7 @@ def save_ai_session_meta(session_id: str, provider: str, conversation_id: str = 
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f)
     except Exception as e:
-        print(f"[save_ai_session_meta Error] {e}")
+        logger.error(f"save_ai_session_meta 실패: {e}")
 
 def _chat_context_already_sent(session_id: str, provider: str) -> bool:
     """이 문서(session_id)의 현재 provider 네이티브 세션에 이미 채팅 풀 컨텍스트
@@ -1273,7 +1276,7 @@ def _mark_chat_context_sent(session_id: str, provider: str) -> None:
         with open(path, "w", encoding="utf-8") as f:
             json.dump(existing, f)
     except Exception as e:
-        print(f"[_mark_chat_context_sent Error] {e}")
+        logger.error(f"_mark_chat_context_sent 실패: {e}")
 
 # 하위 호환: 기존 conversation_id.txt만 남아있는 문서를 위한 폴백 판독
 def get_mapped_conversation_id(session_id: str) -> str:
@@ -1435,14 +1438,14 @@ async def stream_antigravity(
                         if match:
                             new_conv_id = match.group(1)
                             save_ai_session_meta(session_id, provider="antigravity", conversation_id=new_conv_id)
-                            print(f"[stream_antigravity] Initialized session {session_id} to Antigravity conversation {new_conv_id}", flush=True)
+                            logger.info(f"[stream_antigravity] 세션 {session_id} -> Antigravity 대화 {new_conv_id} 초기화 완료")
                             target_conv_id = new_conv_id
                         else:
-                            print(f"[stream_antigravity] Failed to find conversation ID in init log", flush=True)
+                            logger.warning("[stream_antigravity] 초기화 로그에서 대화 ID를 찾지 못함")
                     else:
-                        print(f"[stream_antigravity] Log file was never created at {temp_log_path}", flush=True)
+                        logger.warning(f"[stream_antigravity] 로그 파일이 생성되지 않음: {temp_log_path}")
                 except Exception as ie:
-                    print(f"[stream_antigravity] Session initialization error: {ie}", flush=True)
+                    logger.warning(f"[stream_antigravity] 세션 초기화 오류: {ie}")
                 finally:
                     if os.path.exists(temp_log_path):
                         try:
@@ -1506,7 +1509,7 @@ async def stream_antigravity(
         # (에러 응답, failed_pages 기록 등)이 실제로 작동하게 한다.
         if process.returncode and process.returncode != 0:
             stderr_out = await _finish_stderr_drain(stderr_task)
-            print(f"[Antigravity CLI Error] code={process.returncode} stderr={stderr_out[:500]}", flush=True)
+            logger.error(f"Antigravity CLI 실패: code={process.returncode} stderr={stderr_out[:500]}")
             raise RuntimeError(
                 f"Antigravity CLI 실행 실패 (code={process.returncode}): "
                 f"{stderr_out.strip()[:500] or '알 수 없는 오류'}"
@@ -1517,7 +1520,7 @@ async def stream_antigravity(
         # 캐시에 영구 저장되는 버그가 있었다(실제로 "[Antigravity CLI 실행
         # 에러: ...]"라는 문자열이 논문 카테고리로 분류된 사례가 있었음).
         # 반드시 예외로 전파해 호출부가 실패로 인식하게 해야 한다.
-        print(f"[Antigravity CLI Exec Error] {e}", flush=True)
+        logger.error(f"Antigravity CLI 실행 예외: {e}")
         raise
 
 from typing import List
@@ -1573,7 +1576,7 @@ Category Tags:"""
                     data = response.json()
                     tokens.append(data.get("message", {}).get("content", ""))
     except Exception as e:
-        print(f"Classification failed: {e}")
+        logger.warning(f"논문 카테고리 분류 실패: {e}")
         return []
 
     result = "".join(tokens).strip()

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,45 @@
+"""logging_config.py 테스트 - 파일/콘솔 핸들러가 정상적으로 로그를 남기는지."""
+
+import logging
+import subprocess
+import sys
+
+
+def test_setup_logging_writes_to_rotating_file(tmp_path):
+    """logging_config는 모듈 로드 시점에 로그 디렉터리를 결정하므로, 별도
+    프로세스에서 실행해 임시 디렉터리를 대상으로 격리 검증한다."""
+    import os
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = (
+        "import logging_config, os\n"
+        f"logging_config.LOG_DIR = {str(tmp_path)!r}\n"
+        f"logging_config.LOG_FILE = os.path.join({str(tmp_path)!r}, 'test.log')\n"
+        "logging_config.setup_logging()\n"
+        "import logging\n"
+        "logging.getLogger('test').error('테스트 에러 메시지')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=backend_dir,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+
+    log_file = tmp_path / "test.log"
+    assert log_file.exists()
+    content = log_file.read_text(encoding="utf-8")
+    assert "[ERROR]" in content
+    assert "테스트 에러 메시지" in content
+
+
+def test_setup_logging_is_idempotent():
+    """여러 번 호출해도 핸들러가 중복 등록되지 않아야 한다 (로그 중복 방지)."""
+    from logging_config import setup_logging
+    root1 = setup_logging()
+    handler_count_1 = len(root1.handlers)
+    root2 = setup_logging()
+    handler_count_2 = len(root2.handlers)
+    assert handler_count_1 == handler_count_2
+    assert root1 is root2


### PR DESCRIPTION
# Summary
## 1. 구조화된 로깅 도입 (콘솔 + 로테이팅 파일 핸들러)
- 지금까지는 전부 `print()`로만 로그를 남겨서 레벨별 필터링(에러만 보기 등)이 불가능했고, Windows/macOS처럼 systemd 저널이 없는 환경에서는 터미널을 닫으면 로그가 그냥 사라졌음
- `logging_config.py`: 표준 `logging` 모듈로 콘솔 + 로테이팅 파일 핸들러(`backend/logs/easypaper.log`, 10MB x 5개 백업)를 함께 등록. `main.py` 최상단에서 다른 모듈을 import하기 전에 가장 먼저 초기화
- `services/llm_client.py`의 `print()` 13곳을 `logging`으로 전환 - CLI 실행 실패/타임아웃/세션 초기화 등 이번 세션에 가장 많은 버그가 발견된 모듈이라 우선 전환 대상으로 선정
- 나머지 모듈(`translation_job`/`library`/`pdf_parser`/`db`/`auth` 등)의 `print()`는 이번에는 그대로 두고 점진적으로 옮기는 것으로 범위를 한정함 - 일괄 치환은 200곳 이상을 건드리는 큰 변경이라 회귀 위험이 크고, Linux/systemd 환경에서는 기존처럼 저널에 그대로 남아 당장 로그가 사라지지는 않음

## 검증
- 격리된 임시 디렉터리에서 파일 핸들러가 실제로 로그를 남기는지, 여러 번 초기화해도 핸들러가 중복 등록되지 않는지 테스트로 확인
- 전체 pytest 스위트(46개) 통과 확인, 백엔드 import 정상 동작 확인
