### PR TITLE
fix: 로그인 생략 설정 섹션 여백 통일

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -800,20 +800,20 @@
           <div class="form-actions" style="margin-top: 10px;">
             <button type="submit" class="btn btn-primary">계정 정보 변경</button>
           </div>
-        </form>
 
-        <!-- 로그인 생략 설정 -->
-        <div class="form-group" style="margin-top: 20px; border-top: 1px solid var(--border); padding-top: 15px;">
-          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
-          <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
-            <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
-            다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+          <!-- 로그인 생략 설정 -->
+          <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
+            <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
+              <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
+              다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+            </div>
+            <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+              <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+              로그인 화면 없이 바로 사용하기
+            </label>
           </div>
-          <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
-            <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
-            로그인 화면 없이 바로 사용하기
-          </label>
-        </div>
+        </form>
       </div>
 
       <!-- 고급 설정 탭 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -799,20 +799,20 @@
           <div class="form-actions" style="margin-top: 10px;">
             <button type="submit" class="btn btn-primary">계정 정보 변경</button>
           </div>
-        </form>
 
-        <!-- 로그인 생략 설정 -->
-        <div class="form-group" style="margin-top: 20px; border-top: 1px solid var(--border); padding-top: 15px;">
-          <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
-          <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
-            <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
-            다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+          <!-- 로그인 생략 설정 -->
+          <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
+            <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
+              <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
+              다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
+            </div>
+            <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
+              <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
+              로그인 화면 없이 바로 사용하기
+            </label>
           </div>
-          <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">
-            <input type="checkbox" id="setting-skip-login-checkbox" style="width: 16px; height: 16px; cursor: pointer;" />
-            로그인 화면 없이 바로 사용하기
-          </label>
-        </div>
+        </form>
       </div>
 
       <!-- 고급 설정 탭 -->


### PR DESCRIPTION
# Summary
## 1. 로그인 생략 설정 여백 수정
- \`frontend/index.html\`: "로그인 생략" 섹션이 \`change-credentials-form\` 바깥의 독립된 \`<div>\`로 빠져 있어 모달 폼(\`.modal-form\`)의 28px 패딩과 20px 간격을 상속받지 못해 다른 설정 섹션 대비 여백이 부족했던 문제 수정
- 해당 섹션을 \`change-credentials-form\` 안으로 이동해 다른 폼 필드와 동일한 패딩/간격을 받도록 함
- 구분선 상단 마진도 다른 설정 섹션들(테마 색상, 뷰어 편의 설정 등)과 동일하게 \`margin-top: 20px\` → \`10px\`로 통일