### PR TITLE
feat: 번역 포함 PDF 내보내기를 뷰어처럼 원문·번역 페이지 페어링

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -208,12 +208,10 @@ async def export_annotated_pdf(
         if text:
             translations[str(page_num)] = text
 
-    doc_title = (doc.get("metadata") or {}).get("title") or doc.get("filename", "EasyPaper")
-
     try:
         from services.pdf_export import generate_annotated_pdf
         pdf_bytes = generate_annotated_pdf(
-            pdf_path, doc_title, payload.annotations, translations, payload.memos
+            pdf_path, payload.annotations, translations, payload.memos
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"PDF 생성 실패: {str(e)}")

--- a/backend/services/pdf_export.py
+++ b/backend/services/pdf_export.py
@@ -77,14 +77,24 @@ def _apply_annotations_to_page(page: fitz.Page, annotations: list) -> None:
             continue
 
 
-def _run_story_pages(html: str) -> fitz.Document:
+def _run_story_pages(html: str, page_width: Optional[float] = None, page_height: Optional[float] = None) -> fitz.Document:
     """HTML을 fitz.Story로 흘려보내 필요한 만큼 자동으로 페이지를 나눈
-    새 PDF 문서를 만들어 반환한다 (한글 포함 텍스트도 자연스럽게 렌더링됨)."""
+    새 PDF 문서를 만들어 반환한다 (한글 포함 텍스트도 자연스럽게 렌더링됨).
+
+    page_width/page_height를 지정하면 그 크기로 페이지를 생성한다 - 원본 PDF
+    페이지와 나란히 배치(pair)할 번역 페이지를 원본과 동일한 크기로 맞추기
+    위해 사용한다. 지정하지 않으면 기존처럼 A4 고정 크기를 쓴다.
+    """
     buf = io.BytesIO()
     story = fitz.Story(html=html)
     writer = fitz.DocumentWriter(buf)
-    mediabox = fitz.paper_rect("a4")
-    where = mediabox + (48, 48, -48, -48)
+    if page_width and page_height:
+        mediabox = fitz.Rect(0, 0, page_width, page_height)
+        margin = min(48.0, page_width * 0.08, page_height * 0.08)
+    else:
+        mediabox = fitz.paper_rect("a4")
+        margin = 48.0
+    where = mediabox + (margin, margin, -margin, -margin)
 
     more = 1
     while more:
@@ -98,21 +108,15 @@ def _run_story_pages(html: str) -> fitz.Document:
     return fitz.open("pdf", buf.read())
 
 
-def _build_translation_html(doc_title: str, translations: dict) -> str:
-    parts = [
-        '<div style="font-family: sans-serif;">',
-        f'<h1 style="font-size: 20pt; margin-bottom: 4pt;">{html_escape(doc_title)}</h1>',
-        '<h2 style="font-size: 13pt; color: #555; margin-top: 0;">번역 (Translation)</h2>',
-    ]
-    for page_num in sorted((int(k) for k in translations.keys())):
-        text = (translations.get(str(page_num)) or "").strip()
-        if not text:
-            continue
-        parts.append(f'<h3 style="font-size: 12pt; margin-top: 18pt; color: #333;">{page_num}페이지</h3>')
-        for para in re.split(r"\n\s*\n", text):
-            para = para.strip()
-            if para:
-                parts.append(f'<p style="font-size: 11pt; line-height: 1.6; text-align: justify;">{html_escape(para)}</p>')
+def _build_page_translation_html(text: str) -> str:
+    """한 페이지 분량의 번역 전문을 문단 단위 HTML로 변환한다 (뷰어의 번역
+    패널과 나란히 놓일 페이지이므로 문서 제목/페이지 번호 같은 반복 헤더는
+    넣지 않는다 - 원본 페이지 쪽에 이미 그 정보가 그대로 보이기 때문)."""
+    parts = ['<div style="font-family: sans-serif;">']
+    for para in re.split(r"\n\s*\n", text):
+        para = para.strip()
+        if para:
+            parts.append(f'<p style="font-size: 10.5pt; line-height: 1.6; text-align: justify;">{html_escape(para)}</p>')
     parts.append("</div>")
     return "".join(parts)
 
@@ -145,41 +149,86 @@ def _build_memo_html(memos: dict) -> Optional[str]:
     return "".join(parts)
 
 
+def _add_translation_pair_pages(out_doc: fitz.Document, src_doc: fitz.Document, translations: dict) -> None:
+    """뷰어 화면(원문 | 번역 나란히 배치)과 동일한 모양으로, 원본 페이지마다
+    같은 크기의 출력 페이지를 만들어 왼쪽엔 원본 페이지를(show_pdf_page로
+    벡터 그대로 삽입 - 래스터화하지 않으므로 텍스트 선택/검색 그대로 유지),
+    오른쪽엔 그 페이지의 번역 전문을 배치한다.
+
+    번역 텍스트가 원본 페이지 한 장 분량보다 길어 한 페이지에 다 들어가지
+    않으면(_run_story_pages가 여러 페이지로 나눠 반환), 첫 페이지만 오른쪽
+    절반에 배치하고 나머지는 "번역 계속" 전용 페이지로 바로 뒤에 이어붙인다.
+    """
+    for page_idx in range(src_doc.page_count):
+        src_page = src_doc[page_idx]
+        sr = src_page.rect
+        translation_text = (translations.get(str(page_idx + 1)) or "").strip()
+
+        pair_page = out_doc.new_page(width=sr.width * 2, height=sr.height)
+        left_rect = fitz.Rect(0, 0, sr.width, sr.height)
+        pair_page.show_pdf_page(left_rect, src_doc, page_idx)
+
+        right_rect = fitz.Rect(sr.width, 0, sr.width * 2, sr.height)
+        if not translation_text:
+            pair_page.insert_textbox(
+                right_rect + (16, 16, -16, -16),
+                "(번역 없음)",
+                fontsize=10.5, color=(0.6, 0.6, 0.6), fontname=_KOREAN_TEXTBOX_FONT,
+            )
+            continue
+
+        trans_doc = _run_story_pages(
+            _build_page_translation_html(translation_text),
+            page_width=sr.width, page_height=sr.height,
+        )
+        try:
+            if trans_doc.page_count > 0:
+                pair_page.show_pdf_page(right_rect, trans_doc, 0)
+                if trans_doc.page_count > 1:
+                    out_doc.insert_pdf(trans_doc, from_page=1)
+        finally:
+            trans_doc.close()
+
+
 def generate_annotated_pdf(
     pdf_path: str,
-    doc_title: str,
     annotations: dict,
     translations: dict,
     memos: dict,
 ) -> bytes:
-    """원본 PDF에 하이라이트/밑줄을 구워 넣고, 번역·메모 섹션을 이어붙인
-    최종 PDF를 바이트로 반환한다.
+    """원본 PDF에 하이라이트/밑줄을 구워 넣고, 뷰어 화면처럼 원문과 번역을
+    페이지마다 나란히(pair) 배치한 뒤, 메모 섹션을 이어붙인 최종 PDF를
+    바이트로 반환한다.
 
     annotations: {"page_1": [{"type", "text", "color"}, ...], ...} (프론트 localStorage 형식)
     translations: {"1": "번역 텍스트", ...} (페이지 번호 -> 번역 전문)
     memos: {"page_1": [{"content", "sentenceText"}, ...], ...} (프론트 localStorage 형식)
     """
-    doc = fitz.open(pdf_path)
+    src_doc = fitz.open(pdf_path)
 
     for page_key, page_annotations in (annotations or {}).items():
         m = re.match(r"page_(\d+)$", page_key)
         if not m:
             continue
         page_idx = int(m.group(1)) - 1
-        if 0 <= page_idx < doc.page_count and page_annotations:
-            _apply_annotations_to_page(doc[page_idx], page_annotations)
+        if 0 <= page_idx < src_doc.page_count and page_annotations:
+            _apply_annotations_to_page(src_doc[page_idx], page_annotations)
+
+    out_doc = fitz.open()
 
     if translations:
-        translation_doc = _run_story_pages(_build_translation_html(doc_title, translations))
-        doc.insert_pdf(translation_doc)
-        translation_doc.close()
+        _add_translation_pair_pages(out_doc, src_doc, translations)
+    else:
+        # 번역이 없으면 페어링할 대상이 없으므로 원본 페이지만 그대로 담는다.
+        out_doc.insert_pdf(src_doc)
 
     memo_html = _build_memo_html(memos or {})
     if memo_html:
         memo_doc = _run_story_pages(memo_html)
-        doc.insert_pdf(memo_doc)
+        out_doc.insert_pdf(memo_doc)
         memo_doc.close()
 
-    result = doc.tobytes(garbage=4, deflate=True)
-    doc.close()
+    result = out_doc.tobytes(garbage=4, deflate=True)
+    out_doc.close()
+    src_doc.close()
     return result

--- a/backend/tests/test_pdf_export.py
+++ b/backend/tests/test_pdf_export.py
@@ -29,7 +29,7 @@ def sample_pdf(tmp_path):
 
 
 def test_generate_pdf_preserves_original_pages(sample_pdf):
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, {})
+    result = generate_annotated_pdf(sample_pdf, {}, {}, {})
     doc = fitz.open("pdf", result)
     assert doc.page_count == 2  # 주석/번역/메모가 전부 없으면 원본 페이지 수 그대로
     doc.close()
@@ -37,7 +37,7 @@ def test_generate_pdf_preserves_original_pages(sample_pdf):
 
 def test_generate_pdf_bakes_highlight_annotation(sample_pdf):
     annotations = {"page_1": [{"type": "highlight", "text": "self-attention mechanisms", "color": "#eab308"}]}
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    result = generate_annotated_pdf(sample_pdf, annotations, {}, {})
     doc = fitz.open("pdf", result)
     page1_annots = list(doc[0].annots())
     assert len(page1_annots) == 1
@@ -47,7 +47,7 @@ def test_generate_pdf_bakes_highlight_annotation(sample_pdf):
 
 def test_generate_pdf_bakes_underline_annotation(sample_pdf):
     annotations = {"page_1": [{"type": "underline", "text": "self-attention mechanisms", "color": "#ef4444"}]}
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    result = generate_annotated_pdf(sample_pdf, annotations, {}, {})
     doc = fitz.open("pdf", result)
     page1_annots = list(doc[0].annots())
     assert len(page1_annots) == 1
@@ -58,30 +58,52 @@ def test_generate_pdf_bakes_underline_annotation(sample_pdf):
 def test_generate_pdf_skips_annotation_when_text_not_found(sample_pdf):
     """페이지에 없는 문구를 하이라이트하려 해도 예외 없이 조용히 건너뛰어야 한다."""
     annotations = {"page_1": [{"type": "highlight", "text": "this text does not exist anywhere", "color": "#eab308"}]}
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    result = generate_annotated_pdf(sample_pdf, annotations, {}, {})
     doc = fitz.open("pdf", result)
     assert len(list(doc[0].annots())) == 0
     doc.close()
 
 
-def test_generate_pdf_appends_translation_pages(sample_pdf):
+def test_generate_pdf_pairs_original_and_translation_per_page(sample_pdf):
+    """뷰어 화면처럼 원문과 번역이 페이지마다 나란히(같은 출력 페이지의 좌/우)
+    배치되어야 한다 - 번역을 별도 섹션으로 뒤에 이어붙이는 대신."""
     translations = {
         "1": "트랜스포머 아키텍처는 셀프 어텐션 메커니즘에 의존합니다.",
         "2": "우리의 실험은 강력한 성능을 보여줍니다.",
     }
-    result = generate_annotated_pdf(sample_pdf, "테스트 논문", {}, translations, {})
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
     doc = fitz.open("pdf", result)
-    assert doc.page_count > 2, "번역 섹션이 추가되어 원본 페이지 수보다 많아야 한다"
+    # 각 번역이 원본 페이지 절반 폭에 다 들어가는 짧은 텍스트이므로, 페이지
+    # 수는 원본과 동일하게 유지되고(번역용 페이지가 뒤에 추가되지 않음)
+    assert doc.page_count == 2
 
-    full_text = "".join(page.get_text() for page in doc)
-    assert "테스트 논문" in full_text
-    assert "셀프 어텐션" in full_text
+    src = fitz.open(sample_pdf)
+    src_page_width = src[0].rect.width
+    src.close()
+    # 출력 페이지는 원본 폭의 2배(좌: 원문, 우: 번역)여야 한다
+    assert doc[0].rect.width == pytest.approx(src_page_width * 2, rel=0.01)
+
+    page1_text = doc[0].get_text()
+    assert "self-attention mechanisms" in page1_text  # 왼쪽: 원문 그대로(벡터 삽입, 텍스트 추출 가능)
+    assert "셀프 어텐션" in page1_text  # 오른쪽: 같은 페이지에 번역이 나란히
+    doc.close()
+
+
+def test_generate_pdf_shows_placeholder_for_page_without_translation(sample_pdf):
+    """일부 페이지만 번역이 있는 경우, 번역이 없는 페이지는 페어링이 깨지지
+    않도록 안내 문구만 표시하고 페이지 자체는 그대로 유지해야 한다."""
+    translations = {"1": "트랜스포머 아키텍처는 셀프 어텐션 메커니즘에 의존합니다."}
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
+    doc = fitz.open("pdf", result)
+    assert doc.page_count == 2
+    assert "번역 없음" in doc[1].get_text()
+    assert "Results" in doc[1].get_text()  # 왼쪽 원문은 그대로 보여야 함
     doc.close()
 
 
 def test_generate_pdf_appends_memo_page(sample_pdf):
     memos = {"page_1": [{"content": "이 부분이 핵심입니다.", "sentenceText": "self-attention mechanisms"}]}
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, memos)
+    result = generate_annotated_pdf(sample_pdf, {}, {}, memos)
     doc = fitz.open("pdf", result)
     assert doc.page_count > 2
 
@@ -93,7 +115,7 @@ def test_generate_pdf_appends_memo_page(sample_pdf):
 def test_generate_pdf_with_no_memo_content_adds_no_memo_page(sample_pdf):
     """memo content가 비어있으면 메모 섹션 자체를 추가하지 않아야 한다."""
     memos = {"page_1": [{"content": "  ", "sentenceText": "something"}]}
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", {}, {}, memos)
+    result = generate_annotated_pdf(sample_pdf, {}, {}, memos)
     doc = fitz.open("pdf", result)
     assert doc.page_count == 2
     doc.close()
@@ -105,7 +127,7 @@ def test_generate_pdf_handles_invalid_page_key_gracefully(sample_pdf):
         "page_999": [{"type": "highlight", "text": "anything", "color": "#eab308"}],
         "not-a-page-key": [{"type": "highlight", "text": "anything", "color": "#eab308"}],
     }
-    result = generate_annotated_pdf(sample_pdf, "Test Paper", annotations, {}, {})
+    result = generate_annotated_pdf(sample_pdf, annotations, {}, {})
     doc = fitz.open("pdf", result)
     assert doc.page_count == 2
     doc.close()


### PR DESCRIPTION
# Summary
## 1. 원문/번역 페이지 페어링 (`backend/services/pdf_export.py`)
- 기존에는 원본 페이지 전체 뒤에 모든 페이지의 번역을 한 섹션으로 이어붙였음(뷰어의 "원문 | 번역" 나란히 보기와 다른 구조)
- `_add_translation_pair_pages` 추가: 원본 페이지마다 폭이 2배인 출력 페이지를 만들어 왼쪽엔 원본을, 오른쪽엔 그 페이지의 번역을 배치
- 원본은 `page.show_pdf_page()`로 벡터 그대로 삽입 - 래스터화하지 않으므로 내보낸 PDF에서도 원문 텍스트 선택/검색이 그대로 유지됨
- 번역이 원본 페이지 한 장 분량보다 길어 한 번에 안 들어가면(`_run_story_pages`가 여러 페이지로 자동 분할), 첫 페이지만 오른쪽 절반에 배치하고 나머지는 전체 폭 "이어지는" 페이지로 바로 뒤에 삽입
- 해당 페이지에 번역이 없으면 오른쪽에 "(번역 없음)" 안내만 표시하고 원문은 그대로 유지 (페어링이 깨지지 않도록)
- 번역이 아예 없는 경우(기존 동작 유지)는 원본 페이지만 그대로 담음
- 더 이상 쓰이지 않게 된 `doc_title` 파라미터(예전엔 번역 섹션 맨 앞 제목으로만 쓰였음) 제거 - `backend/routers/library.py` 호출부도 함께 정리

## 2. 테스트 업데이트 (`backend/tests/test_pdf_export.py`)
- `doc_title` 인자 제거에 맞춰 전체 호출부 갱신
- 번역 섹션이 "뒤에 추가"되는지 확인하던 기존 테스트를, 같은 출력 페이지 안에 원문+번역이 함께 있는지 확인하는 `test_generate_pdf_pairs_original_and_translation_per_page`로 교체 (페이지 폭이 원본의 2배인지도 함께 검증)
- 일부 페이지만 번역이 있을 때 번역 없는 페이지에 안내 문구가 뜨는지 검증하는 테스트 추가

## Test plan
- [x] `pytest tests/test_pdf_export.py` 9개 전부 통과
- [x] 실제 논문(EEGPT.pdf, 번역 18/18페이지 완료 상태)으로 직접 내보내기 실행 후 렌더링 이미지로 시각 확인 - 1페이지 출력이 폭 2배(1224pt)로 왼쪽엔 원문, 오른쪽엔 번역이 나란히 배치되고, 번역이 넘치는 부분은 전체 폭의 이어지는 페이지로 자연스럽게 계속되는 것 확인