### PR TITLE
ci: Tauri 릴리스 워크플로우를 main에 추가

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,0 +1,90 @@
+name: Tauri Release
+
+# 태그 push(v*) 또는 수동 트리거로 win/mac-arm64/linux 3개 플랫폼을 빌드해
+# GitHub Release(초안)에 업로드하고, Tauri updater가 읽는 latest.json도
+# 함께 생성한다. TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)로 업데이트 페이로드에
+# 서명하지만, OS 코드사이닝(macOS 공증/Windows Authenticode)은 아직 하지
+# 않으므로 설치 시 Gatekeeper/SmartScreen 경고가 뜬다 - 유료 인증서 발급
+# 후 별도로 추가 필요.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux
+          - os: windows-latest
+            name: windows
+          - os: macos-14
+            name: macos-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install backend deps + PyInstaller
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build sidecar binary (PyInstaller onedir, frontend dist bundled)
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            backend/packaging/build.bat
+          else
+            backend/packaging/build.sh
+          fi
+
+      - name: Copy sidecar into src-tauri/binaries
+        shell: bash
+        run: src-tauri/scripts/copy-sidecar.sh
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux Tauri build deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
+            libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - name: Install root deps (Tauri CLI)
+        run: npm ci
+
+      - uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v0.0.0-manual{0}', github.run_number) }}
+          releaseName: "EasyPaper Desktop ${{ github.ref_type == 'tag' && github.ref_name || 'manual build' }}"
+          releaseBody: |
+            자동 생성된 릴리스입니다. 코드사이닝(macOS 공증/Windows Authenticode)이
+            아직 적용되지 않아 설치 시 운영체제 보안 경고가 뜰 수 있습니다.
+          releaseDraft: true
+          prerelease: false


### PR DESCRIPTION
# Summary
## 1. workflow_dispatch 활성화를 위한 릴리스 워크플로우 파일 추가
- tauri-desktop-spike.yml과 동일한 이유로 default 브랜치에 파일 필요
- 앱 코드/배포 파이프라인에는 영향 없음