### PR TITLE
fix: Windows에서 Antigravity CLI 설치 스크립트 실패 문제 수정

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -424,27 +424,61 @@ async def install_antigravity_stream(current_user: str = Depends(get_current_use
             yield f"data: {json.dumps({'status': 'error', 'message': 'Antigravity CLI가 이미 설치되어 있습니다.'})}\n\n"
             return
 
-        if system == "Windows":
-            # cmd.exe용 공식 설치 스크립트를 %TEMP%에 받아 실행 후 정리한다.
-            command = (
-                'curl -fsSL https://antigravity.google/cli/install.cmd -o "%TEMP%\\antigravity_install.cmd" '
-                '&& call "%TEMP%\\antigravity_install.cmd" '
-                '&& del "%TEMP%\\antigravity_install.cmd"'
-            )
-        else:
-            # macOS와 Linux는 동일한 공식 셸 스크립트를 사용한다.
-            command = "curl -fsSL https://antigravity.google/cli/install.sh | bash"
-
         try:
-            proc = await asyncio.create_subprocess_shell(
-                command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                stdin=asyncio.subprocess.DEVNULL,
-            )
-            async for text in _stream_subprocess_lines(proc):
-                yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
-            await proc.wait()
+            if system == "Windows":
+                # install.cmd 자체에 "명령줄 인자에 &, |, ; 등 위험한 셸 문자가
+                # 있으면 거부"하는 자체 보안 검증이 있다. 예전에는 `curl -o ... &&
+                # call ... && del ...`를 하나의 문자열로 만들어
+                # create_subprocess_shell에 넘겼는데, Python이 shell=True일 때
+                # 이 문자열 전체를 다시 `cmd /c "..."`로 한 번 더 감싸면서 이미
+                # 문자열 안에 있던 큰따옴표들과 중첩되어 cmd.exe가 명령 경계를
+                # 잘못 해석했다. 그 결과 "&&" 뒤의 내용 일부가 install.cmd
+                # 자신에게 인자로 새어 들어가 그 자체 검증에 걸려
+                # "Fatal: Illegal shell characters detected in command line
+                # arguments"로 실패했다(위 Ollama Windows 설치와 동일하게 셸
+                # 문자열 조립 없이 httpx로 직접 받고 create_subprocess_exec로
+                # 실행하면 이 문제가 원천적으로 생기지 않는다).
+                import tempfile
+                from config import windows_safe_exec_args
+
+                yield f"data: {json.dumps({'status': 'progress', 'line': 'Antigravity 설치 스크립트를 다운로드합니다...'})}\n\n"
+                installer_path = os.path.join(tempfile.gettempdir(), "antigravity_install.cmd")
+                try:
+                    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+                        async with client.stream("GET", "https://antigravity.google/cli/install.cmd") as resp:
+                            resp.raise_for_status()
+                            with open(installer_path, "wb") as f:
+                                async for chunk in resp.aiter_bytes():
+                                    f.write(chunk)
+                except Exception as e:
+                    yield f"data: {json.dumps({'status': 'error', 'message': f'설치 스크립트 다운로드 실패: {e}'})}\n\n"
+                    return
+
+                yield f"data: {json.dumps({'status': 'progress', 'line': '다운로드 완료. 설치를 진행합니다...'})}\n\n"
+                proc = await asyncio.create_subprocess_exec(
+                    *windows_safe_exec_args([installer_path]),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    stdin=asyncio.subprocess.DEVNULL,
+                )
+                async for text in _stream_subprocess_lines(proc):
+                    yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+                await proc.wait()
+                try:
+                    os.remove(installer_path)
+                except OSError:
+                    pass
+            else:
+                # macOS와 Linux는 동일한 공식 셸 스크립트를 사용한다.
+                proc = await asyncio.create_subprocess_shell(
+                    "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    stdin=asyncio.subprocess.DEVNULL,
+                )
+                async for text in _stream_subprocess_lines(proc):
+                    yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+                await proc.wait()
 
             agy_path_after = get_agy_path()
             installed = os.path.exists(agy_path_after) or shutil.which(agy_path_after) or shutil.which("agy")


### PR DESCRIPTION
# Summary
## 1. Windows에서 Antigravity CLI 설치 스크립트 실패 문제 수정
- install.cmd 자체의 셸 문자 검증에 걸려 "Fatal: Illegal shell characters detected in command line arguments" 오류로 실패하던 문제 수정
- 기존에는 curl 다운로드+실행+삭제를 문자열 하나로 만들어 create_subprocess_shell에 넘겼는데, Windows에서 shell=True 시 그 문자열 전체가 다시 `cmd /c "..."`로 한 번 더 감싸이면서 문자열 안 큰따옴표들과 중첩되어 install.cmd 자신에게 인자가 새어 들어가는 문제가 있었음
- httpx로 스크립트를 직접 다운로드한 뒤 create_subprocess_exec + windows_safe_exec_args로 실행하는 방식으로 변경 - 셸 문자열 중첩 자체가 없어져 문제 원천 차단
- 바로 위 Ollama Windows 설치 로직과 동일한 패턴 적용, macOS/Linux 설치 경로는 변경 없음