### PR TITLE
feat: 온보딩 Ollama 모델 다운로드 추천 목록에 Gemma 등 최신 모델 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -394,6 +394,11 @@
             <div style="display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px;">
               <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="qwen3.5:9b" style="padding: 5px 10px; font-size: 11.5px;">Qwen 3.5 9B</button>
               <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="llama3.1:8b" style="padding: 5px 10px; font-size: 11.5px;">Llama 3.1 8B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma3n:e4b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 3n E4B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma3:12b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 3 12B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="mistral-nemo" style="padding: 5px 10px; font-size: 11.5px;">Mistral Nemo 12B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="phi4" style="padding: 5px 10px; font-size: 11.5px;">Phi 4 14B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="deepseek-r1:8b" style="padding: 5px 10px; font-size: 11.5px;">DeepSeek R1 8B</button>
             </div>
             <div id="onboarding-pull-progress-area" class="hidden">
               <div style="display: flex; justify-content: space-between; font-size: 11px; margin-bottom: 4px;">
@@ -735,6 +740,11 @@
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="qwen3.5:9b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Qwen 3.5 9B (qwen3.5:9b)</button>
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="llama3.1:8b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Llama 3.1 8B (llama3.1:8b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma3n:e4b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 3n E4B (gemma3n:e4b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma3:12b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 3 12B (gemma3:12b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="mistral-nemo" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Mistral Nemo 12B (mistral-nemo)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="phi4" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Phi 4 14B (phi4)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="deepseek-r1:8b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">DeepSeek R1 8B (deepseek-r1:8b)</button>
             </div>
           </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -394,10 +394,11 @@
             <div style="display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px;">
               <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="qwen3.5:9b" style="padding: 5px 10px; font-size: 11.5px;">Qwen 3.5 9B</button>
               <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="llama3.1:8b" style="padding: 5px 10px; font-size: 11.5px;">Llama 3.1 8B</button>
-              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma3n:e4b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 3n E4B</button>
-              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma3:12b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 3 12B</button>
-              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="mistral-nemo" style="padding: 5px 10px; font-size: 11.5px;">Mistral Nemo 12B</button>
-              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="phi4" style="padding: 5px 10px; font-size: 11.5px;">Phi 4 14B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma4:e4b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 4 E4B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="gemma4:12b" style="padding: 5px 10px; font-size: 11.5px;">Gemma 4 12B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="qwen3.6:27b" style="padding: 5px 10px; font-size: 11.5px;">Qwen 3.6 27B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="mistral-small3.2:24b" style="padding: 5px 10px; font-size: 11.5px;">Mistral Small 3.2 24B</button>
+              <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="phi4-reasoning:14b" style="padding: 5px 10px; font-size: 11.5px;">Phi-4 Reasoning 14B</button>
               <button type="button" class="btn btn-secondary onboarding-pull-model-btn" data-model="deepseek-r1:8b" style="padding: 5px 10px; font-size: 11.5px;">DeepSeek R1 8B</button>
             </div>
             <div id="onboarding-pull-progress-area" class="hidden">
@@ -740,10 +741,11 @@
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="qwen3.5:9b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Qwen 3.5 9B (qwen3.5:9b)</button>
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="llama3.1:8b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Llama 3.1 8B (llama3.1:8b)</button>
-              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma3n:e4b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 3n E4B (gemma3n:e4b)</button>
-              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma3:12b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 3 12B (gemma3:12b)</button>
-              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="mistral-nemo" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Mistral Nemo 12B (mistral-nemo)</button>
-              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="phi4" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Phi 4 14B (phi4)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma4:e4b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 4 E4B (gemma4:e4b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="gemma4:12b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Gemma 4 12B (gemma4:12b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="qwen3.6:27b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Qwen 3.6 27B (qwen3.6:27b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="mistral-small3.2:24b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Mistral Small 3.2 24B (mistral-small3.2:24b)</button>
+              <button type="button" class="btn btn-secondary recommend-model-btn" data-model="phi4-reasoning:14b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">Phi-4 Reasoning 14B (phi4-reasoning:14b)</button>
               <button type="button" class="btn btn-secondary recommend-model-btn" data-model="deepseek-r1:8b" style="padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: var(--radius-sm); border: 1px solid var(--border-strong);">DeepSeek R1 8B (deepseek-r1:8b)</button>
             </div>
           </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1646,9 +1646,13 @@ const PROVIDER_CONFIG = [
   {
     id: 'ollama', label: 'Ollama (로컬)', icon: icon('hardDrive', 13),
     models: [
-      { value: 'gemma4:e4b', label: 'gemma4 e4b' },
       { value: 'qwen3.5:9b', label: 'qwen3.5 9b' },
       { value: 'llama3.1:8b', label: 'llamma 3.1' },
+      { value: 'gemma3n:e4b', label: 'gemma3n e4b' },
+      { value: 'gemma3:12b', label: 'gemma3 12b' },
+      { value: 'mistral-nemo', label: 'mistral-nemo' },
+      { value: 'phi4', label: 'phi4' },
+      { value: 'deepseek-r1:8b', label: 'deepseek-r1 8b' },
       { value: 'custom_input', label: '직접 입력' }
     ]
   },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1648,10 +1648,11 @@ const PROVIDER_CONFIG = [
     models: [
       { value: 'qwen3.5:9b', label: 'qwen3.5 9b' },
       { value: 'llama3.1:8b', label: 'llamma 3.1' },
-      { value: 'gemma3n:e4b', label: 'gemma3n e4b' },
-      { value: 'gemma3:12b', label: 'gemma3 12b' },
-      { value: 'mistral-nemo', label: 'mistral-nemo' },
-      { value: 'phi4', label: 'phi4' },
+      { value: 'gemma4:e4b', label: 'gemma4 e4b' },
+      { value: 'gemma4:12b', label: 'gemma4 12b' },
+      { value: 'qwen3.6:27b', label: 'qwen3.6 27b' },
+      { value: 'mistral-small3.2:24b', label: 'mistral-small3.2 24b' },
+      { value: 'phi4-reasoning:14b', label: 'phi4-reasoning 14b' },
       { value: 'deepseek-r1:8b', label: 'deepseek-r1 8b' },
       { value: 'custom_input', label: '직접 입력' }
     ]


### PR DESCRIPTION
# Summary
## 1. 온보딩/설정 화면 Ollama 모델 다운로드 추천 목록에 최신 모델 추가
- 온보딩 모델 선택 단계 및 설정 화면의 "다른 모델 다운로드" 추천 버튼 목록(frontend/index.html)에 Qwen 3.5 9B, Llama 3.1 8B만 있던 것을 확장
- 웹 검색(ollama.com 라이브러리 직접 조회)으로 각 모델 패밀리의 실제 최신 세대/현재 배포 태그를 검증 후 추가: Gemma 4 E4B(gemma4:e4b), Gemma 4 12B(gemma4:12b), Qwen 3.6 27B(qwen3.6:27b), Mistral Small 3.2 24B(mistral-small3.2:24b), Phi-4 Reasoning 14B(phi4-reasoning:14b), DeepSeek R1 8B(deepseek-r1:8b)
- Llama 4 / DeepSeek V4 등 최신 세대도 확인했으나 최소 용량이 각각 67GB / 284GB급이라 온보딩 원클릭 다운로드로는 비현실적이라 제외
## 2. Provider/Model 드롭다운 카탈로그(PROVIDER_CONFIG)도 동일하게 갱신
- frontend/src/main.js의 PROVIDER_CONFIG.ollama 목록에도 위와 동일한 모델들을 반영해 두 목록 간 일관성 확보
- (수정 이력) 최초 커밋에서 gemma4:e4b를 존재하지 않는 태그로 오판해 gemma3n:e4b로 잘못 교체했던 것을, ollama.com 라이브러리 조회로 gemma4가 실제 최신 세대(다운로드 수 기준 라이브러리 전체 1위)임을 확인하고 원래 태그로 복원