### PR TITLE
feat: 로그인 상태 유지 및 로그인 생략 기능 추가

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -320,9 +320,58 @@ def update_credentials_in_env(new_username: str, new_password_hash: str):
         new_lines.append(f"APP_USERNAME={new_username}\n")
     if not hash_found:
         new_lines.append(f"APP_PASSWORD_HASH={new_password_hash}\n")
-        
+
     with open(env_path, "w", encoding="utf-8") as f:
         f.writelines(new_lines)
+
+
+# 로그인 화면을 완전히 건너뛰고 항상 관리자로 자동 인증할지 여부. 신뢰할 수
+# 있는 개인/로컬 환경(예: 다른 사람이 접근할 수 없는 개인 PC의 Tauri
+# 데스크탑 앱)에서 매번 로그인하는 번거로움을 없애기 위한 설정이다 - 켜면
+# 이 서버에 네트워크로 접근 가능한 모든 사람이 인증 없이 전체 기능을 쓸
+# 수 있게 되므로, 계정 설정 화면에서 명시적으로 켜야만 활성화된다.
+SKIP_LOGIN = os.getenv("SKIP_LOGIN", "false").strip().lower() == "true"
+
+def get_skip_login() -> bool:
+    return SKIP_LOGIN
+
+def set_skip_login(enabled: bool):
+    global SKIP_LOGIN
+    SKIP_LOGIN = enabled
+
+    env_path = os.path.join(_get_config_dir(), ".env")
+    value_str = "true" if enabled else "false"
+    if not os.path.exists(env_path):
+        with open(env_path, "w", encoding="utf-8") as f:
+            f.write(f"SKIP_LOGIN={value_str}\n")
+        return
+
+    with open(env_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    new_lines = []
+    found = False
+    for line in lines:
+        if line.strip().startswith("SKIP_LOGIN="):
+            new_lines.append(f"SKIP_LOGIN={value_str}\n")
+            found = True
+        else:
+            new_lines.append(line)
+    if not found:
+        new_lines.append(f"SKIP_LOGIN={value_str}\n")
+
+    with open(env_path, "w", encoding="utf-8") as f:
+        f.writelines(new_lines)
+
+if SKIP_LOGIN:
+    print(
+        "\n" + "!" * 70 +
+        "\n[보안 경고] 로그인 없이 사용 설정이 켜져 있습니다.\n"
+        "이 서버에 네트워크로 접근 가능한 모든 사람이 인증 없이 전체 기능을\n"
+        "쓸 수 있습니다. 신뢰할 수 있는 개인/로컬 환경이 아니라면 설정에서\n"
+        "즉시 꺼주세요.\n"
+        + "!" * 70 + "\n"
+    )
 
 # 디렉토리 생성
 os.makedirs(UPLOAD_DIR, exist_ok=True)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -25,6 +25,8 @@ from config import (
     get_codex_path,
     find_ollama_binary,
     get_project_root,
+    get_skip_login,
+    set_skip_login,
 )
 from services.llm_client import check_ollama_health
 
@@ -62,6 +64,7 @@ router = APIRouter()
 class LoginRequest(BaseModel):
     username: str
     password: str
+    remember: bool = False
 
 class ChangeCredentialsRequest(BaseModel):
     current_password: str
@@ -70,24 +73,29 @@ class ChangeCredentialsRequest(BaseModel):
 
 @router.post("/auth/login")
 async def login(response: Response, data: LoginRequest):
+    from services.auth import SESSION_TTL_DEFAULT_SECONDS, SESSION_TTL_REMEMBER_SECONDS
     from services.db import get_user
     user = get_user(data.username)
-    
+
     if not user or not verify_password(user["password_hash"], data.password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="아이디 또는 비밀번호가 올바르지 않습니다."
         )
-    
-    token = create_session_token(data.username)
-    
+
+    # "로그인 상태 유지"를 체크하면 훨씬 긴 만료 기간의 세션 쿠키를 발급해,
+    # 다음에 앱을 열 때 자동으로 로그인된 상태로 시작하게 한다(비밀번호를
+    # 별도로 저장하지 않고, 기존의 안전한 HttpOnly 쿠키 메커니즘만 그대로 씀).
+    ttl_seconds = SESSION_TTL_REMEMBER_SECONDS if data.remember else SESSION_TTL_DEFAULT_SECONDS
+    token = create_session_token(data.username, ttl_seconds=ttl_seconds)
+
     # 보안 강화를 위해 HttpOnly, SameSite=Lax 적용 쿠키로 토큰 주입
     response.set_cookie(
         key="session_token",
         value=token,
         httponly=True,
-        max_age=7 * 24 * 3600,  # 7일
-        expires=7 * 24 * 3600,
+        max_age=ttl_seconds,
+        expires=ttl_seconds,
         samesite="lax",
         secure=False,  # 로컬 개발 환경 및 내부망 접속 대응용 (HTTPS 운영 시 True 변경 권장)
         path="/"
@@ -175,6 +183,29 @@ async def change_credentials(
     )
     
     return {"message": "아이디 및 비밀번호가 성공적으로 변경되었습니다.", "username": new_username}
+
+
+class SkipLoginRequest(BaseModel):
+    enabled: bool
+
+
+@router.get("/settings/skip-login")
+async def get_skip_login_endpoint(current_user: str = Depends(get_current_user)):
+    """로그인 화면을 건너뛰는 설정이 켜져 있는지 반환합니다."""
+    return {"enabled": get_skip_login()}
+
+
+@router.post("/settings/skip-login")
+async def set_skip_login_endpoint(data: SkipLoginRequest, current_user: str = Depends(get_current_user)):
+    """로그인 화면을 건너뛰고 항상 관리자로 자동 인증할지 여부를 저장합니다.
+
+    이 서버에 네트워크로 접근 가능한 모든 사람이 인증 없이 전체 기능을 쓸
+    수 있게 되므로, 반드시 이미 로그인된 상태(current_user 의존성)에서만
+    바꿀 수 있게 한다.
+    """
+    set_skip_login(data.enabled)
+    return {"enabled": data.enabled}
+
 
 class SystemSettingsRequest(BaseModel):
     ollama_host: str

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -3,7 +3,7 @@ import hmac
 import os
 import time
 from fastapi import Request, HTTPException, status
-from config import get_app_password, SECRET_KEY
+from config import get_app_password, get_app_username, get_skip_login, SECRET_KEY
 
 def verify_password(stored_password_hash: str, provided_password: str) -> bool:
     # 1. 만약 평문 비밀번호(APP_PASSWORD)가 설정되어 있다면 즉시 비교
@@ -27,9 +27,14 @@ def hash_password(password: str) -> str:
     key = hashlib.pbkdf2_hmac('sha256', password.encode('utf-8'), salt, 100000)
     return f"{salt.hex()}:{key.hex()}"
 
-def create_session_token(username: str) -> str:
-    # 7일 만료
-    expires = int(time.time()) + 7 * 24 * 3600
+SESSION_TTL_DEFAULT_SECONDS = 7 * 24 * 3600
+# "로그인 상태 유지"를 체크했을 때 쓰는 훨씬 긴 만료 기간 - 매번 다시
+# 로그인하지 않아도 되는 "자동 로그인" 효과를 기존의 안전한 HttpOnly
+# 세션 쿠키 메커니즘 그대로(새로운 자격증명 저장 없이) 얻는다.
+SESSION_TTL_REMEMBER_SECONDS = 90 * 24 * 3600
+
+def create_session_token(username: str, ttl_seconds: int = SESSION_TTL_DEFAULT_SECONDS) -> str:
+    expires = int(time.time()) + ttl_seconds
     payload = f"{username}:{expires}"
     signature = hmac.new(SECRET_KEY.encode('utf-8'), payload.encode('utf-8'), hashlib.sha256).hexdigest()
     return f"{payload}:{signature}"
@@ -50,6 +55,9 @@ def verify_session_token(token: str) -> bool:
         return False
 
 async def get_current_user(request: Request) -> str:
+    if get_skip_login():
+        return get_app_username()
+
     token = request.cookies.get("session_token")
     if not token or not verify_session_token(token):
         raise HTTPException(

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -2,11 +2,17 @@
 
 import time
 
+import pytest
+from fastapi import HTTPException
+
 from services.auth import (
     hash_password,
     verify_password,
     create_session_token,
     verify_session_token,
+    get_current_user,
+    SESSION_TTL_DEFAULT_SECONDS,
+    SESSION_TTL_REMEMBER_SECONDS,
 )
 
 
@@ -57,3 +63,32 @@ def test_session_token_rejects_expired_token():
 def test_session_token_rejects_malformed_token():
     assert verify_session_token("not-enough-parts") is False
     assert verify_session_token("") is False
+
+
+def test_create_session_token_respects_custom_ttl():
+    """"로그인 상태 유지" 체크 시 기본 7일보다 훨씬 긴 만료 기간을 써야 한다."""
+    token = create_session_token("admin", ttl_seconds=SESSION_TTL_REMEMBER_SECONDS)
+    _, expires_str, _ = token.split(":")
+    expires = int(expires_str)
+    assert expires - int(time.time()) > SESSION_TTL_DEFAULT_SECONDS
+
+
+async def test_get_current_user_bypasses_cookie_check_when_skip_login_enabled(monkeypatch):
+    """로그인 생략 설정이 켜져 있으면 쿠키 확인 없이 바로 관리자로 인증돼야 한다."""
+    import services.auth as auth_module
+    monkeypatch.setattr(auth_module, "get_skip_login", lambda: True)
+    monkeypatch.setattr(auth_module, "get_app_username", lambda: "admin")
+    username = await get_current_user(None)
+    assert username == "admin"
+
+
+async def test_get_current_user_still_requires_cookie_when_skip_login_disabled(monkeypatch):
+    """로그인 생략 설정이 꺼져 있으면 기존처럼 쿠키가 없을 때 401을 내야 한다."""
+    import services.auth as auth_module
+    monkeypatch.setattr(auth_module, "get_skip_login", lambda: False)
+
+    class FakeRequest:
+        cookies = {}
+
+    with pytest.raises(HTTPException):
+        await get_current_user(FakeRequest())

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -150,3 +150,24 @@ def test_get_or_create_secret_key_persists_across_calls(tmp_path, monkeypatch):
     monkeypatch.setenv("SECRET_KEY", first)
     second = config._get_or_create_secret_key()
     assert second == first
+
+
+def test_skip_login_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("SKIP_LOGIN", raising=False)
+    assert config.get_skip_login() in (True, False)  # 모듈 로드 시점 값 확인용, 아래에서 실제 토글 검증
+
+
+def test_set_skip_login_persists_and_updates_getter(tmp_path, monkeypatch):
+    """로그인 생략 설정을 켜고 끄면 get_skip_login()이 즉시 반영하고, .env 파일에도
+    저장돼야 한다(서버 재시작 후에도 유지)."""
+    monkeypatch.setattr(config, "_get_config_dir", lambda: str(tmp_path))
+
+    config.set_skip_login(True)
+    assert config.get_skip_login() is True
+    env_content = (tmp_path / ".env").read_text()
+    assert "SKIP_LOGIN=true" in env_content
+
+    config.set_skip_login(False)
+    assert config.get_skip_login() is False
+    env_content = (tmp_path / ".env").read_text()
+    assert "SKIP_LOGIN=false" in env_content

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-uDHeKGfS.js"></script>
+  <script type="module" crossorigin src="/assets/index-DeMPjSZ4.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Dwvf_COz.css">
 </head>
 <body>
@@ -52,6 +52,10 @@
             <label for="login-password" style="font-size: 13px; color: var(--text-secondary); font-weight: 500; text-align: left; width: 100%;">비밀번호 (Password)</label>
             <input type="password" id="login-password" placeholder="••••••••" required style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
           </div>
+          <label style="width: 100%; display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+            <input type="checkbox" id="login-remember-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+            로그인 상태 유지 (이 기기에서 자동 로그인)
+          </label>
           <button type="submit" class="file-btn" style="width: 100%; justify-content: center; margin-top: 10px; padding: 12px 28px; border-radius: 12px; border: none;">로그인</button>
         </form>
       </div>
@@ -797,6 +801,19 @@
             <button type="submit" class="btn btn-primary">계정 정보 변경</button>
           </div>
         </form>
+
+        <!-- 로그인 생략 설정 -->
+        <div class="form-group" style="margin-top: 20px; border-top: 1px solid var(--border); padding-top: 15px;">
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
+          <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
+            <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
+            다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+          </div>
+          <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+            <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+            로그인 화면 없이 바로 사용하기
+          </label>
+        </div>
       </div>
 
       <!-- 고급 설정 탭 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,6 +51,10 @@
             <label for="login-password" style="font-size: 13px; color: var(--text-secondary); font-weight: 500; text-align: left; width: 100%;">비밀번호 (Password)</label>
             <input type="password" id="login-password" placeholder="••••••••" required style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
           </div>
+          <label style="width: 100%; display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+            <input type="checkbox" id="login-remember-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+            로그인 상태 유지 (이 기기에서 자동 로그인)
+          </label>
           <button type="submit" class="file-btn" style="width: 100%; justify-content: center; margin-top: 10px; padding: 12px 28px; border-radius: 12px; border: none;">로그인</button>
         </form>
       </div>
@@ -796,6 +800,19 @@
             <button type="submit" class="btn btn-primary">계정 정보 변경</button>
           </div>
         </form>
+
+        <!-- 로그인 생략 설정 -->
+        <div class="form-group" style="margin-top: 20px; border-top: 1px solid var(--border); padding-top: 15px;">
+          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
+          <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
+            <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
+            다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+          </div>
+          <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+            <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+            로그인 화면 없이 바로 사용하기
+          </label>
+        </div>
       </div>
 
       <!-- 고급 설정 탭 -->

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -217,13 +217,14 @@ export async function getPageTranslation(sessionId, pageNum, options) {
 }
 
 /**
- * 로그인 요청을 보냅니다.
+ * 로그인 요청을 보냅니다. remember가 true면 훨씬 긴 만료 기간의 세션
+ * 쿠키를 발급받아, 다음에 앱을 열 때 자동으로 로그인된 상태로 시작한다.
  */
-export async function loginAPI(username, password) {
+export async function loginAPI(username, password, remember = false) {
   const res = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password })
+    body: JSON.stringify({ username, password, remember })
   })
   if (!res.ok) {
     try {
@@ -275,6 +276,28 @@ export async function changeCredentialsAPI(currentPassword, newUsername, newPass
       throw new Error('변경 실패')
     }
   }
+  return res.json()
+}
+
+/**
+ * 로그인 생략(로그인 화면 없이 바로 사용) 설정을 가져옵니다.
+ */
+export async function getSkipLoginAPI() {
+  const res = await fetch(`${API_BASE}/settings/skip-login`)
+  if (!res.ok) throw new Error('로그인 생략 설정 로드 실패')
+  return res.json()
+}
+
+/**
+ * 로그인 생략 설정을 저장합니다.
+ */
+export async function setSkipLoginAPI(enabled) {
+  const res = await fetch(`${API_BASE}/settings/skip-login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled })
+  })
+  if (!res.ok) throw new Error('로그인 생략 설정 저장 실패')
   return res.json()
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import './style.css'
 import { marked } from 'marked'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
@@ -76,6 +76,7 @@ const loginScreen       = $('login-screen')
 const loginForm         = $('login-form')
 const loginUsername     = $('login-username')
 const loginPassword     = $('login-password')
+const loginRememberCheckbox = $('login-remember-checkbox')
 const globalLogoutBtn   = $('global-logout-btn')
 const globalSettingsBtn = $('global-settings-btn')
 const settingsModal     = $('settings-modal')
@@ -86,6 +87,7 @@ const changeCurrentPassword = $('change-current-password')
 const changeNewUsername     = $('change-new-username')
 const changeNewPassword     = $('change-new-password')
 const changeNewPasswordConfirm = $('change-new-password-confirm')
+const settingSkipLoginCheckbox = $('setting-skip-login-checkbox')
 
 // 첫 실행 온보딩 모달
 const onboardingModal        = $('onboarding-modal')
@@ -1529,8 +1531,9 @@ loginForm.addEventListener('submit', async (e) => {
   e.preventDefault()
   const username = loginUsername.value.trim()
   const password = loginPassword.value
+  const remember = loginRememberCheckbox ? loginRememberCheckbox.checked : false
   try {
-    await loginAPI(username, password)
+    await loginAPI(username, password, remember)
     showToast('로그인 성공!', 'success')
     loginPassword.value = ''
     await checkAuthentication()
@@ -2219,6 +2222,16 @@ globalSettingsBtn.addEventListener('click', async () => {
   changeNewUsername.value = state.username || 'admin'
   changeNewPassword.value = ''
   changeNewPasswordConfirm.value = ''
+
+  // 5. 로그인 생략 설정값 로드
+  if (settingSkipLoginCheckbox) {
+    try {
+      const { enabled } = await getSkipLoginAPI()
+      settingSkipLoginCheckbox.checked = enabled
+    } catch (err) {
+      console.warn('로그인 생략 설정 로드 실패:', err)
+    }
+  }
 })
 
 closeSettingsBtn.addEventListener('click', () => {
@@ -2905,6 +2918,31 @@ changeCredentialsForm.addEventListener('submit', async (e) => {
   }
 })
 
+// 로그인 생략 설정 토글 - 켤 때만 보안 영향(네트워크로 접근 가능한 누구나
+// 인증 없이 쓸 수 있게 됨)을 다시 한번 확인받는다. 끌 때는 원래대로
+// 로그인이 필요해지는 방향이라 별도 확인 없이 바로 적용한다.
+if (settingSkipLoginCheckbox) {
+  settingSkipLoginCheckbox.addEventListener('change', async () => {
+    const wantsEnabled = settingSkipLoginCheckbox.checked
+    if (wantsEnabled) {
+      const ok = await showCustomConfirm(
+        '이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있게 됩니다.\n다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.\n계속하시겠습니까?',
+        { title: '로그인 생략 켜기', confirmText: '켜기', danger: true }
+      )
+      if (!ok) {
+        settingSkipLoginCheckbox.checked = false
+        return
+      }
+    }
+    try {
+      await setSkipLoginAPI(wantsEnabled)
+      showToast(wantsEnabled ? '로그인 생략이 켜졌습니다.' : '로그인 생략이 꺼졌습니다.', 'success')
+    } catch (err) {
+      settingSkipLoginCheckbox.checked = !wantsEnabled
+      showToast(err.message, 'error')
+    }
+  })
+}
 
 // ── 초기화 ────────────────────────────────────────
 checkAuthentication()


### PR DESCRIPTION
# Summary
## 1. 로그인 상태 유지 (Remember Me)
- 로그인 페이지에 "로그인 상태 유지" 체크박스 추가 (`frontend/index.html`)
- 체크 시 세션 쿠키 만료를 기본 7일에서 90일로 연장 (`backend/services/auth.py`의 `SESSION_TTL_REMEMBER_SECONDS`)
- 기존 HttpOnly 세션 쿠키 메커니즘을 그대로 재사용해 새로운 자격증명 저장 없이 구현 (`backend/routers/auth.py`의 `/auth/login`)
- `frontend/src/api.js`의 `loginAPI`에 `remember` 파라미터 추가

## 2. 로그인 생략 (Skip Login)
- 계정 설정 탭에 로그인 화면을 건너뛰고 항상 관리자로 자동 인증하는 토글 추가
- `backend/config.py`에 `SKIP_LOGIN` 설정 및 `.env` 영속화 로직(`get_skip_login`/`set_skip_login`) 추가
- `backend/services/auth.py`의 `get_current_user`가 해당 설정이 켜져 있으면 쿠키 검증 없이 즉시 인증 처리
- `backend/routers/auth.py`에 `GET/POST /api/settings/skip-login` 엔드포인트 추가 (변경은 반드시 이미 인증된 상태에서만 가능)
- 켤 때만 보안 경고 확인 다이얼로그 노출 (끌 때는 즉시 적용)
- 서버 시작 시 콘솔에 보안 경고 출력 (기존 `DEFAULT_PASSWORD_HASH` 경고와 동일 패턴)

## 3. 테스트
- `backend/tests/test_auth_service.py`, `backend/tests/test_config_cross_platform.py`에 회귀 테스트 5개 추가
- 백엔드 테스트 스위트 115개 전체 통과
- 실제 curl 기반 E2E 검증: remember 값에 따른 쿠키 만료(7일/90일) 분기, skip-login 켜짐/꺼짐에 따른 인증 우회 동작 확인