### PR TITLE
feat: add Docker containerization support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+.git
+.gitignore
+
+# 백엔드 - 가상환경/캐시/테스트
+backend/.venv
+backend/__pycache__
+backend/**/__pycache__
+backend/.pytest_cache
+backend/tests
+
+# 백엔드 - 실제 운영 데이터/비밀값/로컬 커스터마이징 (절대 이미지에 포함하면
+# 안 됨 - 컨테이너는 항상 /data 볼륨과 환경변수로 이 값들을 새로 받는다.
+# translation_prompt.txt는 없으면 config.py가 기본 템플릿으로 자동 생성함)
+backend/.env
+backend/easypaper.db
+backend/translation_prompt.txt
+backend/uploads
+backend/cache
+backend/library
+backend/logs
+
+# 프론트엔드 - 의존성/빌드산출물/테스트 (이미지 안에서 새로 빌드함)
+frontend/node_modules
+frontend/dist
+frontend/tests
+frontend/playwright-report
+frontend/test-results
+
+# 기타
+ask

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ── Stage 1: 프론트엔드 빌드 ──
+FROM node:20-alpine AS frontend-builder
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/index.html frontend/vite.config.js ./
+COPY frontend/src ./src
+RUN npm run build
+
+# ── Stage 2: 백엔드 런타임 ──
+FROM python:3.12-slim
+WORKDIR /app/backend
+
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./
+COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
+
+# config.py는 .env/translation_prompt.txt를 항상 backend/(이 이미지에서는
+# /app/backend) 기준 상대경로로 읽고 쓴다 - 심볼릭 링크로 /data 볼륨 안을
+# 가리키게 해서, 설정 화면에서 바꾼 계정 정보나 번역 프롬프트 커스터마이징이
+# 컨테이너를 재생성해도 사라지지 않고 남도록 한다.
+RUN ln -sf /data/.env .env && ln -sf /data/translation_prompt.txt translation_prompt.txt
+
+# 문서 DB/업로드/캐시/라이브러리를 컨테이너 밖에 영속화하기 위한 데이터 볼륨.
+# services/db.py의 DB_PATH, config.py의 UPLOAD_DIR/CACHE_DIR/LIBRARY_DIR는
+# 모두 이 환경변수를 우선 사용하도록 되어 있다 (미설정 시 네이티브 실행과
+# 동일하게 backend/ 하위 상대경로로 폴백).
+ENV DB_PATH=/data/easypaper.db \
+    UPLOAD_DIR=/data/uploads \
+    CACHE_DIR=/data/cache \
+    LIBRARY_DIR=/data/library \
+    APP_HOST=0.0.0.0 \
+    APP_PORT=8000
+VOLUME ["/data"]
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/', timeout=3)" || exit 1
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -180,6 +180,39 @@ sudo journalctl -u easypaper -f
 
 ---
 
+## Docker로 실행하기
+
+Python/Node.js를 직접 설치하지 않고 Docker만으로 실행할 수도 있습니다. 프론트엔드 빌드와 백엔드 실행이 하나의 이미지에 담겨 있으며, 문서 DB·업로드·라이브러리·설정 값은 모두 `/data` 볼륨에 영속화되어 컨테이너를 재생성해도 유지됩니다.
+
+```bash
+git clone https://github.com/orion-gz/EasyPaper.git
+cd EasyPaper
+docker compose up -d --build
+```
+
+서버 구동 후 브라우저에서 `http://localhost:8000`에 접속합니다. 초기 로그인 계정은 위의 `admin` / `admin`과 동일합니다.
+
+기본값은 호스트에 설치된 Ollama(`http://host.docker.internal:11434`)를 바라봅니다. Gemini/Claude/OpenAI API를 쓰려면 로그인 후 설정 화면에서 API 키를 입력하면 됩니다(볼륨에 저장되어 유지됨). `docker-compose.yml`의 `environment`에 직접 `GEMINI_API_KEY` 등을 추가해도 됩니다.
+
+> **참고**: Antigravity/Claude Code/Codex 같은 CLI 기반 엔진은 로그인이 필요한 대화형 설치 과정을 거치므로 Docker 이미지에 포함되어 있지 않습니다. 컨테이너 안에서는 Ollama 또는 API 키 기반 프로바이더(Gemini/Claude/OpenAI)만 사용할 수 있습니다.
+
+**로그 확인**
+```bash
+docker compose logs -f
+```
+
+**중지 (데이터는 볼륨에 남아 유지됨)**
+```bash
+docker compose down
+```
+
+**데이터까지 완전히 삭제**
+```bash
+docker compose down -v
+```
+
+---
+
 ## CLI 기반 AI 엔진 (Antigravity / Claude Code / Codex)
 
 EasyPaper는 Google Antigravity(`agy`), Anthropic Claude Code(`claude`), OpenAI Codex(`codex`) CLI를 서브프로세스로 연동하는 전용 LLM Provider를 내장하고 있습니다.

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -4,7 +4,9 @@ import json
 from datetime import datetime, timezone
 from typing import Optional, List, Dict, Any
 
-DB_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "easypaper.db")
+# DB_PATH 환경변수가 있으면 그대로 쓰고(Docker 등에서 데이터 볼륨 경로로
+# 지정), 없으면 기존과 동일하게 backend/의 부모 기준 경로를 그대로 쓴다.
+DB_PATH = os.getenv("DB_PATH") or os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "easypaper.db")
 
 def get_db():
     conn = sqlite3.connect(DB_PATH)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  easypaper:
+    build: .
+    image: easypaper:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - easypaper_data:/data
+    environment:
+      # 호스트에 설치된 Ollama를 그대로 쓰려면 기본값을 유지한다. Linux에서
+      # host.docker.internal을 쓰려면 아래 extra_hosts가 필요하다(Docker
+      # Desktop/Mac/Windows는 기본 지원). 별도 Ollama 컨테이너를 쓰려면 이
+      # 값을 그 서비스명(예: http://ollama:11434)으로 바꾸면 된다.
+      - OLLAMA_HOST=http://host.docker.internal:11434
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+volumes:
+  easypaper_data:


### PR DESCRIPTION
# Summary
## 1. Docker 이미지/컴포즈 추가
- `Dockerfile`: 멀티스테이지 빌드 - 1단계(node:20-alpine)에서 프론트엔드를 빌드하고, 2단계(python:3.12-slim)에서 백엔드 런타임에 빌드 산출물(`frontend/dist`)을 함께 담음
- `docker-compose.yml`: 8000 포트 노출, `/data` 명명 볼륨, 호스트 Ollama 접속을 위한 `host.docker.internal` extra_hosts 매핑, `restart: unless-stopped`
- `.dockerignore`: `.venv`/`node_modules`/테스트/빌드산출물 제외 + 실제 운영 데이터(`easypaper.db`, `uploads/`, `cache/`, `library/`, `.env`, `translation_prompt.txt`)가 이미지에 절대 포함되지 않도록 명시적으로 제외

## 2. 데이터 영속화를 위한 백엔드 변경 (backend/services/db.py)
- `DB_PATH`가 `DB_PATH` 환경변수를 우선 사용하도록 수정(미설정 시 기존과 동일한 기본 경로로 폴백 - 네이티브 실행은 영향 없음)
- Dockerfile에서 `UPLOAD_DIR`/`CACHE_DIR`/`LIBRARY_DIR`/`DB_PATH`를 모두 `/data` 하위로 지정하고, `.env`/`translation_prompt.txt`는 심볼릭 링크로 `/data` 볼륨을 가리키게 해 계정 정보·번역 프롬프트 커스터마이징·SECRET_KEY까지 컨테이너 재생성 후에도 유지되도록 함(직접 이미지 빌드 + 컨테이너 재생성 후 로그인/SECRET_KEY 영속 확인 완료)

## 3. README 업데이트
- "Docker로 실행하기" 섹션 추가 - 실행 방법, 기본 Ollama 연결, API 키 설정 방법, 로그/중지/데이터 삭제 명령어
- CLI 기반 엔진(Antigravity/Claude Code/Codex)은 대화형 로그인이 필요해 Docker 이미지에 포함되지 않는다는 제약사항을 명시

## 4. 검증
- `docker build`로 이미지 빌드 성공 확인
- 컨테이너 기동 후 로그인 API 정상 동작, `/data` 볼륨에 DB/업로드/캐시/라이브러리/.env 생성 확인
- 컨테이너 삭제 후 같은 볼륨으로 재생성해도 DB/SECRET_KEY가 그대로 유지됨을 확인
- 백엔드 pytest 96개 전체 통과(회귀 없음)
