### PR TITLE
fix: macOS CLI 미탐지 및 npm 전역 설치 EACCES 문제 해결

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -327,37 +327,36 @@ def get_app_host() -> str:
 def get_app_port() -> int:
     return APP_PORT
 
-def get_easypaper_npm_prefix() -> str:
-    """이 앱이 설정 화면에서 자체적으로 설치하는 npm 전역 패키지(Claude
-    Code/Codex)를 시스템 npm 전역 prefix가 아니라 이 경로에 설치한다.
-
-    macOS 공식 Node.js 설치본은 전역 prefix(/usr/local/lib/node_modules)가
-    root 소유라, sudo 없이 `npm install -g`를 실행하면 EACCES(permission
-    denied)로 실패한다. 시스템 npm 설정을 건드리는 대신, 항상 쓰기 가능한
-    사용자 홈 하위의 이 앱 전용 디렉터리에 설치해 이 문제를 원천 차단한다.
-    """
-    return os.path.expanduser("~/.easypaper/npm-global")
-
-
 def _resolve_cli_path(configured_path: str, bare_command: str) -> str:
     """설정된 CLI 경로가 실제로 존재하면 그대로 쓰고, 없으면 PATH에서 명령
-    이름으로 찾은 뒤, 그마저 실패하면 이 앱이 자체 설치할 때 쓰는 npm
-    prefix(get_easypaper_npm_prefix) 아래도 확인한다.
+    이름으로 찾은 뒤, 그마저 실패하면 각 CLI 공식 설치 스크립트가 실제로
+    쓰는 OS별 잘 알려진 위치도 한 번 더 확인한다(find_ollama_binary와 동일한
+    패턴).
 
     AGY_PATH/CLAUDE_CODE_PATH/CODEX_PATH의 기본값이 존재하지 않거나, PATH
     탐색이 실패하는 경우(특히 Tauri 데스크탑 앱처럼 GUI로 실행되어 로그인
     셸의 PATH를 물려받지 못하는 환경)에도 최대한 찾아보기 위함이다.
     """
     import os
+    import platform
     import shutil
     if configured_path and os.path.exists(configured_path):
         return configured_path
     found = shutil.which(bare_command)
     if found:
         return found
-    npm_prefix_candidate = os.path.join(get_easypaper_npm_prefix(), "bin", bare_command)
-    if os.path.exists(npm_prefix_candidate):
-        return npm_prefix_candidate
+
+    # Codex의 공식 Windows 설치 스크립트(install.ps1)는 ~/.local/bin이 아니라
+    # %LOCALAPPDATA%\Programs\OpenAI\Codex\bin에 설치한다 - CODEX_PATH
+    # 기본값(~/.local/bin/codex)과 실제 설치 위치가 OS별로 다른 유일한
+    # 경우라 별도로 확인한다.
+    if bare_command == "codex" and platform.system() == "Windows":
+        localappdata = os.environ.get("LOCALAPPDATA", "")
+        if localappdata:
+            candidate = os.path.join(localappdata, "Programs", "OpenAI", "Codex", "bin", "codex.exe")
+            if os.path.exists(candidate):
+                return candidate
+
     return bare_command
 
 def get_agy_path() -> str:

--- a/backend/config.py
+++ b/backend/config.py
@@ -311,10 +311,15 @@ os.makedirs(LIBRARY_DIR, exist_ok=True)
 APP_HOST = os.getenv("APP_HOST", "0.0.0.0")
 APP_PORT = int(os.getenv("APP_PORT", "8000"))
 
-# Antigravity CLI path
-AGY_PATH = os.getenv("AGY_PATH", "/home/ubuntu/.local/bin/agy")
-CLAUDE_CODE_PATH = os.getenv("CLAUDE_CODE_PATH", "/home/ubuntu/.local/bin/claude")
-CODEX_PATH = os.getenv("CODEX_PATH", "/home/ubuntu/.local/bin/codex")
+# Antigravity/Claude Code/Codex CLI 기본 설치 경로. 예전에는 이 프로젝트를
+# 개발한 서버 전용 절대경로(/home/ubuntu/.local/bin/...)가 박혀 있어서 다른
+# 사용자 계정에서는 이 기본값 자체가 항상 존재하지 않는 경로였다. 각 CLI의
+# 공식 curl 설치 스크립트가 공통으로 쓰는 ~/.local/bin 기준으로 바꿔, PATH
+# 탐색(_resolve_cli_path)이 실패하더라도 이 기본값만으로 찾아지는 경우를
+# 늘린다.
+AGY_PATH = os.getenv("AGY_PATH", os.path.expanduser("~/.local/bin/agy"))
+CLAUDE_CODE_PATH = os.getenv("CLAUDE_CODE_PATH", os.path.expanduser("~/.local/bin/claude"))
+CODEX_PATH = os.getenv("CODEX_PATH", os.path.expanduser("~/.local/bin/codex"))
 
 def get_app_host() -> str:
     return APP_HOST
@@ -322,17 +327,26 @@ def get_app_host() -> str:
 def get_app_port() -> int:
     return APP_PORT
 
+def get_easypaper_npm_prefix() -> str:
+    """이 앱이 설정 화면에서 자체적으로 설치하는 npm 전역 패키지(Claude
+    Code/Codex)를 시스템 npm 전역 prefix가 아니라 이 경로에 설치한다.
+
+    macOS 공식 Node.js 설치본은 전역 prefix(/usr/local/lib/node_modules)가
+    root 소유라, sudo 없이 `npm install -g`를 실행하면 EACCES(permission
+    denied)로 실패한다. 시스템 npm 설정을 건드리는 대신, 항상 쓰기 가능한
+    사용자 홈 하위의 이 앱 전용 디렉터리에 설치해 이 문제를 원천 차단한다.
+    """
+    return os.path.expanduser("~/.easypaper/npm-global")
+
+
 def _resolve_cli_path(configured_path: str, bare_command: str) -> str:
     """설정된 CLI 경로가 실제로 존재하면 그대로 쓰고, 없으면 PATH에서 명령
-    이름으로 직접 찾는다.
+    이름으로 찾은 뒤, 그마저 실패하면 이 앱이 자체 설치할 때 쓰는 npm
+    prefix(get_easypaper_npm_prefix) 아래도 확인한다.
 
-    AGY_PATH/CLAUDE_CODE_PATH/CODEX_PATH의 기본값은 이 프로젝트를 개발한
-    서버 환경 기준의 고정 경로(/home/ubuntu/.local/bin/...)라, 다른 사용자
-    계정이나 macOS/Windows 등 다른 환경에서는 애초에 존재하지 않는 경로다.
-    이 경우 자동 감지가 항상 실패해 실제로는 정상 설치되어 있는 CLI도
-    "미설치"로 오판하게 된다. 설정된 경로가 없으면 PATH 검색으로 대체하고,
-    거기서도 못 찾으면 bare 명령 이름을 그대로 반환해 최소한 셸(PATH) 기반
-    실행이라도 시도해볼 수 있게 한다.
+    AGY_PATH/CLAUDE_CODE_PATH/CODEX_PATH의 기본값이 존재하지 않거나, PATH
+    탐색이 실패하는 경우(특히 Tauri 데스크탑 앱처럼 GUI로 실행되어 로그인
+    셸의 PATH를 물려받지 못하는 환경)에도 최대한 찾아보기 위함이다.
     """
     import os
     import shutil
@@ -341,6 +355,9 @@ def _resolve_cli_path(configured_path: str, bare_command: str) -> str:
     found = shutil.which(bare_command)
     if found:
         return found
+    npm_prefix_candidate = os.path.join(get_easypaper_npm_prefix(), "bin", bare_command)
+    if os.path.exists(npm_prefix_candidate):
+        return npm_prefix_candidate
     return bare_command
 
 def get_agy_path() -> str:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -352,6 +352,7 @@ def _make_npm_cli_install_endpoint(package_name: str, path_getter, already_insta
     async def stream(current_user: str = Depends(get_current_user)):
         import asyncio
         import os
+        import platform
         import shutil
 
         async def event_stream():
@@ -364,9 +365,27 @@ def _make_npm_cli_install_endpoint(package_name: str, path_getter, already_insta
                 yield f"data: {json.dumps({'status': 'error', 'message': npm_missing_message})}\n\n"
                 return
 
+            # macOS(공식 설치본)/일부 Linux 배포판은 npm 전역 prefix
+            # (/usr/local/lib/node_modules)가 root 소유라, sudo 없이
+            # `npm install -g`를 실행하면 EACCES로 실패한다(실제로 macOS에서
+            # 재현됨). 시스템 prefix를 건드리는 대신 이 앱 전용의 항상 쓰기
+            # 가능한 --prefix를 지정해 이 문제를 피한다. Windows는 기본
+            # prefix(%APPDATA%\npm)가 이미 사용자 소유라 이 문제가 없고,
+            # 지금처럼 셸 문자열에 따옴표 있는 경로를 추가하면 Windows에서
+            # cmd.exe의 중첩 따옴표 문제(다른 설치 스크립트에서 이미 겪은
+            # "Illegal shell characters" 부류)를 새로 만들 위험이 있어
+            # Windows에서는 기존 방식을 그대로 둔다.
+            if platform.system() == "Windows":
+                command = f"npm install -g {package_name}"
+            else:
+                from config import get_easypaper_npm_prefix
+                prefix_dir = get_easypaper_npm_prefix()
+                os.makedirs(prefix_dir, exist_ok=True)
+                command = f'npm install -g --prefix "{prefix_dir}" {package_name}'
+
             try:
                 proc = await asyncio.create_subprocess_shell(
-                    f"npm install -g {package_name}",
+                    command,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
                     stdin=asyncio.subprocess.DEVNULL,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -345,55 +345,65 @@ async def install_ollama_stream(current_user: str = Depends(get_current_user)):
     )
 
 
-def _make_npm_cli_install_endpoint(package_name: str, path_getter, already_installed_message: str):
-    """claude_code/codex처럼 npm 전역 패키지로 배포되는 CLI를 설치하는 SSE 스트림을 만듭니다.
-    Node.js/npm은 세 OS 모두 이미 EasyPaper의 필수 요구사항이라, 셸을 통한
-    `npm install -g <package>` 한 줄로 플랫폼 분기 없이 동일하게 동작합니다."""
+def _make_native_cli_install_endpoint(
+    unix_install_url: str,
+    windows_install_url: str,
+    path_getter,
+    already_installed_message: str,
+):
+    """claude_code/codex 공식 curl(Unix)/PowerShell(Windows) 네이티브 설치
+    스크립트로 CLI를 설치하는 SSE 스트림을 만듭니다.
+
+    예전에는 `npm install -g <package>`를 썼는데, macOS 공식 Node.js
+    설치본은 npm 전역 prefix(/usr/local/lib/node_modules)가 root 소유라
+    sudo 없이 실행하면 EACCES(permission denied)로 실패했다(실제로
+    재현됨). 두 CLI 모두 Node.js가 전혀 필요 없는 공식 네이티브 바이너리
+    설치 스크립트를 제공하므로(Antigravity와 동일한 배포 방식), npm을
+    아예 거치지 않는 이 방식으로 바꿔 문제를 원천적으로 피한다. 각
+    설치 스크립트가 자체적으로 셸 rc 파일(.zprofile/.bashrc 등)이나
+    Windows 사용자 PATH에 설치 위치를 등록한다.
+    """
     async def stream(current_user: str = Depends(get_current_user)):
         import asyncio
         import os
         import platform
         import shutil
 
+        system = platform.system()  # 'Linux' | 'Darwin' | 'Windows'
+
         async def event_stream():
             cli_path = path_getter()
             if os.path.exists(cli_path) or shutil.which(cli_path):
                 yield f"data: {json.dumps({'status': 'error', 'message': already_installed_message})}\n\n"
                 return
-            if not shutil.which("npm"):
-                npm_missing_message = "'npm' 명령을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인해주세요."
-                yield f"data: {json.dumps({'status': 'error', 'message': npm_missing_message})}\n\n"
-                return
-
-            # macOS(공식 설치본)/일부 Linux 배포판은 npm 전역 prefix
-            # (/usr/local/lib/node_modules)가 root 소유라, sudo 없이
-            # `npm install -g`를 실행하면 EACCES로 실패한다(실제로 macOS에서
-            # 재현됨). 시스템 prefix를 건드리는 대신 이 앱 전용의 항상 쓰기
-            # 가능한 --prefix를 지정해 이 문제를 피한다. Windows는 기본
-            # prefix(%APPDATA%\npm)가 이미 사용자 소유라 이 문제가 없고,
-            # 지금처럼 셸 문자열에 따옴표 있는 경로를 추가하면 Windows에서
-            # cmd.exe의 중첩 따옴표 문제(다른 설치 스크립트에서 이미 겪은
-            # "Illegal shell characters" 부류)를 새로 만들 위험이 있어
-            # Windows에서는 기존 방식을 그대로 둔다.
-            if platform.system() == "Windows":
-                command = f"npm install -g {package_name}"
-            else:
-                from config import get_easypaper_npm_prefix
-                prefix_dir = get_easypaper_npm_prefix()
-                os.makedirs(prefix_dir, exist_ok=True)
-                command = f'npm install -g --prefix "{prefix_dir}" {package_name}'
 
             try:
-                proc = await asyncio.create_subprocess_shell(
-                    command,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
-                    stdin=asyncio.subprocess.DEVNULL,
-                )
+                if system == "Windows":
+                    # PowerShell 명령을 별도 argv 원소로 넘겨 create_subprocess_exec로
+                    # 실행한다 - 셸 문자열 하나로 조립해 create_subprocess_shell에
+                    # 넘기면 Windows에서 cmd /c "..."로 한 번 더 감싸이면서 명령 안의
+                    # 큰따옴표와 중첩되어 명령 경계가 깨지는 문제(Antigravity Windows
+                    # 설치에서 이미 겪은 것과 같은 부류)를 새로 만들 위험이 있다.
+                    proc = await asyncio.create_subprocess_exec(
+                        "powershell", "-NoProfile", "-ExecutionPolicy", "ByPass", "-Command",
+                        f"irm {windows_install_url} | iex",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                        stdin=asyncio.subprocess.DEVNULL,
+                    )
+                else:
+                    proc = await asyncio.create_subprocess_shell(
+                        f"curl -fsSL {unix_install_url} | bash",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                        stdin=asyncio.subprocess.DEVNULL,
+                    )
                 async for text in _stream_subprocess_lines(proc):
                     yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
                 await proc.wait()
-                if proc.returncode == 0:
+
+                installed = os.path.exists(path_getter()) or shutil.which(path_getter())
+                if proc.returncode == 0 and installed:
                     yield f"data: {json.dumps({'status': 'success'})}\n\n"
                 else:
                     yield f"data: {json.dumps({'status': 'error', 'message': f'설치가 오류 코드 {proc.returncode}로 종료되었습니다.'})}\n\n"
@@ -415,13 +425,23 @@ def _make_npm_cli_install_endpoint(package_name: str, path_getter, already_insta
 
 router.add_api_route(
     "/settings/install-claude-code",
-    _make_npm_cli_install_endpoint("@anthropic-ai/claude-code", get_claude_code_path, "Claude Code CLI가 이미 설치되어 있습니다."),
+    _make_native_cli_install_endpoint(
+        "https://claude.ai/install.sh",
+        "https://claude.ai/install.ps1",
+        get_claude_code_path,
+        "Claude Code CLI가 이미 설치되어 있습니다.",
+    ),
     methods=["GET"],
 )
 
 router.add_api_route(
     "/settings/install-codex",
-    _make_npm_cli_install_endpoint("@openai/codex", get_codex_path, "Codex CLI가 이미 설치되어 있습니다."),
+    _make_native_cli_install_endpoint(
+        "https://chatgpt.com/codex/install.sh",
+        "https://chatgpt.com/codex/install.ps1",
+        get_codex_path,
+        "Codex CLI가 이미 설치되어 있습니다.",
+    ),
     methods=["GET"],
 )
 

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -44,25 +44,40 @@ def test_resolve_cli_path_falls_back_to_path_search(monkeypatch):
 
 def test_resolve_cli_path_returns_bare_command_as_last_resort(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda cmd: None)
-    monkeypatch.setattr(config, "get_easypaper_npm_prefix", lambda: "/nonexistent/npm-prefix")
     resolved = config._resolve_cli_path("/nonexistent/claude", "claude")
     assert resolved == "claude"
 
 
-def test_resolve_cli_path_falls_back_to_easypaper_npm_prefix(monkeypatch, tmp_path):
-    """PATH에서도 못 찾으면, 이 앱이 설정 화면에서 자체 설치할 때 쓰는
-    npm --prefix 위치(get_easypaper_npm_prefix) 아래도 확인해야 한다 -
-    macOS에서 시스템 npm 전역 prefix에 EACCES가 나서 이 앱 전용 prefix에
-    설치했을 때, 그 설치 위치를 실제로 찾아낼 수 있어야 하는 회귀 방지."""
-    npm_prefix = tmp_path / "npm-global"
-    bin_dir = npm_prefix / "bin"
+def test_resolve_cli_path_finds_codex_at_windows_localappdata(monkeypatch, tmp_path):
+    """Codex의 공식 Windows 설치 스크립트(install.ps1)는 CODEX_PATH 기본값
+    (~/.local/bin/codex)이 아니라 %LOCALAPPDATA%\\Programs\\OpenAI\\Codex\\bin에
+    설치한다 - PATH 탐색도 실패하는 경우 이 위치를 별도로 확인해야 한다."""
+    localappdata = tmp_path / "LocalAppData"
+    bin_dir = localappdata / "Programs" / "OpenAI" / "Codex" / "bin"
     bin_dir.mkdir(parents=True)
-    (bin_dir / "codex").write_text("#!/bin/sh\n")
+    exe_path = bin_dir / "codex.exe"
+    exe_path.write_text("")
 
     monkeypatch.setattr(shutil, "which", lambda cmd: None)
-    monkeypatch.setattr(config, "get_easypaper_npm_prefix", lambda: str(npm_prefix))
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
     resolved = config._resolve_cli_path("/nonexistent/codex", "codex")
-    assert resolved == str(bin_dir / "codex")
+    assert resolved == str(exe_path)
+
+
+def test_resolve_cli_path_windows_codex_fallback_not_applied_to_other_clis(monkeypatch, tmp_path):
+    """Windows LOCALAPPDATA 폴백은 codex 전용이다 - agy/claude에 잘못 적용되지
+    않아야 한다."""
+    localappdata = tmp_path / "LocalAppData"
+    bin_dir = localappdata / "Programs" / "OpenAI" / "Codex" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "claude.exe").write_text("")
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
+    resolved = config._resolve_cli_path("/nonexistent/claude", "claude")
+    assert resolved == "claude"
 
 
 def test_get_agy_env_never_hardcodes_dev_server_home(monkeypatch):

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -44,8 +44,25 @@ def test_resolve_cli_path_falls_back_to_path_search(monkeypatch):
 
 def test_resolve_cli_path_returns_bare_command_as_last_resort(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(config, "get_easypaper_npm_prefix", lambda: "/nonexistent/npm-prefix")
     resolved = config._resolve_cli_path("/nonexistent/claude", "claude")
     assert resolved == "claude"
+
+
+def test_resolve_cli_path_falls_back_to_easypaper_npm_prefix(monkeypatch, tmp_path):
+    """PATH에서도 못 찾으면, 이 앱이 설정 화면에서 자체 설치할 때 쓰는
+    npm --prefix 위치(get_easypaper_npm_prefix) 아래도 확인해야 한다 -
+    macOS에서 시스템 npm 전역 prefix에 EACCES가 나서 이 앱 전용 prefix에
+    설치했을 때, 그 설치 위치를 실제로 찾아낼 수 있어야 하는 회귀 방지."""
+    npm_prefix = tmp_path / "npm-global"
+    bin_dir = npm_prefix / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "codex").write_text("#!/bin/sh\n")
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(config, "get_easypaper_npm_prefix", lambda: str(npm_prefix))
+    resolved = config._resolve_cli_path("/nonexistent/codex", "codex")
+    assert resolved == str(bin_dir / "codex")
 
 
 def test_get_agy_env_never_hardcodes_dev_server_home(monkeypatch):


### PR DESCRIPTION
# Summary
## 1. CLI 기본 경로 이식성 개선
- AGY_PATH/CLAUDE_CODE_PATH/CODEX_PATH 기본값을 이 프로젝트를 개발한 서버 전용 절대경로에서 각 CLI 공식 curl 설치 스크립트가 공통으로 쓰는 ~/.local/bin 기준으로 변경
## 2. Claude Code/Codex 설치 방식을 npm에서 공식 네이티브 설치 스크립트로 전환
- macOS 공식 Node.js 설치본은 npm 전역 prefix(/usr/local/lib/node_modules)가 root 소유라 `npm install -g`가 EACCES로 실패하는 문제를 확인(재현됨)
- Claude Code/Codex 둘 다 Node.js가 필요 없는 공식 네이티브 바이너리 설치 스크립트(curl for Unix, PowerShell for Windows)를 제공함을 확인해 이 방식으로 전환 - Antigravity와 동일한 배포 패턴
- Windows는 PowerShell 명령을 셸 문자열로 조립하지 않고 별도 argv로 넘겨(create_subprocess_exec) cmd.exe 중첩 따옴표 문제를 원천 방지
- Codex의 공식 Windows 설치 위치(%LOCALAPPDATA%\Programs\OpenAI\Codex\bin)를 확인해 감지 로직에 반영
## 3. 테스트
- 전체 110개 테스트 통과