### PR TITLE
feat: add cross-document comparison chat

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException
+import hashlib
+from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from typing import List
@@ -6,6 +7,8 @@ from typing import List
 from routers.upload import sessions, ensure_session
 from services.llm_client import stream_chat
 from services.db import db_save_chat_message, db_get_chat_history
+from services.library import get_document as lib_get_document
+from services.auth import get_current_user
 
 router = APIRouter()
 
@@ -16,6 +19,40 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     session_id: str
     messages: List[ChatMessage]
+
+# ── 여러 논문 간 비교 채팅 ──────────────────────────────
+MIN_COMPARE_DOCS = 2
+MAX_COMPARE_DOCS = 5
+# 논문 한 편당 컨텍스트가 너무 짧아지지 않도록, 전체 예산을 문서 수로 나눈다
+# (단일 논문 채팅의 40,000자 예산보다 넉넉하게 잡되 무한정 늘리지는 않는다).
+COMPARE_TOTAL_CONTEXT_CHARS = 60000
+
+class CompareChatRequest(BaseModel):
+    doc_ids: List[str]
+    messages: List[ChatMessage]
+
+
+def _build_compare_id(doc_ids: List[str]) -> str:
+    """문서 ID 조합에서 결정론적인 비교 세션 ID를 만든다 - 같은 조합을 어떤
+    순서로 선택하든 동일한 채팅 기록/CLI 대화 세션을 재사용하기 위함."""
+    key = ":".join(sorted(doc_ids))
+    return "cmp_" + hashlib.sha256(key.encode()).hexdigest()[:20]
+
+
+def _require_owned_documents(doc_ids: List[str], current_user: str) -> List[dict]:
+    """모든 문서가 존재하고 현재 사용자 소유인지 확인한다. 하나라도 아니면
+    (다른 사용자 문서인지, 존재하지 않는지 구분하지 않고) 404로 응답한다."""
+    docs = []
+    for doc_id in doc_ids:
+        doc = lib_get_document(doc_id)
+        if not doc or doc.get("username") != current_user:
+            raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+        docs.append(doc)
+    return docs
+
+
+def _dedupe_preserve_order(items: List[str]) -> List[str]:
+    return list(dict.fromkeys(items))
 
 @router.post("/chat/stream")
 async def chat_stream(data: ChatRequest):
@@ -90,6 +127,111 @@ async def chat_stream(data: ChatRequest):
             "Connection": "keep-alive",
         }
     )
+
+
+# 아래 두 엔드포인트(/chat/compare/*)는 "/chat/{session_id}/history"보다
+# 반드시 먼저 등록해야 한다 - 그렇지 않으면 "compare"가 session_id 경로
+# 파라미터로 잡아먹혀 이 라우트에 절대 도달하지 못한다.
+@router.post("/chat/compare/stream")
+async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depends(get_current_user)):
+    """여러 논문을 함께 컨텍스트로 제공해, 논문 간 비교/종합 질문에 답하는
+    스트리밍 채팅입니다.
+    """
+    doc_ids = _dedupe_preserve_order(data.doc_ids)
+    if len(doc_ids) < MIN_COMPARE_DOCS or len(doc_ids) > MAX_COMPARE_DOCS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"비교 채팅은 논문을 {MIN_COMPARE_DOCS}~{MAX_COMPARE_DOCS}편 선택해야 합니다.",
+        )
+
+    docs = _require_owned_documents(doc_ids, current_user)
+
+    per_doc_budget = COMPARE_TOTAL_CONTEXT_CHARS // len(doc_ids)
+    paper_blocks = []
+    titles = []
+    for idx, (doc_id, doc) in enumerate(zip(doc_ids, docs), start=1):
+        if not ensure_session(doc_id):
+            raise HTTPException(status_code=404, detail=f"'{doc.get('filename')}' 문서를 불러올 수 없습니다.")
+
+        title = (doc.get("metadata") or {}).get("title") or doc.get("filename", "제목 없음")
+        titles.append(title)
+
+        pages = sessions[doc_id].get("pages", [])
+        paper_text = ""
+        for p in pages:
+            page_text = (p.get("text", "") or "").strip()
+            if page_text:
+                paper_text += f"\n\n--- Page {p.get('page_num', 0)} ---\n{page_text}"
+        if len(paper_text) > per_doc_budget:
+            paper_text = paper_text[:per_doc_budget] + "\n\n[이하 본문 생략]"
+
+        paper_blocks.append(f"\n\n===== 논문 {idx}: {title} =====\n{paper_text}")
+
+    compare_id = _build_compare_id(doc_ids)
+    titles_list = "\n".join(f"- 논문 {i}: {t}" for i, t in enumerate(titles, start=1))
+    combined_context = "".join(paper_blocks)
+
+    system_prompt = f"""당신은 여러 학술 논문을 비교 분석하는 세계 최고 권위 전문가(Expert Assistant)입니다.
+아래에 서로 다른 {len(doc_ids)}편의 논문 본문이 순서대로 제공됩니다.
+
+[비교 대상 논문 목록]
+{titles_list}
+
+[논문 본문 컨텍스트]
+{combined_context}
+
+[답변 가이드라인]
+1. 여러 논문에 걸친 질문에는 반드시 "논문 1", "논문 2"처럼 번호로 어느 논문의 내용인지 명시하며 비교/대조하세요.
+2. 제공된 논문 본문에 없는 내용이라면 그렇게 명시하고, 일반적인 AI 지식으로 부가 설명을 덧붙이세요.
+3. 한국어로 답변하되, 전문 학술 용어는 원어와 번역을 함께 병기하세요(예: 심층 학습(Deep Learning)).
+4. 수식이나 기호가 포함된 경우 Markdown 수식(LaTeX: $ 또는 $$) 형식으로 명확히 표현하세요.
+5. 친절하고 신뢰감 있는 학술 전문가 톤앤매너로 답변하세요.
+"""
+
+    history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
+
+    if data.messages:
+        latest_msg = data.messages[-1]
+        db_save_chat_message(compare_id, latest_msg.role, latest_msg.content)
+
+    async def event_generator():
+        yield " "
+        full_response = []
+        try:
+            async for token in stream_chat(system_prompt, history_messages, session_id=compare_id):
+                full_response.append(token)
+                yield token
+
+            assistant_content = "".join(full_response).strip()
+            if assistant_content:
+                db_save_chat_message(compare_id, "assistant", assistant_content)
+        except Exception as e:
+            yield f"\n[오류 발생: {str(e)}]"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/plain",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        }
+    )
+
+
+@router.get("/chat/compare/history")
+async def get_compare_chat_history(doc_ids: str, current_user: str = Depends(get_current_user)):
+    """콤마로 구분된 문서 ID 조합에 대한 비교 채팅 히스토리를 반환합니다."""
+    ids = _dedupe_preserve_order([d.strip() for d in doc_ids.split(",") if d.strip()])
+    if len(ids) < MIN_COMPARE_DOCS or len(ids) > MAX_COMPARE_DOCS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"비교 채팅은 논문을 {MIN_COMPARE_DOCS}~{MAX_COMPARE_DOCS}편 선택해야 합니다.",
+        )
+    _require_owned_documents(ids, current_user)
+    compare_id = _build_compare_id(ids)
+    history = db_get_chat_history(compare_id)
+    return {"history": history, "compare_id": compare_id}
 
 
 @router.get("/chat/{session_id}/history")

--- a/backend/tests/test_chat_compare.py
+++ b/backend/tests/test_chat_compare.py
@@ -1,0 +1,132 @@
+"""POST /chat/compare/stream, GET /chat/compare/history HTTP 레벨 테스트.
+
+routers.chat._build_compare_id는 순수 함수라 직접 단위 테스트하고, 스트리밍
+엔드포인트는 routers.chat.stream_chat(모듈 상단에서 `from ... import
+stream_chat`으로 바인딩되어 있으므로 routers.chat.stream_chat을 패치)을
+가짜 비동기 제너레이터로 교체해 실제 CLI/외부 API 호출 없이 검증한다.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from routers.chat import _build_compare_id
+import routers.chat as chat_module
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_fake_sessions():
+    """routers.upload.sessions는 프로세스 전역 dict라 테스트 간 오염을 막기
+    위해, 이 파일에서 주입한 fake 세션 항목을 테스트 후 반드시 지운다."""
+    yield
+    for key in list(chat_module.sessions.keys()):
+        if key.startswith("cmp-doc-"):
+            del chat_module.sessions[key]
+
+
+def _create_doc(isolated_dirs, doc_id, username="testuser", title=None, text="Sample paper text."):
+    db = isolated_dirs["db"]
+    metadata = {"title": title} if title else {}
+    db.db_save_document(doc_id, username, f"{doc_id}.pdf", f"/x/{doc_id}.pdf", 1, metadata)
+    chat_module.sessions[doc_id] = {
+        "pdf_path": f"/x/{doc_id}.pdf",
+        "filename": f"{doc_id}.pdf",
+        "pages": [{"page_num": 1, "text": text}],
+        "total_pages": 1,
+        "metadata": metadata,
+        "from_library": True,
+        "username": username,
+    }
+
+
+async def _fake_stream_chat(system_prompt, history_messages, session_id=None):
+    yield "Hello "
+    yield "World"
+
+
+def test_build_compare_id_is_order_independent():
+    assert _build_compare_id(["a", "b", "c"]) == _build_compare_id(["c", "a", "b"])
+
+
+def test_build_compare_id_differs_for_different_sets():
+    assert _build_compare_id(["a", "b"]) != _build_compare_id(["a", "c"])
+
+
+def test_compare_stream_rejects_fewer_than_two_docs(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1")
+    res = test_client.post("/api/chat/compare/stream", json={"doc_ids": ["cmp-doc-1"], "messages": []})
+    assert res.status_code == 400
+
+
+def test_compare_stream_rejects_more_than_five_docs(test_client, isolated_dirs):
+    ids = []
+    for i in range(6):
+        doc_id = f"cmp-doc-{i}"
+        _create_doc(isolated_dirs, doc_id)
+        ids.append(doc_id)
+    res = test_client.post("/api/chat/compare/stream", json={"doc_ids": ids, "messages": []})
+    assert res.status_code == 400
+
+
+def test_compare_stream_rejects_other_users_document(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1", username="testuser")
+    _create_doc(isolated_dirs, "cmp-doc-2", username="otheruser")
+    res = test_client.post(
+        "/api/chat/compare/stream",
+        json={"doc_ids": ["cmp-doc-1", "cmp-doc-2"], "messages": [{"role": "user", "content": "비교해줘"}]},
+    )
+    assert res.status_code == 404
+
+
+def test_compare_stream_streams_tokens_and_saves_history(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1", title="Paper One", text="Paper one content.")
+    _create_doc(isolated_dirs, "cmp-doc-2", title="Paper Two", text="Paper two content.")
+
+    with patch.object(chat_module, "stream_chat", new=_fake_stream_chat):
+        res = test_client.post(
+            "/api/chat/compare/stream",
+            json={
+                "doc_ids": ["cmp-doc-1", "cmp-doc-2"],
+                "messages": [{"role": "user", "content": "두 논문의 차이가 뭐야?"}],
+            },
+        )
+
+    assert res.status_code == 200
+    assert "Hello" in res.text
+    assert "World" in res.text
+
+    compare_id = _build_compare_id(["cmp-doc-1", "cmp-doc-2"])
+    history = isolated_dirs["db"].db_get_chat_history(compare_id)
+    assert history[0] == {"role": "user", "content": "두 논문의 차이가 뭐야?"}
+    assert history[1]["role"] == "assistant"
+    assert "Hello" in history[1]["content"]
+
+
+def test_compare_history_returns_saved_messages_regardless_of_doc_order(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1", title="Paper One")
+    _create_doc(isolated_dirs, "cmp-doc-2", title="Paper Two")
+
+    with patch.object(chat_module, "stream_chat", new=_fake_stream_chat):
+        test_client.post(
+            "/api/chat/compare/stream",
+            json={"doc_ids": ["cmp-doc-1", "cmp-doc-2"], "messages": [{"role": "user", "content": "질문"}]},
+        )
+
+    # 순서를 바꿔 조회해도 같은 compare_id로 매핑되어 동일한 기록을 반환해야 한다
+    res = test_client.get("/api/chat/compare/history", params={"doc_ids": "cmp-doc-2,cmp-doc-1"})
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["history"]) == 2
+    assert body["history"][0]["content"] == "질문"
+
+
+def test_compare_history_rejects_other_users_document(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1", username="testuser")
+    _create_doc(isolated_dirs, "cmp-doc-2", username="otheruser")
+    res = test_client.get("/api/chat/compare/history", params={"doc_ids": "cmp-doc-1,cmp-doc-2"})
+    assert res.status_code == 404
+
+
+def test_compare_history_rejects_invalid_doc_count(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "cmp-doc-1")
+    res = test_client.get("/api/chat/compare/history", params={"doc_ids": "cmp-doc-1"})
+    assert res.status_code == 400

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CSdrUPUu.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-wXSfWeDV.css">
+  <script type="module" crossorigin src="/assets/index-CiW84ogl.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BQAi4IYa.css">
 </head>
 <body>
 
@@ -65,9 +65,15 @@
           <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></span>
           <span class="logo-text">내 라이브러리</span>
         </div>
-        <button id="lib-upload-btn" class="file-btn">
-          + 새 논문 추가
-        </button>
+        <div style="display: flex; gap: 10px; align-items: center;">
+          <button id="lib-compare-toggle-btn" class="file-btn-outline" title="여러 논문을 선택해 비교 질문을 할 수 있습니다">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+            비교하기
+          </button>
+          <button id="lib-upload-btn" class="file-btn">
+            + 새 논문 추가
+          </button>
+        </div>
       </div>
 
       <!-- 탭 영역 -->
@@ -110,6 +116,47 @@
     <button id="lib-empty-trash-btn" class="file-btn hidden">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
     </button>
+
+    <!-- 비교하기 선택 모드 하단 플로팅 바 -->
+    <div id="compare-select-bar" class="compare-select-bar hidden">
+      <span id="compare-select-count">0/5개 선택됨</span>
+      <div class="compare-select-bar-actions">
+        <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
+        <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 여러 논문 비교 채팅 화면 -->
+  <div id="compare-screen" class="screen">
+    <header class="compare-topbar">
+      <button id="compare-back-btn" class="icon-btn" title="라이브러리로 돌아가기">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
+      </button>
+      <div class="compare-topbar-title">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+        <span>논문 비교 채팅</span>
+      </div>
+      <div id="compare-doc-chips" class="compare-doc-chips"></div>
+    </header>
+
+    <div class="compare-chat-body">
+      <div class="chat-messages" id="compare-chat-messages"></div>
+      <div class="chat-input-area compare-chat-input-area">
+        <div class="chat-input-box">
+          <textarea id="compare-chat-input" class="chat-input-textarea" placeholder="선택한 논문들에 대해 비교 질문을 해보세요..." rows="1"></textarea>
+          <div class="chat-input-footer">
+            <span class="compare-chat-hint">Enter로 전송 · Shift+Enter로 줄바꿈</span>
+            <button id="compare-chat-send-btn" class="chat-send-btn" title="전송">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="22" y1="2" x2="11" y2="13"/>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- 뷰어 화면 -->
@@ -268,7 +315,7 @@
               <img id="chat-quote-img" class="chat-quote-img hidden" alt="Quoted Figure" />
               <button id="chat-quote-close-btn" class="chat-quote-close-btn" title="인용 취소">&times;</button>
             </div>
-            <textarea id="chat-input" placeholder="논문에 대해 궁금한 점을 질문하세요..." rows="1"></textarea>
+            <textarea id="chat-input" class="chat-input-textarea" placeholder="논문에 대해 궁금한 점을 질문하세요..." rows="1"></textarea>
             <div class="chat-input-footer">
               <div id="chat-sidebar-provider"></div>
               <button id="chat-send-btn" class="chat-send-btn" title="전송">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,9 +64,15 @@
           <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></span>
           <span class="logo-text">내 라이브러리</span>
         </div>
-        <button id="lib-upload-btn" class="file-btn">
-          + 새 논문 추가
-        </button>
+        <div style="display: flex; gap: 10px; align-items: center;">
+          <button id="lib-compare-toggle-btn" class="file-btn-outline" title="여러 논문을 선택해 비교 질문을 할 수 있습니다">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+            비교하기
+          </button>
+          <button id="lib-upload-btn" class="file-btn">
+            + 새 논문 추가
+          </button>
+        </div>
       </div>
 
       <!-- 탭 영역 -->
@@ -109,6 +115,47 @@
     <button id="lib-empty-trash-btn" class="file-btn hidden">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
     </button>
+
+    <!-- 비교하기 선택 모드 하단 플로팅 바 -->
+    <div id="compare-select-bar" class="compare-select-bar hidden">
+      <span id="compare-select-count">0/5개 선택됨</span>
+      <div class="compare-select-bar-actions">
+        <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
+        <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 여러 논문 비교 채팅 화면 -->
+  <div id="compare-screen" class="screen">
+    <header class="compare-topbar">
+      <button id="compare-back-btn" class="icon-btn" title="라이브러리로 돌아가기">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
+      </button>
+      <div class="compare-topbar-title">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+        <span>논문 비교 채팅</span>
+      </div>
+      <div id="compare-doc-chips" class="compare-doc-chips"></div>
+    </header>
+
+    <div class="compare-chat-body">
+      <div class="chat-messages" id="compare-chat-messages"></div>
+      <div class="chat-input-area compare-chat-input-area">
+        <div class="chat-input-box">
+          <textarea id="compare-chat-input" class="chat-input-textarea" placeholder="선택한 논문들에 대해 비교 질문을 해보세요..." rows="1"></textarea>
+          <div class="chat-input-footer">
+            <span class="compare-chat-hint">Enter로 전송 · Shift+Enter로 줄바꿈</span>
+            <button id="compare-chat-send-btn" class="chat-send-btn" title="전송">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="22" y1="2" x2="11" y2="13"/>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- 뷰어 화면 -->
@@ -267,7 +314,7 @@
               <img id="chat-quote-img" class="chat-quote-img hidden" alt="Quoted Figure" />
               <button id="chat-quote-close-btn" class="chat-quote-close-btn" title="인용 취소">&times;</button>
             </div>
-            <textarea id="chat-input" placeholder="논문에 대해 궁금한 점을 질문하세요..." rows="1"></textarea>
+            <textarea id="chat-input" class="chat-input-textarea" placeholder="논문에 대해 궁금한 점을 질문하세요..." rows="1"></textarea>
             <div class="chat-input-footer">
               <div id="chat-sidebar-provider"></div>
               <button id="chat-send-btn" class="chat-send-btn" title="전송">

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -534,6 +534,66 @@ export async function getChatHistoryAPI(sessionId) {
 }
 
 /**
+ * 여러 논문을 함께 컨텍스트로 제공해 비교/종합 질문에 답하는 스트리밍 API.
+ * @param {string[]} docIds - 비교할 문서 ID 목록 (2~5개)
+ * @param {Array} messages - [{role: 'user', content: '...'}, ...]
+ */
+export function streamCompareChatAPI(docIds, messages, onToken, onDone, onError) {
+  const controller = new AbortController()
+
+  fetch(`${API_BASE}/chat/compare/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      doc_ids: docIds,
+      messages: messages
+    }),
+    signal: controller.signal
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        try {
+          const err = await res.json()
+          onError(new Error(err.detail || '답변 생성 실패'))
+        } catch {
+          onError(new Error('답변 생성 실패'))
+        }
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+
+        const token = decoder.decode(value, { stream: true })
+        if (token) {
+          onToken(token)
+        }
+      }
+      onDone()
+    })
+    .catch((err) => {
+      if (err.name !== 'AbortError') {
+        onError(err)
+      }
+    })
+
+  return () => controller.abort()
+}
+
+/**
+ * 문서 ID 조합에 대한 비교 채팅 히스토리를 반환합니다.
+ */
+export async function getCompareChatHistoryAPI(docIds) {
+  const res = await fetch(`${API_BASE}/chat/compare/history?doc_ids=${encodeURIComponent(docIds.join(','))}`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('채팅 기록 로드 실패')
+  return res.json()
+}
+
+/**
  * Antigravity CLI 사용량 통계 조회
  */
 export async function getAgyUsageAPI() {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
@@ -176,6 +176,19 @@ const libTabTrash       = $('lib-tab-trash')
 const libEmptyTrashBtn  = $('lib-empty-trash-btn')
 const libraryStatsContainer = $('library-stats-container')
 
+const libCompareToggleBtn   = $('lib-compare-toggle-btn')
+const compareSelectBar      = $('compare-select-bar')
+const compareSelectCount    = $('compare-select-count')
+const compareSelectCancelBtn = $('compare-select-cancel-btn')
+const compareSelectStartBtn = $('compare-select-start-btn')
+
+const compareScreen        = $('compare-screen')
+const compareBackBtn       = $('compare-back-btn')
+const compareDocChips      = $('compare-doc-chips')
+const compareChatMessages  = $('compare-chat-messages')
+const compareChatInput     = $('compare-chat-input')
+const compareChatSendBtn   = $('compare-chat-send-btn')
+
 const docPreviewOverlay  = $('doc-preview-overlay')
 const docPreviewClose    = $('doc-preview-close')
 const docPreviewCoverImg = $('doc-preview-cover-img')
@@ -278,6 +291,19 @@ function showViewer() {
   // 글로벌 테마 토글 숨김 (뷰어 상단바 테마 버튼 사용)
   const globalToggle = $('global-theme-toggle')
   if (globalToggle) globalToggle.classList.add('hidden')
+}
+
+function showCompareScreen() {
+  loginScreen.classList.remove('active')
+  libraryScreen.classList.remove('active')
+  viewerScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.add('active')
+  // 라이브러리 화면과 동일하게 글로벌 테마/로그아웃/설정 버튼을 표시한다
+  // (비교 화면 자체에는 별도의 테마 버튼이 없음)
+  const globalToggle = $('global-theme-toggle')
+  if (globalToggle) globalToggle.classList.remove('hidden')
+  globalLogoutBtn.classList.remove('hidden')
+  globalSettingsBtn.classList.remove('hidden')
 }
 
 function resetState() {
@@ -2826,7 +2852,7 @@ function updateTabUI(activeTab) {
     }
   }
 
-  // 휴지통 탭인 경우 새 논문 추가 플로팅 버튼을 숨깁니다.
+  // 휴지통 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
   if (libUploadBtn) {
     if (activeTab === 'trash') {
       libUploadBtn.classList.add('hidden')
@@ -2834,7 +2860,11 @@ function updateTabUI(activeTab) {
       libUploadBtn.classList.remove('hidden')
     }
   }
-  
+  if (libCompareToggleBtn) {
+    libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash')
+  }
+  setCompareSelectMode(false)
+
   renderLibrary()
 }
 
@@ -2898,6 +2928,321 @@ async function showLibraryScreen(shouldPushState = true) {
 
 
 let activeCategoryFilter = 'ALL'
+
+// ── 여러 논문 비교 채팅: 라이브러리 선택 모드 ──────────────
+let compareSelectMode = false
+const compareSelectedDocs = new Map() // doc.id -> doc
+const COMPARE_MAX_DOCS = 5
+const COMPARE_MIN_DOCS = 2
+
+function updateCompareSelectUI() {
+  const count = compareSelectedDocs.size
+  if (compareSelectCount) compareSelectCount.textContent = `${count}/${COMPARE_MAX_DOCS}개 선택됨`
+  if (compareSelectStartBtn) compareSelectStartBtn.disabled = count < COMPARE_MIN_DOCS
+}
+
+function setCompareCheckboxVisual(container, checked) {
+  const box = container.querySelector('.doc-card-compare-check')
+  if (!box) return
+  box.classList.toggle('checked', checked)
+  box.innerHTML = checked
+    ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>'
+    : ''
+}
+
+function toggleDocCompareSelection(container, doc) {
+  const isSelected = compareSelectedDocs.has(doc.id)
+  if (isSelected) {
+    compareSelectedDocs.delete(doc.id)
+    setCompareCheckboxVisual(container, false)
+  } else {
+    if (compareSelectedDocs.size >= COMPARE_MAX_DOCS) {
+      showToast(`최대 ${COMPARE_MAX_DOCS}편까지 선택할 수 있습니다.`, 'warning')
+      return
+    }
+    compareSelectedDocs.set(doc.id, doc)
+    setCompareCheckboxVisual(container, true)
+  }
+  updateCompareSelectUI()
+}
+
+function setCompareSelectMode(enabled) {
+  compareSelectMode = enabled
+  compareSelectedDocs.clear()
+  if (libraryGrid) libraryGrid.classList.toggle('compare-select-mode', enabled)
+  if (libCompareToggleBtn) libCompareToggleBtn.classList.toggle('active', enabled)
+  if (compareSelectBar) compareSelectBar.classList.toggle('hidden', !enabled)
+  document.querySelectorAll('.doc-card-compare-check').forEach(box => {
+    box.classList.remove('checked')
+    box.innerHTML = ''
+  })
+  updateCompareSelectUI()
+}
+
+if (libCompareToggleBtn) {
+  libCompareToggleBtn.addEventListener('click', () => {
+    setCompareSelectMode(!compareSelectMode)
+  })
+}
+
+if (compareSelectCancelBtn) {
+  compareSelectCancelBtn.addEventListener('click', () => setCompareSelectMode(false))
+}
+
+if (compareSelectStartBtn) {
+  compareSelectStartBtn.addEventListener('click', () => {
+    const ids = Array.from(compareSelectedDocs.keys())
+    if (ids.length < COMPARE_MIN_DOCS) return
+    setCompareSelectMode(false)
+    location.hash = `#compare?ids=${ids.map(encodeURIComponent).join(',')}`
+  })
+}
+
+// ── 여러 논문 비교 채팅 화면 ────────────────────────────
+let compareChatState = { docIds: [], docs: [], history: [], activeStream: null, currentText: '' }
+
+function renderCompareChatMessage(role, content, isHtml = false) {
+  const msgEl = document.createElement('div')
+  msgEl.className = `chat-message ${role}`
+
+  const bubbleEl = document.createElement('div')
+  bubbleEl.className = 'message-bubble'
+  if (isHtml) bubbleEl.innerHTML = content
+  else bubbleEl.textContent = content
+  msgEl.appendChild(bubbleEl)
+
+  if (content) appendCompareActionButtons(msgEl, role, content)
+
+  compareChatMessages.appendChild(msgEl)
+  compareChatMessages.scrollTop = compareChatMessages.scrollHeight
+  return msgEl
+}
+
+function appendCompareActionButtons(msgEl, role, content) {
+  if (!content || content.includes('chat-error-text')) return
+  const actionsEl = document.createElement('div')
+  actionsEl.className = 'message-actions'
+  actionsEl.style.display = 'flex'
+  actionsEl.style.gap = '8px'
+  actionsEl.style.marginTop = '4px'
+  actionsEl.style.alignSelf = role === 'user' ? 'flex-end' : 'flex-start'
+
+  const copyBtn = document.createElement('button')
+  copyBtn.className = 'msg-action-btn'
+  copyBtn.innerHTML = `${icon('clipboard', 12, 'style="vertical-align:-2px;margin-right:3px"')}복사`
+  copyBtn.style.background = 'none'
+  copyBtn.style.border = 'none'
+  copyBtn.style.color = 'var(--text-muted)'
+  copyBtn.style.fontSize = '11px'
+  copyBtn.style.cursor = 'pointer'
+  copyBtn.title = '텍스트 복사'
+  copyBtn.addEventListener('click', () => {
+    const text = msgEl.querySelector('.message-bubble').textContent
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(() => {
+        showToast('텍스트가 복사되었습니다.', 'success')
+      }).catch(() => showToast('복사 실패', 'error'))
+    }
+  })
+  actionsEl.appendChild(copyBtn)
+  msgEl.appendChild(actionsEl)
+}
+
+function appendCompareTypingIndicator() {
+  const msgEl = document.createElement('div')
+  msgEl.className = 'chat-message assistant temp-typing'
+  const bubbleEl = document.createElement('div')
+  bubbleEl.className = 'message-bubble'
+  bubbleEl.innerHTML = `<div class="typing-container" style="display: flex; align-items: center; gap: 8px;"><span class="typing-text" style="font-size: 12px; color: var(--text-secondary);">AI가 답변을 준비하고 있습니다</span><div class="typing-indicator" style="display: flex; gap: 3px; align-items: center;"><span></span><span></span><span></span></div></div>`
+  msgEl.appendChild(bubbleEl)
+  compareChatMessages.appendChild(msgEl)
+  compareChatMessages.scrollTop = compareChatMessages.scrollHeight
+  return msgEl
+}
+
+function removeCompareTypingIndicator() {
+  compareChatMessages.querySelectorAll('.temp-typing').forEach(el => el.remove())
+}
+
+function updateCompareChatSendBtnIcon(isGenerating) {
+  if (!compareChatSendBtn) return
+  if (isGenerating) {
+    compareChatSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2" /></svg>`
+    compareChatSendBtn.title = '답변 생성 중단'
+  } else {
+    compareChatSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`
+    compareChatSendBtn.title = '전송'
+  }
+}
+
+function renderCompareGreeting() {
+  const titles = compareChatState.docs
+    .map((d, i) => `${i + 1}. ${escapeHtml((d.metadata && d.metadata.title) ? d.metadata.title : d.filename)}`)
+    .join('<br>')
+  renderCompareChatMessage('assistant',
+    `선택하신 ${compareChatState.docs.length}편의 논문을 비교해서 답변해 드릴게요.<br><br>` +
+    `<strong>비교 대상:</strong><br>${titles}<br><br>` +
+    `<strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong>` +
+    `<ul><li>두 논문의 핵심 방법론 차이가 뭐야?</li><li>실험 결과를 비교했을 때 어느 쪽이 더 우수해?</li><li>공통적으로 다루는 한계점이 있어?</li></ul>`,
+    true)
+}
+
+// location.hash 대입은 브라우저에 따라 popstate와 hashchange를 둘 다 발생시켜,
+// 두 리스너가 각각 handleRouting()을 호출하면서 openCompareScreen이 같은 문서
+// 조합에 대해 중복 실행되는 경쟁 조건이 있었다(인사말 메시지가 두 번 렌더링됨).
+// 첫 호출이 아직 비동기 작업 중일 때 같은 조합의 재진입 호출을 걸러낸다.
+let compareOpeningIdsKey = null
+
+async function openCompareScreen(docs, shouldPushState = true) {
+  const docIds = docs.map(d => d.id)
+  const idsKey = JSON.stringify([...docIds].sort())
+
+  if (compareOpeningIdsKey === idsKey) return
+  if (compareScreen.classList.contains('active') && JSON.stringify([...compareChatState.docIds].sort()) === idsKey) return
+  compareOpeningIdsKey = idsKey
+
+  if (compareChatState.activeStream) { compareChatState.activeStream(); compareChatState.activeStream = null }
+  compareChatState = { docIds, docs, history: [], activeStream: null, currentText: '' }
+
+  if (shouldPushState) {
+    history.pushState({ screen: 'compare', ids: docIds }, '', `#compare?ids=${docIds.map(encodeURIComponent).join(',')}`)
+  }
+
+  if (compareDocChips) {
+    compareDocChips.innerHTML = docs.map(d => {
+      const title = (d.metadata && d.metadata.title) ? d.metadata.title : d.filename
+      return `<span class="compare-doc-chip" title="${escapeHtml(title)}">${escapeHtml(title)}</span>`
+    }).join('')
+  }
+
+  if (compareChatMessages) compareChatMessages.innerHTML = ''
+  showCompareScreen()
+
+  try {
+    const res = await getCompareChatHistoryAPI(docIds)
+    const savedHistory = res.history || []
+    if (savedHistory.length === 0) {
+      renderCompareGreeting()
+    } else {
+      savedHistory.forEach(msg => {
+        renderCompareChatMessage(msg.role, msg.role === 'assistant' ? formatChatHtml(msg.content) : msg.content, msg.role === 'assistant')
+        compareChatState.history.push({ role: msg.role, content: msg.content })
+      })
+    }
+  } catch (err) {
+    console.warn('비교 채팅 기록 로드 실패:', err)
+    renderCompareGreeting()
+  } finally {
+    if (compareOpeningIdsKey === idsKey) compareOpeningIdsKey = null
+  }
+}
+
+async function sendCompareChatMessage() {
+  if (compareChatState.docIds.length < COMPARE_MIN_DOCS) return
+  if (compareChatState.activeStream) return
+
+  const text = compareChatInput.value.trim()
+  if (!text) return
+
+  compareChatInput.value = ''
+  compareChatInput.style.height = 'auto'
+
+  renderCompareChatMessage('user', text)
+  compareChatState.history.push({ role: 'user', content: text })
+
+  appendCompareTypingIndicator()
+  compareChatInput.disabled = true
+  updateCompareChatSendBtnIcon(true)
+
+  let accumulatedText = ''
+  let replyBubble = null
+  let firstToken = true
+  compareChatState.currentText = ''
+
+  compareChatState.activeStream = streamCompareChatAPI(
+    compareChatState.docIds,
+    compareChatState.history,
+    // onToken
+    (token) => {
+      if (firstToken) {
+        if (!token.trim()) return
+        removeCompareTypingIndicator()
+        replyBubble = renderCompareChatMessage('assistant', '', true).querySelector('.message-bubble')
+        firstToken = false
+      }
+      accumulatedText += token
+      compareChatState.currentText = accumulatedText
+      replyBubble.innerHTML = formatChatHtml(accumulatedText)
+      compareChatMessages.scrollTop = compareChatMessages.scrollHeight
+    },
+    // onDone
+    () => {
+      compareChatState.activeStream = null
+      compareChatState.history.push({ role: 'assistant', content: accumulatedText })
+      if (replyBubble) {
+        replyBubble.innerHTML = formatChatHtml(accumulatedText)
+        if (replyBubble.parentElement) appendCompareActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+      }
+      compareChatInput.disabled = false
+      updateCompareChatSendBtnIcon(false)
+      compareChatInput.focus()
+    },
+    // onError
+    (err) => {
+      removeCompareTypingIndicator()
+      compareChatState.activeStream = null
+      if (firstToken) {
+        renderCompareChatMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
+      } else if (replyBubble) {
+        replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${err.message}]</span>`
+      }
+      compareChatInput.disabled = false
+      updateCompareChatSendBtnIcon(false)
+      compareChatInput.focus()
+    }
+  )
+}
+
+if (compareChatSendBtn) {
+  compareChatSendBtn.addEventListener('click', () => {
+    if (compareChatState.activeStream) {
+      compareChatState.activeStream()
+      compareChatState.activeStream = null
+      removeCompareTypingIndicator()
+      if (compareChatState.currentText) {
+        compareChatState.history.push({ role: 'assistant', content: compareChatState.currentText })
+      } else {
+        compareChatState.history.pop()
+      }
+      showToast('답변 생성이 중단되었습니다.', 'info')
+      compareChatInput.disabled = false
+      updateCompareChatSendBtnIcon(false)
+      compareChatInput.focus()
+    } else {
+      sendCompareChatMessage()
+    }
+  })
+}
+
+if (compareChatInput) {
+  compareChatInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendCompareChatMessage()
+    }
+  })
+  compareChatInput.addEventListener('input', () => {
+    compareChatInput.style.height = 'auto'
+    compareChatInput.style.height = `${compareChatInput.scrollHeight}px`
+  })
+}
+
+if (compareBackBtn) {
+  compareBackBtn.addEventListener('click', () => {
+    if (compareChatState.activeStream) { compareChatState.activeStream(); compareChatState.activeStream = null }
+    showLibraryScreen()
+  })
+}
 
 async function renderLibrary() {
   // 탭 전환 등으로 목록을 새로 불러올 때는 검색 상태를 초기화한다 - 검색
@@ -3159,6 +3504,10 @@ function prepareDocItemHtml(doc) {
     dateHtml = `<span class="doc-meta-chip done">완독 ${readDateStr}</span>`
   }
 
+  const compareCheckHtml = state.currentLibraryTab === 'trash' ? '' : `
+    <div class="doc-card-compare-check" data-id="${doc.id}" title="비교할 논문으로 선택"></div>
+  `
+
   const checkBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
     <button class="doc-card-check-btn ${isRead ? 'checked' : ''}" data-id="${doc.id}" title="${isRead ? '읽지 않음으로 표시' : '읽음으로 표시'}">
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -3215,12 +3564,21 @@ function prepareDocItemHtml(doc) {
     ctaBtnFullHtml = `<button class="doc-open-btn" data-id="${doc.id}"><span>열기</span>${openIcon}</button>`
   }
 
-  return { translated, total, pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, ctaBtnFullHtml }
+  return { translated, total, pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, compareCheckHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, ctaBtnFullHtml }
 }
 
 // 카드/리스트 뷰 공용: 위임 없이 각 아이템 컨테이너에 직접 붙는 이벤트 리스너를 등록한다.
 // 클래스명(.doc-card-check-btn, .doc-open-btn 등)만 맞으면 어떤 레이아웃이든 동작한다.
 function wireDocItemEvents(container, doc, displayTitle) {
+  const compareCheck = container.querySelector('.doc-card-compare-check')
+  if (compareCheck) {
+    setCompareCheckboxVisual(container, compareSelectedDocs.has(doc.id))
+    compareCheck.addEventListener('click', (e) => {
+      e.stopPropagation()
+      toggleDocCompareSelection(container, doc)
+    })
+  }
+
   const checkBtn = container.querySelector('.doc-card-check-btn')
   if (checkBtn) {
     checkBtn.addEventListener('click', async (e) => {
@@ -3370,6 +3728,10 @@ function wireDocItemEvents(container, doc, displayTitle) {
   }
 
   container.addEventListener('click', () => {
+    if (compareSelectMode) {
+      toggleDocCompareSelection(container, doc)
+      return
+    }
     if (state.currentLibraryTab === 'trash') {
       showToast('휴지통에 있는 논문입니다. 복원 후 열 수 있습니다.', 'warning')
       return
@@ -3383,6 +3745,7 @@ function createDocCard(doc) {
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.innerHTML = `
+    ${d.compareCheckHtml}
     <div class="doc-card-zone">
       <div class="doc-card-zone-actions">
         ${d.expandBtnHtml}
@@ -3428,6 +3791,7 @@ function createDocListRow(doc) {
   const row = document.createElement('div')
   row.className = 'doc-list-row'
   row.innerHTML = `
+    ${d.compareCheckHtml}
     ${d.checkBtnHtml}
     <div class="doc-list-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
     ${listTagsHtml}
@@ -8191,6 +8555,25 @@ async function handleRouting() {
           return
         }
       }
+      location.hash = 'library'
+    } else if (hash.startsWith('#compare?ids=')) {
+      const idsParam = hash.split('?ids=')[1]
+      const ids = (idsParam || '').split(',').map(decodeURIComponent).filter(Boolean)
+      if (ids.length >= COMPARE_MIN_DOCS && ids.length <= COMPARE_MAX_DOCS) {
+        if (JSON.stringify(compareChatState.docIds) === JSON.stringify(ids) && compareScreen.classList.contains('active')) {
+          return
+        }
+        try {
+          const docs = await Promise.all(ids.map(id => fetchLibraryDoc(id)))
+          if (docs.every(Boolean)) {
+            await openCompareScreen(docs, false)
+            return
+          }
+        } catch (err) {
+          console.warn('[Router] 비교 문서 로드 실패:', err)
+        }
+      }
+      showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
       location.hash = 'library'
     } else {
       console.log("[Router] Routing to Library screen. Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2429,7 +2429,8 @@ body.light-theme .chat-input-area {
   border-color: var(--accent-mid);
 }
 
-#chat-input {
+#chat-input,
+.chat-input-textarea {
   flex: 1;
   background: transparent;
   border: none;
@@ -4393,6 +4394,174 @@ body.light-theme .citation-marker-box:hover {
 }
 .citation-marker-box.loading {
   cursor: wait;
+}
+
+/* ── 여러 논문 비교 채팅 ── */
+.file-btn-outline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 100px;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: 1px solid var(--border-strong);
+}
+.file-btn-outline:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-glow);
+}
+.file-btn-outline.active {
+  background: color-mix(in srgb, var(--control-accent) 16%, transparent);
+  color: var(--control-accent);
+  border-color: var(--control-accent);
+}
+.file-btn-outline.compact,
+.file-btn.compact {
+  padding: 9px 18px;
+  font-size: 13px;
+}
+.file-btn.compact:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: none;
+}
+
+/* 라이브러리 카드/리스트 위의 비교 선택 체크박스 오버레이 - 평소엔 숨겨져 있다가
+   선택 모드(.compare-select-mode)일 때만 나타난다 */
+.doc-card-compare-check {
+  display: none;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  background: var(--bg-surface);
+  z-index: 4;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  color: transparent;
+  transition: all 0.15s ease;
+}
+.doc-list-row .doc-card-compare-check {
+  position: static;
+  flex-shrink: 0;
+}
+.library-grid.compare-select-mode .doc-card-compare-check {
+  display: flex;
+}
+.doc-card-compare-check.checked {
+  background: var(--control-accent);
+  border-color: var(--control-accent);
+  color: #fff;
+}
+.library-grid.compare-select-mode .doc-card {
+  position: relative;
+}
+.library-grid.compare-select-mode .doc-card .doc-card-title {
+  padding-left: 26px;
+}
+.library-grid.compare-select-mode .doc-card-zone-actions,
+.library-grid.compare-select-mode .doc-icon-actions {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.compare-select-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px 12px 22px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+  box-shadow: var(--shadow-lg, 0 12px 32px rgba(0,0,0,0.35));
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  z-index: 30;
+}
+#compare-select-count {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+.compare-select-bar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ── 비교 채팅 화면 ── */
+.compare-topbar {
+  height: var(--panel-header-h, 56px);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+.compare-topbar-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+.compare-doc-chips {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  flex: 1;
+  min-width: 0;
+}
+.compare-doc-chip {
+  flex-shrink: 0;
+  padding: 5px 12px;
+  border-radius: 100px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.compare-chat-body {
+  display: flex;
+  flex-direction: column;
+  height: calc(100% - var(--panel-header-h, 56px));
+}
+.compare-chat-body .chat-messages {
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+}
+.compare-chat-input-area {
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+  border-top: none;
+  background: transparent;
+}
+.compare-chat-hint {
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 /* 키워드/단어 탭 용어 클릭 시 원문 위치 하이라이트 - 스크롤이 끝난 뒤에 표시되므로

--- a/frontend/tests/e2e/compare-chat.spec.js
+++ b/frontend/tests/e2e/compare-chat.spec.js
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+// 여러 논문 비교 채팅: 라이브러리에서 2편 이상 선택 -> 비교 채팅 화면 -> 질문/답변 -> 뒤로가기
+test('논문 2편을 선택해 비교 채팅을 시작하고, 질문에 대한 답변을 받을 수 있다', async ({ page }) => {
+  const docs = [
+    { id: 'doc-1', filename: 'transformer.pdf', total_pages: 3, metadata: { title: 'Attention Is All You Need' }, translated_pages: [] },
+    { id: 'doc-2', filename: 'gan.pdf', total_pages: 2, metadata: { title: 'GAN Paper' }, translated_pages: [] },
+    { id: 'doc-3', filename: 'vae.pdf', total_pages: 2, metadata: { title: 'VAE Paper' }, translated_pages: [] },
+  ]
+  await mockBaseRoutes(page, { documents: docs })
+
+  let requestedDocIds = null
+  await page.route('**/api/chat/compare/history*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ history: [], compare_id: 'cmp_test' }) }))
+  await page.route('**/api/chat/compare/stream', route => {
+    requestedDocIds = route.request().postDataJSON().doc_ids
+    return route.fulfill({ status: 200, contentType: 'text/plain', body: ' 두 논문은 방법론이 다릅니다.' })
+  })
+
+  await gotoApp(page)
+
+  // 선택 모드 진입 전에는 체크박스가 보이지 않는다
+  await expect(page.locator('.doc-card-compare-check').first()).not.toBeVisible()
+
+  await page.click('#lib-compare-toggle-btn')
+  await expect(page.locator('.doc-card-compare-check').first()).toBeVisible()
+
+  const checkboxes = page.locator('.doc-card-compare-check')
+  await checkboxes.nth(0).click()
+  await checkboxes.nth(1).click()
+
+  await expect(page.locator('#compare-select-count')).toHaveText('2/5개 선택됨')
+  await expect(page.locator('#compare-select-start-btn')).toBeEnabled()
+
+  await page.click('#compare-select-start-btn')
+  await expect(page.locator('#compare-screen')).toHaveClass(/active/)
+  await expect(page).toHaveURL(/#compare\?ids=doc-1,doc-2/)
+
+  const chips = page.locator('.compare-doc-chip')
+  await expect(chips).toHaveCount(2)
+  await expect(chips.nth(0)).toHaveText('Attention Is All You Need')
+  await expect(chips.nth(1)).toHaveText('GAN Paper')
+
+  // 인사말에 두 논문이 모두 언급된다 (중복 렌더링되지 않아야 함)
+  await expect(page.locator('#compare-chat-messages .chat-message.assistant')).toHaveCount(1)
+  await expect(page.locator('#compare-chat-messages')).toContainText('Attention Is All You Need')
+  await expect(page.locator('#compare-chat-messages')).toContainText('GAN Paper')
+
+  await page.fill('#compare-chat-input', '두 논문의 차이가 뭐야?')
+  await page.click('#compare-chat-send-btn')
+
+  await expect(page.locator('#compare-chat-messages')).toContainText('두 논문의 차이가 뭐야?')
+  await expect(page.locator('#compare-chat-messages')).toContainText('두 논문은 방법론이 다릅니다.')
+  expect(requestedDocIds).toEqual(['doc-1', 'doc-2'])
+
+  await page.click('#compare-back-btn')
+  await expect(page.locator('#library-screen')).toHaveClass(/active/)
+})
+
+test('선택하지 않은 상태에서는 비교 채팅 시작 버튼이 비활성화된다', async ({ page }) => {
+  const docs = [
+    { id: 'doc-1', filename: 'a.pdf', total_pages: 1, metadata: { title: 'Paper A' }, translated_pages: [] },
+    { id: 'doc-2', filename: 'b.pdf', total_pages: 1, metadata: { title: 'Paper B' }, translated_pages: [] },
+  ]
+  await mockBaseRoutes(page, { documents: docs })
+
+  await gotoApp(page)
+  await page.click('#lib-compare-toggle-btn')
+  await expect(page.locator('#compare-select-start-btn')).toBeDisabled()
+
+  await page.locator('.doc-card-compare-check').first().click()
+  await expect(page.locator('#compare-select-count')).toHaveText('1/5개 선택됨')
+  await expect(page.locator('#compare-select-start-btn')).toBeDisabled()
+
+  await page.click('#compare-select-cancel-btn')
+  await expect(page.locator('#compare-select-bar')).toHaveClass(/hidden/)
+  await expect(page.locator('.doc-card-compare-check').first()).not.toBeVisible()
+})


### PR DESCRIPTION
# Summary
## 1. 여러 논문 비교 채팅 API 추가 (backend/routers/chat.py)
- `POST /chat/compare/stream`: 논문 2~5편을 함께 컨텍스트로 제공해 비교/종합 질문에 스트리밍으로 답변
- `GET /chat/compare/history`: 문서 ID 조합에 대한 비교 채팅 기록 조회
- `_build_compare_id()`: 문서 ID 조합을 정렬 후 해시해 결정론적 세션 ID 생성 - 같은 조합을 다른 순서로 선택해도 동일한 채팅 기록/CLI 대화 세션 재사용
- `_require_owned_documents()`: 선택한 모든 문서의 소유권을 검증(하나라도 실패 시 404)
- 문서 수에 비례해 전체 컨텍스트 예산(60,000자)을 나눠 배분
- 기존 `chats` 테이블을 스키마 변경 없이 재사용(가상 세션 ID를 doc_id처럼 사용, FK 미강제 확인됨)
- 라우트 순서: `/chat/compare/history`를 `/chat/{session_id}/history`보다 먼저 등록(경로 파라미터에 가로채이는 것 방지)

## 2. 라이브러리 다중 선택 UI 추가 (frontend/index.html, src/main.js, src/style.css)
- 라이브러리 헤더에 "비교하기" 토글 버튼 추가 - 활성화 시 각 문서 카드/리스트 행에 체크박스 오버레이 표시
- 최대 5편까지 선택 가능, 하단 플로팅 바에 선택 개수 표시 및 "비교 채팅 시작"/"취소" 버튼
- 휴지통 탭에서는 비교 기능 숨김

## 3. 비교 채팅 화면 추가 (frontend/index.html, src/main.js, src/style.css)
- 새 `#compare-screen` 전체 화면 - 선택한 논문 제목 칩, 채팅 메시지 영역, 입력창
- 기존 단일 문서 채팅과 동일한 스트리밍/마크다운/수식 렌더링(`formatChatHtml`) 재사용
- `#compare?ids=doc1,doc2` 해시 라우팅 지원(새로고침/뒤로가기 대응)
- `location.hash` 대입이 popstate와 hashchange를 동시에 발생시켜 인사말이 두 번 렌더링되던 경쟁 조건을 재진입 가드로 수정

## 4. 테스트
- `backend/tests/test_chat_compare.py` (9개): compare_id 결정론성, 문서 수 검증(2~5편), 소유권 검증, 스트리밍/기록 저장 - 백엔드 전체 96개 테스트 통과
- `frontend/tests/e2e/compare-chat.spec.js` (2개): 선택 -> 비교 채팅 시작 -> 질문/답변 -> 뒤로가기 전체 플로우, 선택 개수에 따른 버튼 활성화 - 프론트엔드 전체 18개 테스트 통과
