### PR TITLE
feat: Figure/Table 참조 호버 미리보기 추가

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,6 +1,6 @@
 import fitz  # PyMuPDF
 import re
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 
 def extract_pages(pdf_path: str) -> List[Dict[str, Any]]:
@@ -500,10 +500,72 @@ def render_cover_image(pdf_path: str, output_path: str, top_fraction: float = 0.
         doc.close()
 
 
+_CAPTION_RE = re.compile(r"^\s*(Fig(?:ure)?|Table)\.?\s*(\d+)\b", re.IGNORECASE)
+
+
+def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
+    """
+    페이지에서 "Figure 1", "Table 2" 처럼 캡션으로 시작하는 텍스트 블록을 찾아
+    (라벨, bbox) 목록으로 반환합니다. 본문 중간에 이런 단어가 우연히 나오는 경우를
+    배제하기 위해 블록의 "첫 줄"이 캡션 패턴으로 시작하는 경우만 인정합니다.
+    """
+    captions = []
+    blocks = page.get_text("dict")["blocks"]
+    for b in blocks:
+        lines = b.get("lines")
+        if not lines:
+            continue
+        first_line_text = "".join(
+            span.get("text", "") for span in lines[0].get("spans", [])
+        ).strip()
+        if not first_line_text:
+            continue
+        m = _CAPTION_RE.match(first_line_text)
+        if not m:
+            continue
+        kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"
+        number = m.group(2)
+        captions.append({
+            "label": f"{kind} {number}",
+            "bbox": b["bbox"],
+        })
+    return captions
+
+
+def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Optional[str]:
+    """
+    주어진 이미지/테이블 사각형과 가장 가까운 캡션을 찾아 라벨을 반환합니다.
+    캡션은 보통 그림 바로 아래, 표는 바로 위에 위치하므로 상하 인접 캡션을 모두
+    후보로 보되, 가로 범위가 겹치고 세로 거리가 가장 짧은 것을 채택합니다.
+    """
+    x0, y0, x1, y1 = rect
+    best_label = None
+    best_dist = None
+    for cap in captions:
+        cx0, cy0, cx1, cy1 = cap["bbox"]
+        # 가로 방향 겹침 여부 확인 (캡션이 그림/표 폭 범위와 어느 정도 겹쳐야 함)
+        overlap = min(x1, cx1) - max(x0, cx0)
+        if overlap <= 0:
+            continue
+        if cy0 >= y1:
+            dist = cy0 - y1  # 캡션이 아래에 있는 경우 (Figure)
+        elif cy1 <= y0:
+            dist = y0 - cy1  # 캡션이 위에 있는 경우 (Table)
+        else:
+            continue  # 겹치는 영역에 있는 캡션은 대상에서 제외
+        if dist > 40.0:
+            continue
+        if best_dist is None or dist < best_dist:
+            best_dist = dist
+            best_label = cap["label"]
+    return best_label
+
+
 def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
     """
     PDF의 각 페이지에서 실제 그림/이미지(Figure) 및 테이블(Table)의 영역 정보를 추출합니다.
     인접한 이미지/테이블 요소를 그룹화(Merge)하고 마진(Padding)을 주어 크롭 시 잘림 현상을 방지합니다.
+    가능한 경우 근처 캡션("Figure 1", "Table 2" 등)을 찾아 label로 함께 반환합니다.
     """
     doc = fitz.open(pdf_path)
     images_data = []
@@ -514,7 +576,8 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
         page_height = page.rect.height
         if page_width == 0 or page_height == 0:
             continue
-            
+
+        page_captions = _find_page_captions(page)
         raw_rects = []
         
         # 1. 래스터 이미지(Raster Images) 좌표 수집
@@ -612,30 +675,34 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
         
         # 4. 여백 보정 및 최소 규격 필터링
         for r in merged_rects:
+            # 캡션 매칭은 패딩을 적용하기 전 원본 사각형 기준으로 수행 (더 정확한 인접도 판단)
+            label = _match_caption_for_rect(r, page_captions)
+
             # 여백(Padding) 8포인트 적용하여 차트 라벨이나 테이블 테두리가 잘리지 않도록 안전 확보
             x0 = max(0.0, r[0] - 8.0)
             y0 = max(0.0, r[1] - 8.0)
             x1 = min(page_width, r[2] + 8.0)
             y1 = min(page_height, r[3] + 8.0)
-            
+
             w = x1 - x0
             h = y1 - y0
             # 최종 크기가 가로/세로 40포인트 이상인 진짜 그림/테이블만 선별
             if w < 40 or h < 40:
                 continue
-                
+
             # 백분율 좌표 계산
             left = (x0 / page_width) * 100
             top = (y0 / page_height) * 100
             width = (w / page_width) * 100
             height = (h / page_height) * 100
-            
+
             images_data.append({
                 "page": page_num + 1,
                 "left": left,
                 "top": top,
                 "width": width,
-                "height": height
+                "height": height,
+                "label": label
             })
             
     doc.close()

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { marked } from 'marked'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI } from './api.js'
-import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline } from './pdfViewer.js'
+import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
 
@@ -4033,6 +4033,9 @@ async function loadDocumentImages(docId) {
       if (pageWrapper) {
         const pageNum = parseInt(pageWrapper.dataset.page)
         renderImageOverlayLayer(textLayerDiv, pageNum)
+        // Figure/Table 라벨은 documentImages가 로드되어야 알 수 있으므로,
+        // 이미 렌더링된 페이지들의 본문 참조 오버레이도 여기서 함께 다시 그린다.
+        renderFigureRefOverlayLayer(textLayerDiv, pageNum)
       }
     })
   } catch (e) {
@@ -5950,6 +5953,7 @@ window.onTextLayerRendered = (textLayerDiv, pageNum) => {
 
   renderImageOverlayLayer(textLayerDiv, pageNum)
   renderCitationOverlayLayer(textLayerDiv, pageNum)
+  renderFigureRefOverlayLayer(textLayerDiv, pageNum)
 
   // Render floating memos
   renderPageMemos(pageNum)
@@ -6154,6 +6158,141 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
     addCitationBox(match.index, match.index + match[0].length, keys[0])
   }
 }
+
+// 본문 중 "Figure 1", "Fig. 2", "Table 3" 같은 표기를 감지해, 호버 시 실제
+// 해당 그림/표를 오버레이로 미리 보여준다(멀리 떨어진 페이지로 매번 스크롤해서
+// 찾아보러 가야 하는 불편을 줄이기 위함). 인용 표기 오버레이와 동일한 원칙으로,
+// 백엔드가 좌표+라벨을 뽑아낸(=documentImages에 실제로 존재하는) 그림/표를
+// 가리키는 표기만 호버 가능한 박스로 그린다.
+const FIGURE_TABLE_REF_RE = /\b(Fig(?:ure)?|Table)\.?\s*(\d+)\b/gi
+
+function normalizeFigureTableLabel(keyword, number) {
+  const kind = keyword.toLowerCase().startsWith('fig') ? 'Figure' : 'Table'
+  return `${kind} ${number}`
+}
+
+function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
+  const pageWrapper = textLayerDiv.closest('.pdf-page-wrapper')
+  if (!pageWrapper) return
+
+  const overlay = getOrCreateOverlay(pageWrapper)
+  overlay.querySelectorAll('.figure-ref-marker-box').forEach(el => el.remove())
+
+  const images = state.documentImages || []
+  if (images.length === 0) return
+
+  const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum]
+  if (!vtm || !vtm.fullText) return
+
+  FIGURE_TABLE_REF_RE.lastIndex = 0
+  let match
+  while ((match = FIGURE_TABLE_REF_RE.exec(vtm.fullText)) !== null) {
+    const label = normalizeFigureTableLabel(match[1], match[2])
+    const targetImg = images.find(img => img.label === label)
+    if (!targetImg) continue
+
+    const rects = getSentenceRects({ charStart: match.index, charEnd: match.index + match[0].length }, vtm, textLayerDiv)
+    rects.forEach(r => {
+      const box = document.createElement('div')
+      box.className = 'figure-ref-marker-box'
+      box.style.left   = `${r.left}px`
+      box.style.top    = `${r.top}px`
+      box.style.width  = `${r.width}px`
+      box.style.height = `${r.height}px`
+      box.addEventListener('mouseenter', () => showFigurePreviewTooltip(targetImg, box))
+      box.addEventListener('mouseleave', scheduleFigurePreviewTooltipHide)
+      overlay.appendChild(box)
+    })
+  }
+}
+
+// ── Figure/Table 참조 호버 미리보기 툴팁 ──────────
+let figurePreviewTooltipEl = null
+let figurePreviewHideTimer = null
+let figurePreviewBoxEl = null
+let figurePreviewRequestId = 0
+
+function getOrCreateFigurePreviewTooltip() {
+  if (figurePreviewTooltipEl) return figurePreviewTooltipEl
+  const el = document.createElement('div')
+  el.className = 'figure-preview-tooltip hidden'
+  el.innerHTML = `
+    <div class="figure-preview-tooltip-label"></div>
+    <div class="figure-preview-tooltip-loading">${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...</div>
+    <img class="figure-preview-tooltip-img hidden" alt="" />
+  `
+  document.body.appendChild(el)
+
+  el.addEventListener('mouseenter', () => {
+    if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
+  })
+  el.addEventListener('mouseleave', scheduleFigurePreviewTooltipHide)
+
+  figurePreviewTooltipEl = el
+  return el
+}
+
+function positionFigurePreviewTooltip() {
+  if (!figurePreviewTooltipEl || !figurePreviewBoxEl) return
+  const rect = figurePreviewBoxEl.getBoundingClientRect()
+  const tw = figurePreviewTooltipEl.offsetWidth || 280
+  const th = figurePreviewTooltipEl.offsetHeight || 160
+  let left = rect.left + rect.width / 2 - tw / 2
+  left = Math.max(8, Math.min(left, window.innerWidth - tw - 8))
+  let top = rect.top - th - 10
+  if (top < 8) top = rect.bottom + 10
+  figurePreviewTooltipEl.style.left = `${left}px`
+  figurePreviewTooltipEl.style.top = `${top}px`
+}
+
+async function showFigurePreviewTooltip(imgEntry, boxEl) {
+  if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
+  figurePreviewBoxEl = boxEl
+  const requestId = ++figurePreviewRequestId
+
+  const tooltip = getOrCreateFigurePreviewTooltip()
+  tooltip.querySelector('.figure-preview-tooltip-label').textContent = `${imgEntry.label} · p.${imgEntry.page}`
+  const loadingEl = tooltip.querySelector('.figure-preview-tooltip-loading')
+  const imgEl = tooltip.querySelector('.figure-preview-tooltip-img')
+  loadingEl.classList.remove('hidden')
+  loadingEl.textContent = ''
+  loadingEl.innerHTML = `${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...`
+  imgEl.classList.add('hidden')
+  imgEl.removeAttribute('src')
+
+  tooltip.classList.remove('hidden')
+  positionFigurePreviewTooltip()
+
+  try {
+    const dataUrl = await renderFigureCrop(imgEntry.page, imgEntry)
+    // 그 사이 다른 표기로 호버가 옮겨갔거나 툴팁이 닫혔으면 결과를 버린다
+    if (requestId !== figurePreviewRequestId || figurePreviewTooltipEl.classList.contains('hidden')) return
+    if (!dataUrl) throw new Error('empty crop')
+    imgEl.onload = () => positionFigurePreviewTooltip()
+    imgEl.src = dataUrl
+    loadingEl.classList.add('hidden')
+    imgEl.classList.remove('hidden')
+  } catch (e) {
+    console.warn('그림/표 미리보기 렌더 실패:', e)
+    if (requestId !== figurePreviewRequestId) return
+    loadingEl.innerHTML = '미리보기를 불러올 수 없습니다.'
+  }
+}
+
+function hideFigurePreviewTooltip() {
+  if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
+  if (figurePreviewTooltipEl) figurePreviewTooltipEl.classList.add('hidden')
+  figurePreviewBoxEl = null
+}
+
+function scheduleFigurePreviewTooltipHide() {
+  if (figurePreviewHideTimer) clearTimeout(figurePreviewHideTimer)
+  figurePreviewHideTimer = setTimeout(hideFigurePreviewTooltip, 220)
+}
+
+document.addEventListener('scroll', () => {
+  if (figurePreviewTooltipEl && !figurePreviewTooltipEl.classList.contains('hidden')) hideFigurePreviewTooltip()
+}, true)
 
 // ── 인용 표기 호버 툴팁: 참고문헌 원문 + 외부 링크 찾기 + Google Scholar 검색 ──
 let citationTooltipEl = null

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -35,7 +35,51 @@ async function loadPDFJS() {
 export async function loadPDF(url) {
   await loadPDFJS()
   pdfDoc = await pdfjsLib.getDocument(url).promise
+  figureCropCache.clear()
   return pdfDoc.numPages
+}
+
+// pageNum이 현재 화면에 렌더링되어 있지 않아도(가상 스크롤로 아직 마운트 전이거나
+// 이미 스크롤을 벗어나 언마운트됐어도) 크롭할 수 있도록, DOM의 canvas에 의존하지
+// 않고 pdfDoc에서 직접 해당 페이지를 오프스크린 캔버스로 렌더링해 크롭한다.
+// 문서 어디서든 본문이 "Figure 1"을 언급하면 그 그림이 실제로는 다른 페이지에
+// 있을 수 있기 때문에 필요하다. 같은 좌표를 반복 호버할 때 매번 다시 렌더링하지
+// 않도록 결과를 캐싱한다(문서를 새로 열면 loadPDF에서 캐시를 비운다).
+const figureCropCache = new Map()
+
+export async function renderFigureCrop(pageNum, imgPercent) {
+  if (!pdfDoc) return null
+  const cacheKey = `${pageNum}:${imgPercent.left}:${imgPercent.top}:${imgPercent.width}:${imgPercent.height}`
+  if (figureCropCache.has(cacheKey)) return figureCropCache.get(cacheKey)
+
+  try {
+    const page = await pdfDoc.getPage(pageNum)
+    const viewport = page.getViewport({ scale: 2.5 })
+
+    const pageCanvas = document.createElement('canvas')
+    pageCanvas.width = Math.floor(viewport.width)
+    pageCanvas.height = Math.floor(viewport.height)
+    await page.render({ canvasContext: pageCanvas.getContext('2d'), viewport }).promise
+
+    const leftPx   = (imgPercent.left   / 100) * pageCanvas.width
+    const topPx    = (imgPercent.top    / 100) * pageCanvas.height
+    const widthPx  = (imgPercent.width  / 100) * pageCanvas.width
+    const heightPx = (imgPercent.height / 100) * pageCanvas.height
+
+    const cropCanvas = document.createElement('canvas')
+    cropCanvas.width = widthPx
+    cropCanvas.height = heightPx
+    cropCanvas.getContext('2d').drawImage(
+      pageCanvas, leftPx, topPx, widthPx, heightPx, 0, 0, widthPx, heightPx
+    )
+
+    const dataUrl = cropCanvas.toDataURL('image/png')
+    figureCropCache.set(cacheKey, dataUrl)
+    return dataUrl
+  } catch (e) {
+    console.error(`Figure crop render failed p.${pageNum}:`, e)
+    return null
+  }
 }
 
 /**

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4481,6 +4481,68 @@ body.light-theme .citation-tooltip {
   cursor: wait;
 }
 
+/* ── 본문 "Figure N"/"Table N" 참조 호버 미리보기 ── */
+.figure-ref-marker-box {
+  position: absolute;
+  pointer-events: auto !important;
+  cursor: pointer;
+  border-radius: 1px;
+  border-bottom: 1px dotted rgba(217, 158, 47, 0.7);
+}
+.figure-ref-marker-box:hover {
+  background-color: rgba(217, 158, 47, 0.20);
+}
+body.light-theme .figure-ref-marker-box:hover {
+  background-color: rgba(217, 158, 47, 0.15);
+}
+.figure-preview-tooltip {
+  position: fixed;
+  z-index: 200;
+  max-width: min(420px, calc(100vw - 16px));
+  background: rgba(23, 20, 38, 0.97);
+  color: var(--text-primary);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: fadeInTooltip 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+body.light-theme .figure-preview-tooltip {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: var(--border-strong);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+.figure-preview-tooltip.hidden {
+  display: none;
+}
+.figure-preview-tooltip-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+.figure-preview-tooltip-loading {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  padding: 20px 4px;
+  text-align: center;
+}
+.figure-preview-tooltip-img {
+  display: block;
+  max-width: 100%;
+  max-height: min(60vh, 480px);
+  width: auto;
+  height: auto;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  background: #fff;
+}
+.figure-preview-tooltip-img.hidden {
+  display: none;
+}
+
 /* ── 여러 논문 비교 채팅 ── */
 .file-btn-outline {
   display: inline-flex;


### PR DESCRIPTION
# Summary
## 1. Figure/Table 캡션 라벨 추출 (백엔드)
- `backend/services/pdf_parser.py`의 `extract_pdf_images`가 그림/표 bbox 근처의 캡션 텍스트("Figure 1", "Fig. 2", "Table 3" 등)를 감지해 `label` 필드로 함께 반환하도록 확장
- `_find_page_captions`: 페이지 텍스트 블록 중 첫 줄이 캡션 패턴으로 시작하는 블록을 라벨 후보로 수집
- `_match_caption_for_rect`: 그림/표 사각형과 가로 겹침이 있고 세로 거리(40pt 이내)가 가장 가까운 캡션을 매칭

## 2. 본문 참조 호버 오버레이 (프론트엔드)
- `frontend/src/main.js`: 정규식(`FIGURE_TABLE_REF_RE`)으로 본문에서 "Figure N"/"Table N" 표기를 스캔, 백엔드가 라벨을 붙인 실제 그림/표를 가리키는 경우만(참고문헌 인용 오버레이와 동일한 원칙) 호버 가능한 박스(`figure-ref-marker-box`)로 표시
- `renderFigureRefOverlayLayer`: 페이지 텍스트 레이어 렌더 완료 시 및 `documentImages` 로드 완료 시 호출
- `showFigurePreviewTooltip`/`hideFigurePreviewTooltip`: 호버 시 해당 그림/표를 크롭해 오버레이 툴팁으로 미리보기 표시 (인용 툴팁과 동일한 UX 패턴)

## 3. 페이지 무관 크롭 렌더링 (프론트엔드)
- `frontend/src/pdfViewer.js`: `renderFigureCrop(pageNum, imgPercent)` 추가 - 가상 스크롤로 아직 마운트되지 않았거나 이미 스크롤을 벗어난 페이지도 `pdfDoc.getPage()`로 직접 오프스크린 렌더링 후 크롭 (참조된 그림/표가 현재 보이는 페이지가 아니어도 동작)
- 크롭 결과 캐싱, 문서 전환 시(`loadPDF`) 캐시 초기화

## 4. 스타일
- `frontend/src/style.css`: `.figure-ref-marker-box`, `.figure-preview-tooltip*` 스타일 추가 (기존 인용 툴팁과 톤 일치, 색상만 구분)

## Test plan
- [x] 합성 PDF로 캡션 매칭 로직 단위 검증 (Figure/Table 라벨 정상 추출 확인)
- [x] 로컬에서 백엔드+프론트엔드 실행 후 Playwright로 실제 논문(EEGPT.pdf) 열어 확인
  - 같은 페이지 내 참조("Figure 2") 호버 시 미리보기 정상 표시
  - 다른 페이지에 있는 그림/표를 가리키는 참조(7페이지 본문의 "Table 3" → 실제로는 8페이지에 위치) 호버 시에도 정상적으로 해당 페이지를 오프스크린 렌더링해 미리보기 표시