### PR TITLE
feat: support CLI-based AI engines in Docker via host credential mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,34 @@ RUN npm run build
 FROM python:3.12-slim
 WORKDIR /app/backend
 
+# curl(agy 공식 설치 스크립트) + Node.js/npm(claude-code, codex 설치용).
+# claude/codex/agy 바이너리 자체는 설치 후 독립 실행형 네이티브 바이너리라
+# 런타임에 Node.js가 필요하지 않지만, npm install -g 설치 과정 자체에는
+# 필요하다.
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/ ./
 COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
+
+# CLI 기반 AI 엔진(Antigravity/Claude Code/Codex) 설치. 실제 로그인
+# 자격증명은 이미지에 절대 포함되지 않는다 - 컨테이너 실행 시 호스트의
+# ~/.claude, ~/.codex, ~/.antigravitycli, ~/.gemini를 볼륨으로 그대로
+# 마운트해, 호스트에서 이미 완료해둔 로그인을 그대로 재사용하는 방식이다
+# (README 참고). 컨테이너는 root로 실행되므로 HOME=/root 기준 경로에
+# 설치한다. claude/codex는 npm 전역 설치 시 이미 PATH에 있는
+# /usr/local/bin에 설치되어 별도 경로 지정이 필요 없고, agy 설치 스크립트만
+# $HOME/.local/bin을 쓰므로 그 경로만 PATH/AGY_PATH에 추가한다.
+ENV HOME=/root \
+    PATH="/root/.local/bin:${PATH}" \
+    AGY_PATH=/root/.local/bin/agy
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+    && curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 # config.py는 .env/translation_prompt.txt를 항상 backend/(이 이미지에서는
 # /app/backend) 기준 상대경로로 읽고 쓴다 - 심볼릭 링크로 /data 볼륨 안을

--- a/README.md
+++ b/README.md
@@ -194,7 +194,19 @@ docker compose up -d --build
 
 기본값은 호스트에 설치된 Ollama(`http://host.docker.internal:11434`)를 바라봅니다. Gemini/Claude/OpenAI API를 쓰려면 로그인 후 설정 화면에서 API 키를 입력하면 됩니다(볼륨에 저장되어 유지됨). `docker-compose.yml`의 `environment`에 직접 `GEMINI_API_KEY` 등을 추가해도 됩니다.
 
-> **참고**: Antigravity/Claude Code/Codex 같은 CLI 기반 엔진은 로그인이 필요한 대화형 설치 과정을 거치므로 Docker 이미지에 포함되어 있지 않습니다. 컨테이너 안에서는 Ollama 또는 API 키 기반 프로바이더(Gemini/Claude/OpenAI)만 사용할 수 있습니다.
+### Docker 안에서 CLI 기반 엔진(Antigravity/Claude Code/Codex) 쓰기
+
+이미지에는 세 CLI가 모두 미리 설치되어 있지만, 로그인(OAuth) 자격증명은 이미지에 절대 포함되지 않습니다. 대신 컨테이너가 호스트의 로그인 정보를 볼륨으로 그대로 재사용합니다(`docker-compose.yml`에 이미 설정되어 있음). 그래서 **먼저 호스트(컨테이너 밖)에서 CLI를 정상적으로 설치하고 로그인**해야 합니다:
+
+```bash
+# 예: Claude Code
+npm install -g @anthropic-ai/claude-code
+claude auth login
+```
+
+(또는 EasyPaper를 네이티브로 한 번 실행해서 설정 화면의 "설치" 버튼으로 설치·로그인해도 됩니다.) 로그인이 끝난 뒤 `docker compose up -d`로 컨테이너를 (재)시작하면, 호스트에서 완료한 로그인이 컨테이너 안으로 그대로 반영되어 별도 설정 없이 바로 사용할 수 있습니다. 호스트에 설치/로그인하지 않은 CLI는 그냥 "미설치" 상태로 표시될 뿐이라 안전합니다.
+
+> Claude Code가 컨테이너 안에서 `~/.claude.json 파일을 찾을 수 없습니다` 같은 백업 복원 안내를 한 번 출력할 수 있는데, 인증 자체에는 영향이 없습니다(무시해도 됩니다). 완전히 없애고 싶다면 `docker-compose.yml`에 `${HOME}/.claude.json:/root/.claude.json` 마운트를 추가하세요 — 단, 호스트에 그 파일이 실제로 존재할 때만 추가해야 합니다(존재하지 않는 파일 경로를 마운트하면 Docker가 그 자리에 빈 디렉터리를 만들어버려 이후 네이티브 설치가 깨질 수 있습니다).
 
 **로그 확인**
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,15 @@ services:
       - "8000:8000"
     volumes:
       - easypaper_data:/data
+      # CLI 기반 AI 엔진(Antigravity/Claude Code/Codex)용 - 컨테이너 안에서
+      # 새로 로그인할 필요 없이, 호스트에서 이미 완료해둔 로그인을 그대로
+      # 재사용한다. 해당 CLI를 호스트에 설치/로그인한 적이 없다면 Docker가
+      # 빈 디렉터리를 새로 만들 뿐이라 안전하다 - 그 엔진은 그냥 "미설치"로
+      # 표시된다. 쓰지 않을 CLI는 그냥 줄을 지워도 된다.
+      - ${HOME}/.claude:/root/.claude
+      - ${HOME}/.codex:/root/.codex
+      - ${HOME}/.antigravitycli:/root/.antigravitycli
+      - ${HOME}/.gemini:/root/.gemini
     environment:
       # 호스트에 설치된 Ollama를 그대로 쓰려면 기본값을 유지한다. Linux에서
       # host.docker.internal을 쓰려면 아래 extra_hosts가 필요하다(Docker


### PR DESCRIPTION
# Summary
## 1. Docker 이미지에 CLI 기반 AI 엔진 설치 추가 (Dockerfile)
- Node.js 20(nodesource) + curl 설치
- `npm install -g @anthropic-ai/claude-code @openai/codex`, Antigravity 공식 설치 스크립트로 세 CLI를 이미지 빌드 시 미리 설치(모두 독립 실행형 네이티브 바이너리라 런타임에 Node.js 불필요, 설치 과정에만 필요)
- `AGY_PATH`/`PATH`를 agy의 실제 설치 위치(`/root/.local/bin`)에 맞게 설정. claude/codex는 npm이 이미 PATH 상의 `/usr/local/bin`에 설치하므로 별도 경로 지정 불필요(직접 빌드해서 확인함)

## 2. 로그인 자격증명 볼륨 마운트 (docker-compose.yml)
- 컨테이너 안에서 헤드리스 OAuth 로그인을 새로 시도하지 않고, 호스트의 `~/.claude`, `~/.codex`, `~/.antigravitycli`, `~/.gemini`를 그대로 볼륨 마운트해 호스트에서 이미 완료해둔 로그인을 재사용
- `~/.claude.json`(디렉터리가 아닌 파일)은 기본 마운트에서 제외 - 존재하지 않는 파일 경로를 바인드 마운트하면 Docker가 그 자리에 빈 디렉터리를 만들어버려 이후 네이티브 설치를 깨뜨릴 수 있음을 실측으로 확인, README에 선택적 추가 방법과 주의사항 안내

## 3. README 업데이트
- 기존 "CLI 엔진은 Docker에서 지원 안 됨" 안내를 정정하고, 호스트에서 먼저 설치/로그인 후 컨테이너를 (재)시작하면 그대로 재사용된다는 실제 사용법 추가

## 4. 검증
- 이미지 빌드 성공 확인(Node.js + 3개 CLI 설치 전부 성공)
- 컨테이너 기동 후 `/api/availability`가 antigravity/claude_code/codex 모두 `true` 반환 확인
- `agy --print`로 실제 인증된 호출이 성공하는 것까지 확인(Antigravity)
- `claude auth status`, `codex login status`로 Claude Code/Codex 로그인 상태 정상 확인
- `docker compose config` 유효성 확인, compose로 빌드한 이미지로도 동일하게 재검증
- 백엔드 pytest 96개 전체 통과(회귀 없음)
