### PR TITLE
fix: macOS 뷰어 번역 진행 스피너가 타원형으로 찌그러지는 문제 수정

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -774,6 +774,7 @@ body:not(.light-theme) .pdf-page-inner canvas {
 
 .spinner {
   width: 16px; height: 16px;
+  flex-shrink: 0;
   border: 2px solid rgba(74, 135, 181, 0.2);
   border-top-color: var(--accent-mid);
   border-radius: 50%;


### PR DESCRIPTION
# Summary
## 1. macOS에서 번역 진행 중 뷰어 상단 스피너가 타원형으로 찌그러지던 문제 수정
- 뷰어 상단바의 번역 진행 스피너(`#translate-spinner`, `.spinner` 클래스)에 `flex-shrink`가 지정되어 있지 않았음
- `.spinner`의 부모 요소(`.translation-status` → `.topbar-right`)가 flex 레이아웃인데, 번역 진행 중 진행률 텍스트/뱃지 등과 함께 상단바 오른쪽 영역의 총 폭이 창 폭을 초과하면 `flex-shrink` 기본값(1)에 의해 스피너의 가로 폭만 줄어들어 원이 타원으로 왜곡됨
- 같은 스타일을 쓰는 대기 스피너(`.trans-wait-spinner`)는 이미 `flex-shrink: 0`이 있어 문제가 없었던 점을 근거로, `.spinner`에도 동일하게 `flex-shrink: 0`을 추가해 크기를 고정 (`frontend/src/style.css`)