### PR TITLE
refactor: unify changelog UI across settings and update popups

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BistNBQq.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BGlOq8XW.css">
+  <script type="module" crossorigin src="/assets/index-Bq4-xbJ2.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CAz7Mjbk.css">
 </head>
 <body>
 
@@ -462,9 +462,10 @@
         <button id="update-available-close-btn" class="close-btn">&times;</button>
       </div>
       <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
-        <p id="update-available-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
-        <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">변경 내용</div>
-        <ul id="update-available-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        <div class="update-changelog-box" style="margin-bottom: 18px;">
+          <div id="update-available-version-line" class="update-changelog-version-line"></div>
+          <ul id="update-available-changelog" class="update-changelog-list"></ul>
+        </div>
 
         <div id="update-available-progress-area" class="hidden">
           <div id="update-available-status" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 8px;">업데이트 진행 중...</div>
@@ -488,9 +489,9 @@
       </div>
       <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
         <p id="update-complete-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
-        <div id="update-complete-changelog-wrap">
-          <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">이번 업데이트에서 바뀐 점</div>
-          <ul id="update-complete-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        <div id="update-complete-changelog-wrap" class="update-changelog-box" style="margin-bottom: 18px;">
+          <div class="update-changelog-heading">이번 업데이트에서 바뀐 점</div>
+          <ul id="update-complete-changelog" class="update-changelog-list"></ul>
         </div>
         <div style="text-align: right;">
           <button type="button" id="update-complete-confirm-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">확인</button>
@@ -614,9 +615,9 @@
               </div>
               <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
-            <div id="system-update-changelog-box" class="hidden" style="background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px;">
-              <div id="system-update-version-line" style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; font-family: var(--font-mono);"></div>
-              <ul id="system-update-changelog" style="margin: 0; padding-left: 4px; list-style: none; display: flex; flex-direction: column; gap: 4px;"></ul>
+            <div id="system-update-changelog-box" class="update-changelog-box hidden" style="margin-bottom: 12px;">
+              <div id="system-update-version-line" class="update-changelog-version-line"></div>
+              <ul id="system-update-changelog" class="update-changelog-list"></ul>
             </div>
             <div style="display: flex; gap: 10px; align-items: center;">
               <button type="button" id="system-update-check-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -461,9 +461,10 @@
         <button id="update-available-close-btn" class="close-btn">&times;</button>
       </div>
       <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
-        <p id="update-available-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
-        <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">변경 내용</div>
-        <ul id="update-available-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        <div class="update-changelog-box" style="margin-bottom: 18px;">
+          <div id="update-available-version-line" class="update-changelog-version-line"></div>
+          <ul id="update-available-changelog" class="update-changelog-list"></ul>
+        </div>
 
         <div id="update-available-progress-area" class="hidden">
           <div id="update-available-status" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 8px;">업데이트 진행 중...</div>
@@ -487,9 +488,9 @@
       </div>
       <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">
         <p id="update-complete-version-line" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;"></p>
-        <div id="update-complete-changelog-wrap">
-          <div style="font-size: 12px; font-weight: 700; color: var(--text-secondary); margin-bottom: 8px;">이번 업데이트에서 바뀐 점</div>
-          <ul id="update-complete-changelog" style="list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-direction: column; gap: 7px; max-height: 260px; overflow-y: auto;"></ul>
+        <div id="update-complete-changelog-wrap" class="update-changelog-box" style="margin-bottom: 18px;">
+          <div class="update-changelog-heading">이번 업데이트에서 바뀐 점</div>
+          <ul id="update-complete-changelog" class="update-changelog-list"></ul>
         </div>
         <div style="text-align: right;">
           <button type="button" id="update-complete-confirm-btn" class="btn btn-primary" style="padding: 9px 20px; font-size: 13px;">확인</button>
@@ -613,9 +614,9 @@
               </div>
               <span id="current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
-            <div id="system-update-changelog-box" class="hidden" style="background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px;">
-              <div id="system-update-version-line" style="font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; font-family: var(--font-mono);"></div>
-              <ul id="system-update-changelog" style="margin: 0; padding-left: 4px; list-style: none; display: flex; flex-direction: column; gap: 4px;"></ul>
+            <div id="system-update-changelog-box" class="update-changelog-box hidden" style="margin-bottom: 12px;">
+              <div id="system-update-version-line" class="update-changelog-version-line"></div>
+              <ul id="system-update-changelog" class="update-changelog-list"></ul>
             </div>
             <div style="display: flex; gap: 10px; align-items: center;">
               <button type="button" id="system-update-check-btn" class="btn btn-secondary" style="background: var(--bg-hover); border: 1px solid var(--border-strong); padding: 10px 18px; border-radius: var(--radius-md); font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text-primary); transition: all 0.2s; height: 38px;">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4437,6 +4437,37 @@ body.light-theme .citation-marker-box:hover {
   cursor: not-allowed;
 }
 
+/* 설정 화면 수동 확인/자동 팝업(새 업데이트 안내·업데이트 완료 안내)이 모두
+   같은 변경 로그 UI를 쓰도록 공용 클래스로 통일한다. */
+.update-changelog-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+}
+.update-changelog-version-line {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+  font-family: var(--font-mono);
+}
+.update-changelog-heading {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+.update-changelog-list {
+  margin: 0;
+  padding-left: 4px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
 /* 라이브러리 카드/리스트 위의 비교 선택 체크박스 오버레이 - 평소엔 숨겨져 있다가
    선택 모드(.compare-select-mode)일 때만 나타난다 */
 .doc-card-compare-check {


### PR DESCRIPTION
설정 화면의 박스형 변경 로그 UI를 자동 업데이트 안내 팝업(새 업데이트 발견/업데이트 완료)에도 동일하게 적용. 공용 CSS 클래스(`.update-changelog-box`/`-version-line`/`-heading`/`-list`)로 통일. 렌더링 함수(`renderChangelogList`)는 기존과 동일해 로직 변경 없음, 프론트엔드 전체 21개 테스트 통과.