### PR TITLE
feat: separate update check/run buttons and show changelog in settings

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-C5YLP8O5.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BQAi4IYa.css">
+  <script type="module" crossorigin src="/assets/index-BistNBQq.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BGlOq8XW.css">
 </head>
 <body>
 
@@ -614,8 +614,15 @@
               </div>
               <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
+            <div id="system-update-changelog-box" class="hidden" style="background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px;">
+              <div id="system-update-version-line" style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; font-family: var(--font-mono);"></div>
+              <ul id="system-update-changelog" style="margin: 0; padding-left: 4px; list-style: none; display: flex; flex-direction: column; gap: 4px;"></ul>
+            </div>
             <div style="display: flex; gap: 10px; align-items: center;">
-              <button type="button" id="system-update-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
+              <button type="button" id="system-update-check-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>업데이트 확인
+              </button>
+              <button type="button" id="system-update-run-btn" class="btn btn-secondary" disabled style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>최신 업데이트 실행
               </button>
               <span id="system-update-status" style="font-size: 12.5px; color: var(--text-secondary);"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -613,8 +613,15 @@
               </div>
               <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
+            <div id="system-update-changelog-box" class="hidden" style="background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px;">
+              <div id="system-update-version-line" style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; font-family: var(--font-mono);"></div>
+              <ul id="system-update-changelog" style="margin: 0; padding-left: 4px; list-style: none; display: flex; flex-direction: column; gap: 4px;"></ul>
+            </div>
             <div style="display: flex; gap: 10px; align-items: center;">
-              <button type="button" id="system-update-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
+              <button type="button" id="system-update-check-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>업데이트 확인
+              </button>
+              <button type="button" id="system-update-run-btn" class="btn btn-secondary" disabled style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>최신 업데이트 실행
               </button>
               <span id="system-update-status" style="font-size: 12.5px; color: var(--text-secondary);"></span>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2511,50 +2511,97 @@ if (advancedSettingsForm) {
   })
 }
 
-// 시스템 자동 업데이트 실행
-const systemUpdateBtn = $('system-update-btn')
+// 시스템 자동 업데이트: 확인(check)과 실행(run)을 분리한다 - 확인해서 새
+// 업데이트가 있을 때만 실행 버튼이 활성화되고, 확인 시 변경 로그를 함께
+// 보여준다. (waitForServerRestartAndReload/renderChangelogList/
+// formatVersionLabel은 이 파일 아래쪽에 정의되어 있지만 function 선언이라
+// 호이스팅되어 여기서도 안전하게 쓸 수 있다.)
+const systemUpdateCheckBtn = $('system-update-check-btn')
+const systemUpdateRunBtn = $('system-update-run-btn')
 const systemUpdateStatus = $('system-update-status')
-if (systemUpdateBtn) {
-  systemUpdateBtn.addEventListener('click', async () => {
-    const ok = await showCustomConfirm('정말 깃허브 최신 코드로 자동 업데이트를 실행하시겠습니까?\n업데이트가 완료되면 서비스 데몬이 자동으로 재기동되며 약 3~5초간 접속이 중단될 수 있습니다.', { title: '시스템 업데이트', confirmText: '업데이트', danger: true })
-    if (!ok) {
-      return
+const systemUpdateChangelogBox = $('system-update-changelog-box')
+const systemUpdateVersionLine = $('system-update-version-line')
+const systemUpdateChangelogList = $('system-update-changelog')
+
+let pendingSystemUpdateAvailable = false
+
+function resetSystemUpdateCheckState() {
+  pendingSystemUpdateAvailable = false
+  if (systemUpdateRunBtn) systemUpdateRunBtn.disabled = true
+  if (systemUpdateChangelogBox) systemUpdateChangelogBox.classList.add('hidden')
+}
+
+if (systemUpdateCheckBtn) {
+  systemUpdateCheckBtn.addEventListener('click', async () => {
+    systemUpdateCheckBtn.disabled = true
+    systemUpdateCheckBtn.innerHTML = icon('refreshCw', 13, 'style="vertical-align:-2px;margin-right:4px"') + '확인 중...'
+    resetSystemUpdateCheckState()
+    if (systemUpdateStatus) { systemUpdateStatus.style.color = 'var(--text-secondary)'; systemUpdateStatus.textContent = '' }
+
+    try {
+      const result = await checkForUpdateAPI()
+      if (currentVersionLabel && result.current_version) {
+        currentVersionLabel.textContent = `현재 버전: ${formatVersionLabel(result.current_version, result.current_version_date)}`
+      }
+      if (!result.ok) {
+        systemUpdateStatus.style.color = '#ef4444'
+        systemUpdateStatus.textContent = result.error || '업데이트 확인 실패'
+      } else if (result.update_available) {
+        pendingSystemUpdateAvailable = true
+        if (systemUpdateVersionLine) {
+          systemUpdateVersionLine.textContent = `${formatVersionLabel(result.current_version, result.current_version_date)} → ${formatVersionLabel(result.latest_version, result.latest_version_date)}`
+        }
+        renderChangelogList(systemUpdateChangelogList, result.changelog)
+        if (systemUpdateChangelogBox) systemUpdateChangelogBox.classList.remove('hidden')
+        if (systemUpdateRunBtn) systemUpdateRunBtn.disabled = false
+        systemUpdateStatus.style.color = '#10b981'
+        systemUpdateStatus.textContent = '새 업데이트가 있습니다.'
+      } else {
+        systemUpdateStatus.style.color = 'var(--text-secondary)'
+        systemUpdateStatus.textContent = '이미 최신 버전입니다.'
+      }
+    } catch (err) {
+      systemUpdateStatus.style.color = '#ef4444'
+      systemUpdateStatus.textContent = err.message || '업데이트 확인 실패'
+    } finally {
+      systemUpdateCheckBtn.disabled = false
+      systemUpdateCheckBtn.innerHTML = icon('checkCircle', 13, 'style="vertical-align:-2px;margin-right:4px"') + '업데이트 확인'
     }
-    
-    systemUpdateBtn.disabled = true
-    systemUpdateBtn.innerHTML = icon('refreshCw', 13, 'style="vertical-align:-2px;margin-right:4px"') + '업데이트 진행 중...'
+  })
+}
+
+if (systemUpdateRunBtn) {
+  systemUpdateRunBtn.addEventListener('click', async () => {
+    if (!pendingSystemUpdateAvailable) return
+    const ok = await showCustomConfirm('정말 깃허브 최신 코드로 자동 업데이트를 실행하시겠습니까?\n업데이트가 완료되면 서비스 데몬이 자동으로 재기동되며 약 3~5초간 접속이 중단될 수 있습니다.', { title: '시스템 업데이트', confirmText: '업데이트', danger: true })
+    if (!ok) return
+
+    systemUpdateRunBtn.disabled = true
+    if (systemUpdateCheckBtn) systemUpdateCheckBtn.disabled = true
+    systemUpdateRunBtn.innerHTML = icon('refreshCw', 13, 'style="vertical-align:-2px;margin-right:4px"') + '업데이트 진행 중...'
     systemUpdateStatus.style.color = 'var(--text-secondary)'
     systemUpdateStatus.textContent = 'GitHub 코드 가져오는 중...'
-    
+
     try {
       const res = await triggerSystemUpdateAPI()
       if (res.ok) {
         systemUpdateStatus.style.color = '#10b981' // 초록색
-        systemUpdateStatus.textContent = '업데이트 성공! 잠시 후 자동 새로고침됩니다.'
+        systemUpdateStatus.textContent = '업데이트 성공! 서버 재시작을 기다리는 중...'
         showToast(res.message, 'success')
-        
-        // 5초 후에 페이지 새로고침
-        setTimeout(() => {
-          location.reload()
-        }, 5000)
+        await waitForServerRestartAndReload()
       } else {
-        systemUpdateBtn.disabled = false
-        systemUpdateBtn.innerHTML = icon('download', 13, 'style="vertical-align:-2px;margin-right:4px"') + '최신 업데이트 실행'
+        systemUpdateRunBtn.disabled = false
+        if (systemUpdateCheckBtn) systemUpdateCheckBtn.disabled = false
+        systemUpdateRunBtn.innerHTML = icon('download', 13, 'style="vertical-align:-2px;margin-right:4px"') + '최신 업데이트 실행'
         systemUpdateStatus.style.color = '#ef4444' // 빨간색
         systemUpdateStatus.textContent = res.message
         showToast(res.message, 'error')
       }
     } catch (err) {
-      systemUpdateBtn.disabled = false
-      systemUpdateBtn.innerHTML = icon('download', 13, 'style="vertical-align:-2px;margin-right:4px"') + '최신 업데이트 실행'
       systemUpdateStatus.style.color = '#ef4444'
-      systemUpdateStatus.textContent = '서버 재시작 대기 중...'
+      systemUpdateStatus.textContent = '서버 재시작을 감지했습니다. 잠시 후 새로고침합니다...'
       showToast('서버 재기동을 감지했습니다. 잠시 후 새로고침합니다.', 'info')
-      
-      // 5초 후에 페이지 새로고침
-      setTimeout(() => {
-        location.reload()
-      }, 5000)
+      await waitForServerRestartAndReload()
     }
   })
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4432,6 +4432,11 @@ body.light-theme .citation-marker-box:hover {
   filter: none;
 }
 
+#system-update-run-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* 라이브러리 카드/리스트 위의 비교 선택 체크박스 오버레이 - 평소엔 숨겨져 있다가
    선택 모드(.compare-select-mode)일 때만 나타난다 */
 .doc-card-compare-check {

--- a/frontend/tests/e2e/update-notifications.spec.js
+++ b/frontend/tests/e2e/update-notifications.spec.js
@@ -69,6 +69,75 @@ test('업데이트도 없고 방금 업데이트되지도 않았으면 아무 �
   await expect(page.locator('#update-available-modal')).toHaveClass(/hidden/)
 })
 
+test('설정 화면에서 업데이트 확인 버튼을 누르면 새 업데이트가 있을 때만 변경 로그가 표시되고 실행 버튼이 활성화된다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: true })
+  // 이 테스트는 설정 화면의 수동 확인/실행 버튼만 검증한다 - 자동 백그라운드
+  // 확인 팝업이 함께 뜨면 설정 모달 클릭을 가로채므로 꺼둔다.
+  await page.route('**/api/settings/update-check-config', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify({ interval: 'never', last_checked_at: null }),
+  }))
+
+  await gotoApp(page)
+  await page.waitForTimeout(600)
+  await page.click('#global-settings-btn')
+  await page.waitForTimeout(400)
+
+  // 확인 전에는 실행 버튼이 비활성 상태여야 한다
+  await expect(page.locator('#system-update-run-btn')).toBeDisabled()
+  await expect(page.locator('#system-update-changelog-box')).toHaveClass(/hidden/)
+
+  await page.click('#system-update-check-btn')
+  await page.waitForTimeout(300)
+
+  await expect(page.locator('#system-update-changelog-box')).not.toHaveClass(/hidden/)
+  await expect(page.locator('#system-update-version-line')).toHaveText('2026-07-15 · abc1234 → 2026-07-21 · def5678')
+  await expect(page.locator('#system-update-changelog')).toContainText('feat: 새 기능 추가')
+  await expect(page.locator('#system-update-changelog')).toContainText('fix: 버그 수정')
+  await expect(page.locator('#system-update-run-btn')).toBeEnabled()
+  await expect(page.locator('#system-update-status')).toHaveText('새 업데이트가 있습니다.')
+})
+
+test('설정 화면에서 업데이트 확인 결과 이미 최신 버전이면 실행 버튼이 계속 비활성 상태로 남는다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
+
+  await gotoApp(page)
+  await page.waitForTimeout(600)
+  await page.click('#global-settings-btn')
+  await page.waitForTimeout(400)
+
+  await page.click('#system-update-check-btn')
+  await page.waitForTimeout(300)
+
+  await expect(page.locator('#system-update-status')).toHaveText('이미 최신 버전입니다.')
+  await expect(page.locator('#system-update-run-btn')).toBeDisabled()
+  await expect(page.locator('#system-update-changelog-box')).toHaveClass(/hidden/)
+})
+
+test('업데이트 실행 후 확인을 다시 누르지 않고는 실행 버튼을 다시 활성화할 수 없다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: true })
+  await page.route('**/api/settings/update-check-config', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify({ interval: 'never', last_checked_at: null }),
+  }))
+
+  await gotoApp(page)
+  await page.waitForTimeout(600)
+  await page.click('#global-settings-btn')
+  await page.waitForTimeout(400)
+
+  await page.click('#system-update-check-btn')
+  await page.waitForTimeout(300)
+  await expect(page.locator('#system-update-run-btn')).toBeEnabled()
+
+  // 다시 확인을 누르면(예: 그 사이 최신 버전이 됐다고 가정) 실행 버튼이 다시 비활성화된다
+  await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
+  await page.click('#system-update-check-btn')
+  await page.waitForTimeout(300)
+  await expect(page.locator('#system-update-run-btn')).toBeDisabled()
+})
+
 test('설정 화면에서 업데이트 확인 주기를 변경하면 저장된다', async ({ page }) => {
   await mockBaseRoutes(page, { documents: [] })
   await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })


### PR DESCRIPTION
# Summary
## 1. 설정 화면 시스템 업데이트 버튼을 확인/실행으로 분리 (frontend/index.html, src/main.js)
- 기존 단일 `#system-update-btn`("최신 업데이트 실행")을 `#system-update-check-btn`("업데이트 확인") + `#system-update-run-btn`("최신 업데이트 실행")으로 분리
- 실행 버튼은 확인 결과 `update_available`이 true일 때만 활성화되고, 다시 확인해 최신 버전으로 판명되면 다시 비활성화됨
- 확인 시 버전 전환 라인(`현재 → 최신`)과 변경 로그(커밋 목록)를 표시하는 영역 추가 - 기존 자동 업데이트 팝업(`updateAvailableModal`)에서 이미 쓰던 `renderChangelogList`/`formatVersionLabel`을 그대로 재사용
- 실행 시 재시작 대기는 팝업 플로우와 동일하게 `waitForServerRestartAndReload()`로 통일(기존엔 고정 5초 타이머 후 새로고침이라 더 불안정했음)
- 백엔드는 이미 `GET /settings/update-check`(확인+changelog)와 `POST /settings/update`(실행)가 분리되어 있어 변경 없음

## 2. CSS
- `#system-update-run-btn:disabled` 스타일 추가

## 3. 테스트
- `frontend/tests/e2e/update-notifications.spec.js`에 3개 테스트 추가: 확인 후 업데이트 있을 때 changelog 표시+실행 버튼 활성화, 이미 최신 버전이면 실행 버튼 비활성 유지, 재확인 시 실행 버튼이 다시 비활성화되는 것 - 프론트엔드 전체 21개 테스트 통과
