### PR TITLE
fix: prevent library view toggle from overlapping category tags

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -90,7 +90,7 @@
       <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
 
       <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
-      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
+      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 20px;">
         <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
         <div id="library-view-toggle" class="library-view-toggle">
           <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,7 +89,7 @@
       <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
 
       <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
-      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px;">
+      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 20px;">
         <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
         <div id="library-view-toggle" class="library-view-toggle">
           <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>


### PR DESCRIPTION
카테고리 태그가 여러 줄로 줄바꿈될 때 카드/리스트 보기 토글과 겹치던 문제 수정 (align-items: center → flex-start).