### PR TITLE
feat: 본문 인용 오버레이에 (Author, Year) 스타일 지원 추가

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -1,11 +1,14 @@
 """
-논문 원문 텍스트에서 References/참고문헌 섹션을 찾아 번호별 항목으로
-파싱하는 순수 텍스트 처리 로직 (네트워크 호출 없음).
+논문 원문 텍스트에서 References/참고문헌 섹션을 찾아 항목별로 파싱하는
+순수 텍스트 처리 로직 (네트워크 호출 없음).
 
-번호가 매겨진 인용 스타일(`[12] ...` 또는 `12. ...`)만 지원한다 - (Author,
-Year) 스타일은 패턴이 훨씬 다양하고 오탐이 잦아 이번 범위에서는 제외했다.
-CS/ML 논문 대부분이 번호 인용 스타일을 쓰므로 이 앱의 실제 사용처에서는
-충분히 유용하다.
+번호가 매겨진 인용 스타일(`[12] ...`, `12. ...`, `12) ...`)을 우선 지원하고,
+번호 스타일 항목이 하나도 파싱되지 않으면 (Author, Year) 스타일(APA류)
+참고문헌 목록으로 폴백해서 파싱한다. 두 스타일을 한 문서에서 섞어 쓰는
+경우는 드물어서 폴백 방식으로 충분하다. (Author, Year) 항목은 번호가 없어
+"첫 저자 성(소문자) + 연도"를 키로 쓴다(예: "vaswani2017") - 프론트엔드의
+본문 인용 표기 매칭(main.js의 parseAuthorYearKeys)과 반드시 같은 키 형식을
+써야 한다.
 """
 
 import re
@@ -16,7 +19,13 @@ _SECTION_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 _BRACKET_ENTRY_RE = re.compile(r"^\s*\[(\d{1,3})\]\s*(.+)")
-_PLAIN_NUMBERED_ENTRY_RE = re.compile(r"^\s*(\d{1,3})\.\s+(.+)")
+_PLAIN_NUMBERED_ENTRY_RE = re.compile(r"^\s*(\d{1,3})[.)]\s+(.+)")
+
+# (Author, Year) 스타일 항목의 시작 줄 판별용 - "Surname, Initial..." 형태로
+# 시작하는 줄을 새 항목의 시작으로 본다. 실제로 참고문헌 항목인지는 flush 시점에
+# 텍스트 전체에서 연도((\d{4}))가 발견되는지로 한 번 더 검증한다(오탐 방지).
+_AUTHOR_YEAR_ENTRY_START_RE = re.compile(r"^\s*([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+),\s")
+_YEAR_RE = re.compile(r"\((\d{4})[a-z]?\)")
 
 _MAX_ENTRY_LENGTH = 500
 
@@ -76,6 +85,54 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
             current_num = m.group(1)
             current_parts = [m.group(2)]
         elif current_num is not None:
+            current_parts.append(line)
+
+    flush()
+
+    if not entries:
+        entries = _parse_author_year_entries(body_lines)
+
+    return entries
+
+
+def _parse_author_year_entries(body_lines: List[str]) -> Dict[str, str]:
+    """번호가 없는 (Author, Year) 스타일 참고문헌 목록을 파싱합니다.
+
+    "Surname, Initial. ..." 형태로 시작하는 줄을 새 항목의 시작으로 보고,
+    그 항목(여러 줄에 걸칠 수 있음)을 전부 모은 뒤 연도가 실제로 포함돼
+    있는지 확인해서만 채택한다 - 그냥 대문자로 시작하는 일반 문장이 새
+    항목으로 오인되는 것을 막기 위함이다. 키는 "성(소문자)+연도"
+    (예: "vaswani2017")이며, 같은 저자가 같은 해에 여러 편을 낸 경우
+    (2020a/2020b 등) 먼저 나온 항목만 유지한다.
+    """
+    entries: Dict[str, str] = {}
+    current_first_line = None
+    current_parts: List[str] = []
+
+    def flush():
+        if current_first_line is None:
+            return
+        text = re.sub(r"\s+", " ", " ".join(current_parts)).strip()
+        if not text:
+            return
+        year_match = _YEAR_RE.search(text)
+        surname_match = _AUTHOR_YEAR_ENTRY_START_RE.match(current_first_line)
+        if not (year_match and surname_match):
+            return
+        key = f"{surname_match.group(1).lower()}{year_match.group(1)}"
+        if key not in entries:
+            entries[key] = text[:_MAX_ENTRY_LENGTH]
+
+    for raw_line in body_lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if _AUTHOR_YEAR_ENTRY_START_RE.match(line):
+            flush()
+            current_first_line = line
+            current_parts = [line]
+        elif current_first_line is not None:
             current_parts.append(line)
 
     flush()

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -69,3 +69,64 @@ def test_does_not_crash_on_malformed_page_data():
     """text 키가 없거나 None이어도 예외 없이 빈 결과를 반환해야 한다."""
     assert extract_reference_list([{"page_num": 1}]) == {}
     assert extract_reference_list([{"page_num": 1, "text": None}]) == {}
+
+
+def test_parses_paren_numbered_references():
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "1) Smith, J. Deep Learning Basics. NeurIPS 2020.\n\n"
+        "2) Lee, K. Attention Mechanisms Survey. ICML 2021."
+    )}]
+    refs = extract_reference_list(pages)
+    assert refs == {
+        "1": "Smith, J. Deep Learning Basics. NeurIPS 2020.",
+        "2": "Lee, K. Attention Mechanisms Survey. ICML 2021.",
+    }
+
+
+def test_parses_author_year_style_references():
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, "
+        "A. N., Kaiser, L., & Polosukhin, I. (2017). Attention is all you need. "
+        "Advances in Neural Information Processing Systems, 30.\n\n"
+        "Devlin, J., Chang, M. W., Lee, K., & Toutanova, K. (2019). BERT: "
+        "Pre-training of deep bidirectional transformers for language "
+        "understanding. NAACL."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"vaswani2017", "devlin2019"}
+    assert "Attention is all you need" in refs["vaswani2017"]
+    assert "BERT" in refs["devlin2019"]
+
+
+def test_author_year_entry_spans_multiple_lines():
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Cheng, J., Dong, L., & Lapata, M. Long short-term memory-networks\n"
+        "for machine reading. In Proceedings of EMNLP (2016)."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"cheng2016"}
+    assert "machine reading" in refs["cheng2016"]
+
+
+def test_author_year_ignores_non_reference_sentences_without_year():
+    """대문자로 시작하고 쉼표가 있어도 연도가 없으면 참고문헌 항목으로 오인하지 않는다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Note, this section intentionally left without a proper citation list."
+    )}]
+    assert extract_reference_list(pages) == {}
+
+
+def test_author_year_keeps_first_entry_on_duplicate_key():
+    """같은 저자가 같은 해에 여러 편(2020a/2020b 등)이면 먼저 나온 항목만 유지한다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Kim, S. (2020a). First paper title.\n\n"
+        "Kim, S. (2020b). Second paper title."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"kim2020"}
+    assert "First paper title" in refs["kim2020"]

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -22,7 +22,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DwhXIeDz.js"></script>
+  <script type="module" crossorigin src="/assets/index-DAUTG9br.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DSvdeqfT.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5962,9 +5962,16 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
   inner.appendChild(layer)
 }
 
-// 번호 인용 스타일만 지원 ([12], [12, 13], [12-14] 등) - (Author, Year) 스타일은
-// 백엔드 reference_parser.py와 동일하게 이번 범위에서 제외했다.
+// 본문 인용 표기 두 스타일을 지원한다:
+// 1) 번호 인용: [12], [12, 13], [12-14]
+// 2) 저자-연도 인용: (Smith, 2020), (Smith et al., 2020), (Smith & Jones, 2020),
+//    (Smith, 2020; Jones, 2019) 등 - 백엔드 reference_parser.py의
+//    _parse_author_year_entries와 동일하게 "저자 성(소문자)+연도"를 키로 매칭한다.
 const CITATION_MARKER_RE = /\[\s*\d{1,3}(?:\s*[,\-–]\s*\d{1,3})*\s*\]/g
+// 여는 괄호 바로 뒤 대문자로 시작하고, 닫는 괄호 전 20자 이내에 4자리 연도가
+// 있어야 인용으로 인정한다(오탐 방지 - 그냥 "(그림 2020년 기준)" 같은 일반
+// 괄호 문구가 걸리지 않도록 대문자 시작 + 연도 둘 다 요구).
+const CITATION_AUTHOR_YEAR_MARKER_RE = /\([A-ZÀ-Ö][^()]{2,160}?\d{4}[a-z]?[^()]{0,20}\)/g
 
 // "[12, 14-16]" 형태의 대괄호 안 내용을 개별 참고문헌 번호 목록으로 펼친다
 function parseCitationNumbers(bracketText) {
@@ -5987,7 +5994,24 @@ function parseCitationNumbers(bracketText) {
   return nums
 }
 
-// 본문 인용 표기 오버레이 - 참고문헌 목록에 실제로 존재하는 번호를 가리키는
+// "(Smith, 2020; Jones et al., 2019)" 형태를 세미콜론 기준으로 나눠 각각에서
+// 앞쪽 저자 성과 끝쪽 연도만 앵커로 뽑는다(공저자 나열/"et al." 등 그 사이
+// 내용은 굳이 파싱하지 않아도 이 두 앵커만으로 백엔드 키와 매칭 가능).
+function parseAuthorYearKeys(parenText) {
+  const inner = parenText.slice(1, -1)
+  const keys = []
+  inner.split(';').forEach(part => {
+    const trimmed = part.trim()
+    const surnameMatch = trimmed.match(/^([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+)/)
+    const yearMatch = trimmed.match(/(\d{4})[a-z]?/)
+    if (surnameMatch && yearMatch) {
+      keys.push(`${surnameMatch[1].toLowerCase()}${yearMatch[1]}`)
+    }
+  })
+  return keys
+}
+
+// 본문 인용 표기 오버레이 - 참고문헌 목록에 실제로 존재하는 항목을 가리키는
 // 표기만 클릭 가능하게 만든다(오탐/미매칭 표기까지 다 클릭되게 하면 클릭할
 // 때마다 404 토스트만 뜨는 경험이 되므로).
 function renderCitationOverlayLayer(textLayerDiv, pageNum) {
@@ -6006,20 +6030,8 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
   const docId = state.currentDocId
   if (!docId) return
 
-  CITATION_MARKER_RE.lastIndex = 0
-  let match
-  while ((match = CITATION_MARKER_RE.exec(vtm.fullText)) !== null) {
-    const nums = parseCitationNumbers(match[0]).filter(n => refMap[n])
-    if (nums.length === 0) continue
-
-    const charStart = match.index
-    const charEnd = match.index + match[0].length
+  const addCitationBox = (charStart, charEnd, refKey) => {
     const rects = getSentenceRects({ charStart, charEnd }, vtm, textLayerDiv)
-    if (rects.length === 0) continue
-
-    // 대괄호 안에 여러 번호가 있어도([12, 13]) 툴팁은 첫 번째 매칭 번호 기준으로만
-    // 보여준다 - 대부분 단일 인용이고, 여러 개를 한 번에 보여주면 오히려 복잡해진다.
-    const refNum = nums[0]
     rects.forEach(r => {
       const box = document.createElement('div')
       box.className = 'citation-marker-box'
@@ -6027,8 +6039,8 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.style.top    = `${r.top}px`
       box.style.width  = `${r.width}px`
       box.style.height = `${r.height}px`
-      box.dataset.refNum = refNum
-      box.addEventListener('mouseenter', () => showCitationTooltip(docId, refNum, refMap[refNum] || '', box))
+      box.dataset.refNum = refKey
+      box.addEventListener('mouseenter', () => showCitationTooltip(docId, refKey, refMap[refKey] || '', box))
       box.addEventListener('mouseleave', scheduleCitationTooltipHide)
       // 클릭도 항상 툴팁을 띄운다(호버가 없는 터치 기기 대응). 실제 마우스
       // 클릭은 브라우저가 클릭 직전에 mouseenter를 먼저 쏘므로, 여기서 굳이
@@ -6038,10 +6050,27 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
-        showCitationTooltip(docId, refNum, refMap[refNum] || '', box)
+        showCitationTooltip(docId, refKey, refMap[refKey] || '', box)
       })
       overlay.appendChild(box)
     })
+  }
+
+  // 대괄호 안에 여러 번호가 있어도([12, 13]) 툴팁은 첫 번째 매칭 번호 기준으로만
+  // 보여준다 - 대부분 단일 인용이고, 여러 개를 한 번에 보여주면 오히려 복잡해진다.
+  CITATION_MARKER_RE.lastIndex = 0
+  let match
+  while ((match = CITATION_MARKER_RE.exec(vtm.fullText)) !== null) {
+    const nums = parseCitationNumbers(match[0]).filter(n => refMap[n])
+    if (nums.length === 0) continue
+    addCitationBox(match.index, match.index + match[0].length, nums[0])
+  }
+
+  CITATION_AUTHOR_YEAR_MARKER_RE.lastIndex = 0
+  while ((match = CITATION_AUTHOR_YEAR_MARKER_RE.exec(vtm.fullText)) !== null) {
+    const keys = parseAuthorYearKeys(match[0]).filter(k => refMap[k])
+    if (keys.length === 0) continue
+    addCitationBox(match.index, match.index + match[0].length, keys[0])
   }
 }
 


### PR DESCRIPTION
# Summary
## 1. 참고문헌 목록 파싱 형식 확장
- 번호 인용 참고문헌 목록에 "12)" 형식 추가 지원 (기존 "[12]", "12."에 더해)
- 번호 스타일 항목이 하나도 파싱되지 않으면 (Author, Year) 스타일(APA류) 참고문헌 목록으로 자동 폴백 파싱하는 로직 추가 - "Surname, Initial..."로 시작하는 줄을 새 항목으로 보고, 실제로 연도가 포함될 때만 채택해 오탐 방지
## 2. 본문 인용 오버레이에 저자-연도 스타일 지원 추가
- 기존엔 번호 인용([12] 등)만 지원했는데, (Smith, 2020), (Smith et al., 2020), (Smith & Jones, 2020), (Smith, 2020; Jones, 2019) 등 괄호 인용 표기 탐지 및 호버 오버레이 신규 추가
- 저자 성(소문자)+연도를 키로 백엔드 참고문헌 목록과 매칭
- 번호/저자-연도 두 경로가 박스 생성 로직(addCitationBox)을 공통으로 재사용하도록 리팩토링
## 3. 테스트 추가
- backend/tests/test_reference_parser.py에 paren 번호 형식, author-year 기본 파싱/줄바꿈 항목/오탐 방지/중복 키 처리 등 테스트 6개 추가