### PR TITLE
fix: 온보딩 번역 엔진 선택 후 뷰어에 ollama로 표시되는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9351,6 +9351,11 @@ if (onboardingConfirmBtn) {
         claude_api_key: sys.claude_api_key,
         translation_prompt_template: sys.translation_prompt_template,
       })
+      // sync compact pickers so the viewer/chat UI reflects the newly selected engine immediately
+      viewerTransPicker.setValue(entry.provider, model)
+      settingTransPicker.setValue(entry.provider, model)
+      chatSidebarPicker.setValue(entry.provider, model)
+      settingChatPicker.setValue(entry.provider, model)
       showToast(`${entry.label}을(를) 기본 AI 엔진으로 설정했습니다.`, 'success')
       closeOnboarding()
     } catch (err) {


### PR DESCRIPTION
# Summary
## 1. 온보딩에서 번역 엔진 선택 후 뷰어에 항상 ollama로 표시되던 문제 수정
- 온보딩 완료(`onboardingConfirmBtn` 클릭) 시 `saveSystemSettingsAPI`로 백엔드에는 선택한 엔진이 정상 저장되지만, 뷰어/설정창의 provider picker(`viewerTransPicker`, `settingTransPicker`, `chatSidebarPicker`, `settingChatPicker`)를 갱신하는 코드가 누락되어 있었음
- 실제 번역은 선택한 엔진으로 정상 수행되나, 화면에는 앱 최초 실행 시 기본값(`ollama`)이 계속 표시되던 것이 원인
- 기존 설정 폼 저장 로직(`frontend/src/main.js` 일반/고급 설정 제출 핸들러)과 동일하게, `saveSystemSettingsAPI` 성공 직후 4개 picker 값을 새로 선택한 provider/model로 동기화하도록 수정 (`frontend/src/main.js`)