### PR TITLE
feat: 데이터 백업/복원 스크립트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,3 +376,6 @@ frontend/blob-report/
 
 # EasyPaper 로그 파일
 backend/logs/
+
+# EasyPaper 데이터 백업 아카이브
+backups/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ npm run test:e2e
 
 ---
 
+## 데이터 백업 및 복원
+
+DB(`easypaper.db`) + 논문 라이브러리(`library/`) + 업로드 원본(`uploads/`)을 타임스탬프가 찍힌 압축 파일로 `backups/`에 저장합니다. 재생성 가능한 `cache/`는 백업 대상에서 제외됩니다. 기본적으로 최신 10개만 보관하고 오래된 백업은 자동으로 정리됩니다(`EASYPAPER_BACKUP_KEEP` 환경변수로 조절 가능).
+
+**macOS / Linux**
+```bash
+./scripts/sh/backup.sh
+./scripts/sh/restore.sh backups/easypaper_backup_20260101_120000.tar.gz
+```
+
+**Windows**
+```bat
+scripts\bat\backup.bat
+scripts\bat\restore.bat backups\easypaper_backup_20260101_120000.zip
+```
+
+주기적으로 자동 백업하려면 `backup.sh`/`backup.bat`을 각 OS의 스케줄러(Linux/macOS는 `cron`, Windows는 작업 스케줄러)에 등록하세요.
+
+---
+
 ## 상시 구동 — systemd 서비스 등록 (선택 사항)
 
 Linux 서버에서 EasyPaper를 백그라운드 데몬으로 상시 실행하려면 제공된 `easypaper.service` 파일을 활용하세요.

--- a/scripts/bat/backup.bat
+++ b/scripts/bat/backup.bat
@@ -1,0 +1,55 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM EasyPaper 데이터 백업 스크립트 (Windows)
+REM DB(easypaper.db) + library\ + uploads\를 타임스탬프가 찍힌 zip 파일로
+REM backups\ 디렉터리에 저장하고, 오래된 백업은 자동으로 정리합니다.
+REM cache\는 재생성 가능한 파생 데이터라 백업 대상에서 제외합니다.
+
+cd /d "%~dp0..\.."
+
+set "BACKUP_DIR=backups"
+if not defined EASYPAPER_BACKUP_KEEP set "EASYPAPER_BACKUP_KEEP=10"
+
+if not exist "%BACKUP_DIR%" mkdir "%BACKUP_DIR%"
+
+for /f "tokens=2 delims==" %%I in ('wmic os get localdatetime /value') do set "DT=%%I"
+set "TIMESTAMP=%DT:~0,8%_%DT:~8,6%"
+set "ARCHIVE_NAME=easypaper_backup_%TIMESTAMP%.zip"
+
+echo 📦 EasyPaper 데이터 백업 시작...
+
+set "HAS_TARGET=0"
+if exist "backend\easypaper.db" set "HAS_TARGET=1"
+if exist "backend\library" set "HAS_TARGET=1"
+if exist "backend\uploads" set "HAS_TARGET=1"
+
+if "%HAS_TARGET%"=="0" (
+    echo 백업할 데이터^(DB/library/uploads^)가 없습니다. 아직 실행되지 않은 설치일 수 있습니다.
+    exit /b 0
+)
+
+powershell -NoProfile -Command ^
+    "$items = @(); " ^
+    "if (Test-Path 'backend\easypaper.db') { $items += 'backend\easypaper.db' }; " ^
+    "if (Test-Path 'backend\library') { $items += 'backend\library' }; " ^
+    "if (Test-Path 'backend\uploads') { $items += 'backend\uploads' }; " ^
+    "Compress-Archive -Path $items -DestinationPath '%BACKUP_DIR%\%ARCHIVE_NAME%' -Force"
+
+if errorlevel 1 (
+    echo 백업 실패.
+    exit /b 1
+)
+
+echo 백업 완료: %BACKUP_DIR%\%ARCHIVE_NAME%
+
+REM 오래된 백업 정리 (최신 EASYPAPER_BACKUP_KEEP개만 유지)
+powershell -NoProfile -Command ^
+    "$keep = %EASYPAPER_BACKUP_KEEP%; " ^
+    "$files = Get-ChildItem '%BACKUP_DIR%\easypaper_backup_*.zip' | Sort-Object LastWriteTime -Descending; " ^
+    "if ($files.Count -gt $keep) { $files | Select-Object -Skip $keep | Remove-Item -Force; Write-Host ('오래된 백업 ' + ($files.Count - $keep) + '개를 정리했습니다.') }"
+
+echo 현재 보관 중인 백업 목록:
+dir /b /o-d "%BACKUP_DIR%\easypaper_backup_*.zip" 2>nul
+
+pause

--- a/scripts/bat/restore.bat
+++ b/scripts/bat/restore.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal
+
+REM EasyPaper 데이터 복원 스크립트 (Windows)
+REM backup.bat으로 만든 백업 zip 파일에서 DB/library/uploads를 복원합니다.
+
+cd /d "%~dp0..\.."
+
+if "%~1"=="" (
+    echo 사용법: %~nx0 ^<백업파일.zip^>
+    echo.
+    echo 사용 가능한 백업 목록:
+    dir /b /o-d "backups\easypaper_backup_*.zip" 2>nul
+    exit /b 1
+)
+
+set "BACKUP_FILE=%~1"
+if not exist "%BACKUP_FILE%" (
+    echo 백업 파일을 찾을 수 없습니다: %BACKUP_FILE%
+    exit /b 1
+)
+
+echo 이 작업은 현재 backend\easypaper.db, backend\library\, backend\uploads\를
+echo 백업 파일 시점의 데이터로 덮어씁니다.
+set /p REPLY="계속하시겠습니까? (y/N) "
+if /i not "%REPLY%"=="y" (
+    echo 취소되었습니다.
+    exit /b 0
+)
+
+echo 복원 중: %BACKUP_FILE% ...
+powershell -NoProfile -Command "Expand-Archive -Path '%BACKUP_FILE%' -DestinationPath '.' -Force"
+
+if errorlevel 1 (
+    echo 복원 실패.
+    exit /b 1
+)
+
+echo 복원 완료. 서비스를 재시작해주세요 ^(scripts\bat\start.bat^).
+pause

--- a/scripts/sh/backup.sh
+++ b/scripts/sh/backup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# EasyPaper 데이터 백업 스크립트 (macOS / Linux)
+# DB(easypaper.db) + library/ + uploads/를 타임스탬프가 찍힌 하나의
+# 압축파일로 backups/ 디렉터리에 저장하고, 오래된 백업은 자동으로 정리합니다.
+# cache/는 재생성 가능한 파생 데이터라 백업 대상에서 제외합니다.
+
+set -e
+
+# 저장소 루트 기준으로 동작하도록 이동 (이 스크립트는 scripts/sh/ 하위에 있음)
+cd "$(dirname "$0")/../.."
+
+BACKUP_DIR="backups"
+KEEP_COUNT="${EASYPAPER_BACKUP_KEEP:-10}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+ARCHIVE_NAME="easypaper_backup_${TIMESTAMP}.tar.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "📦 EasyPaper 데이터 백업 시작..."
+
+TARGETS=()
+[ -f "backend/easypaper.db" ] && TARGETS+=("backend/easypaper.db")
+[ -d "backend/library" ] && TARGETS+=("backend/library")
+[ -d "backend/uploads" ] && TARGETS+=("backend/uploads")
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+    echo "⚠️  백업할 데이터(DB/library/uploads)가 없습니다. 아직 실행되지 않은 설치일 수 있습니다."
+    exit 0
+fi
+
+tar -czf "${BACKUP_DIR}/${ARCHIVE_NAME}" "${TARGETS[@]}"
+
+BACKUP_SIZE=$(du -h "${BACKUP_DIR}/${ARCHIVE_NAME}" | cut -f1)
+echo "✅ 백업 완료: ${BACKUP_DIR}/${ARCHIVE_NAME} (${BACKUP_SIZE})"
+
+# 오래된 백업 정리 (최신 KEEP_COUNT개만 유지)
+BACKUP_COUNT=$(ls -1 "${BACKUP_DIR}"/easypaper_backup_*.tar.gz 2>/dev/null | wc -l | tr -d ' ')
+if [ "$BACKUP_COUNT" -gt "$KEEP_COUNT" ]; then
+    TO_DELETE=$((BACKUP_COUNT - KEEP_COUNT))
+    echo "🧹 백업 개수(${BACKUP_COUNT})가 보관 한도(${KEEP_COUNT})를 초과해 오래된 백업 ${TO_DELETE}개를 정리합니다..."
+    ls -1t "${BACKUP_DIR}"/easypaper_backup_*.tar.gz | tail -n "$TO_DELETE" | xargs rm -f
+fi
+
+echo "📂 현재 보관 중인 백업 목록:"
+ls -1t "${BACKUP_DIR}"/easypaper_backup_*.tar.gz 2>/dev/null | head -n "$KEEP_COUNT"

--- a/scripts/sh/restore.sh
+++ b/scripts/sh/restore.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# EasyPaper 데이터 복원 스크립트 (macOS / Linux)
+# backup.sh로 만든 백업 압축파일에서 DB/library/uploads를 복원합니다.
+# 실행 전 서비스를 중지해두는 것을 권장합니다 (백업 파일과 현재 데이터가
+# 동시에 쓰기 충돌하지 않도록).
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+if [ -z "$1" ]; then
+    echo "사용법: $0 <백업파일.tar.gz>"
+    echo ""
+    echo "사용 가능한 백업 목록:"
+    ls -1t backups/easypaper_backup_*.tar.gz 2>/dev/null || echo "  (backups/ 디렉터리에 백업이 없습니다)"
+    exit 1
+fi
+
+BACKUP_FILE="$1"
+if [ ! -f "$BACKUP_FILE" ]; then
+    echo "❌ 백업 파일을 찾을 수 없습니다: $BACKUP_FILE"
+    exit 1
+fi
+
+echo "⚠️  이 작업은 현재 backend/easypaper.db, backend/library/, backend/uploads/를"
+echo "    백업 파일 시점의 데이터로 덮어씁니다."
+read -p "계속하시겠습니까? (y/N) " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "취소되었습니다."
+    exit 0
+fi
+
+echo "📦 복원 중: $BACKUP_FILE ..."
+tar -xzf "$BACKUP_FILE" -C .
+
+echo "✅ 복원 완료. 서비스를 재시작해주세요:"
+echo "   sudo systemctl restart easypaper   (systemd로 등록한 경우)"
+echo "   또는 scripts/sh/start.sh를 다시 실행"


### PR DESCRIPTION
# Summary
## 1. 데이터 백업/복원 스크립트 추가 (macOS/Linux/Windows)
- `easypaper.db` + `library/`(논문 라이브러리) + `uploads/`(업로드 원본)를 타임스탬프가 찍힌 압축 파일로 `backups/`에 저장 - 지금까지 백업 수단이 전혀 없어서 디스크 장애 시 전체 라이브러리가 유실될 위험이 있었음. 재생성 가능한 `cache/`는 백업 대상에서 제외
- macOS/Linux는 `scripts/sh/backup.sh`(tar.gz), Windows는 `scripts/bat/backup.bat`(PowerShell `Compress-Archive`로 zip) 제공. 기본적으로 최신 10개만 보관하고 오래된 백업은 자동 정리(`EASYPAPER_BACKUP_KEEP` 환경변수로 조절 가능)
- 대응하는 `restore.sh`/`restore.bat`도 함께 제공 - 복원 전 확인 프롬프트로 실수로 현재 데이터를 덮어쓰는 것을 방지
- README에 사용법 및 스케줄러(cron/Windows 작업 스케줄러) 등록 안내 추가

## 검증
- 실제로 더미 DB/library/uploads 파일로 백업 → 데이터 훼손 시뮬레이션(파일 삭제/내용 변경) → 복원까지 전체 흐름이 정상 동작하는지 확인
- 보관 개수(`EASYPAPER_BACKUP_KEEP`)를 초과했을 때 오래된 백업이 정확히 정리되고 최신 N개만 남는지 확인
