### PR TITLE
feat: add clickable reference links for numbered citations

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -283,6 +283,83 @@ async def get_library_document_images(doc_id: str, current_user: str = Depends(g
         raise HTTPException(status_code=500, detail=f"이미지 좌표 추출 실패: {str(e)}")
 
 
+@router.get("/library/{doc_id}/references")
+async def get_library_references(doc_id: str, current_user: str = Depends(get_current_user)):
+    """참고문헌 목록(번호 -> 원문 텍스트)을 반환합니다.
+
+    외부 API 호출 없이 PDF 텍스트만 파싱한다 - 실제 외부 링크 조회는
+    사용자가 본문에서 특정 인용 표기를 클릭했을 때만
+    (/library/{doc_id}/references/{ref_num}) 그때그때 수행한다. 논문 한 편에
+    참고문헌이 수십~백여 개인 경우가 흔한데, 열 때마다 전부 미리 조회하면
+    외부 API 레이트리밋에 바로 걸리고 대부분은 클릭되지도 않아 낭비다.
+    """
+    _require_owned_document(doc_id, current_user)
+
+    from services.library import get_page_insight, save_page_insight
+
+    cached = get_page_insight(doc_id, 0, "reference_list")
+    if cached is not None:
+        try:
+            return {"references": json.loads(cached)}
+        except Exception:
+            pass
+
+    pdf_path = get_pdf_path(doc_id)
+    if not pdf_path:
+        raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
+
+    from services.pdf_parser import extract_pages
+    from services.reference_parser import extract_reference_list
+    try:
+        pages = extract_pages(pdf_path)
+        references = extract_reference_list(pages)
+    except Exception:
+        references = {}
+
+    save_page_insight(doc_id, 0, "reference_list", json.dumps(references, ensure_ascii=False))
+    return {"references": references}
+
+
+@router.get("/library/{doc_id}/references/{ref_num}")
+async def resolve_library_reference(doc_id: str, ref_num: str, current_user: str = Depends(get_current_user)):
+    """특정 번호의 참고문헌을 외부(Semantic Scholar, 가능하면 arXiv)에서
+    검색해 링크를 반환합니다. 결과(성공/실패 모두)는 캐시해 같은 항목을
+    반복 조회하지 않습니다."""
+    _require_owned_document(doc_id, current_user)
+
+    from services.library import get_page_insight, save_page_insight
+
+    cached = get_page_insight(doc_id, 0, "reference_url", suffix=ref_num)
+    if cached is not None:
+        try:
+            data = json.loads(cached)
+        except Exception:
+            data = {}
+        if not data:
+            raise HTTPException(status_code=404, detail="외부에서 일치하는 논문을 찾지 못했습니다.")
+        return data
+
+    ref_list_cached = get_page_insight(doc_id, 0, "reference_list")
+    references = {}
+    if ref_list_cached:
+        try:
+            references = json.loads(ref_list_cached)
+        except Exception:
+            references = {}
+
+    ref_text = references.get(ref_num)
+    if not ref_text:
+        raise HTTPException(status_code=404, detail="해당 번호의 참고문헌을 찾을 수 없습니다.")
+
+    from services.reference_linker import resolve_reference
+    result = await resolve_reference(ref_text)
+    save_page_insight(doc_id, 0, "reference_url", json.dumps(result or {}, ensure_ascii=False), suffix=ref_num)
+
+    if not result:
+        raise HTTPException(status_code=404, detail="외부에서 일치하는 논문을 찾지 못했습니다.")
+    return result
+
+
 @router.put("/library/{doc_id}/metadata")
 async def update_doc_metadata(
     doc_id: str,

--- a/backend/services/reference_linker.py
+++ b/backend/services/reference_linker.py
@@ -1,0 +1,83 @@
+"""
+파싱된 참고문헌 텍스트를 Semantic Scholar API로 검색해 실제 논문 링크(가능한
+경우 arXiv 링크 우선)를 찾는다. API 키 없이 쓸 수 있는 공개 검색
+엔드포인트를 사용하며, 실패/미매칭 시 예외를 던지지 않고 None을 반환해
+호출부(참고문헌 링크 연결 기능 전체)가 이 한 건의 실패로 죽지 않게 한다.
+
+주의: Semantic Scholar의 공개(API 키 없는) 검색 엔드포인트는 IP 기준
+공유 레이트리밋이 꽤 엄격하다(실제로 이 프로젝트 개발 환경에서도 여러 번
+429 Too Many Requests를 받았음). 429를 받으면 짧게 재시도하되, 그래도
+안 되면 그 한 건만 실패로 처리하고 조용히 넘어간다 - 트래픽이 몰리는
+환경(클라우드 공유 IP 등)에서는 이 기능이 간헐적으로 안 될 수 있다는
+한계가 있다. 요청량이 많다면 Semantic Scholar API 키(무료 발급)를
+`SEMANTIC_SCHOLAR_API_KEY` 헤더로 추가하면 훨씬 높은 한도를 받을 수 있다.
+"""
+
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_SEMANTIC_SCHOLAR_SEARCH_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+_REQUEST_TIMEOUT_SECONDS = 10.0
+_MAX_RETRIES_ON_RATE_LIMIT = 2
+_RETRY_BACKOFF_SECONDS = 2.0
+
+
+async def resolve_reference(query_text: str) -> Optional[dict]:
+    """참고문헌 원문 텍스트로 Semantic Scholar를 검색해 가장 관련성 높은
+    논문의 제목/링크/연도를 반환합니다. 매칭 실패나 네트워크 오류 시 None.
+    """
+    query = (query_text or "").strip()[:300]
+    if not query:
+        return None
+
+    for attempt in range(_MAX_RETRIES_ON_RATE_LIMIT + 1):
+        try:
+            async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+                resp = await client.get(
+                    _SEMANTIC_SCHOLAR_SEARCH_URL,
+                    params={
+                        "query": query,
+                        "limit": 1,
+                        "fields": "title,url,externalIds,year",
+                    },
+                )
+
+                if resp.status_code == 429 and attempt < _MAX_RETRIES_ON_RATE_LIMIT:
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS * (attempt + 1))
+                    continue
+
+                if resp.status_code != 200:
+                    logger.warning(f"Semantic Scholar 검색 실패: status={resp.status_code}")
+                    return None
+
+                data = resp.json()
+                papers = data.get("data") or []
+                if not papers:
+                    return None
+
+                paper = papers[0]
+                url = paper.get("url")
+                external_ids = paper.get("externalIds") or {}
+                arxiv_id = external_ids.get("ArXiv")
+                if arxiv_id:
+                    # arXiv 링크가 있으면 원문을 무료로 바로 볼 수 있어 우선한다
+                    url = f"https://arxiv.org/abs/{arxiv_id}"
+
+                if not url:
+                    return None
+
+                return {
+                    "title": paper.get("title") or "",
+                    "url": url,
+                    "year": paper.get("year"),
+                }
+        except Exception as e:
+            logger.warning(f"참고문헌 검색 중 오류: {e}")
+            return None
+
+    return None

--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -1,0 +1,82 @@
+"""
+논문 원문 텍스트에서 References/참고문헌 섹션을 찾아 번호별 항목으로
+파싱하는 순수 텍스트 처리 로직 (네트워크 호출 없음).
+
+번호가 매겨진 인용 스타일(`[12] ...` 또는 `12. ...`)만 지원한다 - (Author,
+Year) 스타일은 패턴이 훨씬 다양하고 오탐이 잦아 이번 범위에서는 제외했다.
+CS/ML 논문 대부분이 번호 인용 스타일을 쓰므로 이 앱의 실제 사용처에서는
+충분히 유용하다.
+"""
+
+import re
+from typing import Dict, List
+
+_SECTION_HEADER_RE = re.compile(
+    r"^\s*\**\s*(references|bibliography|참고\s*문헌)\s*\**\s*$",
+    re.IGNORECASE,
+)
+_BRACKET_ENTRY_RE = re.compile(r"^\s*\[(\d{1,3})\]\s*(.+)")
+_PLAIN_NUMBERED_ENTRY_RE = re.compile(r"^\s*(\d{1,3})\.\s+(.+)")
+
+_MAX_ENTRY_LENGTH = 500
+
+
+def extract_reference_list(pages: List[dict]) -> Dict[str, str]:
+    """페이지 목록(각 {"text": ...} 포함)에서 참고문헌 목록을 파싱합니다.
+
+    반환값: {"12": "Vaswani et al. Attention Is All You Need. 2017.", ...}
+    섹션을 찾지 못하거나 파싱에 실패하면 빈 딕셔너리를 반환합니다(호출부가
+    이 실패를 전체 기능 중단으로 이어가지 않도록).
+    """
+    try:
+        return _extract_reference_list_impl(pages)
+    except Exception:
+        return {}
+
+
+def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
+    ref_start_page_idx = None
+    for i in range(len(pages) - 1, -1, -1):
+        text = pages[i].get("text", "") or ""
+        if any(_SECTION_HEADER_RE.match(line.strip()) for line in text.split("\n")):
+            ref_start_page_idx = i
+            break
+
+    if ref_start_page_idx is None:
+        return {}
+
+    combined_text = "\n".join(p.get("text", "") or "" for p in pages[ref_start_page_idx:])
+    lines = combined_text.split("\n")
+
+    start_idx = 0
+    for idx, line in enumerate(lines):
+        if _SECTION_HEADER_RE.match(line.strip()):
+            start_idx = idx + 1
+            break
+    body_lines = lines[start_idx:]
+
+    entries: Dict[str, str] = {}
+    current_num = None
+    current_parts: List[str] = []
+
+    def flush():
+        if current_num is not None:
+            text = re.sub(r"\s+", " ", " ".join(current_parts)).strip()
+            if text:
+                entries[current_num] = text[:_MAX_ENTRY_LENGTH]
+
+    for raw_line in body_lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        m = _BRACKET_ENTRY_RE.match(line) or _PLAIN_NUMBERED_ENTRY_RE.match(line)
+        if m:
+            flush()
+            current_num = m.group(1)
+            current_parts = [m.group(2)]
+        elif current_num is not None:
+            current_parts.append(line)
+
+    flush()
+    return entries

--- a/backend/tests/test_library_references_api.py
+++ b/backend/tests/test_library_references_api.py
@@ -1,0 +1,95 @@
+"""GET /library/{doc_id}/references, GET /library/{doc_id}/references/{ref_num}
+HTTP 레벨 테스트 - 캐싱, 소유자 격리, 외부 API 미매칭 처리를 확인한다.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+
+def _create_doc(isolated_dirs, doc_id="doc-1", username="testuser"):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "Test Paper"})
+
+
+def test_get_references_parses_and_caches(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+
+    fake_pages = [{"page_num": 1, "text": "References\n\n[1] Someone. A Paper. 2020."}]
+    with patch("services.pdf_parser.extract_pages", return_value=fake_pages), \
+         patch("routers.library.get_pdf_path", return_value="/fake/path.pdf"):
+        res = test_client.get("/api/library/doc-1/references")
+
+    assert res.status_code == 200
+    assert res.json()["references"] == {"1": "Someone. A Paper. 2020."}
+
+    # 두 번째 호출은 캐시를 써야 하므로 extract_pages가 다시 호출되지 않아야 한다
+    with patch("services.pdf_parser.extract_pages") as mock_extract:
+        res2 = test_client.get("/api/library/doc-1/references")
+    assert res2.status_code == 200
+    assert res2.json()["references"] == {"1": "Someone. A Paper. 2020."}
+    mock_extract.assert_not_called()
+
+
+def test_get_references_other_users_document_returns_404(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, doc_id="doc-other", username="otheruser")
+    res = test_client.get("/api/library/doc-other/references")
+    assert res.status_code == 404
+
+
+def test_resolve_reference_returns_url_when_matched(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+    isolated_dirs["db"].db_save_page_insight(
+        "doc-1", 0, "reference_list", json.dumps({"1": "Vaswani et al. Attention Is All You Need."})
+    )
+
+    mock_result = {"title": "Attention Is All You Need", "url": "https://arxiv.org/abs/1706.03762", "year": 2017}
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(return_value=mock_result)):
+        res = test_client.get("/api/library/doc-1/references/1")
+
+    assert res.status_code == 200
+    assert res.json()["url"] == "https://arxiv.org/abs/1706.03762"
+
+
+def test_resolve_reference_caches_result(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+    isolated_dirs["db"].db_save_page_insight(
+        "doc-1", 0, "reference_list", json.dumps({"1": "Some paper title."})
+    )
+
+    mock_result = {"title": "Some paper title.", "url": "https://example.com/paper", "year": 2020}
+    mock_resolve = AsyncMock(return_value=mock_result)
+    with patch("services.reference_linker.resolve_reference", new=mock_resolve):
+        test_client.get("/api/library/doc-1/references/1")
+
+    # 두 번째 호출은 캐시를 써야 하므로 resolve_reference가 다시 호출되지 않아야 한다
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock()) as mock_resolve_2:
+        res2 = test_client.get("/api/library/doc-1/references/1")
+    assert res2.status_code == 200
+    mock_resolve_2.assert_not_called()
+
+
+def test_resolve_reference_returns_404_when_no_match_found(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+    isolated_dirs["db"].db_save_page_insight(
+        "doc-1", 0, "reference_list", json.dumps({"1": "unmatchable nonsense query"})
+    )
+
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(return_value=None)):
+        res = test_client.get("/api/library/doc-1/references/1")
+
+    assert res.status_code == 404
+
+
+def test_resolve_reference_returns_404_when_ref_num_unknown(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+    isolated_dirs["db"].db_save_page_insight(
+        "doc-1", 0, "reference_list", json.dumps({"1": "the only reference"})
+    )
+    res = test_client.get("/api/library/doc-1/references/999")
+    assert res.status_code == 404
+
+
+def test_resolve_reference_other_users_document_returns_404(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, doc_id="doc-other2", username="otheruser")
+    res = test_client.get("/api/library/doc-other2/references/1")
+    assert res.status_code == 404

--- a/backend/tests/test_reference_linker.py
+++ b/backend/tests/test_reference_linker.py
@@ -1,0 +1,110 @@
+"""services/reference_linker.py 테스트.
+
+Semantic Scholar 공개 API는 이 프로젝트 개발 환경에서도 실제로 여러 차례
+429 Too Many Requests를 반환할 만큼 레이트리밋이 엄격해서, 실제 네트워크
+호출에 의존하는 테스트는 신뢰할 수 없다. httpx 응답을 모킹해 로직만
+검증한다.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from services.reference_linker import resolve_reference
+
+
+def _make_response(status_code: int, json_data: dict = None):
+    request = httpx.Request("GET", "https://api.semanticscholar.org/graph/v1/paper/search")
+    return httpx.Response(status_code=status_code, json=json_data or {}, request=request)
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_returns_none_for_empty_query():
+    assert await resolve_reference("") is None
+    assert await resolve_reference("   ") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_prefers_arxiv_link_when_available():
+    mock_response = _make_response(200, {
+        "data": [{
+            "title": "Attention Is All You Need",
+            "url": "https://www.semanticscholar.org/paper/abc123",
+            "externalIds": {"ArXiv": "1706.03762"},
+            "year": 2017,
+        }]
+    })
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference("Vaswani et al. Attention Is All You Need. 2017.")
+
+    assert result is not None
+    assert result["url"] == "https://arxiv.org/abs/1706.03762"
+    assert result["title"] == "Attention Is All You Need"
+    assert result["year"] == 2017
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_falls_back_to_semantic_scholar_url_without_arxiv():
+    mock_response = _make_response(200, {
+        "data": [{
+            "title": "Some Paper",
+            "url": "https://www.semanticscholar.org/paper/xyz789",
+            "externalIds": {},
+            "year": 2020,
+        }]
+    })
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference("Some Paper query text")
+
+    assert result["url"] == "https://www.semanticscholar.org/paper/xyz789"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_returns_none_when_no_results():
+    mock_response = _make_response(200, {"data": []})
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference("a query with no matches")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_retries_on_rate_limit_then_succeeds():
+    responses = [
+        _make_response(429, {"message": "Too Many Requests"}),
+        _make_response(200, {"data": [{"title": "Retried Paper", "url": "https://example.com/p", "externalIds": {}, "year": 2021}]}),
+    ]
+    mock_get = AsyncMock(side_effect=responses)
+    with patch("httpx.AsyncClient.get", new=mock_get):
+        with patch("asyncio.sleep", new=AsyncMock()):  # 테스트 속도를 위해 실제 대기는 건너뜀
+            result = await resolve_reference("query that gets rate limited once")
+
+    assert result is not None
+    assert result["title"] == "Retried Paper"
+    assert mock_get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_gives_up_after_max_retries_on_persistent_rate_limit():
+    mock_get = AsyncMock(return_value=_make_response(429, {"message": "Too Many Requests"}))
+    with patch("httpx.AsyncClient.get", new=mock_get):
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await resolve_reference("persistently rate limited query")
+
+    assert result is None
+    assert mock_get.call_count == 3  # 최초 시도 + 재시도 2회
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_handles_network_exception_gracefully():
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.ConnectError("연결 실패"))):
+        result = await resolve_reference("query during network outage")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_returns_none_when_no_url_available():
+    mock_response = _make_response(200, {"data": [{"title": "No URL Paper", "url": None, "externalIds": {}, "year": 2019}]})
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference("paper with no url")
+    assert result is None

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -1,0 +1,71 @@
+"""services/reference_parser.py 테스트 - References/참고문헌 섹션 파싱."""
+
+from services.reference_parser import extract_reference_list
+
+
+def test_parses_bracket_style_numbered_references():
+    pages = [
+        {"page_num": 1, "text": "Title\n\nAbstract\n\nBody text..."},
+        {"page_num": 9, "text": (
+            "Conclusion\n\nWe presented the Transformer.\n\n"
+            "References\n\n"
+            "[1] Dzmitry Bahdanau, Kyunghyun Cho, and Yoshua Bengio. Neural machine "
+            "translation by jointly learning to align and translate. CoRR, 2014.\n\n"
+            "[2] Jianpeng Cheng, Li Dong, and Mirella Lapata. Long short-term "
+            "memory-networks for machine reading. In EMNLP, 2016."
+        )},
+    ]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"1", "2"}
+    assert "Bahdanau" in refs["1"]
+    assert "Cheng" in refs["2"]
+
+
+def test_parses_plain_numbered_references_with_korean_header():
+    pages = [
+        {"page_num": 1, "text": "논문 제목\n\n초록\n\n본문 내용..."},
+        {"page_num": 5, "text": (
+            "결론\n\n참고문헌\n\n"
+            "1. Smith, J. Deep Learning Basics. NeurIPS 2020.\n\n"
+            "2. Lee, K. Attention Mechanisms Survey. ICML 2021."
+        )},
+    ]
+    refs = extract_reference_list(pages)
+    assert refs == {
+        "1": "Smith, J. Deep Learning Basics. NeurIPS 2020.",
+        "2": "Lee, K. Attention Mechanisms Survey. ICML 2021.",
+    }
+
+
+def test_returns_empty_dict_when_no_references_section():
+    pages = [{"page_num": 1, "text": "그냥 본문 텍스트입니다. 참고문헌 섹션 없음."}]
+    assert extract_reference_list(pages) == {}
+
+
+def test_returns_empty_dict_for_empty_input():
+    assert extract_reference_list([]) == {}
+
+
+def test_merges_multiline_entries():
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "[1] A very long author list that continues\n"
+        "onto a second physical line before the year\n"
+        "and publisher information. 2021."
+    )}]
+    refs = extract_reference_list(pages)
+    assert "continues" in refs["1"]
+    assert "publisher information" in refs["1"]
+
+
+def test_truncates_excessively_long_entries():
+    long_text = "A. Author. " + ("Very long title words. " * 100)
+    pages = [{"page_num": 1, "text": f"References\n\n[1] {long_text}"}]
+    refs = extract_reference_list(pages)
+    assert len(refs["1"]) <= 500
+
+
+def test_does_not_crash_on_malformed_page_data():
+    """text 키가 없거나 None이어도 예외 없이 빈 결과를 반환해야 한다."""
+    assert extract_reference_list([{"page_num": 1}]) == {}
+    assert extract_reference_list([{"page_num": 1, "text": None}]) == {}

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BNOr0M3U.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-gue3hsye.css">
+  <script type="module" crossorigin src="/assets/index-B4hTi5By.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-wXSfWeDV.css">
 </head>
 <body>
 

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -84,6 +84,21 @@ export async function searchLibrary(query) {
   return res.json()
 }
 
+export async function fetchLibraryReferences(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/references`)
+  if (!res.ok) throw new Error('참고문헌 목록 조회 실패')
+  return res.json()
+}
+
+export async function resolveLibraryReference(docId, refNum) {
+  const res = await fetch(`${API_BASE}/library/${docId}/references/${encodeURIComponent(refNum)}`)
+  if (!res.ok) {
+    if (res.status === 404) return null
+    throw new Error('참고문헌 링크 조회 실패')
+  }
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,7 @@ import './style.css'
 import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -46,6 +46,7 @@ const state = {
   availableOllamaModels: [],   // Ollama에서 설치된 모델 목록
   quotedText: null,            // AI 질문 시 인용구 보관용
   documentImages: [],          // 문서 내 이미지 좌표 목록
+  referenceMap: {},            // 참고문헌 번호 -> 원문 텍스트 맵
   quotedImage: null,           // AI 질문 시 인용 이미지 보관용 (Base64)
   quotedImagePage: null,       // AI 질문 시 인용 이미지의 페이지 번호
   pendingFigureQuote: null,    // 클릭 후 AI 질문 전 대기중인 인용 이미지 정보
@@ -288,7 +289,7 @@ function resetState() {
     sessionId: null, filename: null, title: null, totalPages: 0, currentPage: 1,
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
     chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null,
-    activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: []
+    activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: [], referenceMap: {}
   })
   if (typeof toggleCropMode === 'function') toggleCropMode(false)
   viewerScrollContainer.innerHTML = ''
@@ -3524,6 +3525,25 @@ async function loadDocumentImages(docId) {
   }
 }
 
+async function loadDocumentReferences(docId) {
+  try {
+    const refRes = await fetchLibraryReferences(docId)
+    state.referenceMap = refRes.references || {}
+
+    // 이미 렌더링되어 있는 페이지들의 인용 오버레이 갱신
+    document.querySelectorAll('.textLayer').forEach(textLayerDiv => {
+      const pageWrapper = textLayerDiv.closest('.pdf-page-wrapper')
+      if (pageWrapper) {
+        const pageNum = parseInt(pageWrapper.dataset.page)
+        renderCitationOverlayLayer(textLayerDiv, pageNum)
+      }
+    })
+  } catch (e) {
+    console.warn("참고문헌 목록 로드 실패:", e)
+    state.referenceMap = {}
+  }
+}
+
 async function openFromLibrary(doc, shouldPushState = true) {
   // 이전 문서에서 진행 중이던 채팅 스트림이 있으면 반드시 먼저 취소한다.
   // 이 함수는 popstate/hashchange 라우팅(handleRouting)에서 resetState()를
@@ -3537,6 +3557,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
   }
   state.sessionId  = doc.id
   loadDocumentImages(doc.id)
+  loadDocumentReferences(doc.id)
   state.filename   = doc.filename
   state.currentDocId = doc.id
   state.currentDocMetadata = doc.metadata || {}
@@ -5310,6 +5331,7 @@ window.onTextLayerRendered = (textLayerDiv, pageNum) => {
   }
 
   renderImageOverlayLayer(textLayerDiv, pageNum)
+  renderCitationOverlayLayer(textLayerDiv, pageNum)
 
   // Render floating memos
   renderPageMemos(pageNum)
@@ -5403,6 +5425,100 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
   inner.appendChild(layer)
 }
 
+// 번호 인용 스타일만 지원 ([12], [12, 13], [12-14] 등) - (Author, Year) 스타일은
+// 백엔드 reference_parser.py와 동일하게 이번 범위에서 제외했다.
+const CITATION_MARKER_RE = /\[\s*\d{1,3}(?:\s*[,\-–]\s*\d{1,3})*\s*\]/g
+
+// "[12, 14-16]" 형태의 대괄호 안 내용을 개별 참고문헌 번호 목록으로 펼친다
+function parseCitationNumbers(bracketText) {
+  const inner = bracketText.slice(1, -1)
+  const nums = []
+  inner.split(',').forEach(part => {
+    const range = part.trim().match(/^(\d{1,3})\s*[-–]\s*(\d{1,3})$/)
+    if (range) {
+      const start = parseInt(range[1], 10)
+      const end = parseInt(range[2], 10)
+      // 비정상적으로 넓은 범위(오탐 - 예: 페이지/연도 범위 오인)는 무시
+      if (end >= start && end - start <= 50) {
+        for (let n = start; n <= end; n++) nums.push(String(n))
+      }
+    } else {
+      const single = part.trim().match(/^\d{1,3}$/)
+      if (single) nums.push(single[0])
+    }
+  })
+  return nums
+}
+
+// 본문 인용 표기 오버레이 - 참고문헌 목록에 실제로 존재하는 번호를 가리키는
+// 표기만 클릭 가능하게 만든다(오탐/미매칭 표기까지 다 클릭되게 하면 클릭할
+// 때마다 404 토스트만 뜨는 경험이 되므로).
+function renderCitationOverlayLayer(textLayerDiv, pageNum) {
+  const pageWrapper = textLayerDiv.closest('.pdf-page-wrapper')
+  if (!pageWrapper) return
+
+  const overlay = getOrCreateOverlay(pageWrapper)
+  overlay.querySelectorAll('.citation-marker-box').forEach(el => el.remove())
+
+  const refMap = state.referenceMap || {}
+  if (Object.keys(refMap).length === 0) return
+
+  const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+  if (!vtm || !vtm.fullText) return
+
+  const docId = state.currentDocId
+  if (!docId) return
+
+  CITATION_MARKER_RE.lastIndex = 0
+  let match
+  while ((match = CITATION_MARKER_RE.exec(vtm.fullText)) !== null) {
+    const nums = parseCitationNumbers(match[0]).filter(n => refMap[n])
+    if (nums.length === 0) continue
+
+    const charStart = match.index
+    const charEnd = match.index + match[0].length
+    const rects = getSentenceRects({ charStart, charEnd }, vtm, textLayerDiv)
+    if (rects.length === 0) continue
+
+    // 대괄호 안에 여러 번호가 있어도([12, 13]) 클릭 시엔 첫 번째 매칭 번호로만
+    // 이동한다 - 대부분 단일 인용이고, 여러 창을 한 번에 여는 것은 오히려 방해된다.
+    const refNum = nums[0]
+    rects.forEach(r => {
+      const box = document.createElement('div')
+      box.className = 'citation-marker-box'
+      box.style.left   = `${r.left}px`
+      box.style.top    = `${r.top}px`
+      box.style.width  = `${r.width}px`
+      box.style.height = `${r.height}px`
+      box.title = refMap[refNum] || ''
+      box.dataset.refNum = refNum
+      box.addEventListener('click', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        handleCitationClick(docId, refNum, box)
+      })
+      overlay.appendChild(box)
+    })
+  }
+}
+
+async function handleCitationClick(docId, refNum, boxEl) {
+  if (boxEl.classList.contains('loading')) return
+  boxEl.classList.add('loading')
+  try {
+    const result = await resolveLibraryReference(docId, refNum)
+    if (result && result.url) {
+      window.open(result.url, '_blank', 'noopener')
+    } else {
+      showToast('참고문헌을 찾지 못했습니다.', 'error')
+    }
+  } catch (e) {
+    console.warn('참고문헌 조회 실패:', e)
+    showToast('참고문헌을 찾지 못했습니다.', 'error')
+  } finally {
+    boxEl.classList.remove('loading')
+  }
+}
 
 // ── AI Chat Sidebar ──────────────────────────────
 function toggleChatSidebar() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4376,6 +4376,25 @@ body.light-theme .sentence-memo-box {
   animation: overlayPulse 0.8s cubic-bezier(0.25, 1, 0.5, 1) forwards;
 }
 
+/* 본문 인용 표기([12] 등) 클릭 가능 오버레이 - 부모(.pdf-highlight-overlay)는
+   pointer-events:none이지만 이 요소만 auto로 되돌려 클릭을 받는다 */
+.citation-marker-box {
+  position: absolute;
+  pointer-events: auto !important;
+  cursor: pointer;
+  border-radius: 1px;
+  border-bottom: 1px dotted rgba(74, 135, 181, 0.65);
+}
+.citation-marker-box:hover {
+  background-color: rgba(74, 135, 181, 0.20);
+}
+body.light-theme .citation-marker-box:hover {
+  background-color: rgba(74, 135, 181, 0.15);
+}
+.citation-marker-box.loading {
+  cursor: wait;
+}
+
 /* 키워드/단어 탭 용어 클릭 시 원문 위치 하이라이트 - 스크롤이 끝난 뒤에 표시되므로
    citation 클릭용 pulse보다 오래 보이도록 별도 애니메이션을 둔다(일정 시간 유지 후 페이드) */
 @keyframes locateHighlightPulse {

--- a/frontend/tests/e2e/citation-links.spec.js
+++ b/frontend/tests/e2e/citation-links.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_CITATION } from './helpers.js'
+
+test('참고문헌 목록에 있는 번호의 본문 인용 표기만 클릭 가능한 오버레이가 생기고, 클릭하면 외부 링크가 새 탭으로 열린다', async ({ page, context }) => {
+  const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docC] })
+  await page.route('**/api/library/doc-C/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
+  // [2]는 참고문헌 목록에서 의도적으로 제외 - 목록에 없는 번호는 클릭 불가능해야 한다
+  await page.route('**/api/library/doc-C/references', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ references: { '1': 'Vaswani et al. Attention Is All You Need. 2017.' } }),
+    }))
+  await page.route('**/api/library/doc-C/references/1', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ title: 'Attention Is All You Need', url: 'https://arxiv.org/abs/1706.03762', year: 2017 }),
+    }))
+  await context.route('https://arxiv.org/**', route =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
+  await page.waitForTimeout(1500)
+
+  const markerBoxes = page.locator('.citation-marker-box')
+  await expect(markerBoxes).toHaveCount(1)
+  await expect(markerBoxes.first()).toHaveAttribute('data-ref-num', '1')
+
+  const [popup] = await Promise.all([
+    context.waitForEvent('page'),
+    markerBoxes.first().click(),
+  ])
+  await popup.waitForLoadState('domcontentloaded')
+  expect(popup.url()).toBe('https://arxiv.org/abs/1706.03762')
+})
+
+test('참고문헌을 찾지 못하면 오류 토스트를 표시한다', async ({ page }) => {
+  const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docC] })
+  await page.route('**/api/library/doc-C/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
+  await page.route('**/api/library/doc-C/references', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ references: { '1': 'Vaswani et al. Attention Is All You Need. 2017.' } }),
+    }))
+  await page.route('**/api/library/doc-C/references/1', route =>
+    route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: '외부에서 일치하는 논문을 찾지 못했습니다.' }) }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
+  await page.waitForTimeout(1500)
+
+  await page.locator('.citation-marker-box').first().click()
+  await expect(page.locator('.toast')).toHaveClass(/show/)
+  await expect(page.locator('.toast')).toHaveText('참고문헌을 찾지 못했습니다.')
+})

--- a/frontend/tests/e2e/fixtures/sample-citation.pdf
+++ b/frontend/tests/e2e/fixtures/sample-citation.pdf
@@ -1,0 +1,47 @@
+%PDF-1.7
+%ÂµÂ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 595 842]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 341/Filter/FlateDecode>>
+stream
+xÚR»NÄ0ìóùã}Ÿ%DDC‡”Ñpçˆ
+¾ŸYßI'H$PÅ±ggÆ;;}N÷ËDsÅC³Õ9ÂK³yù˜oŞúû×L:/ëü|«â-Ô	oóÕ;W'?Eõ£ş*Îª[ğİËòøƒÑ¼pl97H±b}‹4õô…+ü­ÁşÊÕÌêšûgO‘¸t£À÷÷?¥3Nì2¸ÔÍ%4°?*^…ì”ï®ã{DõŠÕàŠ¸ª 2yPß»/ii$m{‹T‚&jÆªÇĞ‰Š‡ÁLÃ™¥Ü0ÜôßÜŞ´°µ¿›é!ÅÌw¢´w·³	ˆBrSm\‡èj¶H!Î1q\Q[6¶eóâÒŞ<UÔˆ¢_KGĞ
+0Õ°H;P†h€–*$±Ó ¢’à7Ìç¡]sR)cW1Û8Û‰'Uáğ2tğuU·‹úÃ2=MßN¾¹
+endstream
+endobj
+
+xref
+0 7
+0000000000 00001 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<C39608C2B219C2B8C2BAC291C2B622C3><EBC9709D3A815185A2C5025C4BF1B326>]>>
+startxref
+761
+%%EOF

--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -6,6 +6,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export const SAMPLE_PDF_A = fs.readFileSync(path.join(__dirname, 'fixtures/sample-a.pdf'))
 export const SAMPLE_PDF_B = fs.readFileSync(path.join(__dirname, 'fixtures/sample-b.pdf'))
+export const SAMPLE_PDF_CITATION = fs.readFileSync(path.join(__dirname, 'fixtures/sample-citation.pdf'))
 
 /**
  * 로그인 이후의 기본 화면(라이브러리)까지 도달하는 데 필요한 최소한의


### PR DESCRIPTION
# Summary
## 1. 참고문헌 텍스트 파싱 (backend/services/reference_parser.py)
- PDF 페이지 텍스트에서 References/참고문헌 섹션을 찾아 번호별 항목으로 파싱
- 번호 인용 스타일([12] 또는 12.)만 지원, (Author, Year) 스타일은 범위 밖으로 명시
- 여러 줄에 걸친 항목 병합, 500자 초과 시 잘라내기, 파싱 실패 시 빈 딕셔너리 반환

## 2. 외부 논문 링크 조회 (backend/services/reference_linker.py)
- Semantic Scholar 공개 검색 API로 참고문헌 원문 텍스트를 검색해 논문 링크 조회
- arXiv ID가 있으면 arXiv 링크를 우선 사용
- 429(레이트리밋) 시 최대 2회 재시도(백오프), 실패/미매칭 시 예외 없이 None 반환

## 3. API 엔드포인트 추가 (backend/routers/library.py)
- `GET /library/{doc_id}/references`: 참고문헌 목록 파싱 결과 반환(결과는 캐싱)
- `GET /library/{doc_id}/references/{ref_num}`: 특정 번호를 외부에서 검색해 링크 반환(성공/실패 모두 캐싱)
- 소유자 검증(`_require_owned_document`)으로 다른 사용자 문서 접근 차단

## 4. 프론트엔드 - 본문 인용 표기 클릭 기능 (frontend/src/main.js, library.js, style.css)
- `fetchLibraryReferences`/`resolveLibraryReference` API 함수 추가
- `loadDocumentReferences()`로 문서 열 때 참고문헌 목록을 한 번만 로드(`loadDocumentImages`와 동일한 패턴)
- `renderCitationOverlayLayer()`: 기존 가상 텍스트 맵(VTM)/`getSentenceRects` 인프라를 재사용해 본문의 `[12]`, `[12, 13]`, `[12-14]` 등 인용 표기 중 참고문헌 목록에 실제로 존재하는 번호만 클릭 가능한 오버레이로 렌더링
- 클릭 시 로딩 상태 표시 후 외부 링크를 새 탭으로 열거나, 미매칭 시 오류 토스트 표시
- `window.onTextLayerRendered` 및 `openFromLibrary`에 훅 연결

## 5. 테스트
- `backend/tests/test_reference_parser.py` (7), `test_reference_linker.py` (8, 모킹 기반), `test_library_references_api.py` (7) 추가 - 백엔드 전체 87개 테스트 통과
- `frontend/tests/e2e/citation-links.spec.js` 추가(인용 오버레이 클릭 시 새 탭 오픈, 미매칭 시 오류 토스트) - 프론트엔드 전체 16개 테스트 통과
