### PR TITLE
feat: Figure/Table/수식 참조 호버 미리보기 개선

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -500,14 +500,22 @@ def render_cover_image(pdf_path: str, output_path: str, top_fraction: float = 0.
         doc.close()
 
 
-_CAPTION_RE = re.compile(r"^\s*(Fig(?:ure)?|Table)\.?\s*(\d+)\b", re.IGNORECASE)
+_CAPTION_RE = re.compile(r"^\s*(Fig(?:ure)?|Table)\.?\s*(\d+)\b\.?\s*[:.\-]?\s*", re.IGNORECASE)
+# 수식 번호: 줄 끝에 "(3)"처럼 소괄호 숫자만 단독으로 오는 경우만 인정한다. 인용
+# 연도("...(2020)")와 헷갈리지 않도록 자릿수를 1~3자리로 제한한다(수식 번호가
+# 999개를 넘는 논문은 사실상 없음. 반면 연도는 항상 4자리라 자동으로 배제됨).
+_EQUATION_LINE_RE = re.compile(r"\((\d{1,3})\)\s*$")
 
 
 def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
     """
-    페이지에서 "Figure 1", "Table 2" 처럼 캡션으로 시작하는 텍스트 블록을 찾아
-    (라벨, bbox) 목록으로 반환합니다. 본문 중간에 이런 단어가 우연히 나오는 경우를
-    배제하기 위해 블록의 "첫 줄"이 캡션 패턴으로 시작하는 경우만 인정합니다.
+    페이지에서 "Figure 1", "Table 2" 처럼 캡션으로 시작하는 줄을 찾아
+    (라벨, bbox, 캡션 전문) 목록으로 반환합니다. 두 단 레이아웃 등에서 캡션이
+    문단 블록의 "첫 줄"이 아니라 블록 중간에 낄 수도 있어(예: 이전 문단과
+    캡션이 한 블록으로 묶인 경우) 블록의 모든 줄을 훑되, 각 줄의 시작이
+    캡션 패턴인 경우만 인정해 본문 중간에 우연히 나오는 경우를 배제한다.
+    캡션 전문은 매칭된 줄부터 블록 끝까지의 텍스트를 이어붙여 구성한다
+    (캡션이 보통 그 블록에서 끝까지 이어지는 독립된 문단이기 때문).
     """
     captions = []
     blocks = page.get_text("dict")["blocks"]
@@ -515,31 +523,37 @@ def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
         lines = b.get("lines")
         if not lines:
             continue
-        first_line_text = "".join(
-            span.get("text", "") for span in lines[0].get("spans", [])
-        ).strip()
-        if not first_line_text:
-            continue
-        m = _CAPTION_RE.match(first_line_text)
-        if not m:
-            continue
-        kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"
-        number = m.group(2)
-        captions.append({
-            "label": f"{kind} {number}",
-            "bbox": b["bbox"],
-        })
+        line_texts = [
+            "".join(span.get("text", "") for span in ln.get("spans", [])).strip()
+            for ln in lines
+        ]
+        for i, line_text in enumerate(line_texts):
+            if not line_text:
+                continue
+            m = _CAPTION_RE.match(line_text)
+            if not m:
+                continue
+            kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"
+            number = m.group(2)
+            caption_text = " ".join(t for t in line_texts[i:] if t).strip()
+            captions.append({
+                "label": f"{kind} {number}",
+                "bbox": lines[i]["bbox"],
+                "text": caption_text[:600],
+            })
+            break  # 한 블록에서 캡션은 한 번만 인정 (이후 줄은 caption_text에 이미 포함됨)
     return captions
 
 
-def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Optional[str]:
+def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Dict[str, Optional[str]]:
     """
-    주어진 이미지/테이블 사각형과 가장 가까운 캡션을 찾아 라벨을 반환합니다.
+    주어진 이미지/테이블 사각형과 가장 가까운 캡션을 찾아 라벨+전문을 반환합니다.
     캡션은 보통 그림 바로 아래, 표는 바로 위에 위치하므로 상하 인접 캡션을 모두
     후보로 보되, 가로 범위가 겹치고 세로 거리가 가장 짧은 것을 채택합니다.
     """
     x0, y0, x1, y1 = rect
     best_label = None
+    best_text = None
     best_dist = None
     for cap in captions:
         cx0, cy0, cx1, cy1 = cap["bbox"]
@@ -558,7 +572,31 @@ def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Optio
         if best_dist is None or dist < best_dist:
             best_dist = dist
             best_label = cap["label"]
-    return best_label
+            best_text = cap["text"]
+    return {"label": best_label, "text": best_text}
+
+
+def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
+    """
+    번호가 매겨진 수식(예: "... = mc^2   (3)")을 찾아 그 줄 전체를 오버레이 대상으로
+    반환합니다. 그림/표와 달리 수식은 이미 본문 텍스트 레이어에 문자로 존재하므로
+    별도 이미지 인식 없이, 줄 끝의 "(N)" 패턴만으로 위치를 특정한다.
+    """
+    equations = []
+    blocks = page.get_text("dict")["blocks"]
+    for b in blocks:
+        for ln in b.get("lines", []):
+            line_text = "".join(span.get("text", "") for span in ln.get("spans", [])).strip()
+            if not line_text:
+                continue
+            m = _EQUATION_LINE_RE.search(line_text)
+            if not m:
+                continue
+            equations.append({
+                "label": f"Equation {m.group(1)}",
+                "bbox": ln["bbox"],
+            })
+    return equations
 
 
 def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
@@ -676,7 +714,7 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
         # 4. 여백 보정 및 최소 규격 필터링
         for r in merged_rects:
             # 캡션 매칭은 패딩을 적용하기 전 원본 사각형 기준으로 수행 (더 정확한 인접도 판단)
-            label = _match_caption_for_rect(r, page_captions)
+            match = _match_caption_for_rect(r, page_captions)
 
             # 여백(Padding) 8포인트 적용하여 차트 라벨이나 테이블 테두리가 잘리지 않도록 안전 확보
             x0 = max(0.0, r[0] - 8.0)
@@ -702,9 +740,34 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
                 "top": top,
                 "width": width,
                 "height": height,
-                "label": label
+                "label": match["label"],
+                "caption": match["text"],
             })
-            
+
+        # 5. 번호 매겨진 수식 - 그림/표와 달리 별도 그래픽 영역이 아니라 텍스트 한
+        # 줄이므로, 위의 40pt 최소 크기 필터를 거치지 않고 그 줄의 bbox에 작은
+        # 패딩만 적용해 바로 추가한다.
+        for eq in _find_page_equations(page):
+            ex0, ey0, ex1, ey1 = eq["bbox"]
+            x0 = max(0.0, ex0 - 4.0)
+            y0 = max(0.0, ey0 - 4.0)
+            x1 = min(page_width, ex1 + 4.0)
+            y1 = min(page_height, ey1 + 4.0)
+            w = x1 - x0
+            h = y1 - y0
+            if w <= 0 or h <= 0:
+                continue
+
+            images_data.append({
+                "page": page_num + 1,
+                "left": (x0 / page_width) * 100,
+                "top": (y0 / page_height) * 100,
+                "width": (w / page_width) * 100,
+                "height": (h / page_height) * 100,
+                "label": eq["label"],
+                "caption": None,
+            })
+
     doc.close()
     return images_data
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6159,16 +6159,45 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
   }
 }
 
-// 본문 중 "Figure 1", "Fig. 2", "Table 3" 같은 표기를 감지해, 호버 시 실제
-// 해당 그림/표를 오버레이로 미리 보여준다(멀리 떨어진 페이지로 매번 스크롤해서
-// 찾아보러 가야 하는 불편을 줄이기 위함). 인용 표기 오버레이와 동일한 원칙으로,
-// 백엔드가 좌표+라벨을 뽑아낸(=documentImages에 실제로 존재하는) 그림/표를
-// 가리키는 표기만 호버 가능한 박스로 그린다.
-const FIGURE_TABLE_REF_RE = /\b(Fig(?:ure)?|Table)\.?\s*(\d+)\b/gi
+// 본문 중 "Figure 1", "Figs. 3-5", "Table 2", "Eq. (3)" 같은 표기를 감지해,
+// 호버 시 실제 해당 그림/표/수식을 오버레이로 미리 보여준다(멀리 떨어진
+// 페이지로 매번 스크롤해서 찾아보러 가야 하는 불편을 줄이기 위함). 인용 표기
+// 오버레이와 동일한 원칙으로, 백엔드가 좌표+라벨을 뽑아낸(=documentImages에
+// 실제로 존재하는) 대상을 가리키는 표기만 호버 가능한 박스로 그린다.
+//
+// 복수형(Figures/Figs/Tables)과 "Figs. 3-5", "Figures 1 and 2", "Table 1, 2"
+// 처럼 여러 개를 한 번에 가리키는 표기도 지원하기 위해, 키워드 뒤에 오는
+// 숫자 나열 전체를 그룹으로 캡처한 뒤 parseFigureTableNumberList로 펼친다.
+const FIGURE_TABLE_REF_RE = /\b(Figures?|Figs?|Tables?|Equations?|Eqns?|Eqs?)\.?\s*\(?\s*((?:\d+\s*(?:(?:[-–,]|and|&)\s*)+)*\d+)\b\)?/gi
 
-function normalizeFigureTableLabel(keyword, number) {
-  const kind = keyword.toLowerCase().startsWith('fig') ? 'Figure' : 'Table'
-  return `${kind} ${number}`
+function normalizeFigureTableKind(keyword) {
+  const kw = keyword.toLowerCase()
+  if (kw.startsWith('fig')) return 'Figure'
+  if (kw.startsWith('tab')) return 'Table'
+  return 'Equation'
+}
+
+// "1", "1, 2", "3-5", "1 and 2", "1, 2 and 3" 같은 숫자 나열을 개별 번호
+// 목록으로 펼친다 (본문 인용 파싱의 parseCitationNumbers와 동일한 원칙).
+function parseFigureTableNumberList(text) {
+  const nums = []
+  const normalized = text.replace(/&/g, ',').replace(/\band\b/gi, ',')
+  normalized.split(',').forEach(part => {
+    const trimmed = part.trim()
+    if (!trimmed) return
+    const range = trimmed.match(/^(\d+)\s*[-–]\s*(\d+)$/)
+    if (range) {
+      const start = parseInt(range[1], 10)
+      const end = parseInt(range[2], 10)
+      if (end >= start && end - start <= 50) {
+        for (let n = start; n <= end; n++) nums.push(String(n))
+      }
+    } else {
+      const single = trimmed.match(/^\d+$/)
+      if (single) nums.push(single[0])
+    }
+  })
+  return nums
 }
 
 function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
@@ -6187,9 +6216,12 @@ function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
   FIGURE_TABLE_REF_RE.lastIndex = 0
   let match
   while ((match = FIGURE_TABLE_REF_RE.exec(vtm.fullText)) !== null) {
-    const label = normalizeFigureTableLabel(match[1], match[2])
-    const targetImg = images.find(img => img.label === label)
-    if (!targetImg) continue
+    const kind = normalizeFigureTableKind(match[1])
+    const numbers = parseFigureTableNumberList(match[2])
+    const targets = numbers
+      .map(n => images.find(img => img.label === `${kind} ${n}`))
+      .filter(Boolean)
+    if (targets.length === 0) continue
 
     const rects = getSentenceRects({ charStart: match.index, charEnd: match.index + match[0].length }, vtm, textLayerDiv)
     rects.forEach(r => {
@@ -6199,14 +6231,14 @@ function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
       box.style.top    = `${r.top}px`
       box.style.width  = `${r.width}px`
       box.style.height = `${r.height}px`
-      box.addEventListener('mouseenter', () => showFigurePreviewTooltip(targetImg, box))
+      box.addEventListener('mouseenter', () => showFigurePreviewTooltip(targets, box))
       box.addEventListener('mouseleave', scheduleFigurePreviewTooltipHide)
       overlay.appendChild(box)
     })
   }
 }
 
-// ── Figure/Table 참조 호버 미리보기 툴팁 ──────────
+// ── Figure/Table/Equation 참조 호버 미리보기 툴팁 ──────────
 let figurePreviewTooltipEl = null
 let figurePreviewHideTimer = null
 let figurePreviewBoxEl = null
@@ -6216,11 +6248,7 @@ function getOrCreateFigurePreviewTooltip() {
   if (figurePreviewTooltipEl) return figurePreviewTooltipEl
   const el = document.createElement('div')
   el.className = 'figure-preview-tooltip hidden'
-  el.innerHTML = `
-    <div class="figure-preview-tooltip-label"></div>
-    <div class="figure-preview-tooltip-loading">${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...</div>
-    <img class="figure-preview-tooltip-img hidden" alt="" />
-  `
+  el.innerHTML = `<div class="figure-preview-tooltip-items"></div>`
   document.body.appendChild(el)
 
   el.addEventListener('mouseenter', () => {
@@ -6245,38 +6273,47 @@ function positionFigurePreviewTooltip() {
   figurePreviewTooltipEl.style.top = `${top}px`
 }
 
-async function showFigurePreviewTooltip(imgEntry, boxEl) {
+// targets: documentImages 항목 배열(1개 이상 - "Figures 1 and 2"처럼 여러 개를
+// 한 번에 가리키는 표기는 각각을 세로로 쌓아 보여준다)
+async function showFigurePreviewTooltip(targets, boxEl) {
   if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
   figurePreviewBoxEl = boxEl
   const requestId = ++figurePreviewRequestId
 
   const tooltip = getOrCreateFigurePreviewTooltip()
-  tooltip.querySelector('.figure-preview-tooltip-label').textContent = `${imgEntry.label} · p.${imgEntry.page}`
-  const loadingEl = tooltip.querySelector('.figure-preview-tooltip-loading')
-  const imgEl = tooltip.querySelector('.figure-preview-tooltip-img')
-  loadingEl.classList.remove('hidden')
-  loadingEl.textContent = ''
-  loadingEl.innerHTML = `${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...`
-  imgEl.classList.add('hidden')
-  imgEl.removeAttribute('src')
+  const itemsEl = tooltip.querySelector('.figure-preview-tooltip-items')
+  itemsEl.innerHTML = targets.map((t, idx) => `
+    <div class="figure-preview-tooltip-item" data-idx="${idx}">
+      <div class="figure-preview-tooltip-label">${escapeHtml(t.label)} · p.${t.page}</div>
+      <div class="figure-preview-tooltip-loading">${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...</div>
+      <img class="figure-preview-tooltip-img hidden" alt="" />
+      ${t.caption ? `<div class="figure-preview-tooltip-caption">${escapeHtml(t.caption)}</div>` : ''}
+    </div>
+  `).join('')
 
   tooltip.classList.remove('hidden')
   positionFigurePreviewTooltip()
 
-  try {
-    const dataUrl = await renderFigureCrop(imgEntry.page, imgEntry)
-    // 그 사이 다른 표기로 호버가 옮겨갔거나 툴팁이 닫혔으면 결과를 버린다
-    if (requestId !== figurePreviewRequestId || figurePreviewTooltipEl.classList.contains('hidden')) return
-    if (!dataUrl) throw new Error('empty crop')
-    imgEl.onload = () => positionFigurePreviewTooltip()
-    imgEl.src = dataUrl
-    loadingEl.classList.add('hidden')
-    imgEl.classList.remove('hidden')
-  } catch (e) {
-    console.warn('그림/표 미리보기 렌더 실패:', e)
-    if (requestId !== figurePreviewRequestId) return
-    loadingEl.innerHTML = '미리보기를 불러올 수 없습니다.'
-  }
+  targets.forEach(async (t, idx) => {
+    const itemEl = itemsEl.querySelector(`.figure-preview-tooltip-item[data-idx="${idx}"]`)
+    if (!itemEl) return
+    const loadingEl = itemEl.querySelector('.figure-preview-tooltip-loading')
+    const imgEl = itemEl.querySelector('.figure-preview-tooltip-img')
+    try {
+      const dataUrl = await renderFigureCrop(t.page, t)
+      // 그 사이 다른 표기로 호버가 옮겨갔거나 툴팁이 닫혔으면 결과를 버린다
+      if (requestId !== figurePreviewRequestId || figurePreviewTooltipEl.classList.contains('hidden')) return
+      if (!dataUrl) throw new Error('empty crop')
+      imgEl.onload = () => positionFigurePreviewTooltip()
+      imgEl.src = dataUrl
+      loadingEl.classList.add('hidden')
+      imgEl.classList.remove('hidden')
+    } catch (e) {
+      console.warn('그림/표/수식 미리보기 렌더 실패:', e)
+      if (requestId !== figurePreviewRequestId) return
+      loadingEl.innerHTML = '미리보기를 불러올 수 없습니다.'
+    }
+  })
 }
 
 function hideFigurePreviewTooltip() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4517,6 +4517,15 @@ body.light-theme .figure-preview-tooltip {
 .figure-preview-tooltip.hidden {
   display: none;
 }
+.figure-preview-tooltip-items {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+.figure-preview-tooltip-item + .figure-preview-tooltip-item {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
 .figure-preview-tooltip-label {
   font-size: 12px;
   font-weight: 600;
@@ -4532,7 +4541,7 @@ body.light-theme .figure-preview-tooltip {
 .figure-preview-tooltip-img {
   display: block;
   max-width: 100%;
-  max-height: min(60vh, 480px);
+  max-height: min(50vh, 420px);
   width: auto;
   height: auto;
   border-radius: 4px;
@@ -4541,6 +4550,12 @@ body.light-theme .figure-preview-tooltip {
 }
 .figure-preview-tooltip-img.hidden {
   display: none;
+}
+.figure-preview-tooltip-caption {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  margin-top: 8px;
 }
 
 /* ── 여러 논문 비교 채팅 ── */


### PR DESCRIPTION
# Summary
## 1. 놓치던 참조 표기 인식 범위 확장
- `frontend/src/main.js`의 `FIGURE_TABLE_REF_RE`가 `Fig`/`Figure`/`Table` 단수형만 인식하던 것을, `Figures`/`Figs`/`Tables` 복수형과 `Figs. 3-5`(범위), `Figures 1 and 2`(and 나열), `Table 1, 2, and 3`(콤마+Oxford comma 나열)까지 인식하도록 확장
- `parseFigureTableNumberList`: 숫자 나열/범위 문자열을 개별 번호 목록으로 펼치는 헬퍼 추가 (기존 인용 파싱 `parseCitationNumbers`와 동일한 원칙)
- `renderFigureRefOverlayLayer`가 한 표기에 여러 번호가 걸리면 각각을 개별 대상(targets)으로 모아 하나의 박스에서 여러 그림/표를 함께 보여줌
- `backend/services/pdf_parser.py`의 `_find_page_captions`가 "블록의 첫 줄"만 검사하던 것을 "블록 내 모든 줄"로 넓혀, 2단 레이아웃 등에서 캡션이 문단 중간에 낀 경우도 인식

## 2. 캡션 텍스트 포함
- `_find_page_captions`/`_match_caption_for_rect`가 캡션 전문(여러 줄로 줄바꿈된 경우 이어붙임, 최대 600자)을 함께 반환하도록 확장
- `extract_pdf_images`가 각 그림/표 항목에 `caption` 필드 추가
- 프론트 호버 미리보기 툴팁이 이미지 아래에 캡션 텍스트를 표시 (`figure-preview-tooltip-caption`)

## 3. 수식(Equation) 참조 오버레이 지원
- `_find_page_equations`: 줄 끝의 `(N)` 패턴(1~3자리 - 4자리 연도 인용과 구분)으로 번호가 매겨진 수식 줄을 탐지해 `Equation N` 라벨로 추가 (그림/표와 달리 최소 40pt 크기 필터를 적용하지 않고 텍스트 줄 bbox에 작은 패딩만 적용)
- 프론트 정규식이 `Eq.`, `Eqn.`, `Equation`, `Eqs.` 등의 표기를 감지해 동일한 호버 미리보기 파이프라인 재사용

## Test plan
- [x] 합성 PDF로 캡션 전문 추출(줄바꿈 포함) 및 수식 라벨링(4자리 연도 오탐 없음) 단위 검증
- [x] Node 스크립트로 정규식/숫자 나열 파싱 엣지 케이스 검증 (`Fig.2`, `Figs. 3-5`, `Figures 1, 2, and 3`, `Eq. (3)`, `Table 2a`(비매칭), `(2020)`(비매칭) 등)
- [x] 실제 논문(EEGPT.pdf, VAE.pdf)에서 Playwright로 확인
  - 수식 참조("eqs (21)") 호버 시 해당 수식 라인 미리보기 정상 표시
  - 복수 대상 참조("figures 4 and 5") 호버 시 Figure 4·5 두 항목이 각각 캡션과 함께 표시
  - 캡션 탐지 개선 후 라벨링된 그림/표 수 증가 확인
  - 콘솔 에러 없이 문서 전체 스크롤 시 정상 동작