### PR TITLE
fix: 드롭캡/줄내 이어붙음으로 References 헤더를 못 찾던 문제 수정

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -12,10 +12,14 @@
 """
 
 import re
-from typing import Dict, List
+from typing import Dict, List, Optional
 
-_SECTION_HEADER_RE = re.compile(
-    r"^\s*\**\s*(references|bibliography|참고\s*문헌)\s*\**\s*$",
+# 헤더 단어의 글자 사이에 공백을 허용한다 - 드롭캡(첫 글자만 별도 폰트/굵기)
+# 렌더링 시 "**R** **EFERENCES**"처럼 글자 사이에 공백이 끼어드는 경우까지
+# 대응하기 위함이다(별표는 별도로 먼저 제거).
+_HEADER_PREFIX_RE = re.compile(
+    r"^\s*(?:r\s*e\s*f\s*e\s*r\s*e\s*n\s*c\s*e\s*s|b\s*i\s*b\s*l\s*i\s*o\s*g\s*r\s*a\s*p\s*h\s*y|"
+    r"참\s*고\s*문\s*헌)\b",
     re.IGNORECASE,
 )
 _BRACKET_ENTRY_RE = re.compile(r"^\s*\[(\d{1,3})\]\s*(.+)")
@@ -28,6 +32,31 @@ _AUTHOR_YEAR_ENTRY_START_RE = re.compile(r"^\s*([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ
 _YEAR_RE = re.compile(r"\((\d{4})[a-z]?\)")
 
 _MAX_ENTRY_LENGTH = 500
+
+
+def _match_section_header_prefix(line: str) -> Optional[str]:
+    """줄이 References/Bibliography/참고문헌 헤더로 시작하면 그 뒤에 남는
+    텍스트를 반환하고, 헤더로 시작하지 않으면 None을 반환합니다.
+
+    일부 논문(특히 Nature류)은 헤더 다음에 개행 없이 바로 첫 항목이 이어져
+    "**References** 48. Haist, F. ..."처럼 한 줄에 같이 붙어 나온다. 이
+    경우 남는 텍스트("48. Haist, F. ...")가 실제로 참고문헌 항목의 시작처럼
+    보일 때만 헤더로 인정한다 - 그냥 "References"로 시작하는 일반 문장을
+    섹션 시작으로 오인하지 않기 위함이다. 헤더만 있고 뒤에 아무것도 없는
+    깔끔한 줄은 그대로 빈 문자열을 반환한다.
+    """
+    no_asterisks = re.sub(r"\*+", "", line)
+    m = _HEADER_PREFIX_RE.match(no_asterisks)
+    if not m:
+        return None
+
+    remainder = no_asterisks[m.end():].strip()
+    if not remainder:
+        return remainder
+    if (_BRACKET_ENTRY_RE.match(remainder) or _PLAIN_NUMBERED_ENTRY_RE.match(remainder)
+            or _AUTHOR_YEAR_ENTRY_START_RE.match(remainder)):
+        return remainder
+    return None
 
 
 def extract_reference_list(pages: List[dict]) -> Dict[str, str]:
@@ -47,7 +76,7 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
     ref_start_page_idx = None
     for i in range(len(pages) - 1, -1, -1):
         text = pages[i].get("text", "") or ""
-        if any(_SECTION_HEADER_RE.match(line.strip()) for line in text.split("\n")):
+        if any(_match_section_header_prefix(line) is not None for line in text.split("\n")):
             ref_start_page_idx = i
             break
 
@@ -59,8 +88,12 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
 
     start_idx = 0
     for idx, line in enumerate(lines):
-        if _SECTION_HEADER_RE.match(line.strip()):
-            start_idx = idx + 1
+        remainder = _match_section_header_prefix(line)
+        if remainder is not None:
+            # 헤더 뒤에 같은 줄로 바로 이어지는 첫 항목이 있으면(remainder)
+            # 그 부분은 버리지 않고 body_lines의 첫 줄로 그대로 살린다.
+            lines[idx] = remainder
+            start_idx = idx
             break
     body_lines = lines[start_idx:]
 

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -120,6 +120,31 @@ def test_author_year_ignores_non_reference_sentences_without_year():
     assert extract_reference_list(pages) == {}
 
 
+def test_parses_header_with_drop_cap_bold_split():
+    """일부 논문 템플릿은 섹션 제목 첫 글자를 드롭캡으로 렌더링해서, 텍스트
+    추출 시 "**R****EFERENCES**"처럼 단어 중간에 마크다운 볼드(**)가 끼어드는
+    경우가 있다(실제 UniFormer 논문에서 재현된 케이스)."""
+    pages = [{"page_num": 1, "text": (
+        "some conclusion text.\n\n"
+        "**R****EFERENCES**\n\n"
+        "[1] A. Arnab, M. Dehghani. Vivit: A video vision transformer. ICCV, 2021.\n\n"
+        "[2] Jimmy Ba, Jamie Ryan Kiros. Layer normalization. ArXiv, 2016."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"1", "2"}
+    assert "Vivit" in refs["1"]
+
+
+def test_parses_header_with_space_separated_drop_cap():
+    """드롭캡 뒤에 공백까지 끼는 "**R** **EFERENCES**" 형태도 지원한다."""
+    pages = [{"page_num": 1, "text": (
+        "**R** **EFERENCES**\n\n"
+        "[1] Some Author. A paper title. 2020."
+    )}]
+    refs = extract_reference_list(pages)
+    assert refs == {"1": "Some Author. A paper title. 2020."}
+
+
 def test_author_year_keeps_first_entry_on_duplicate_key():
     """같은 저자가 같은 해에 여러 편(2020a/2020b 등)이면 먼저 나온 항목만 유지한다."""
     pages = [{"page_num": 1, "text": (


### PR DESCRIPTION
# Summary
## 1. References 헤더 감지 로직 강화
- 일부 논문(UniFormer 등)은 섹션 제목 첫 글자를 드롭캡으로 렌더링해서 "**R****EFERENCES**"처럼 단어 중간에 마크다운 볼드(**)가 끼어든 채로 텍스트가 추출됨 - 기존 정규식은 줄 앞뒤의 별표만 허용해서 이 경우를 못 잡고 있었음
- Nature류 논문은 헤더 뒤에 개행 없이 바로 첫 항목이 이어지는 경우("**References** 48. Haist, F. ...")도 있어, 헤더가 줄 전체와 정확히 일치해야 하던 기존 방식으로는 매칭 자체가 안 됐음
- _match_section_header_prefix로 교체: 별표 제거 후 헤더 단어 글자 사이 공백을 허용하는 정규식으로 접두사 매칭하고, 뒤에 남는 텍스트가 실제 참고문헌 항목의 시작처럼 보일 때만(번호/저자-연도 패턴 매칭) 헤더로 인정 - 일반 문장 오탐 방지
## 2. 테스트 추가
- 드롭캡 붙여쓰기/공백 포함 케이스 테스트 2개 추가, 전체 108개 테스트 통과
## 3. 실제 검증
- 서버에 이미 올라와 있던 UniFormer, SNN 논문으로 재현 및 수정 확인(각각 0개 -> 124개, 213개 참고문헌 정상 파싱)
- 두 문서는 수정 전 코드로 이미 열어봐서 빈 결과가 캐시되어 있었던 것도 운영 DB에서 별도로 정리함

## 한계
Nature 논문 사례에서 참고문헌 항목들이 줄바꿈 없이 한 덩어리로 이어져 추출되는 별도 문제를 발견했으나, 이번 수정(헤더 인식)과는 다른 원인이라 이번 범위에서는 다루지 않음(항목 경계를 줄 단위가 아니라 패턴 단위로 다시 나누는 별도 작업 필요).