### PR TITLE
feat: 라이브러리 전체 검색 기능 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import FileResponse
 from services.auth import get_current_user
 from services.library import (
-    list_documents, get_document, permanently_delete_document,
+    list_documents, search_documents, get_document, permanently_delete_document,
     soft_delete_document, restore_document, empty_trash,
     get_translation, get_pdf_path, get_cover_path, update_document_metadata
 )
@@ -62,6 +62,17 @@ async def empty_library_trash(current_user: str = Depends(get_current_user)):
     if not empty_trash(current_user):
         raise HTTPException(status_code=500, detail="휴지통 비우기에 실패했습니다.")
     return {"message": "휴지통이 비워졌습니다."}
+
+
+@router.get("/library/search")
+async def search_library(q: str = "", current_user: str = Depends(get_current_user)):
+    """파일명/제목·카테고리와 번역된 본문 텍스트를 가로질러 검색합니다.
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - 그렇지 않으면 "search"가
+    doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    docs = search_documents(current_user, q)
+    return {"documents": docs, "total": len(docs)}
 
 
 @router.get("/library/{doc_id}")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -229,6 +229,50 @@ def db_list_documents(username: Optional[str] = None, only_trash: bool = False) 
             docs.append(doc)
         return docs
 
+
+def _escape_like(text: str) -> str:
+    """LIKE 패턴의 와일드카드(%, _)를 리터럴로 취급하도록 이스케이프한다."""
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def db_search_documents(username: str, query: str, only_trash: bool = False) -> list:
+    """파일명/제목·카테고리(metadata)와 페이지별 번역 텍스트를 가로질러 검색어를
+    찾아 매칭되는 문서 목록을 반환합니다 (대소문자 구분 없음).
+
+    원문(PDF에서 추출한 텍스트)은 세션 메모리에만 있고 DB에 영속화되지
+    않아 검색 대상에 포함하지 못한다 - 파일명/제목/카테고리와 번역된
+    텍스트만 검색 대상이다.
+    """
+    is_deleted_val = 1 if only_trash else 0
+    like_query = f"%{_escape_like(query)}%"
+
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT DISTINCT d.id, d.username, d.filename, d.pdf_path, d.total_pages,
+                   d.metadata, d.is_deleted, d.created_at
+            FROM documents d
+            LEFT JOIN translations t ON t.doc_id = d.id
+            WHERE d.username = ? AND d.is_deleted = ?
+              AND (
+                    d.filename LIKE ? ESCAPE '\\'
+                 OR d.metadata LIKE ? ESCAPE '\\'
+                 OR t.translation LIKE ? ESCAPE '\\'
+              )
+            ORDER BY d.created_at DESC
+            """,
+            (username, is_deleted_val, like_query, like_query, like_query)
+        )
+        rows = cursor.fetchall()
+        docs = []
+        for r in rows:
+            doc = dict(r)
+            doc["metadata"] = json.loads(doc["metadata"]) if doc["metadata"] else {}
+            docs.append(doc)
+        return docs
+
+
 def db_delete_document(doc_id: str) -> bool:
     with get_db() as conn:
         cursor = conn.cursor()

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -8,6 +8,7 @@ from services.db import (
     db_save_document,
     db_get_document,
     db_list_documents,
+    db_search_documents,
     db_delete_document,
     db_soft_delete_document,
     db_restore_document,
@@ -145,6 +146,24 @@ def list_documents(
                     )
                     pages = [r["page_num"] for r in cursor.fetchall()]
         doc["translated_pages"] = pages
+    return docs
+
+
+def search_documents(username: str, query: str, only_trash: bool = False) -> list:
+    """파일명/제목·카테고리와 번역된 텍스트를 가로질러 검색어와 매칭되는
+    문서 목록을 최신순으로 반환합니다."""
+    query = (query or "").strip()
+    if not query:
+        return []
+    docs = db_search_documents(username, query, only_trash=only_trash)
+    for doc in docs:
+        with get_db() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? ORDER BY page_num ASC",
+                (doc["id"],)
+            )
+            doc["translated_pages"] = [r["page_num"] for r in cursor.fetchall()]
     return docs
 
 

--- a/backend/tests/test_library_ownership_api.py
+++ b/backend/tests/test_library_ownership_api.py
@@ -70,3 +70,22 @@ def test_library_list_only_returns_own_documents(test_client, isolated_dirs):
     assert res.status_code == 200
     ids = {d["id"] for d in res.json()["documents"]}
     assert ids == {"doc-mine-3"}
+
+
+def test_library_search_only_returns_own_documents(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-mine-7", "testuser", "shared_topic.pdf", "/x", 1, {"title": "Attention Paper"})
+    db.db_save_document("doc-other-7", "otheruser", "shared_topic2.pdf", "/x", 1, {"title": "Attention Survey"})
+
+    res = test_client.get("/api/library/search", params={"q": "Attention"})
+    assert res.status_code == 200
+    ids = {d["id"] for d in res.json()["documents"]}
+    assert ids == {"doc-mine-7"}
+
+
+def test_library_search_route_does_not_shadow_document_id_route(test_client, isolated_dirs):
+    """/library/search가 /library/{doc_id}보다 먼저 등록되어 있어야, "search"가
+    doc_id로 잘못 매칭되지 않는다."""
+    res = test_client.get("/api/library/search", params={"q": "nonexistent"})
+    assert res.status_code == 200
+    assert res.json() == {"documents": [], "total": 0}

--- a/backend/tests/test_library_search.py
+++ b/backend/tests/test_library_search.py
@@ -1,0 +1,96 @@
+"""라이브러리 전체 검색(services.library.search_documents, db_search_documents) 테스트.
+
+파일명/제목·카테고리와 페이지별 번역 텍스트를 가로지르는 검색과, 다른
+사용자 문서가 결과에 섞이지 않는지를 확인한다.
+"""
+
+import json
+
+
+def test_search_matches_filename(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "transformer_paper.pdf", "/x", 3, {"title": "Attention Is All You Need"})
+    db.db_save_document("doc-2", "admin", "gan_paper.pdf", "/x", 2, {"title": "GAN"})
+
+    results = library.search_documents("admin", "transformer")
+    assert [d["id"] for d in results] == ["doc-1"]
+
+
+def test_search_matches_title_in_metadata(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {"title": "Generative Adversarial Networks"})
+
+    results = library.search_documents("admin", "Generative")
+    assert [d["id"] for d in results] == ["doc-1"]
+
+
+def test_search_matches_translated_text(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {"title": "GAN"})
+    db.db_save_translation(
+        "doc-1", 1,
+        json.dumps({"translation": "이 논문은 셀프 어텐션 메커니즘을 다루지 않습니다.", "sentences": []}, ensure_ascii=False)
+    )
+
+    results = library.search_documents("admin", "셀프 어텐션")
+    assert [d["id"] for d in results] == ["doc-1"]
+
+
+def test_search_excludes_other_users_documents(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-mine", "admin", "p1.pdf", "/x", 1, {"title": "Attention Paper"})
+    db.db_save_document("doc-other", "otheruser", "p2.pdf", "/x", 1, {"title": "Attention Survey"})
+
+    results = library.search_documents("admin", "Attention")
+    assert [d["id"] for d in results] == ["doc-mine"]
+
+
+def test_search_excludes_trashed_documents_by_default(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {"title": "Trashed Paper"})
+    db.db_soft_delete_document("doc-1")
+
+    assert library.search_documents("admin", "Trashed") == []
+
+
+def test_search_empty_query_returns_no_results(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {"title": "Anything"})
+
+    assert library.search_documents("admin", "") == []
+    assert library.search_documents("admin", "   ") == []
+
+
+def test_search_no_match_returns_empty_list(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 1, {"title": "Something"})
+
+    assert library.search_documents("admin", "xyzzy_no_such_term") == []
+
+
+def test_search_wildcard_characters_are_treated_literally(isolated_dirs):
+    """검색어에 SQL LIKE 와일드카드(%, _)가 그대로 들어와도 에러 없이, 리터럴
+    문자로 취급되어야 한다 (모든 문서가 매칭되는 의도치 않은 동작 방지)."""
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "normal_paper.pdf", "/x", 1, {"title": "Normal"})
+
+    results = library.search_documents("admin", "%")
+    assert results == [], "와일드카드 %가 리터럴로 취급되어 아무 문서와도 매칭되지 않아야 한다"
+
+
+def test_search_result_includes_translated_pages(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 2, {"title": "Searchable"})
+    db.db_save_translation("doc-1", 1, json.dumps({"translation": "첫 페이지", "sentences": []}, ensure_ascii=False))
+
+    results = library.search_documents("admin", "Searchable")
+    assert results[0]["translated_pages"] == [1]

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-QjtQQT1p.js"></script>
+  <script type="module" crossorigin src="/assets/index-B4-qZQDA.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>
@@ -79,8 +79,18 @@
       <!-- 독서 통계 위젯 영역 -->
       <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
 
+      <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
+      <div style="position: relative; margin-bottom: 14px;">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
+        <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </button>
+      </div>
+      <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
+
       <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
-      <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
+      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
         <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
         <div id="library-view-toggle" class="library-view-toggle">
           <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,8 +78,18 @@
       <!-- 독서 통계 위젯 영역 -->
       <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
 
+      <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
+      <div style="position: relative; margin-bottom: 14px;">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
+        <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </button>
+      </div>
+      <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
+
       <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
-      <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
+      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
         <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
         <div id="library-view-toggle" class="library-view-toggle">
           <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -59,6 +59,12 @@ export async function updateLibraryTranslation(docId, pageNum, payload, options 
   if (!res.ok) throw new Error('번역 수정 저장 실패')
   return res.json()
 }
+export async function searchLibrary(query) {
+  const res = await fetch(`${API_BASE}/library/search?q=${encodeURIComponent(query)}`)
+  if (!res.ok) throw new Error('검색 실패')
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,7 @@ import './style.css'
 import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -164,6 +164,10 @@ const fileInput         = $('file-input')
 const libUploadBtn      = $('lib-upload-btn')
 const libraryGrid       = $('library-grid')
 const libraryCategoryFilters = $('library-category-filters')
+const librarySearchInput = $('library-search-input')
+const librarySearchClearBtn = $('library-search-clear-btn')
+const librarySearchStatus = $('library-search-status')
+const libraryFilterRow  = $('library-filter-row')
 const libraryCountBadge = $('library-count-badge')
 const libTabArchive     = $('lib-tab-archive')
 const libTabHistory     = $('lib-tab-history')
@@ -2795,6 +2799,14 @@ async function showLibraryScreen(shouldPushState = true) {
 let activeCategoryFilter = 'ALL'
 
 async function renderLibrary() {
+  // 탭 전환 등으로 목록을 새로 불러올 때는 검색 상태를 초기화한다 - 검색
+  // 결과가 다른 탭의 목록과 뒤섞여 보이는 것을 방지
+  if (librarySearchInput) librarySearchInput.value = ''
+  if (librarySearchClearBtn) librarySearchClearBtn.classList.add('hidden')
+  if (librarySearchStatus) librarySearchStatus.classList.add('hidden')
+  if (libraryFilterRow) libraryFilterRow.style.display = ''
+  isLibrarySearchActive = false
+
   libraryGrid.innerHTML = ''
   libraryCategoryFilters.innerHTML = ''
   try {
@@ -2924,6 +2936,81 @@ function filterLibraryCards(docs) {
 
   const createItem = libraryViewMode === 'list' ? createDocListRow : createDocCard
   filteredDocs.forEach(doc => libraryGrid.appendChild(createItem(doc)))
+}
+
+// ── 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) ──────
+let isLibrarySearchActive = false
+let librarySearchDebounceTimer = null
+
+function renderLibrarySearchResults(docs, query) {
+  libraryGrid.innerHTML = ''
+  libraryGrid.classList.toggle('list-view', libraryViewMode === 'list')
+
+  if (docs.length === 0) {
+    const el = document.createElement('div')
+    el.className = 'lib-empty'
+    el.innerHTML = `<div style="margin-bottom:16px;color:var(--text-muted)">${icon('book', 48)}</div>
+      <p>"${escapeHtml(query)}"에 대한 검색 결과가 없습니다</p>
+      <p style="font-size:13px;color:var(--text-muted);margin-top:8px">논문 제목, 파일명, 번역된 본문 내용을 검색합니다</p>`
+    libraryGrid.appendChild(el)
+  } else {
+    const createItem = libraryViewMode === 'list' ? createDocListRow : createDocCard
+    docs.forEach(doc => libraryGrid.appendChild(createItem(doc)))
+  }
+
+  if (librarySearchStatus) {
+    librarySearchStatus.textContent = `"${query}" 검색 결과 ${docs.length}건`
+    librarySearchStatus.classList.remove('hidden')
+  }
+}
+
+async function runLibrarySearch(query) {
+  try {
+    const res = await searchLibrary(query)
+    // 디바운스 중 사용자가 입력을 더 바꿨을 수 있으므로, 지금 입력값과 다르면 버린다
+    if (librarySearchInput.value.trim() !== query) return
+    renderLibrarySearchResults(res.documents || [], query)
+  } catch (err) {
+    console.error(err)
+    if (librarySearchStatus) {
+      librarySearchStatus.textContent = '검색 중 오류가 발생했습니다.'
+      librarySearchStatus.classList.remove('hidden')
+    }
+  }
+}
+
+function exitLibrarySearch() {
+  isLibrarySearchActive = false
+  if (librarySearchStatus) librarySearchStatus.classList.add('hidden')
+  if (libraryFilterRow) libraryFilterRow.style.display = ''
+  filterLibraryCards(currentLibraryDocs)
+}
+
+if (librarySearchInput) {
+  librarySearchInput.addEventListener('input', () => {
+    const query = librarySearchInput.value.trim()
+    if (librarySearchClearBtn) librarySearchClearBtn.classList.toggle('hidden', !query)
+    clearTimeout(librarySearchDebounceTimer)
+
+    if (!query) {
+      if (isLibrarySearchActive) exitLibrarySearch()
+      return
+    }
+    librarySearchDebounceTimer = setTimeout(() => {
+      isLibrarySearchActive = true
+      if (libraryFilterRow) libraryFilterRow.style.display = 'none'
+      runLibrarySearch(query)
+    }, 300)
+  })
+}
+
+if (librarySearchClearBtn) {
+  librarySearchClearBtn.addEventListener('click', () => {
+    librarySearchInput.value = ''
+    librarySearchClearBtn.classList.add('hidden')
+    exitLibrarySearch()
+    librarySearchInput.focus()
+  })
 }
 
 function createEmptyState(isHistory = false) {

--- a/frontend/tests/e2e/library-search.spec.js
+++ b/frontend/tests/e2e/library-search.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+// 라이브러리 전체 검색: 파일명/제목/카테고리 + 번역된 본문 텍스트를 가로지르는 검색
+test('검색어 입력 시 서버 검색 결과가 표시되고, 지우면 원래 목록으로 돌아간다', async ({ page }) => {
+  const docs = [
+    { id: 'doc-1', filename: 'transformer.pdf', total_pages: 3, metadata: { title: 'Attention Is All You Need' }, translated_pages: [] },
+    { id: 'doc-2', filename: 'gan.pdf', total_pages: 2, metadata: { title: 'GAN Paper' }, translated_pages: [] },
+  ]
+  await mockBaseRoutes(page, { documents: docs })
+
+  let searchQuery = null
+  await page.route('**/api/library/search*', route => {
+    const url = new URL(route.request().url())
+    searchQuery = url.searchParams.get('q')
+    const matched = docs.filter(d => d.metadata.title.toLowerCase().includes(searchQuery.toLowerCase()))
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents: matched, total: matched.length }) })
+  })
+
+  await gotoApp(page)
+  await expect(page.getByText('Attention Is All You Need')).toBeVisible()
+  await expect(page.getByText('GAN Paper')).toBeVisible()
+
+  await page.fill('#library-search-input', 'Attention')
+  await page.waitForTimeout(500) // 디바운스 대기
+
+  expect(searchQuery).toBe('Attention')
+  await expect(page.getByText('Attention Is All You Need')).toBeVisible()
+  await expect(page.getByText('GAN Paper')).not.toBeVisible()
+  await expect(page.locator('#library-search-status')).toContainText('검색 결과 1건')
+
+  // 검색 지우기 -> 원래 전체 목록으로 복귀
+  await page.click('#library-search-clear-btn')
+  await page.waitForTimeout(300)
+  await expect(page.getByText('Attention Is All You Need')).toBeVisible()
+  await expect(page.getByText('GAN Paper')).toBeVisible()
+  await expect(page.locator('#library-search-status')).toHaveClass(/hidden/)
+})
+
+test('검색 결과가 없으면 안내 메시지가 표시된다', async ({ page }) => {
+  const docs = [
+    { id: 'doc-1', filename: 'paper.pdf', total_pages: 1, metadata: { title: 'Some Paper' }, translated_pages: [] },
+  ]
+  await mockBaseRoutes(page, { documents: docs })
+  await page.route('**/api/library/search*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents: [], total: 0 }) }))
+
+  await gotoApp(page)
+  await page.fill('#library-search-input', '존재하지않는검색어')
+  await page.waitForTimeout(500)
+
+  await expect(page.getByText('검색 결과가 없습니다')).toBeVisible()
+  await expect(page.locator('#library-search-status')).toContainText('검색 결과 0건')
+})


### PR DESCRIPTION
# Summary
## 1. 라이브러리 전체 검색 기능 추가
- 논문 제목/파일명/카테고리와 페이지별 번역 텍스트를 가로지르는 검색을 추가 - 기존에는 카테고리 필터만 있고 텍스트 검색이 전혀 없었음
- `backend/services/db.py`: `db_search_documents()`가 `documents`(파일명/metadata)와 `translations`(번역 텍스트)를 `LEFT JOIN`해 `LIKE` 검색. 와일드카드(`%`, `_`)는 리터럴로 이스케이프해 검색어에 그대로 들어와도 의도치 않게 전체 매칭되지 않도록 함
- `backend/services/library.py`: `search_documents()`가 검색 결과에 `translated_pages`를 붙여 기존 목록 API와 동일한 형태로 반환
- `backend/routers/library.py`: `GET /library/search?q=...` 신규 추가. `/library/{doc_id}`보다 반드시 먼저 등록해야 "search"가 `doc_id`로 잘못 매칭되지 않음 (라우트 순서 주석으로 명시)
- 프론트: 라이브러리 화면에 검색창 추가, 300ms 디바운스로 서버 검색 호출 후 결과를 기존 카드/리스트 뷰로 렌더링. 검색 중에는 카테고리 필터 행을 숨기고, 검색어를 지우면 원래 목록으로 복귀. 탭 전환 시 검색 상태 자동 초기화
- 원문(PDF에서 추출한 텍스트)은 DB에 영속화되지 않아 검색 대상에서 제외되고 번역된 텍스트만 검색됨 - 알려진 제약사항

## 검증
- 백엔드 pytest 11개 추가 (서비스 레이어 검색 로직 9개: 파일명/제목/번역 텍스트 매칭, 다른 사용자 문서 제외, 휴지통 제외, 와일드카드 리터럴 처리 등 + 소유자 격리 HTTP 테스트 2개)
- 프론트 Playwright 2개 추가 (검색 → 결과 표시 → 지우기 → 원복, 검색 결과 없음 안내)
- 전체 스위트 통과 확인: 백엔드 57개, 프론트 12개
- 실제 UI 스크린샷으로 검색 전/후 화면 확인 (카테고리 필터 숨김, 검색 결과 개수 표시, 지우기 버튼 동작)
