### PR TITLE
fix: system update restart failure and stale frontend build after update

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -24,6 +24,7 @@ from config import (
     get_claude_code_path,
     get_codex_path,
     find_ollama_binary,
+    get_project_root,
 )
 from services.llm_client import check_ollama_health
 
@@ -588,9 +589,16 @@ async def system_update(current_user: str = Depends(get_current_user)):
     import os
 
     try:
-        # 프로젝트 루트 디렉토리 찾기
-        project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        
+        # 프로젝트 루트 디렉토리 찾기. os.path.dirname(__file__)로 직접 계산하면
+        # 이 파일(routers/auth.py)이 backend/ 밑 한 단계 더 깊은 routers/ 안에
+        # 있다는 걸 놓치기 쉬워, 실제로 project_dir이 backend/를 가리키게 되는
+        # 버그가 있었다(그 결과 frontend_dir이 backend/frontend로 계산되어
+        # 존재하지 않으니 프론트엔드 빌드가 조용히 스킵되고, _restart_server_process
+        # 에서도 backend_dir이 backend/backend로 계산되어 재시작이
+        # "No such file or directory"로 실패했다). config.py의 검증된
+        # get_project_root()를 그대로 재사용해 이런 계산 실수를 원천 차단한다.
+        project_dir = get_project_root()
+
         # 1. git pull origin main
         pull_proc = await asyncio.create_subprocess_exec(
             "git", "pull", "origin", "main",

--- a/backend/tests/test_system_update.py
+++ b/backend/tests/test_system_update.py
@@ -1,0 +1,95 @@
+"""POST /settings/update의 프로젝트 루트 경로 계산 회귀 테스트.
+
+routers/auth.py의 system_update()가 project_dir을
+os.path.join(os.path.dirname(__file__), "..")로 직접 계산했었는데, 이
+파일(routers/auth.py)이 backend/ 밑 한 단계 더 깊은 routers/ 안에 있다는
+걸 놓쳐 실제로는 backend/ 자체를 project_dir로 착각하는 버그가 있었다.
+그 결과:
+  - frontend_dir이 backend/frontend로 계산되어 존재하지 않으니 프론트엔드
+    빌드가 조용히 스킵됨 (index.html은 git pull로 갱신되지만 dist/assets는
+    재빌드되지 않아 자산 해시가 어긋나 화면이 깨짐)
+  - _restart_server_process에도 같은 project_dir이 전달되어 backend_dir이
+    backend/backend로 계산되고, 재시작이 "No such file or directory"로 실패
+
+config.py의 검증된 get_project_root()를 재사용하도록 고쳤으므로, git
+pull/npm build가 실제로 올바른 디렉터리를 cwd로 쓰는지 확인한다. 실제
+git/npm 명령은 전부 모킹해 테스트 중 진짜 pull/build가 일어나지 않는다.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import config
+
+
+def _make_subprocess_mock(returncode=0, stdout=b"", stderr=b""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+def test_system_update_runs_git_pull_in_actual_project_root(test_client):
+    calls = []
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append({"args": args, "cwd": kwargs.get("cwd")})
+        return _make_subprocess_mock(returncode=0, stdout=b"Already up to date.\n")
+
+    with patch("asyncio.create_subprocess_exec", new=fake_create_subprocess_exec), \
+         patch("routers.auth._restart_server_process", new=AsyncMock()):
+        res = test_client.post("/api/settings/update")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+
+    git_call = next(c for c in calls if c["args"][0] == "git")
+    assert git_call["cwd"] == config.get_project_root()
+    # 회귀 확인: cwd가 backend/backend나 backend/frontend처럼 backend가 중첩되면 안 된다
+    assert not git_call["cwd"].rstrip(os.sep).endswith(f"backend{os.sep}backend")
+
+
+def test_system_update_builds_frontend_in_actual_frontend_dir_when_pull_has_changes(test_client):
+    calls = []
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append({"args": args, "cwd": kwargs.get("cwd")})
+        if args[0] == "git":
+            return _make_subprocess_mock(returncode=0, stdout=b"Updating abc123..def456\n")
+        return _make_subprocess_mock(returncode=0, stdout=b"build ok\n")
+
+    with patch("asyncio.create_subprocess_exec", new=fake_create_subprocess_exec), \
+         patch("routers.auth._restart_server_process", new=AsyncMock()):
+        res = test_client.post("/api/settings/update")
+
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+    npm_call = next(c for c in calls if "npm" in c["args"][0] or (len(c["args"]) > 0 and "npm" in str(c["args"])))
+    expected_frontend_dir = os.path.join(config.get_project_root(), "frontend")
+    assert npm_call["cwd"] == expected_frontend_dir
+    assert os.path.isdir(expected_frontend_dir), "frontend_dir 계산이 맞다면 실제로 존재하는 디렉터리여야 한다"
+
+
+def test_restart_server_process_computes_correct_backend_dir(monkeypatch):
+    """_restart_server_process가 올바른 project_dir을 받으면, 새 프로세스를
+    backend/backend가 아니라 backend/에서 띄운다."""
+    from routers.auth import _restart_server_process
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")  # systemd 분기 건너뛰기
+
+    captured = {}
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured["cwd"] = kwargs.get("cwd")
+        return MagicMock()
+
+    with patch("subprocess.Popen", side_effect=fake_popen), \
+         patch("os._exit", side_effect=lambda code: None):
+        import asyncio
+        asyncio.run(_restart_server_process(config.get_project_root()))
+
+    assert captured["cwd"] == os.path.join(config.get_project_root(), "backend")
+    assert os.path.isdir(captured["cwd"])

--- a/scripts/bat/start.bat
+++ b/scripts/bat/start.bat
@@ -1,5 +1,29 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
+
+set "REPO_ROOT=%~dp0..\.."
+
+REM frontend\dist\index.html이 참조하는 자산 파일이 실제로 dist\assets\에 없으면
+REM (예: 과거 자동 업데이트가 git pull만 하고 npm run build를 건너뛰어 index.html은
+REM 새 자산 해시를 가리키는데 실제 파일은 재생성되지 않은 경우) 화면이 깨진 채로
+REM 뜬다. 매번 재시작할 때마다 자동으로 다시 빌드해 스스로 복구하도록 한다.
+for /f "usebackq delims=" %%R in (`powershell -NoProfile -Command ^
+    "$idx = Join-Path '%REPO_ROOT%' 'frontend\dist\index.html'; " ^
+    "if (-not (Test-Path $idx)) { 'BUILD'; exit }; " ^
+    "$missing = $false; " ^
+    "(Select-String -Path $idx -Pattern '\"(/assets/[^\"]+\.(js|css))\"' -AllMatches).Matches | ForEach-Object { " ^
+    "  $p = Join-Path '%REPO_ROOT%' ('frontend\dist' + $_.Groups[1].Value.Replace('/', '\')); " ^
+    "  if (-not (Test-Path $p)) { $missing = $true } " ^
+    "}; " ^
+    "if ($missing) { 'BUILD' } else { 'OK' }"`) do set "BUILD_CHECK_RESULT=%%R"
+
+if "%BUILD_CHECK_RESULT%"=="BUILD" (
+    echo Warning: frontend build output is missing or out of date, rebuilding...
+    pushd "%REPO_ROOT%\frontend"
+    call npm install
+    call npm run build
+    popd
+)
 
 cd /d "%~dp0..\..\backend"
 

--- a/scripts/sh/start.sh
+++ b/scripts/sh/start.sh
@@ -5,6 +5,27 @@ set -e
 
 echo "📡 EasyPaper 서버 시작 중..."
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# frontend/dist/index.html이 참조하는 자산 파일이 실제로 dist/assets/에 없으면
+# (예: 과거 자동 업데이트가 git pull만 하고 npm run build를 건너뛰어 index.html은
+# 새 자산 해시를 가리키는데 실제 파일은 재생성되지 않은 경우) 화면이 깨진 채로
+# 뜬다. 매번 재시작할 때마다 자동으로 다시 빌드해 스스로 복구하도록 한다.
+DIST_INDEX="$REPO_ROOT/frontend/dist/index.html"
+NEEDS_BUILD=0
+if [ ! -f "$DIST_INDEX" ]; then
+    NEEDS_BUILD=1
+else
+    while IFS= read -r asset_path; do
+        [ -f "$REPO_ROOT/frontend/dist${asset_path}" ] || NEEDS_BUILD=1
+    done < <(grep -oE '"/assets/[^"]+\.(js|css)"' "$DIST_INDEX" | tr -d '"')
+fi
+
+if [ "$NEEDS_BUILD" = "1" ]; then
+    echo "⚠️  프론트엔드 빌드 산출물이 없거나 최신 소스와 어긋나 다시 빌드합니다..."
+    (cd "$REPO_ROOT/frontend" && npm install && npm run build)
+fi
+
 # Ensure we run from backend folder with .venv python (이 스크립트는 scripts/sh/ 하위에 있음)
 cd "$(dirname "$0")/../../backend"
 


### PR DESCRIPTION
# Summary
## 1. 시스템 업데이트 재시작 경로 계산 버그 수정 (backend/routers/auth.py)
- `system_update()`가 `os.path.join(os.path.dirname(__file__), "..")`로 project_dir을 직접 계산했는데, `routers/auth.py`가 `backend/` 밑 한 단계 더 깊은 `routers/`에 있다는 걸 놓쳐 실제로는 `project_dir`이 `backend/` 자체를 가리키는 버그였음
- 그 결과: `frontend_dir`이 `backend/frontend`로 계산되어 존재하지 않으니 프론트엔드 재빌드가 조용히 스킵되고, `_restart_server_process`에도 같은 값이 전달되어 `backend_dir`이 `backend/backend`가 되어 재시작이 `[Errno 2] No such file or directory`로 실패
- 이미 검증되어 다른 곳(update_checker.py 등)에서도 쓰이는 `config.py`의 `get_project_root()`를 재사용하도록 수정

## 2. start.sh / start.bat에 프론트엔드 빌드 자가 복구 로직 추가
- 위 버그로 `git pull`은 되고(git 추적 대상인 `dist/index.html`은 새 자산 해시를 참조하도록 갱신됨) 실제 빌드는 스킵되어, 화면이 깨진 채로 남는 경우가 있었음(`setup.sh`를 다시 돌려야만 복구됨)
- 재시작할 때마다 `dist/index.html`이 참조하는 자산 파일이 실제로 `dist/assets/`에 있는지 확인하고, 없으면 자동으로 `npm install && npm run build`를 실행하도록 함 - 이번 버그뿐 아니라 다른 이유로 dist가 어긋나는 경우에도 동일하게 자가 복구됨

## 3. 테스트
- `backend/tests/test_system_update.py` 신규 추가(3개) - git pull/npm build가 실제 프로젝트 루트 기준 올바른 디렉터리를 cwd로 쓰는지, `_restart_server_process`가 올바른 backend 디렉터리를 계산하는지 검증. 수정 전 코드로 되돌려 실행해보면 2개가 실제로 실패하는 것까지 확인함(회귀 테스트로서 유효함을 검증)
- 백엔드 전체 99개 테스트 통과
