### PR TITLE
feat: add Gemini 3.6 Flash model to Antigravity provider list

### DIFF
--- a/backend/routers/agy.py
+++ b/backend/routers/agy.py
@@ -45,6 +45,9 @@ async def get_agy_models():
         return {
             "ok": True,
             "models": [
+                "Gemini 3.6 Flash (Medium)",
+                "Gemini 3.6 Flash (High)",
+                "Gemini 3.6 Flash (Low)",
                 "Gemini 3.5 Flash (Medium)",
                 "Gemini 3.5 Flash (High)",
                 "Gemini 3.5 Flash (Low)",

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,7 +16,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CiW84ogl.js"></script>
+  <script type="module" crossorigin src="/assets/index-C5YLP8O5.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BQAi4IYa.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1575,6 +1575,10 @@ const PROVIDER_CONFIG = [
   {
     id: 'antigravity', label: 'Antigravity', icon: icon('zap', 13),
     models: [
+      // Gemini 3.6 Flash
+      { value: 'Gemini 3.6 Flash (Low)',    label: 'Flash · Low',    group: 'Gemini 3.6 Flash' },
+      { value: 'Gemini 3.6 Flash (Medium)', label: 'Flash · Medium', group: 'Gemini 3.6 Flash' },
+      { value: 'Gemini 3.6 Flash (High)',   label: 'Flash · High',   group: 'Gemini 3.6 Flash' },
       // Gemini 3.5 Flash
       { value: 'Gemini 3.5 Flash (Low)',    label: 'Flash · Low',    group: 'Gemini 3.5 Flash' },
       { value: 'Gemini 3.5 Flash (Medium)', label: 'Flash · Medium', group: 'Gemini 3.5 Flash' },


### PR DESCRIPTION
agy CLI에 새로 출시된 Gemini 3.6 Flash(Low/Medium/High) 모델을 번역/채팅 프로바이더 선택 목록에 추가. `agy models` 명령으로 실제 지원 확인 후 반영, 기존 3.5 Flash/3.1 Pro 등 다른 옵션은 그대로 유지.