### PR TITLE
fix: 서브플롯 여러 개로 나뉜 그림의 호버 오버레이가 절반만 보이던 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -825,7 +825,16 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
         # 3. 바운딩 박스 그룹화 (인접 임계값을 4.0포인트로 대폭 좁혀서 과도하게 커지는 현상 방지)
         merged_rects = merge_bboxes(raw_rects, threshold=4.0)
         
-        # 4. 여백 보정 및 최소 규격 필터링
+        # 4. 캡션 매칭 - 그림이 여러 서브플롯(sub-panel)으로 나뉘어 그려진
+        # 경우(예: "왼쪽/오른쪽" 두 그래프로 구성된 Figure), 각 서브플롯이
+        # 독립된 사각형으로 감지되어 같은 캡션 하나에 개별적으로 매칭될 수
+        # 있다. 이걸 그대로 각각 별도 항목으로 내보내면 프론트엔드가 그중
+        # 하나만 골라 써서(예: 왼쪽 패널만 보이고 오른쪽이 통째로 잘려나감)
+        # 오버레이가 실제 그림 전체를 담지 못하는 문제가 있었다. 따라서 같은
+        # 라벨로 매칭된 사각형들은 최종적으로 하나의 bbox로 합친다.
+        label_groups: Dict[str, Dict[str, Any]] = {}
+        unlabeled_rects = []
+
         for r in merged_rects:
             # 캡션 매칭은 패딩을 적용하기 전 원본 사각형 기준으로 수행 (더 정확한 인접도 판단)
             match = _match_caption_for_rect(r, page_captions)
@@ -838,34 +847,48 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
                 rect_y1 = min(rect_y1, match["clip_y1"])
             if match.get("clip_y0") is not None:
                 rect_y0 = max(rect_y0, match["clip_y0"])
+            clipped = [r[0], rect_y0, r[2], rect_y1]
 
+            label = match["label"]
+            if not label:
+                unlabeled_rects.append(clipped)
+                continue
+            if label in label_groups:
+                g = label_groups[label]["rect"]
+                g[0] = min(g[0], clipped[0])
+                g[1] = min(g[1], clipped[1])
+                g[2] = max(g[2], clipped[2])
+                g[3] = max(g[3], clipped[3])
+            else:
+                label_groups[label] = {"rect": clipped, "text": match["text"]}
+
+        def _emit(rect: list, label: Optional[str], caption_text: Optional[str]) -> None:
             # 여백(Padding) 8포인트 적용하여 차트 라벨이나 테이블 테두리가 잘리지 않도록 안전 확보
-            x0 = max(0.0, r[0] - 8.0)
-            y0 = max(0.0, rect_y0 - 8.0)
-            x1 = min(page_width, r[2] + 8.0)
-            y1 = min(page_height, rect_y1 + 8.0)
+            x0 = max(0.0, rect[0] - 8.0)
+            y0 = max(0.0, rect[1] - 8.0)
+            x1 = min(page_width, rect[2] + 8.0)
+            y1 = min(page_height, rect[3] + 8.0)
 
             w = x1 - x0
             h = y1 - y0
             # 최종 크기가 가로/세로 40포인트 이상인 진짜 그림/테이블만 선별
             if w < 40 or h < 40:
-                continue
-
-            # 백분율 좌표 계산
-            left = (x0 / page_width) * 100
-            top = (y0 / page_height) * 100
-            width = (w / page_width) * 100
-            height = (h / page_height) * 100
+                return
 
             images_data.append({
                 "page": page_num + 1,
-                "left": left,
-                "top": top,
-                "width": width,
-                "height": height,
-                "label": match["label"],
-                "caption": match["text"],
+                "left": (x0 / page_width) * 100,
+                "top": (y0 / page_height) * 100,
+                "width": (w / page_width) * 100,
+                "height": (h / page_height) * 100,
+                "label": label,
+                "caption": caption_text,
             })
+
+        for label, g in label_groups.items():
+            _emit(g["rect"], label, g["text"])
+        for rect in unlabeled_rects:
+            _emit(rect, None, None)
 
         # 5. 번호 매겨진 수식 - 그림/표와 달리 별도 그래픽 영역이 아니라 텍스트 한
         # 줄이므로, 위의 40pt 최소 크기 필터를 거치지 않고 그 줄의 bbox에 작은

--- a/backend/tests/test_pdf_parser_images.py
+++ b/backend/tests/test_pdf_parser_images.py
@@ -1,0 +1,79 @@
+"""services/pdf_parser.py의 extract_pdf_images() 테스트 - 그림/표/수식 좌표
+및 캡션 라벨 추출."""
+
+import fitz
+import pytest
+
+from services.pdf_parser import extract_pdf_images
+
+
+def test_multi_panel_figure_merges_into_single_labeled_region(tmp_path):
+    """하나의 그림이 좌/우 두 개의 서브플롯(sub-panel)으로 나뉘어 그려진
+    경우(예: matplotlib의 두 서브플롯을 나란히 배치한 Figure), 각 패널이
+    독립된 벡터 그래픽 영역으로 감지되어 같은 캡션에 개별적으로 매칭될 수
+    있다. 이를 각각 별도 항목으로 내보내면 프론트엔드가 그중 하나만 골라
+    써서 그림의 절반이 통째로 잘려나가는 버그가 있었다 - 같은 라벨로
+    매칭된 사각형들은 하나로 합쳐져야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    # 좌측 서브플롯 (테두리가 있는 벡터 사각형 - 흰 배경 채우기가 아니므로
+    # 배경 필터에 걸리지 않음)
+    left_rect = fitz.Rect(50, 100, 250, 300)
+    page.draw_rect(left_rect, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(60, 150), fitz.Point(240, 250), color=(0, 0, 0), width=1)
+
+    # 우측 서브플롯 - 좌측과 40pt 넘게 떨어져 있어(벡터 클러스터링 임계값
+    # 10pt를 넘음) 별도 클러스터로 감지됨
+    right_rect = fitz.Rect(340, 100, 540, 300)
+    page.draw_rect(right_rect, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(350, 250), fitz.Point(530, 150), color=(0, 0, 0), width=1)
+
+    # 두 패널 폭 전체에 걸친 캡션 한 줄 (두 사각형 모두와 가로로 겹치도록 충분히 길게)
+    page.insert_text(
+        (50, 320),
+        "Figure 1: Left panel shows metric A across settings, right panel shows metric B for comparison.",
+        fontsize=9,
+    )
+
+    path = tmp_path / "multi_panel.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    fig1_entries = [r for r in result if r.get("label") == "Figure 1"]
+
+    assert len(fig1_entries) == 1, f"Figure 1이 하나로 합쳐져야 하는데 {len(fig1_entries)}개로 쪼개짐: {fig1_entries}"
+
+    entry = fig1_entries[0]
+    # 합쳐진 bbox가 좌측 패널의 왼쪽 끝부터 우측 패널의 오른쪽 끝까지를 모두 포함해야 함
+    entry_left_pct = entry["left"]
+    entry_right_pct = entry["left"] + entry["width"]
+    page_width = 595
+    assert entry_left_pct <= (left_rect.x0 / page_width) * 100 + 1
+    assert entry_right_pct >= (right_rect.x1 / page_width) * 100 - 1
+
+
+def test_unrelated_unlabeled_regions_are_not_merged(tmp_path):
+    """캡션에 매칭되지 않는(라벨이 없는) 영역들은 서로 다른 그림/표의 잔여
+    조각일 수 있으므로 하나로 합쳐지면 안 되고, 감지된 개수만큼 개별
+    항목으로 남아야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    r1 = fitz.Rect(50, 100, 250, 300)
+    page.draw_rect(r1, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(60, 150), fitz.Point(240, 250), color=(0, 0, 0), width=1)
+
+    r2 = fitz.Rect(340, 500, 540, 700)
+    page.draw_rect(r2, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(350, 550), fitz.Point(530, 650), color=(0, 0, 0), width=1)
+    # 캡션을 넣지 않아 두 영역 모두 라벨이 없는 상태로 남는다
+
+    path = tmp_path / "unlabeled.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    unlabeled = [r for r in result if not r.get("label")]
+    assert len(unlabeled) == 2


### PR DESCRIPTION
# Summary
## 1. 원인
- 좌/우 두 개의 서브플롯으로 구성된 그림(예: matplotlib으로 나란히 그린 두 그래프)은 벡터 그래픽 클러스터링(#133에서 추가) 단계에서 두 패널이 서로 멀리 떨어져 있어 별도의 사각형 두 개로 감지됨
- 두 사각형 모두 같은 캡션("Fig. 4. ...") 하나에 독립적으로 매칭되어, `documentImages` 응답에 동일한 `label: "Figure 4"`를 가진 항목이 두 개 생성됨
- 프론트엔드의 `images.find(img => img.label === label)`는 첫 번째 매칭 항목만 사용하므로, 왼쪽 패널만 오버레이로 보이고 오른쪽 패널은 통째로 잘려나가는 버그 발생 (`ask/fig4.png` vs `ask/fig4_hover.png` 스크린샷으로 재현 확인)

## 2. 수정 (`backend/services/pdf_parser.py`)
- `extract_pdf_images`의 캡션 매칭 단계를 재구성: 각 후보 사각형을 캡션에 매칭한 뒤 바로 내보내는 대신, 먼저 라벨별로 그룹화(`label_groups`)
- 같은 라벨로 매칭된 사각형이 여러 개면 하나의 bbox로 합쳐서(union) 최종 한 항목만 내보냄 - 그림이 몇 개의 서브플롯으로 쪼개져 감지되든 항상 온전한 그림 전체가 오버레이로 나오도록 보장
- 라벨이 없는(캡션에 매칭되지 않은) 사각형들은 서로 다른 그림/표의 잔여 조각일 수 있으므로 합치지 않고 기존대로 개별 유지

## 3. 테스트
- `backend/tests/test_pdf_parser_images.py` 신규 추가: 합성 PDF로 두 서브플롯이 하나의 캡션에 매칭될 때 단일 bbox로 합쳐지는지, 라벨 없는 영역들은 서로 합쳐지지 않는지 검증

## Test plan
- [x] `pytest tests/test_pdf_parser_images.py` 2개 전부 통과
- [x] `pytest` 전체 스위트 126개 전부 통과 (회귀 없음)
- [x] 실제 버그 재현 문서(Uniformer.pdf)로 재확인 - 기존에 `Figure 4` 항목이 좌/우 패널 두 개로 쪼개져 있던 것이 수정 후 하나의 항목(두 패널을 모두 포함하는 bbox)으로 합쳐짐. 해당 bbox로 크롭한 이미지가 원본 그림 전체(`ask/fig4.png`)와 동일하게 나오는 것을 렌더링 이미지로 시각 확인
- [x] 라이브러리 전체 문서(53개) 대상 `extract_pdf_images` 전수 실행 - 크래시 없음, 같은 페이지 내 라벨 중복 잔존 사례 0건