### PR TITLE
feat: Figure/Table/수식 참조 클릭 시 해당 페이지로 이동

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6268,6 +6268,16 @@ function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
       box.style.height = `${r.height}px`
       box.addEventListener('mouseenter', () => showFigurePreviewTooltip(targets, box))
       box.addEventListener('mouseleave', scheduleFigurePreviewTooltipHide)
+      // 클릭하면 해당 그림/표/수식이 실제로 있는 페이지로 이동한다. 여러 개를
+      // 한 번에 가리키는 표기("Figures 1 and 2")는 첫 번째 대상 기준으로
+      // 이동하고, 나머지는 미리보기 툴팁 안의 각 항목을 클릭해 개별 이동한다.
+      box.addEventListener('click', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        window.getSelection().removeAllRanges()
+        hideFigurePreviewTooltip()
+        scrollToPage(viewerScrollContainer, targets[0].page)
+      })
       overlay.appendChild(box)
     })
   }
@@ -6278,6 +6288,10 @@ let figurePreviewTooltipEl = null
 let figurePreviewHideTimer = null
 let figurePreviewBoxEl = null
 let figurePreviewRequestId = 0
+
+// showFigurePreviewTooltip이 마지막으로 그린 targets 배열 - 툴팁 안 개별
+// 항목을 클릭했을 때 어느 페이지로 이동할지 idx로 되찾기 위해 보관한다.
+let figurePreviewCurrentTargets = []
 
 function getOrCreateFigurePreviewTooltip() {
   if (figurePreviewTooltipEl) return figurePreviewTooltipEl
@@ -6290,6 +6304,17 @@ function getOrCreateFigurePreviewTooltip() {
     if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
   })
   el.addEventListener('mouseleave', scheduleFigurePreviewTooltipHide)
+  // 여러 대상이 한 툴팁에 쌓여 있을 때, 특정 항목을 클릭하면 그 항목의
+  // 페이지로 이동한다 (내용은 매번 innerHTML로 다시 그려지므로 이벤트
+  // 위임으로 한 번만 등록해둔다).
+  el.querySelector('.figure-preview-tooltip-items').addEventListener('click', (e) => {
+    const itemEl = e.target.closest('.figure-preview-tooltip-item')
+    if (!itemEl) return
+    const target = figurePreviewCurrentTargets[parseInt(itemEl.dataset.idx, 10)]
+    if (!target) return
+    hideFigurePreviewTooltip()
+    scrollToPage(viewerScrollContainer, target.page)
+  })
 
   figurePreviewTooltipEl = el
   return el
@@ -6313,6 +6338,7 @@ function positionFigurePreviewTooltip() {
 async function showFigurePreviewTooltip(targets, boxEl) {
   if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
   figurePreviewBoxEl = boxEl
+  figurePreviewCurrentTargets = targets
   const requestId = ++figurePreviewRequestId
 
   const tooltip = getOrCreateFigurePreviewTooltip()

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4526,6 +4526,14 @@ body.light-theme .figure-preview-tooltip {
   padding-top: 12px;
   border-top: 1px solid var(--border);
 }
+.figure-preview-tooltip-item {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.15s ease;
+}
+.figure-preview-tooltip-item:hover {
+  background-color: rgba(217, 158, 47, 0.10);
+}
 .figure-preview-tooltip-label {
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
# Summary
## 1. 참조 표기 클릭 시 페이지 이동
- `renderFigureRefOverlayLayer`에서 만드는 `.figure-ref-marker-box`에 click 리스너 추가 - 클릭하면 `scrollToPage`로 첫 번째 대상의 실제 페이지로 이동
- "Figures 1 and 2"처럼 한 표기가 여러 대상을 가리키는 경우, 클릭은 첫 번째 대상 기준으로 이동

## 2. 미리보기 툴팁 내 개별 항목 클릭 이동
- `figure-preview-tooltip-items`에 이벤트 위임으로 클릭 리스너를 한 번만 등록해, 여러 대상이 쌓여 있을 때 특정 항목(이미지+캡션)을 클릭하면 그 항목의 페이지로 개별 이동 가능
- 클릭 가능함을 알 수 있도록 `.figure-preview-tooltip-item`에 hover 시 배경색 강조 CSS 추가

## Test plan
- [x] Playwright로 VAE.pdf에서 "eqs (14)" 참조 박스를 클릭 → 14페이지에서 실제 Equation 14가 있는 13페이지로 정상 이동, 페이지 인디케이터(13/14)와 스크롤 위치 변경까지 확인