### PR TITLE
fix: restore flex layout on library filter row after inline style reset

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-B4hTi5By.js"></script>
+  <script type="module" crossorigin src="/assets/index-CSdrUPUu.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-wXSfWeDV.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2905,7 +2905,11 @@ async function renderLibrary() {
   if (librarySearchInput) librarySearchInput.value = ''
   if (librarySearchClearBtn) librarySearchClearBtn.classList.add('hidden')
   if (librarySearchStatus) librarySearchStatus.classList.add('hidden')
-  if (libraryFilterRow) libraryFilterRow.style.display = ''
+  // #library-filter-row의 display:flex는 CSS 클래스가 아닌 인라인 스타일로만
+  // 선언되어 있어서, ''로 지우면(인라인 속성 제거) flex가 아니라 div의 기본값인
+  // block으로 되돌아가 카테고리 태그/보기 전환 버튼이 옆으로 나란히 배치되지
+  // 못하고 세로로 붙어버린다. 반드시 'flex'로 명시적으로 되돌려야 한다.
+  if (libraryFilterRow) libraryFilterRow.style.display = 'flex'
   isLibrarySearchActive = false
 
   libraryGrid.innerHTML = ''
@@ -3083,7 +3087,7 @@ async function runLibrarySearch(query) {
 function exitLibrarySearch() {
   isLibrarySearchActive = false
   if (librarySearchStatus) librarySearchStatus.classList.add('hidden')
-  if (libraryFilterRow) libraryFilterRow.style.display = ''
+  if (libraryFilterRow) libraryFilterRow.style.display = 'flex'
   filterLibraryCards(currentLibraryDocs)
 }
 


### PR DESCRIPTION
검색 종료/탭 전환 시 `#library-filter-row`의 `style.display`를 `''`로 초기화하던 코드가 인라인으로만 선언된 `display:flex`를 완전히 지워 block으로 되돌리는 버그 수정. 카테고리 태그와 카드/리스트 보기 전환 버튼이 간격 없이 세로로 붙던 문제(사용자 스크린샷으로 확인)의 근본 원인.