### PR TITLE
feat: add hover tooltip and Google Scholar fallback for citation references

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -16,8 +16,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Bq4-xbJ2.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CAz7Mjbk.css">
+  <script type="module" crossorigin src="/assets/index-DyOOOr0k.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-d8NbX4O9.css">
 </head>
 <body>
 

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -35,6 +35,8 @@ const PATHS = {
   clipboard: '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>',
   edit3: '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>',
   image: '<rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>',
+  search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
+  externalLink: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5899,8 +5899,8 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
     const rects = getSentenceRects({ charStart, charEnd }, vtm, textLayerDiv)
     if (rects.length === 0) continue
 
-    // 대괄호 안에 여러 번호가 있어도([12, 13]) 클릭 시엔 첫 번째 매칭 번호로만
-    // 이동한다 - 대부분 단일 인용이고, 여러 창을 한 번에 여는 것은 오히려 방해된다.
+    // 대괄호 안에 여러 번호가 있어도([12, 13]) 툴팁은 첫 번째 매칭 번호 기준으로만
+    // 보여준다 - 대부분 단일 인용이고, 여러 개를 한 번에 보여주면 오히려 복잡해진다.
     const refNum = nums[0]
     rects.forEach(r => {
       const box = document.createElement('div')
@@ -5909,35 +5909,154 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.style.top    = `${r.top}px`
       box.style.width  = `${r.width}px`
       box.style.height = `${r.height}px`
-      box.title = refMap[refNum] || ''
       box.dataset.refNum = refNum
+      box.addEventListener('mouseenter', () => showCitationTooltip(docId, refNum, refMap[refNum] || '', box))
+      box.addEventListener('mouseleave', scheduleCitationTooltipHide)
+      // 클릭도 항상 툴팁을 띄운다(호버가 없는 터치 기기 대응). 실제 마우스
+      // 클릭은 브라우저가 클릭 직전에 mouseenter를 먼저 쏘므로, 여기서 굳이
+      // "이미 열려 있으면 닫기" 토글을 넣으면 방금 호버가 연 툴팁을 클릭이
+      // 곧바로 다시 닫아버리는 문제가 있어 단순히 show만 호출한다. 닫기는
+      // 바깥 클릭/스크롤/mouseleave로 처리한다.
       box.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
-        handleCitationClick(docId, refNum, box)
+        showCitationTooltip(docId, refNum, refMap[refNum] || '', box)
       })
       overlay.appendChild(box)
     })
   }
 }
 
-async function handleCitationClick(docId, refNum, boxEl) {
-  if (boxEl.classList.contains('loading')) return
-  boxEl.classList.add('loading')
+// ── 인용 표기 호버 툴팁: 참고문헌 원문 + 외부 링크 찾기 + Google Scholar 검색 ──
+let citationTooltipEl = null
+let citationTooltipHideTimer = null
+let citationTooltipDocId = null
+let citationTooltipRefNum = null
+let citationTooltipBoxEl = null
+
+function buildScholarSearchUrl(refText) {
+  return `https://scholar.google.com/scholar?q=${encodeURIComponent((refText || '').slice(0, 300))}`
+}
+
+function getOrCreateCitationTooltip() {
+  if (citationTooltipEl) return citationTooltipEl
+  const el = document.createElement('div')
+  el.className = 'citation-tooltip hidden'
+  el.innerHTML = `
+    <div class="citation-tooltip-text"></div>
+    <div class="citation-tooltip-result hidden"></div>
+    <div class="citation-tooltip-actions">
+      <button type="button" class="citation-tooltip-action-btn citation-tooltip-resolve-btn">${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}원문 링크 찾기</button>
+      <button type="button" class="citation-tooltip-action-btn citation-tooltip-scholar-btn">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px"')}Google Scholar 검색</button>
+    </div>
+  `
+  document.body.appendChild(el)
+
+  el.addEventListener('mouseenter', () => {
+    if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
+  })
+  el.addEventListener('mouseleave', scheduleCitationTooltipHide)
+  el.querySelector('.citation-tooltip-resolve-btn').addEventListener('click', (e) => {
+    e.stopPropagation()
+    resolveCitationTooltip()
+  })
+  el.querySelector('.citation-tooltip-scholar-btn').addEventListener('click', (e) => {
+    e.stopPropagation()
+    const text = el.querySelector('.citation-tooltip-text').textContent
+    window.open(buildScholarSearchUrl(text), '_blank', 'noopener')
+  })
+
+  citationTooltipEl = el
+  return el
+}
+
+function positionCitationTooltip() {
+  if (!citationTooltipEl || !citationTooltipBoxEl) return
+  const rect = citationTooltipBoxEl.getBoundingClientRect()
+  const tw = citationTooltipEl.offsetWidth || 300
+  const th = citationTooltipEl.offsetHeight || 100
+  let left = rect.left + rect.width / 2 - tw / 2
+  left = Math.max(8, Math.min(left, window.innerWidth - tw - 8))
+  let top = rect.top - th - 10
+  if (top < 8) top = rect.bottom + 10
+  citationTooltipEl.style.left = `${left}px`
+  citationTooltipEl.style.top = `${top}px`
+}
+
+function showCitationTooltip(docId, refNum, refText, boxEl) {
+  if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
+  citationTooltipDocId = docId
+  citationTooltipRefNum = refNum
+  citationTooltipBoxEl = boxEl
+
+  const tooltip = getOrCreateCitationTooltip()
+  tooltip.querySelector('.citation-tooltip-text').textContent = refText
+  const resultEl = tooltip.querySelector('.citation-tooltip-result')
+  resultEl.className = 'citation-tooltip-result hidden'
+  resultEl.innerHTML = ''
+  const resolveBtn = tooltip.querySelector('.citation-tooltip-resolve-btn')
+  resolveBtn.disabled = false
+  resolveBtn.innerHTML = `${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}원문 링크 찾기`
+
+  tooltip.classList.remove('hidden')
+  positionCitationTooltip()
+}
+
+function hideCitationTooltip() {
+  if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
+  if (citationTooltipEl) citationTooltipEl.classList.add('hidden')
+  citationTooltipBoxEl = null
+}
+
+function scheduleCitationTooltipHide() {
+  if (citationTooltipHideTimer) clearTimeout(citationTooltipHideTimer)
+  citationTooltipHideTimer = setTimeout(hideCitationTooltip, 220)
+}
+
+async function resolveCitationTooltip() {
+  if (!citationTooltipEl || !citationTooltipDocId || !citationTooltipRefNum) return
+  const resolveBtn = citationTooltipEl.querySelector('.citation-tooltip-resolve-btn')
+  const resultEl = citationTooltipEl.querySelector('.citation-tooltip-result')
+  if (resolveBtn.disabled) return
+
+  resolveBtn.disabled = true
+  resolveBtn.innerHTML = `${icon('refreshCw', 12, 'style="vertical-align:-2px;margin-right:4px"')}찾는 중...`
+
   try {
-    const result = await resolveLibraryReference(docId, refNum)
+    const result = await resolveLibraryReference(citationTooltipDocId, citationTooltipRefNum)
     if (result && result.url) {
-      window.open(result.url, '_blank', 'noopener')
+      resultEl.className = 'citation-tooltip-result'
+      const label = result.title ? `${result.title}${result.year ? ` (${result.year})` : ''}` : result.url
+      resultEl.innerHTML = `<a href="${escapeHtml(result.url)}" target="_blank" rel="noopener">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px;flex-shrink:0"')}<span>${escapeHtml(label)}</span></a>`
     } else {
-      showToast('참고문헌을 찾지 못했습니다.', 'error')
+      resultEl.className = 'citation-tooltip-result citation-tooltip-result-empty'
+      resultEl.textContent = '원문 링크를 찾지 못했습니다. Google Scholar 검색을 이용해보세요.'
     }
   } catch (e) {
     console.warn('참고문헌 조회 실패:', e)
-    showToast('참고문헌을 찾지 못했습니다.', 'error')
+    resultEl.className = 'citation-tooltip-result citation-tooltip-result-empty'
+    resultEl.textContent = '조회 중 오류가 발생했습니다.'
   } finally {
-    boxEl.classList.remove('loading')
+    resolveBtn.disabled = false
+    resolveBtn.innerHTML = `${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}다시 찾기`
+    positionCitationTooltip()
   }
 }
+
+// PDF 스크롤 중에는 인용 박스와 툴팁의 상대 위치가 계속 바뀌므로, 스크롤이
+// 시작되면 곧바로 닫는다(매 스크롤 이벤트마다 재계산하는 것보다 훨씬 가볍다).
+document.addEventListener('scroll', () => {
+  if (citationTooltipEl && !citationTooltipEl.classList.contains('hidden')) hideCitationTooltip()
+}, true)
+
+// 툴팁/인용 표기 바깥을 클릭하면 닫는다 - 호버가 없는 터치 기기에서 닫는
+// 유일한 방법이라 필요하다.
+document.addEventListener('click', (e) => {
+  if (!citationTooltipEl || citationTooltipEl.classList.contains('hidden')) return
+  if (citationTooltipEl.contains(e.target)) return
+  if (citationTooltipBoxEl && citationTooltipBoxEl.contains(e.target)) return
+  hideCitationTooltip()
+})
 
 // ── AI Chat Sidebar ──────────────────────────────
 function toggleChatSidebar() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4392,7 +4392,91 @@ body.light-theme .sentence-memo-box {
 body.light-theme .citation-marker-box:hover {
   background-color: rgba(74, 135, 181, 0.15);
 }
-.citation-marker-box.loading {
+/* 인용 표기 호버/클릭 시 뜨는 툴팁 - 참고문헌 원문 + 외부 링크 찾기 +
+   Google Scholar 검색을 한 곳에서 보여준다. body에 직접 붙여
+   position:fixed로 뷰포트 기준 좌표를 쓴다(PDF 페이지 스크롤 컨테이너
+   내부에 있으면 overflow:hidden에 잘릴 수 있어서). */
+.citation-tooltip {
+  position: fixed;
+  z-index: 200;
+  width: 300px;
+  max-width: calc(100vw - 16px);
+  background: rgba(23, 20, 38, 0.97);
+  color: var(--text-primary);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: fadeInTooltip 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+body.light-theme .citation-tooltip {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: var(--border-strong);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+.citation-tooltip.hidden {
+  display: none;
+}
+.citation-tooltip-text {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  max-height: 110px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+.citation-tooltip-result {
+  font-size: 12.5px;
+  line-height: 1.5;
+  margin-bottom: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.citation-tooltip-result.hidden {
+  display: none;
+}
+.citation-tooltip-result a {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  color: var(--control-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+.citation-tooltip-result a:hover {
+  text-decoration: underline;
+}
+.citation-tooltip-result-empty {
+  color: var(--text-muted);
+}
+.citation-tooltip-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.citation-tooltip-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.citation-tooltip-action-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--accent-mid);
+}
+.citation-tooltip-action-btn:disabled {
+  opacity: 0.6;
   cursor: wait;
 }
 

--- a/frontend/tests/e2e/citation-links.spec.js
+++ b/frontend/tests/e2e/citation-links.spec.js
@@ -1,12 +1,36 @@
 import { test, expect } from '@playwright/test'
 import { mockBaseRoutes, gotoApp, SAMPLE_PDF_CITATION } from './helpers.js'
 
-test('참고문헌 목록에 있는 번호의 본문 인용 표기만 클릭 가능한 오버레이가 생기고, 클릭하면 외부 링크가 새 탭으로 열린다', async ({ page, context }) => {
+test('참고문헌 목록에 있는 번호의 본문 인용 표기만 클릭 가능한 오버레이가 생기고, 클릭하면 원문 텍스트와 함께 툴팁이 뜬다', async ({ page }) => {
   const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
   await mockBaseRoutes(page, { documents: [docC] })
   await page.route('**/api/library/doc-C/pdf', route =>
     route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
   // [2]는 참고문헌 목록에서 의도적으로 제외 - 목록에 없는 번호는 클릭 불가능해야 한다
+  await page.route('**/api/library/doc-C/references', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ references: { '1': 'Vaswani et al. Attention Is All You Need. 2017.' } }),
+    }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
+  await page.waitForTimeout(1500)
+
+  const markerBoxes = page.locator('.citation-marker-box')
+  await expect(markerBoxes).toHaveCount(1)
+  await expect(markerBoxes.first()).toHaveAttribute('data-ref-num', '1')
+
+  await markerBoxes.first().click()
+  await expect(page.locator('.citation-tooltip')).not.toHaveClass(/hidden/)
+  await expect(page.locator('.citation-tooltip-text')).toHaveText('Vaswani et al. Attention Is All You Need. 2017.')
+})
+
+test('툴팁에서 원문 링크 찾기를 누르면 결과 링크가 표시되고, 클릭하면 새 탭으로 열린다', async ({ page, context }) => {
+  const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docC] })
+  await page.route('**/api/library/doc-C/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
   await page.route('**/api/library/doc-C/references', route =>
     route.fulfill({
       status: 200, contentType: 'application/json',
@@ -24,19 +48,19 @@ test('참고문헌 목록에 있는 번호의 본문 인용 표기만 클릭 가
   await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
   await page.waitForTimeout(1500)
 
-  const markerBoxes = page.locator('.citation-marker-box')
-  await expect(markerBoxes).toHaveCount(1)
-  await expect(markerBoxes.first()).toHaveAttribute('data-ref-num', '1')
+  await page.locator('.citation-marker-box').first().click()
+  await page.click('.citation-tooltip-resolve-btn')
+  await expect(page.locator('.citation-tooltip-result a')).toContainText('Attention Is All You Need (2017)')
 
   const [popup] = await Promise.all([
     context.waitForEvent('page'),
-    markerBoxes.first().click(),
+    page.click('.citation-tooltip-result a'),
   ])
   await popup.waitForLoadState('domcontentloaded')
   expect(popup.url()).toBe('https://arxiv.org/abs/1706.03762')
 })
 
-test('참고문헌을 찾지 못하면 오류 토스트를 표시한다', async ({ page }) => {
+test('원문 링크를 찾지 못하면 안내 문구가 뜨고, Google Scholar 검색 버튼으로 대체 검색을 할 수 있다', async ({ page, context }) => {
   const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
   await mockBaseRoutes(page, { documents: [docC] })
   await page.route('**/api/library/doc-C/pdf', route =>
@@ -48,12 +72,43 @@ test('참고문헌을 찾지 못하면 오류 토스트를 표시한다', async 
     }))
   await page.route('**/api/library/doc-C/references/1', route =>
     route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: '외부에서 일치하는 논문을 찾지 못했습니다.' }) }))
+  await context.route('https://scholar.google.com/**', route =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' }))
 
   await gotoApp(page)
   await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
   await page.waitForTimeout(1500)
 
   await page.locator('.citation-marker-box').first().click()
-  await expect(page.locator('.toast')).toHaveClass(/show/)
-  await expect(page.locator('.toast')).toHaveText('참고문헌을 찾지 못했습니다.')
+  await page.click('.citation-tooltip-resolve-btn')
+  await expect(page.locator('.citation-tooltip-result')).toHaveText('원문 링크를 찾지 못했습니다. Google Scholar 검색을 이용해보세요.')
+
+  const [popup] = await Promise.all([
+    context.waitForEvent('page'),
+    page.click('.citation-tooltip-scholar-btn'),
+  ])
+  await popup.waitForLoadState('domcontentloaded')
+  expect(decodeURIComponent(popup.url())).toBe('https://scholar.google.com/scholar?q=Vaswani et al. Attention Is All You Need. 2017.')
+})
+
+test('인용 표기가 아닌 다른 곳을 클릭하면(예: 스크롤) 열려 있던 툴팁이 닫힌다', async ({ page }) => {
+  const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docC] })
+  await page.route('**/api/library/doc-C/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
+  await page.route('**/api/library/doc-C/references', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ references: { '1': 'Vaswani et al. Attention Is All You Need. 2017.' } }),
+    }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
+  await page.waitForTimeout(1500)
+
+  await page.locator('.citation-marker-box').first().click()
+  await expect(page.locator('.citation-tooltip')).not.toHaveClass(/hidden/)
+
+  await page.evaluate(() => document.querySelector('#viewer-scroll-container')?.dispatchEvent(new Event('scroll', { bubbles: true })))
+  await expect(page.locator('.citation-tooltip')).toHaveClass(/hidden/)
 })


### PR DESCRIPTION
# Summary
## 1. 인용 표기 호버/클릭 툴팁 추가 (frontend/src/main.js, style.css)
- 기존엔 인용 표기 클릭 시 Semantic Scholar 조회 후 성공하면 바로 새 탭으로 이동, 실패하면 토스트만 뜨는 방식이었음
- 이를 호버(또는 클릭 - 터치 기기 대응)하면 뜨는 툴팁으로 변경. 툴팁은 항상 참고문헌 원문 텍스트를 즉시 보여줌(네트워크 호출 없이 이미 파싱해둔 목록 재사용)
- 툴팁 안 "원문 링크 찾기" 버튼을 눌러야 실제 Semantic Scholar 조회(기존 `GET /library/{doc_id}/references/{ref_num}` API 그대로 재사용, 백엔드 변경 없음)가 일어나고, 결과를 링크로 표시
- 스크롤 시작 시 / 바깥 클릭 시 자동으로 닫힘

## 2. Google Scholar 검색 대체 기능 추가
- Semantic Scholar가 매칭을 못 찾는 경우(사용자가 실제로 자주 겪던 문제)를 위해, 툴팁에 항상 "Google Scholar 검색" 버튼을 추가 - 참고문헌 원문 텍스트로 `scholar.google.com/scholar?q=...` 검색 결과를 새 탭에서 염(공식 검색 API가 없어 백엔드 호출 없이 프론트엔드에서 URL만 구성)

## 3. 아이콘 추가 (frontend/src/icons.js)
- `search`, `externalLink` 아이콘 추가

## 4. 테스트
- `frontend/tests/e2e/citation-links.spec.js` 전면 재작성(4개): 호버/클릭 시 원문 텍스트 툴팁 표시, 원문 링크 찾기 성공 시 링크 클릭하면 새 탭 오픈, 실패 시 안내 문구 + Google Scholar 검색 버튼 동작, 스크롤 시 툴팁 닫힘
- 프론트엔드 전체 23개 테스트 통과, 백엔드 96개 테스트 통과(백엔드 변경 없음, 회귀 확인용)
