### PR TITLE
fix: PDF 내보내기에서 긴 번역을 축소해 한 페이지에 강제로 맞춤

### DIFF
--- a/backend/services/pdf_export.py
+++ b/backend/services/pdf_export.py
@@ -77,24 +77,14 @@ def _apply_annotations_to_page(page: fitz.Page, annotations: list) -> None:
             continue
 
 
-def _run_story_pages(html: str, page_width: Optional[float] = None, page_height: Optional[float] = None) -> fitz.Document:
+def _run_story_pages(html: str) -> fitz.Document:
     """HTML을 fitz.Story로 흘려보내 필요한 만큼 자동으로 페이지를 나눈
-    새 PDF 문서를 만들어 반환한다 (한글 포함 텍스트도 자연스럽게 렌더링됨).
-
-    page_width/page_height를 지정하면 그 크기로 페이지를 생성한다 - 원본 PDF
-    페이지와 나란히 배치(pair)할 번역 페이지를 원본과 동일한 크기로 맞추기
-    위해 사용한다. 지정하지 않으면 기존처럼 A4 고정 크기를 쓴다.
-    """
+    새 PDF 문서를 만들어 반환한다 (한글 포함 텍스트도 자연스럽게 렌더링됨)."""
     buf = io.BytesIO()
     story = fitz.Story(html=html)
     writer = fitz.DocumentWriter(buf)
-    if page_width and page_height:
-        mediabox = fitz.Rect(0, 0, page_width, page_height)
-        margin = min(48.0, page_width * 0.08, page_height * 0.08)
-    else:
-        mediabox = fitz.paper_rect("a4")
-        margin = 48.0
-    where = mediabox + (margin, margin, -margin, -margin)
+    mediabox = fitz.paper_rect("a4")
+    where = mediabox + (48, 48, -48, -48)
 
     more = 1
     while more:
@@ -155,9 +145,10 @@ def _add_translation_pair_pages(out_doc: fitz.Document, src_doc: fitz.Document, 
     벡터 그대로 삽입 - 래스터화하지 않으므로 텍스트 선택/검색 그대로 유지),
     오른쪽엔 그 페이지의 번역 전문을 배치한다.
 
-    번역 텍스트가 원본 페이지 한 장 분량보다 길어 한 페이지에 다 들어가지
-    않으면(_run_story_pages가 여러 페이지로 나눠 반환), 첫 페이지만 오른쪽
-    절반에 배치하고 나머지는 "번역 계속" 전용 페이지로 바로 뒤에 이어붙인다.
+    원문과의 1:1 페어링(같은 페이지 번호 = 같은 출력 페이지)을 항상 유지하기
+    위해, 번역이 원본 페이지 한 장 분량보다 길어도 별도 페이지로 넘기지
+    않는다. 대신 insert_htmlbox(scale_low=0)로 필요한 만큼 글자 크기를
+    무제한 축소해서라도 반드시 한 페이지 오른쪽 절반 안에 다 들어가게 한다.
     """
     for page_idx in range(src_doc.page_count):
         src_page = src_doc[page_idx]
@@ -168,26 +159,16 @@ def _add_translation_pair_pages(out_doc: fitz.Document, src_doc: fitz.Document, 
         left_rect = fitz.Rect(0, 0, sr.width, sr.height)
         pair_page.show_pdf_page(left_rect, src_doc, page_idx)
 
-        right_rect = fitz.Rect(sr.width, 0, sr.width * 2, sr.height)
+        right_rect = fitz.Rect(sr.width, 0, sr.width * 2, sr.height) + (16, 16, -16, -16)
         if not translation_text:
             pair_page.insert_textbox(
-                right_rect + (16, 16, -16, -16),
+                right_rect,
                 "(번역 없음)",
                 fontsize=10.5, color=(0.6, 0.6, 0.6), fontname=_KOREAN_TEXTBOX_FONT,
             )
             continue
 
-        trans_doc = _run_story_pages(
-            _build_page_translation_html(translation_text),
-            page_width=sr.width, page_height=sr.height,
-        )
-        try:
-            if trans_doc.page_count > 0:
-                pair_page.show_pdf_page(right_rect, trans_doc, 0)
-                if trans_doc.page_count > 1:
-                    out_doc.insert_pdf(trans_doc, from_page=1)
-        finally:
-            trans_doc.close()
+        pair_page.insert_htmlbox(right_rect, _build_page_translation_html(translation_text), scale_low=0)
 
 
 def generate_annotated_pdf(

--- a/backend/tests/test_pdf_export.py
+++ b/backend/tests/test_pdf_export.py
@@ -73,8 +73,7 @@ def test_generate_pdf_pairs_original_and_translation_per_page(sample_pdf):
     }
     result = generate_annotated_pdf(sample_pdf, {}, translations, {})
     doc = fitz.open("pdf", result)
-    # 각 번역이 원본 페이지 절반 폭에 다 들어가는 짧은 텍스트이므로, 페이지
-    # 수는 원본과 동일하게 유지되고(번역용 페이지가 뒤에 추가되지 않음)
+    # 페이지 수는 항상 원본과 1:1로 유지된다(번역용 페이지가 뒤에 추가되지 않음)
     assert doc.page_count == 2
 
     src = fitz.open(sample_pdf)
@@ -86,6 +85,22 @@ def test_generate_pdf_pairs_original_and_translation_per_page(sample_pdf):
     page1_text = doc[0].get_text()
     assert "self-attention mechanisms" in page1_text  # 왼쪽: 원문 그대로(벡터 삽입, 텍스트 추출 가능)
     assert "셀프 어텐션" in page1_text  # 오른쪽: 같은 페이지에 번역이 나란히
+    doc.close()
+
+
+def test_generate_pdf_shrinks_long_translation_to_fit_single_page(sample_pdf):
+    """번역이 원본 페이지 한 장에 다 들어가지 않을 만큼 길어도, 페어링(원문
+    페이지 수 = 출력 페이지 수)을 깨는 별도 페이지를 추가하는 대신 글자
+    크기를 줄여서라도 반드시 한 페이지 안에 담아야 한다."""
+    long_translation = "이 문장은 페이지를 넘칠 정도로 아주 길게 반복되는 번역 텍스트입니다. " * 400
+    translations = {"1": long_translation}
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
+    doc = fitz.open("pdf", result)
+    assert doc.page_count == 2  # 번역이 아무리 길어도 원본 페이지 수 그대로
+
+    page1_text = doc[0].get_text()
+    assert "self-attention mechanisms" in page1_text
+    assert "아주 길게 반복되는" in page1_text  # 축소되어도 텍스트 자체는 온전히 들어가 있어야 함
     doc.close()
 
 


### PR DESCRIPTION
# Summary
## 1. 번역이 페이지를 넘칠 때 별도 페이지 추가 대신 축소해서 맞춤
- 직전 PR(#136)에서 번역/주석 포함 PDF 내보내기를 원문·번역 페어링 구조로 바꿨는데, 번역이 원본 페이지 한 장보다 길면 `_run_story_pages`가 자동으로 다음 페이지를 만들어 이어붙이는 방식이라 원본 페이지 수와 출력 페이지 수가 어긋나는 경우가 있었음(예: 18페이지 논문이 35페이지로 출력)
- `_add_translation_pair_pages`가 `_run_story_pages`(여러 페이지 자동 분할) 대신 `page.insert_htmlbox(rect, html, scale_low=0)`을 사용하도록 변경 - 번역 텍스트가 아무리 길어도 글자 크기를 무제한 축소해서라도 반드시 오른쪽 절반 한 페이지 안에 다 들어가게 강제
- 결과적으로 출력 페이지 수가 항상 원본 페이지 수와 정확히 1:1로 유지됨
- 더 이상 필요 없어진 "번역 계속" 페이지 삽입 로직 및 `_run_story_pages`의 커스텀 페이지 크기 파라미터 제거(사용처가 없어짐 - 메모 섹션은 기존 A4 고정 크기 그대로 사용)

## 2. 테스트
- 매우 긴 번역(문장 400회 반복)을 넣어도 페이지 수가 원본과 동일하게 유지되고 텍스트 내용은 축소되어도 그대로 보존되는지 검증하는 테스트 추가

## Test plan
- [x] `pytest tests/test_pdf_export.py` 10개 전부 통과
- [x] 실제 논문(EEGPT.pdf, 18페이지, 이전에는 번역 오버플로우로 35페이지까지 늘어났던 문서)으로 재실행 - 출력이 정확히 18페이지로 원본과 1:1 매칭되는 것 확인
- [x] 렌더링 이미지로 번역이 축소되어 한 페이지 안에 전부 들어가 있는 것 시각 확인 (내용 손실 없음)