### PR TITLE
feat: 번역/하이라이트/밑줄/메모 포함 PDF 내보내기 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -169,6 +169,69 @@ async def get_library_pdf(doc_id: str, current_user: str = Depends(get_current_u
     return FileResponse(pdf_path, media_type="application/pdf")
 
 
+class ExportPdfRequest(BaseModel):
+    annotations: dict = {}
+    memos: dict = {}
+    target_lang: Optional[str] = None
+    style: Optional[str] = None
+    ignore_math: Optional[bool] = None
+    ignore_table: Optional[bool] = None
+    ignore_refs: Optional[bool] = None
+
+
+@router.post("/library/{doc_id}/export-pdf")
+async def export_annotated_pdf(
+    doc_id: str,
+    payload: ExportPdfRequest,
+    current_user: str = Depends(get_current_user)
+):
+    """번역/하이라이트/밑줄/메모가 반영된 PDF를 생성해 반환합니다.
+
+    하이라이트·밑줄·메모는 브라우저 localStorage에만 있으므로 요청 본문으로
+    전달받는다(서버는 이 데이터를 저장하지 않고 즉시 PDF 생성에만 사용).
+    """
+    doc = _require_owned_document(doc_id, current_user)
+    pdf_path = get_pdf_path(doc_id)
+    if not pdf_path:
+        raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
+
+    suffix = ""
+    if payload.target_lang is not None and payload.style is not None:
+        suffix = f"{payload.target_lang}_{payload.style}_math{int(payload.ignore_math)}_table{int(payload.ignore_table)}_refs{int(payload.ignore_refs)}"
+
+    from services.library import get_translation_full
+    total_pages = doc.get("total_pages", 0) or 0
+    translations = {}
+    for page_num in range(1, total_pages + 1):
+        full = get_translation_full(doc_id, page_num, suffix)
+        text = (full or {}).get("translation")
+        if text:
+            translations[str(page_num)] = text
+
+    doc_title = (doc.get("metadata") or {}).get("title") or doc.get("filename", "EasyPaper")
+
+    try:
+        from services.pdf_export import generate_annotated_pdf
+        pdf_bytes = generate_annotated_pdf(
+            pdf_path, doc_title, payload.annotations, translations, payload.memos
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"PDF 생성 실패: {str(e)}")
+
+    from fastapi.responses import Response
+    from urllib.parse import quote
+    base_filename = (doc.get("filename") or "document").rsplit(".", 1)[0]
+    export_filename = f"{base_filename}_번역_주석.pdf"
+    encoded_filename = quote(export_filename)
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f"attachment; filename=\"export.pdf\"; filename*=UTF-8''{encoded_filename}"
+        }
+    )
+
+
 @router.get("/library/{doc_id}/cover")
 async def get_library_cover(doc_id: str, current_user: str = Depends(get_current_user)):
     """라이브러리 카드 미리보기용 1페이지 상단(제목+abstract) 캡쳐 이미지를 서빙합니다."""

--- a/backend/services/pdf_export.py
+++ b/backend/services/pdf_export.py
@@ -1,0 +1,185 @@
+"""
+번역/주석(하이라이트·밑줄·메모)이 포함된 PDF 내보내기.
+
+하이라이트/밑줄/메모는 브라우저 localStorage에만 저장되고 백엔드에는 전혀
+없다 - 그래서 이 기능은 프론트엔드가 내보내기 요청 시 그 데이터를 함께
+보내야 하고(POST body), 서버는 PyMuPDF(fitz)로 그 정보를 원본 PDF 위에
+실제 PDF 주석 객체로 구워 넣은 뒤, 번역 텍스트와 메모 요약을 별도 섹션으로
+이어붙여 하나의 PDF로 합쳐 반환한다.
+
+브라우저에서 저장하는 하이라이트/밑줄은 문자 offset(해당 페이지 textLayer
+기준)이 아니라 원본 텍스트 문자열 자체도 함께 저장하므로, PDF 좌표계로
+직접 변환하는 대신 PyMuPDF의 page.search_for()로 그 문자열을 페이지에서
+찾아 위치(quad)를 알아내는 방식을 쓴다 - pdf.js와 PyMuPDF의 텍스트 추출
+결과가 100% 동일하지는 않아 완벽하지 않지만, 대부분의 경우 잘 맞고 실패해도
+그 항목만 조용히 건너뛴다(전체 내보내기가 실패하지 않음).
+"""
+
+import io
+import re
+from html import escape as html_escape
+from typing import Optional
+
+import fitz
+
+_HIGHLIGHT_DEFAULT_COLOR = (1, 0.92, 0.23)  # 노랑
+_UNDERLINE_DEFAULT_COLOR = (0.93, 0.26, 0.26)  # 빨강
+
+# PyMuPDF 내장 CJK 폰트 - 기본 14종 폰트(helv 등)는 한글 글리프가 없어
+# "??"로만 표시되므로, 한글이 섞인 텍스트는 반드시 이 폰트를 써야 한다.
+_KOREAN_TEXTBOX_FONT = "korea"
+
+
+def _hex_to_rgb01(hex_color: Optional[str], fallback: tuple) -> tuple:
+    if not hex_color:
+        return fallback
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        return fallback
+    try:
+        r = int(hex_color[0:2], 16) / 255
+        g = int(hex_color[2:4], 16) / 255
+        b = int(hex_color[4:6], 16) / 255
+        return (r, g, b)
+    except ValueError:
+        return fallback
+
+
+def _apply_annotations_to_page(page: fitz.Page, annotations: list) -> None:
+    """이 페이지에 저장된 하이라이트/밑줄을 실제 PDF 주석으로 굽는다."""
+    for ann in annotations:
+        text = (ann.get("text") or "").strip()
+        ann_type = ann.get("type")
+        if not text or ann_type not in ("highlight", "underline"):
+            continue
+
+        color = _hex_to_rgb01(
+            ann.get("color"),
+            _HIGHLIGHT_DEFAULT_COLOR if ann_type == "highlight" else _UNDERLINE_DEFAULT_COLOR,
+        )
+        try:
+            # 개행이 포함된 긴 인용은 검색이 실패하기 쉬우므로 공백으로 정규화
+            search_text = " ".join(text.split())
+            quads = page.search_for(search_text, quads=True)
+        except Exception:
+            quads = []
+        if not quads:
+            continue
+
+        try:
+            if ann_type == "highlight":
+                annot = page.add_highlight_annot(quads)
+            else:
+                annot = page.add_underline_annot(quads)
+            annot.set_colors(stroke=color)
+            annot.update()
+        except Exception:
+            continue
+
+
+def _run_story_pages(html: str) -> fitz.Document:
+    """HTML을 fitz.Story로 흘려보내 필요한 만큼 자동으로 페이지를 나눈
+    새 PDF 문서를 만들어 반환한다 (한글 포함 텍스트도 자연스럽게 렌더링됨)."""
+    buf = io.BytesIO()
+    story = fitz.Story(html=html)
+    writer = fitz.DocumentWriter(buf)
+    mediabox = fitz.paper_rect("a4")
+    where = mediabox + (48, 48, -48, -48)
+
+    more = 1
+    while more:
+        device = writer.begin_page(mediabox)
+        more, _ = story.place(where)
+        story.draw(device)
+        writer.end_page()
+    writer.close()
+
+    buf.seek(0)
+    return fitz.open("pdf", buf.read())
+
+
+def _build_translation_html(doc_title: str, translations: dict) -> str:
+    parts = [
+        '<div style="font-family: sans-serif;">',
+        f'<h1 style="font-size: 20pt; margin-bottom: 4pt;">{html_escape(doc_title)}</h1>',
+        '<h2 style="font-size: 13pt; color: #555; margin-top: 0;">번역 (Translation)</h2>',
+    ]
+    for page_num in sorted((int(k) for k in translations.keys())):
+        text = (translations.get(str(page_num)) or "").strip()
+        if not text:
+            continue
+        parts.append(f'<h3 style="font-size: 12pt; margin-top: 18pt; color: #333;">{page_num}페이지</h3>')
+        for para in re.split(r"\n\s*\n", text):
+            para = para.strip()
+            if para:
+                parts.append(f'<p style="font-size: 11pt; line-height: 1.6; text-align: justify;">{html_escape(para)}</p>')
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def _build_memo_html(memos: dict) -> Optional[str]:
+    entries = []
+    for page_key in sorted(memos.keys(), key=lambda k: int(k.replace("page_", "")) if k.replace("page_", "").isdigit() else 0):
+        page_num = page_key.replace("page_", "")
+        for memo in memos.get(page_key, []):
+            content = (memo.get("content") or "").strip()
+            if not content:
+                continue
+            anchor = (memo.get("sentenceText") or "").strip()
+            entries.append((page_num, anchor, content))
+
+    if not entries:
+        return None
+
+    parts = [
+        '<div style="font-family: sans-serif;">',
+        '<h2 style="font-size: 16pt;">메모 (Memos)</h2>',
+    ]
+    for page_num, anchor, content in entries:
+        parts.append(f'<h4 style="font-size: 11pt; margin-top: 14pt; margin-bottom: 2pt; color: #333;">{page_num}페이지</h4>')
+        if anchor:
+            snippet = anchor[:150] + ("…" if len(anchor) > 150 else "")
+            parts.append(f'<p style="font-size: 9.5pt; color: #888; margin: 0 0 3pt; font-style: italic;">"{html_escape(snippet)}"</p>')
+        parts.append(f'<p style="font-size: 10.5pt; line-height: 1.5; margin-top: 0;">{html_escape(content)}</p>')
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def generate_annotated_pdf(
+    pdf_path: str,
+    doc_title: str,
+    annotations: dict,
+    translations: dict,
+    memos: dict,
+) -> bytes:
+    """원본 PDF에 하이라이트/밑줄을 구워 넣고, 번역·메모 섹션을 이어붙인
+    최종 PDF를 바이트로 반환한다.
+
+    annotations: {"page_1": [{"type", "text", "color"}, ...], ...} (프론트 localStorage 형식)
+    translations: {"1": "번역 텍스트", ...} (페이지 번호 -> 번역 전문)
+    memos: {"page_1": [{"content", "sentenceText"}, ...], ...} (프론트 localStorage 형식)
+    """
+    doc = fitz.open(pdf_path)
+
+    for page_key, page_annotations in (annotations or {}).items():
+        m = re.match(r"page_(\d+)$", page_key)
+        if not m:
+            continue
+        page_idx = int(m.group(1)) - 1
+        if 0 <= page_idx < doc.page_count and page_annotations:
+            _apply_annotations_to_page(doc[page_idx], page_annotations)
+
+    if translations:
+        translation_doc = _run_story_pages(_build_translation_html(doc_title, translations))
+        doc.insert_pdf(translation_doc)
+        translation_doc.close()
+
+    memo_html = _build_memo_html(memos or {})
+    if memo_html:
+        memo_doc = _run_story_pages(memo_html)
+        doc.insert_pdf(memo_doc)
+        memo_doc.close()
+
+    result = doc.tobytes(garbage=4, deflate=True)
+    doc.close()
+    return result

--- a/backend/tests/test_pdf_export.py
+++ b/backend/tests/test_pdf_export.py
@@ -1,0 +1,111 @@
+"""services/pdf_export.py 테스트 - 번역/하이라이트/밑줄/메모가 포함된 PDF 생성."""
+
+import fitz
+import pytest
+
+from services.pdf_export import generate_annotated_pdf
+
+
+@pytest.fixture()
+def sample_pdf(tmp_path):
+    """2페이지짜리 간단한 영문 PDF를 만들어 경로를 반환한다."""
+    doc = fitz.open()
+    p1 = doc.new_page()
+    p1.insert_textbox(
+        fitz.Rect(50, 50, 545, 700),
+        "Transformer Architecture\n\nThe transformer relies on self-attention mechanisms.",
+        fontsize=12, fontname="helv",
+    )
+    p2 = doc.new_page()
+    p2.insert_textbox(
+        fitz.Rect(50, 50, 545, 700),
+        "Results\n\nOur experiments show strong performance.",
+        fontsize=12, fontname="helv",
+    )
+    path = tmp_path / "source.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+def test_generate_pdf_preserves_original_pages(sample_pdf):
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, {})
+    doc = fitz.open("pdf", result)
+    assert doc.page_count == 2  # 주석/번역/메모가 전부 없으면 원본 페이지 수 그대로
+    doc.close()
+
+
+def test_generate_pdf_bakes_highlight_annotation(sample_pdf):
+    annotations = {"page_1": [{"type": "highlight", "text": "self-attention mechanisms", "color": "#eab308"}]}
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    doc = fitz.open("pdf", result)
+    page1_annots = list(doc[0].annots())
+    assert len(page1_annots) == 1
+    assert page1_annots[0].type[1] == "Highlight"
+    doc.close()
+
+
+def test_generate_pdf_bakes_underline_annotation(sample_pdf):
+    annotations = {"page_1": [{"type": "underline", "text": "self-attention mechanisms", "color": "#ef4444"}]}
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    doc = fitz.open("pdf", result)
+    page1_annots = list(doc[0].annots())
+    assert len(page1_annots) == 1
+    assert page1_annots[0].type[1] == "Underline"
+    doc.close()
+
+
+def test_generate_pdf_skips_annotation_when_text_not_found(sample_pdf):
+    """페이지에 없는 문구를 하이라이트하려 해도 예외 없이 조용히 건너뛰어야 한다."""
+    annotations = {"page_1": [{"type": "highlight", "text": "this text does not exist anywhere", "color": "#eab308"}]}
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    doc = fitz.open("pdf", result)
+    assert len(list(doc[0].annots())) == 0
+    doc.close()
+
+
+def test_generate_pdf_appends_translation_pages(sample_pdf):
+    translations = {
+        "1": "트랜스포머 아키텍처는 셀프 어텐션 메커니즘에 의존합니다.",
+        "2": "우리의 실험은 강력한 성능을 보여줍니다.",
+    }
+    result = generate_annotated_pdf(sample_pdf, "테스트 논문", {}, translations, {})
+    doc = fitz.open("pdf", result)
+    assert doc.page_count > 2, "번역 섹션이 추가되어 원본 페이지 수보다 많아야 한다"
+
+    full_text = "".join(page.get_text() for page in doc)
+    assert "테스트 논문" in full_text
+    assert "셀프 어텐션" in full_text
+    doc.close()
+
+
+def test_generate_pdf_appends_memo_page(sample_pdf):
+    memos = {"page_1": [{"content": "이 부분이 핵심입니다.", "sentenceText": "self-attention mechanisms"}]}
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, memos)
+    doc = fitz.open("pdf", result)
+    assert doc.page_count > 2
+
+    full_text = "".join(page.get_text() for page in doc)
+    assert "이 부분이 핵심입니다" in full_text
+    doc.close()
+
+
+def test_generate_pdf_with_no_memo_content_adds_no_memo_page(sample_pdf):
+    """memo content가 비어있으면 메모 섹션 자체를 추가하지 않아야 한다."""
+    memos = {"page_1": [{"content": "  ", "sentenceText": "something"}]}
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, memos)
+    doc = fitz.open("pdf", result)
+    assert doc.page_count == 2
+    doc.close()
+
+
+def test_generate_pdf_handles_invalid_page_key_gracefully(sample_pdf):
+    """존재하지 않는 페이지 번호나 잘못된 키 형식이 들어와도 에러 없이 무시해야 한다."""
+    annotations = {
+        "page_999": [{"type": "highlight", "text": "anything", "color": "#eab308"}],
+        "not-a-page-key": [{"type": "highlight", "text": "anything", "color": "#eab308"}],
+    }
+    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    doc = fitz.open("pdf", result)
+    assert doc.page_count == 2
+    doc.close()

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-B4-qZQDA.js"></script>
+  <script type="module" crossorigin src="/assets/index-BNOr0M3U.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
 </head>
 <body>

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -59,6 +59,25 @@ export async function updateLibraryTranslation(docId, pageNum, payload, options 
   if (!res.ok) throw new Error('번역 수정 저장 실패')
   return res.json()
 }
+export async function exportAnnotatedPdf(docId, payload) {
+  const res = await fetch(`${API_BASE}/library/${docId}/export-pdf`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+  if (!res.ok) {
+    let message = 'PDF 내보내기 실패'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  return res.blob()
+}
+
 export async function searchLibrary(query) {
   const res = await fetch(`${API_BASE}/library/search?q=${encodeURIComponent(query)}`)
   if (!res.ok) throw new Error('검색 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,7 @@ import './style.css'
 import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -1106,25 +1106,29 @@ viewerScrollContainer.addEventListener('touchend', (e) => {
 })
 
 // ── 내보내기 ──────────────────────────────────────
-exportBtn.addEventListener('click', async () => {
-  // 캐시에 로드되지 않은 번역 완료 페이지가 있다면 다운로드 전 비동기로 로드
+// 캐시에 로드되지 않은 번역 완료 페이지가 있다면 내보내기 전 비동기로 채워 넣는다
+// (마크다운/PDF 내보내기가 공용으로 사용)
+async function ensureAllTranslationsLoaded() {
   const missingPages = Array.from(state.translatedPages).filter(pageNum => {
     return !state.translationCache[pageNum] || state.translationCache[pageNum] === '__fetching__'
   })
-  
-  if (missingPages.length > 0) {
-    showToast('전체 번역 데이터를 가져오는 중입니다...', 'info')
-    const opts = getTranslationOptions()
-    await Promise.all(missingPages.map(async (pageNum) => {
-      try {
-        const res = await fetchLibraryTranslation(state.sessionId, pageNum, opts)
-        state.translationCache[pageNum] = res.translation
-        state.translationSentences[pageNum] = res.sentences || []
-      } catch (err) {
-        console.warn(`Failed to fetch translation for page ${pageNum} during export:`, err)
-      }
-    }))
-  }
+  if (missingPages.length === 0) return
+
+  showToast('전체 번역 데이터를 가져오는 중입니다...', 'info')
+  const opts = getTranslationOptions()
+  await Promise.all(missingPages.map(async (pageNum) => {
+    try {
+      const res = await fetchLibraryTranslation(state.sessionId, pageNum, opts)
+      state.translationCache[pageNum] = res.translation
+      state.translationSentences[pageNum] = res.sentences || []
+    } catch (err) {
+      console.warn(`Failed to fetch translation for page ${pageNum} during export:`, err)
+    }
+  }))
+}
+
+async function exportAsMarkdown() {
+  await ensureAllTranslationsLoaded()
 
   const pages = Object.entries(state.translationCache)
     .filter(([_, text]) => text && text !== '__fetching__')
@@ -1140,6 +1144,102 @@ exportBtn.addEventListener('click', async () => {
   a.href = url; a.download = `${state.filename}_번역.md`; a.click()
   URL.revokeObjectURL(url)
   showToast('번역 파일을 다운로드했습니다 ✓', 'success')
+}
+
+// 하이라이트/밑줄/메모(브라우저 localStorage 보관)를 실제 PDF 주석으로 구워
+// 넣고, 번역·메모 섹션을 이어붙인 PDF를 서버에서 생성해 내려받는다.
+async function exportAsAnnotatedPdf() {
+  if (!state.sessionId) return
+  await ensureAllTranslationsLoaded()
+
+  const annotations = loadAnnotations(state.sessionId)
+  const memos = loadMemos(state.sessionId)
+  const opts = getTranslationOptions()
+
+  showToast('번역·주석이 포함된 PDF를 생성하는 중입니다. 잠시만 기다려주세요...', 'info')
+  try {
+    const blob = await exportAnnotatedPdf(state.sessionId, {
+      annotations,
+      memos,
+      target_lang: opts.targetLang,
+      style: opts.style,
+      ignore_math: opts.ignoreMath,
+      ignore_table: opts.ignoreTable,
+      ignore_refs: opts.ignoreRefs,
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    const baseName = (state.filename || 'document').replace(/\.pdf$/i, '')
+    a.href = url; a.download = `${baseName}_번역_주석.pdf`; a.click()
+    URL.revokeObjectURL(url)
+    showToast('PDF 파일을 다운로드했습니다 ✓', 'success')
+  } catch (err) {
+    showToast(err.message || 'PDF 내보내기 실패', 'error')
+  }
+}
+
+// 내보내기 버튼 클릭 시 형식(마크다운/PDF)을 고르는 작은 드롭다운 메뉴
+let exportFormatMenu = null
+
+function createExportFormatMenu() {
+  if (exportFormatMenu) return exportFormatMenu
+  const menu = document.createElement('div')
+  menu.id = 'export-format-menu'
+  menu.className = 'selection-menu hidden'
+  menu.style.flexDirection = 'column'
+  menu.style.alignItems = 'stretch'
+  menu.style.height = 'auto'
+  menu.style.gap = '2px'
+  menu.innerHTML = `
+    <button type="button" class="menu-btn export-format-item" data-format="md" style="justify-content: flex-start; width: 100%; padding: 8px 12px; font-size: 12.5px; font-weight: 600; white-space: nowrap;">
+      ${icon('fileText', 14, 'style="margin-right:6px;vertical-align:-2px"')}마크다운 (.md)
+    </button>
+    <button type="button" class="menu-btn export-format-item" data-format="pdf" style="justify-content: flex-start; width: 100%; padding: 8px 12px; font-size: 12.5px; font-weight: 600; white-space: nowrap;">
+      ${icon('download', 14, 'style="margin-right:6px;vertical-align:-2px"')}PDF (번역·주석 포함)
+    </button>
+  `
+  document.body.appendChild(menu)
+  exportFormatMenu = menu
+
+  menu.querySelectorAll('.export-format-item').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      hideExportFormatMenu()
+      if (btn.dataset.format === 'md') {
+        exportAsMarkdown()
+      } else {
+        exportAsAnnotatedPdf()
+      }
+    })
+  })
+
+  document.addEventListener('click', (e) => {
+    if (exportFormatMenu && !exportFormatMenu.classList.contains('hidden') &&
+        !exportFormatMenu.contains(e.target) && e.target !== exportBtn && !exportBtn.contains(e.target)) {
+      hideExportFormatMenu()
+    }
+  })
+
+  return menu
+}
+
+function hideExportFormatMenu() {
+  if (exportFormatMenu) exportFormatMenu.classList.add('hidden')
+}
+
+exportBtn.addEventListener('click', (e) => {
+  e.stopPropagation()
+  const menu = createExportFormatMenu()
+  const isHidden = menu.classList.contains('hidden')
+  if (!isHidden) { hideExportFormatMenu(); return }
+
+  menu.classList.remove('hidden')
+  const rect = exportBtn.getBoundingClientRect()
+  const menuWidth = menu.offsetWidth || 210
+  const idealLeft = rect.left + rect.width / 2 - menuWidth / 2 + window.scrollX
+  const maxLeft = window.scrollX + document.documentElement.clientWidth - menuWidth - 8
+  menu.style.left = `${Math.max(8, Math.min(idealLeft, maxLeft))}px`
+  menu.style.top = `${rect.bottom + 8 + window.scrollY}px`
 })
 
 // ── 다시 번역하기 ──────────────────────────────────

--- a/frontend/tests/e2e/export-pdf.spec.js
+++ b/frontend/tests/e2e/export-pdf.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+test('내보내기 버튼 클릭 시 형식 선택 메뉴가 뜨고, PDF 선택 시 서버에 올바른 데이터를 보낸다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [1] }
+  await mockBaseRoutes(page, { documents: [docA] })
+  await page.route('**/api/library/doc-A/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+  await page.route('**/api/library/doc-A/translation/1*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ page: 1, translation: '테스트 번역입니다.', sentences: [] }) }))
+
+  let exportRequestBody = null
+  await page.route('**/api/library/doc-A/export-pdf', route => {
+    exportRequestBody = route.request().postDataJSON()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/pdf',
+      headers: { 'Content-Disposition': 'attachment; filename="export.pdf"' },
+      body: Buffer.from('%PDF-1.4 fake pdf content'),
+    })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_annotations_doc-A', JSON.stringify({
+      page_1: [{ type: 'highlight', text: 'sample text', startOffset: 0, endOffset: 11, color: '#eab308' }],
+    }))
+    localStorage.setItem('easypaper_memos_doc-A', JSON.stringify({
+      page_1: [{ id: 'memo_1', pageNum: 1, sentenceIdx: 0, sentenceText: 'sample', content: '메모 내용', x: 10, y: 10 }],
+    }))
+  })
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1200)
+
+  await page.click('#export-btn')
+  await expect(page.locator('#export-format-menu')).not.toHaveClass(/hidden/)
+  await expect(page.getByText('마크다운 (.md)')).toBeVisible()
+  await expect(page.getByText('PDF (번역·주석 포함)')).toBeVisible()
+
+  const downloadPromise = page.waitForEvent('download')
+  await page.click('.export-format-item[data-format="pdf"]')
+  const download = await downloadPromise
+
+  expect(exportRequestBody).not.toBeNull()
+  expect(exportRequestBody.annotations.page_1[0].text).toBe('sample text')
+  expect(exportRequestBody.memos.page_1[0].content).toBe('메모 내용')
+  expect(exportRequestBody.target_lang).toBeTruthy()
+
+  expect(download.suggestedFilename()).toContain('번역_주석.pdf')
+})
+
+test('메뉴 바깥을 클릭하면 형식 선택 메뉴가 닫힌다', async ({ page }) => {
+  const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docA] })
+  await page.route('**/api/library/doc-A/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1000)
+
+  await page.click('#export-btn')
+  await expect(page.locator('#export-format-menu')).not.toHaveClass(/hidden/)
+
+  await page.mouse.click(20, 400)
+  await expect(page.locator('#export-format-menu')).toHaveClass(/hidden/)
+})


### PR DESCRIPTION
# Summary
## 1. 번역/하이라이트/밑줄/메모가 포함된 PDF 내보내기 추가
- 기존 "번역본 내보내기" 버튼(마크다운 전용)을 클릭 시 형식을 고르는 작은 드롭다운으로 확장 - 기존 마크다운 내보내기는 그대로 유지하고 "PDF (번역·주석 포함)" 옵션을 추가
- 하이라이트/밑줄/메모는 브라우저 localStorage에만 있고 백엔드는 전혀 모르므로, 내보내기 시점에 프론트가 그 데이터를 함께 POST로 전송하고 서버가 즉시 PDF를 생성해 반환(서버에 저장하지 않음)
- `backend/services/pdf_export.py` (신규): PyMuPDF(`fitz`, 이미 설치된 의존성이라 새 패키지 불필요)로 원본 PDF 각 페이지에 하이라이트/밑줄을 실제 PDF 주석으로 굽는다 - 브라우저가 저장한 문자 offset은 PDF 좌표계와 무관해 재사용할 수 없으므로, 저장된 텍스트 문자열 자체를 페이지에서 검색(`search_for`)해 위치를 찾는 방식을 씀(대부분 잘 맞고, 못 찾으면 그 항목만 조용히 건너뜀 - 전체 내보내기가 실패하지 않음)
- 번역 전문과 메모 요약은 `fitz.Story`(HTML 기반 자동 페이지네이션)로 별도 섹션으로 이어붙임 - PyMuPDF 기본 14종 폰트는 한글 글리프가 없어 깨지므로 반드시 이 경로를 써야 함(`insert_textbox` 직접 사용 시 한글이 "??"로 깨지는 것을 실제로 확인 후 `Story` 방식으로 전환)
- `backend/routers/library.py`: `POST /library/{doc_id}/export-pdf` 신규 추가. `Content-Disposition`에 한글 파일명을 RFC 5987로 인코딩해 포함

## 검증
- 백엔드 pytest 8개 추가: 주석 굽기(하이라이트/밑줄), 텍스트 미발견 시 안전 스킵, 번역·메모 섹션 추가, 빈 메모 스킵, 잘못된 페이지 키 방어
- 프론트 Playwright 2개 추가: 형식 선택 메뉴 동작(열기/닫기/바깥 클릭), 실제 PDF 다운로드 요청에 담기는 데이터(annotations/memos/번역 옵션) 검증
- 전체 스위트 통과 확인: 백엔드 65개, 프론트 14개
- 실제 PDF를 생성해 렌더링까지 확인: 하이라이트/밑줄이 정확한 색상으로 원본 페이지에 적용되고, 한글 번역·메모 섹션이 깨짐 없이 자연스럽게 렌더링됨을 스크린샷으로 확인
