### PR TITLE
fix: 세션 유지형 번역 프롬프트에서 표 제외 규칙 드리프트 수정

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -142,6 +142,21 @@ async def stream_translation(
             truncated_prev = prev_context[-1000:] if len(prev_context) > 1000 else prev_context
             context_part = f"\n[참고 문맥 정보]\n- 이전 페이지/단락의 번역 결과 (참고용):\n\"\"\"\n{truncated_prev}\n\"\"\"\n"
 
+        # 제외 옵션(수식/표/참고문헌)은 "앞서 안내한 규칙을 유지하라"는 말만으로는
+        # 세션이 길어질수록 모델이 잊어버리는 경우가 있었다(특히 표 제외 규칙 -
+        # 표는 시각적으로 두드러진 콘텐츠라 지시를 무시하고 그대로 재현하려는
+        # 경향이 강함). 5페이지마다만 리마인드하는 전체 규칙과 별개로, 이 세
+        # 가지 제외 옵션만큼은 매 페이지 짧은 프롬프트에도 항상 명시적으로
+        # 다시 못박아 드리프트를 방지한다.
+        exclusion_reminders = []
+        if ignore_math:
+            exclusion_reminders.append("수식은 번역하지 말고 생략하거나 단순 기호 처리하세요.")
+        if ignore_table:
+            exclusion_reminders.append("Markdown 표(Table) 형식의 출력은 절대 하지 말고, 표 데이터는 번역 결과에서 완전히 제외하세요.")
+        if ignore_refs:
+            exclusion_reminders.append("참고문헌(References) 목록이나 각주 정보는 번역하지 말고 결과에서 제외하세요.")
+        exclusion_part = ("\n" + "\n".join(exclusion_reminders) + "\n") if exclusion_reminders else ""
+
         prompt = (
             "앞서 안내한 문체·용어·수식·표·참고문헌 처리 규칙을 동일하게 유지하며 이어지는 다음 원문을 번역하세요.\n"
             "서론이나 설명 없이 번역 결과만 즉시 출력하세요. 입력 텍스트의 각 문장 앞에 있는 [S0], [S1] 등 문장 식별자 "
@@ -151,6 +166,7 @@ async def stream_translation(
             "임의로 더 쪼개어 추가 태그를 붙이지도 마세요. 일부 태그는 [S3:I]처럼 콜론 뒤에 알파벳이 붙어 있을 수 "
             "있는데, 이것도 지우거나 숫자만 남기지 말고 태그 전체를 그대로 유지하세요. 원문에서 **별표 두 개로 감싸인 "
             "부분**은 볼드 처리였으니 번역 결과에서도 그 부분을 동일하게 **볼드**로 감싸서 출력하세요.\n"
+            f"{exclusion_part}"
             f"{context_part}\n"
             f"원문:\n{text}\n\n"
             f"{target_lang} 번역:"

--- a/backend/tests/test_llm_client_prompt.py
+++ b/backend/tests/test_llm_client_prompt.py
@@ -1,0 +1,92 @@
+"""services/llm_client.py의 stream_translation() 프롬프트 구성 테스트.
+
+세션이 지속되는 provider(antigravity/claude_code/codex)는 매 페이지마다 규칙
+전문을 다시 보내지 않고, 5페이지에 한 번만 리마인드하는 "짧은 프롬프트"를
+쓴다. 이때 수식/표/참고문헌 제외 옵션까지 "앞서 안내한 규칙을 유지하라"는
+말에만 의존하면 세션이 길어질수록 모델이 잊어버려 표가 번역 결과에 섞여
+들어오는 문제가 있었다 - 이를 방지하기 위해 이 옵션들만큼은 짧은 프롬프트
+에도 매번 명시적으로 재포함되는지 검증한다.
+"""
+
+import pytest
+
+import services.llm_client as llm_client
+
+
+@pytest.fixture()
+def capture_antigravity_prompt(monkeypatch):
+    """stream_antigravity가 실제로 외부 CLI를 호출하지 않도록 대체하고,
+    전달된 prompt를 캡처해 반환하는 리스트를 제공한다."""
+    captured = []
+
+    async def fake_stream_antigravity(prompt, model=None, session_id=None):
+        captured.append(prompt)
+        yield "번역결과"
+
+    monkeypatch.setattr(llm_client, "stream_antigravity", fake_stream_antigravity)
+    monkeypatch.setattr(llm_client, "get_trans_provider", lambda: "antigravity")
+    monkeypatch.setattr(llm_client, "get_trans_model", lambda: "gemini")
+    return captured
+
+
+async def _drain(agen):
+    async for _ in agen:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_short_prompt_reminds_ignore_table(capture_antigravity_prompt):
+    await _drain(llm_client.stream_translation(
+        text="[S0] Some table content here.",
+        ignore_table=True,
+        session_id="sess-1",
+        page_num=3,  # (3-1) % 5 != 0 이고 1도 아니므로 짧은 프롬프트 경로
+    ))
+    prompt = capture_antigravity_prompt[0]
+    assert "Markdown 표" in prompt and "완전히 제외" in prompt
+
+
+@pytest.mark.asyncio
+async def test_short_prompt_omits_table_reminder_when_not_ignoring(capture_antigravity_prompt):
+    await _drain(llm_client.stream_translation(
+        text="[S0] Some table content here.",
+        ignore_table=False,
+        session_id="sess-1",
+        page_num=3,
+    ))
+    prompt = capture_antigravity_prompt[0]
+    assert "Markdown 표" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_short_prompt_reminds_ignore_math_and_refs(capture_antigravity_prompt):
+    await _drain(llm_client.stream_translation(
+        text="[S0] Some equation content here.",
+        ignore_math=True,
+        ignore_table=False,
+        ignore_refs=True,
+        session_id="sess-1",
+        page_num=3,
+    ))
+    prompt = capture_antigravity_prompt[0]
+    assert "수식은 번역하지 말고" in prompt
+    assert "참고문헌" in prompt
+
+
+@pytest.mark.asyncio
+async def test_reminder_page_uses_full_prompt_not_short_prompt(capture_antigravity_prompt, monkeypatch):
+    """page_num=1(리마인드 페이지)은 짧은 프롬프트 경로를 타지 않고 전체
+    규칙이 담긴 프롬프트를 그대로 사용해야 한다."""
+    monkeypatch.setattr(llm_client, "get_translation_prompt_template", lambda: (
+        "{{LANG_INSTRUCTION}}\n{{STYLE_INSTRUCTION}}\n{{RULES_TEXT}}\n{{CONTEXT_PART}}\n{{TEXT}}\n{{TARGET_LANG}}"
+    ))
+    await _drain(llm_client.stream_translation(
+        text="[S0] Some table content here.",
+        ignore_table=True,
+        session_id="sess-1",
+        page_num=1,
+    ))
+    prompt = capture_antigravity_prompt[0]
+    # 전체 프롬프트 경로는 "앞서 안내한 규칙을 유지" 문구를 쓰지 않는다
+    assert "앞서 안내한" not in prompt
+    assert "완전히 제외" in prompt


### PR DESCRIPTION
# Summary
## 1. 짧은 프롬프트에 표/수식/참고문헌 제외 규칙 재포함
- `services/llm_client.py`의 `stream_translation()`: antigravity/claude_code/codex처럼 세션이 유지되는 provider는 5페이지마다 한 번만 전체 규칙을 리마인드하고, 그 사이 페이지들은 "앞서 안내한 문체·용어·수식·표·참고문헌 처리 규칙을 동일하게 유지"라는 말만 담긴 짧은 프롬프트를 씀
- 문제: 표 제외("Markdown 표 형식의 출력은 절대 하지 말고...")처럼 시각적으로 두드러진 콘텐츠에 대한 규칙은, 세션이 길어질수록 이 짧은 프롬프트만으로는 모델이 잊어버려 번역 결과에 표가 그대로 섞여 들어오는 경우가 있었음(원본 텍스트에 표가 포함된 페이지에서 특히 눈에 띔)
- 수정: `ignore_math`/`ignore_table`/`ignore_refs` 옵션이 켜져 있으면, 5페이지 리마인드 주기와 무관하게 매 페이지 짧은 프롬프트에도 해당 제외 규칙을 명시적으로 다시 포함하도록 변경(옵션이 꺼져 있으면 당연히 추가하지 않음)

## 2. 테스트 추가 (`backend/tests/test_llm_client_prompt.py`)
- 짧은 프롬프트 경로(비-리마인드 페이지)에서 `ignore_table=True`일 때 표 제외 문구가 실제로 프롬프트에 포함되는지, `False`일 때는 포함되지 않는지 검증
- `ignore_math`/`ignore_refs` 조합도 동일하게 검증
- 리마인드 페이지(`page_num=1`)는 짧은 프롬프트 경로를 타지 않고 전체 프롬프트를 그대로 쓰는지 검증

## Test plan
- [x] `pytest tests/test_llm_client_prompt.py` 4개 전부 통과
- [x] `pytest` 전체 스위트 121개 전부 통과 (회귀 없음)
- [x] 실제 호출 전 수동 검증: `stream_antigravity`를 모킹해 `page_num=3`(비-리마인드 페이지) 프롬프트를 캡처, 표 제외 문구가 실제로 포함됨을 확인