### PR TITLE
fix: PDF 내보내기에서 markdown 볼드/LaTeX 수식 렌더링 수정

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ httpx==0.27.2
 pydantic==2.8.2
 aiofiles==23.2.1
 python-dotenv==1.0.1
+matplotlib==3.11.1
+pillow==12.3.0

--- a/backend/services/pdf_export.py
+++ b/backend/services/pdf_export.py
@@ -15,12 +15,16 @@
 그 항목만 조용히 건너뛴다(전체 내보내기가 실패하지 않음).
 """
 
+import base64
 import io
 import re
 from html import escape as html_escape
 from typing import Optional
 
 import fitz
+from matplotlib import mathtext
+from matplotlib.font_manager import FontProperties
+from PIL import Image
 
 _HIGHLIGHT_DEFAULT_COLOR = (1, 0.92, 0.23)  # 노랑
 _UNDERLINE_DEFAULT_COLOR = (0.93, 0.26, 0.26)  # 빨강
@@ -28,6 +32,18 @@ _UNDERLINE_DEFAULT_COLOR = (0.93, 0.26, 0.26)  # 빨강
 # PyMuPDF 내장 CJK 폰트 - 기본 14종 폰트(helv 등)는 한글 글리프가 없어
 # "??"로만 표시되므로, 한글이 섞인 텍스트는 반드시 이 폰트를 써야 한다.
 _KOREAN_TEXTBOX_FONT = "korea"
+
+# 번역 텍스트 안의 "**볼드**" 및 "$인라인 수식$"/"$$블록 수식$$" 를 찾기 위한
+# 패턴. $$...$$를 $...$보다 먼저 시도해야 블록 수식이 인라인으로 잘못
+# 쪼개지지 않는다.
+_FORMULA_SPLIT_RE = re.compile(r"(\$\$.+?\$\$|\$[^$\n]+?\$)", re.DOTALL)
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+# matplotlib mathtext에 내장된 수식용 폰트는 한글 글리프가 없어(뷰어의 KaTeX와
+# 달리 시스템 폰트로 대체되지 않음) 한글이 섞인 "수식"을 렌더링하면 네모 박스
+# (tofu)로 깨진다. 번역 모델이 `\text{여기서 ...}`처럼 수식 안에 한글 설명을
+# 끼워 넣는 경우가 실제로 있어, 이런 세그먼트는 이미지 렌더링을 시도하지 않고
+# 일반 텍스트로 안전하게 대체한다.
+_HANGUL_RE = re.compile(r"[가-힣]")
 
 
 def _hex_to_rgb01(hex_color: Optional[str], fallback: tuple) -> tuple:
@@ -98,15 +114,95 @@ def _run_story_pages(html: str) -> fitz.Document:
     return fitz.open("pdf", buf.read())
 
 
+def _render_formula_img_tag(formula: str, fontsize: float) -> Optional[str]:
+    """LaTeX 수식 문자열을 matplotlib의 mathtext로 렌더링해 <img> 태그로
+    반환한다. PyMuPDF의 Story/insert_htmlbox HTML 엔진은 MathML/LaTeX를 전혀
+    해석하지 못해(렌더링해보면 태그와 수식 구조가 통째로 사라지고 글자만
+    나열됨) 수식을 이렇게 별도 이미지로 만들어 끼워 넣지 않으면 뷰어에서
+    보던 수식이 원문 그대로의 "$", "\\frac" 같은 깨진 텍스트로 노출된다.
+
+    렌더링에 실패하면(mathtext가 지원하지 않는 LaTeX 명령 등) None을 반환해
+    호출부가 원문 텍스트로라도 대체할 수 있게 한다 - 전체 내보내기가
+    실패하면 안 되므로.
+    """
+    formula = formula.strip()
+    if not formula:
+        return None
+    try:
+        dpi = 200
+        buf = io.BytesIO()
+        mathtext.math_to_image(f"${formula}$", buf, dpi=dpi, prop=FontProperties(size=fontsize), format="png")
+        png_bytes = buf.getvalue()
+        with Image.open(io.BytesIO(png_bytes)) as im:
+            px_w, px_h = im.size
+        pt_w, pt_h = px_w / dpi * 72, px_h / dpi * 72
+        b64 = base64.b64encode(png_bytes).decode("ascii")
+        # PyMuPDF의 HTML 엔진은 <img>에 vertical-align을 적용하지 않아(테스트로
+        # 확인) 이미지 하단이 텍스트 기준선에 맞춰진다 - 수식이 줄 높이보다
+        # 커서 살짝 위로 떠 보일 수 있지만, 원문 그대로의 깨진 LaTeX 텍스트보다는
+        # 훨씬 낫다.
+        return f'<img src="data:image/png;base64,{b64}" width="{pt_w:.1f}" height="{pt_h:.1f}">'
+    except Exception:
+        return None
+
+
+def _plain_text_with_bold_to_html(text: str) -> str:
+    """"**볼드**" 마크다운만 처리하는 일반 텍스트 -> HTML 변환 (수식이 아닌
+    구간, 그리고 한글이 섞여 렌더링할 수 없는 "가짜 수식" 구간에 공통으로 쓴다)."""
+    parts = []
+    pos = 0
+    for m in _BOLD_RE.finditer(text):
+        parts.append(html_escape(text[pos:m.start()]))
+        parts.append(f"<b>{html_escape(m.group(1))}</b>")
+        pos = m.end()
+    parts.append(html_escape(text[pos:]))
+    return "".join(parts)
+
+
+def _inline_content_to_html(text: str, fontsize: float) -> str:
+    """"**볼드**"와 "$인라인 수식$"/"$$블록 수식$$"이 섞인 한 문단 텍스트를,
+    HTML 이스케이프된 일반 텍스트 + <b> + 수식 이미지가 섞인 HTML로 변환한다."""
+    html_parts = []
+    for chunk in _FORMULA_SPLIT_RE.split(text):
+        if not chunk:
+            continue
+        is_block = chunk.startswith("$$") and chunk.endswith("$$")
+        is_inline = not is_block and chunk.startswith("$") and chunk.endswith("$")
+        if is_block or is_inline:
+            formula = chunk.strip("$")
+            # 한글이 섞인 "수식"(예: \text{여기서 ...})은 mathtext 폰트에 한글
+            # 글리프가 없어 렌더링해도 네모 박스로 깨지므로 애초에 이미지로
+            # 만들지 않는다.
+            img_tag = None if _HANGUL_RE.search(formula) else _render_formula_img_tag(
+                formula, fontsize=fontsize * (1.25 if is_block else 1.0)
+            )
+            if img_tag:
+                html_parts.append(
+                    f'<div style="text-align:center; margin:4pt 0;">{img_tag}</div>' if is_block else img_tag
+                )
+            else:
+                # 렌더링을 시도하지 않았거나 실패한 경우, 전체 내보내기를 막지
+                # 않도록 "$" 구분자만 뗀 원문을 일반 텍스트로 대체 표시한다.
+                html_parts.append(_plain_text_with_bold_to_html(formula))
+            continue
+
+        html_parts.append(_plain_text_with_bold_to_html(chunk))
+    return "".join(html_parts)
+
+
 def _build_page_translation_html(text: str) -> str:
     """한 페이지 분량의 번역 전문을 문단 단위 HTML로 변환한다 (뷰어의 번역
     패널과 나란히 놓일 페이지이므로 문서 제목/페이지 번호 같은 반복 헤더는
     넣지 않는다 - 원본 페이지 쪽에 이미 그 정보가 그대로 보이기 때문)."""
+    fontsize = 10.5
     parts = ['<div style="font-family: sans-serif;">']
     for para in re.split(r"\n\s*\n", text):
         para = para.strip()
         if para:
-            parts.append(f'<p style="font-size: 10.5pt; line-height: 1.6; text-align: justify;">{html_escape(para)}</p>')
+            parts.append(
+                f'<p style="font-size: {fontsize}pt; line-height: 1.6; text-align: justify;">'
+                f'{_inline_content_to_html(para, fontsize)}</p>'
+            )
     parts.append("</div>")
     return "".join(parts)
 

--- a/backend/tests/test_pdf_export.py
+++ b/backend/tests/test_pdf_export.py
@@ -104,6 +104,44 @@ def test_generate_pdf_shrinks_long_translation_to_fit_single_page(sample_pdf):
     doc.close()
 
 
+def test_generate_pdf_renders_markdown_bold_without_literal_asterisks(sample_pdf):
+    """번역 텍스트의 "**볼드**" 마크다운이 <b> 태그로 변환되어야 하며, 원문
+    그대로의 "**" 기호가 출력 텍스트에 남아있으면 안 된다."""
+    translations = {"1": "이것은 **매우 중요한** 결과입니다."}
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
+    doc = fitz.open("pdf", result)
+    page1_text = doc[0].get_text()
+    assert "**" not in page1_text
+    assert "매우 중요한" in page1_text
+    doc.close()
+
+
+def test_generate_pdf_renders_latex_formula_as_image_not_raw_text(sample_pdf):
+    """번역 텍스트의 LaTeX 수식($...$/$$...$$)은 원문 그대로의 "$", "\\sum"
+    같은 기호로 노출되지 말고, 실제 렌더링된 이미지로 삽입되어야 한다."""
+    translations = {"1": "손실 함수는 $f(x) = \\sum_{i=1}^n x_i$ 로 정의됩니다."}
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
+    doc = fitz.open("pdf", result)
+    page1_text = doc[0].get_text()
+    assert "$" not in page1_text
+    assert "\\sum" not in page1_text
+    assert len(doc[0].get_images()) >= 1  # 수식이 이미지로 삽입됨
+    doc.close()
+
+
+def test_generate_pdf_falls_back_to_plain_text_for_korean_inside_formula(sample_pdf):
+    """수식 렌더링용 폰트(matplotlib mathtext)에는 한글 글리프가 없어, 번역
+    모델이 실수로 수식 안에 한글을 넣은 경우(예: \\text{여기서 ...}) 그대로
+    이미지화하면 네모 박스(tofu)로 깨진다 - 이 경우는 이미지 대신 일반
+    텍스트로 안전하게 대체되어야 하며, 예외 없이 내보내기가 끝나야 한다."""
+    translations = {"1": "다음이 성립합니다: $\\int f(z) dz \\quad \\left(\\text{여기서 } z \\sim p(z)\\right)$"}
+    result = generate_annotated_pdf(sample_pdf, {}, translations, {})
+    doc = fitz.open("pdf", result)
+    page1_text = doc[0].get_text()
+    assert "여기서" in page1_text  # 렌더링 대신 텍스트로라도 내용은 보존되어야 함
+    doc.close()
+
+
 def test_generate_pdf_shows_placeholder_for_page_without_translation(sample_pdf):
     """일부 페이지만 번역이 있는 경우, 번역이 없는 페이지는 페어링이 깨지지
     않도록 안내 문구만 표시하고 페이지 자체는 그대로 유지해야 한다."""


### PR DESCRIPTION
# Summary
## 1. 수식/볼드 마크다운이 원문 그대로 노출되던 문제 수정
- 번역 텍스트에는 뷰어에서 marked+KaTeX로 렌더링하는 `**볼드**`, `$인라인 수식$`, `$$블록 수식$$` 문법이 그대로 포함되어 있는데, PDF 내보내기(`_build_page_translation_html`)는 단순 `html_escape`만 거쳐서 이 기호들이 원문 그대로("**", "$", "\\sum" 등) 노출되고 있었음
- PyMuPDF의 Story/`insert_htmlbox` HTML 엔진은 MathML을 아예 해석하지 못함(직접 확인 - `<math><mfrac>...` 태그를 넣어도 구조가 전부 사라지고 글자만 나열됨)을 확인하고, 대신 `matplotlib.mathtext.math_to_image()`로 LaTeX 수식을 PNG로 렌더링해 `<img>`로 삽입하는 방식을 채택
- `**볼드**`는 `<b>` 태그로 변환

## 2. 한글이 섞인 "수식" 처리
- 실제 번역 결과를 검사해보니 모델이 종종 `\text{여기서 ...}`처럼 수식 안에 한글 설명을 끼워 넣는 경우가 있었는데, matplotlib mathtext의 내장 수식 폰트에는 한글 글리프가 없어(뷰어의 KaTeX는 `\text{}`를 시스템 폰트로 렌더링하므로 문제없음) 그대로 이미지화하면 네모 박스(tofu)로 깨짐
- 수식 세그먼트에 한글이 포함되어 있으면 이미지 렌더링을 시도하지 않고 `$` 구분자만 뗀 일반 텍스트로 안전하게 대체하도록 처리(예외 없이 읽을 수 있는 내용은 보존)
- 그 외 렌더링 실패(지원하지 않는 LaTeX 명령 등)도 동일하게 원문 텍스트로 폴백해 전체 내보내기가 실패하지 않도록 함

## 3. 의존성 추가
- `matplotlib==3.11.1`, `pillow==12.3.0`을 `requirements.txt`에 추가 (수식 이미지 렌더링 및 크기 측정용)

## Test plan
- [x] `pytest tests/test_pdf_export.py` 13개 전부 통과(마크다운 볼드 변환, LaTeX 수식 이미지화, 한글 섞인 수식 폴백 테스트 3개 신규 추가)
- [x] `pytest` 전체 스위트 124개 전부 통과 (회귀 없음)
- [x] 실제 논문(VAE.pdf, 수식이 많은 논문)의 실제 번역 결과로 전체 내보내기 실행 - 블록/인라인 수식이 실제 수식처럼 렌더링되는 것을 이미지로 시각 확인, 한글이 섞인 두 개의 실제 수식 세그먼트에서도 예외나 깨진 글리프 없이 정상적으로 폴백되는 것 확인