### PR TITLE
fix: 상하로 쌓인 서브패널 그림의 호버 오버레이 잘림 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -672,6 +672,33 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
     return equations
 
 
+def _vertical_gap(a: list, b: list) -> float:
+    """두 사각형의 세로 간격을 반환한다. 겹치면 -1."""
+    if a[3] <= b[1]:
+        return b[1] - a[3]
+    if b[3] <= a[1]:
+        return a[1] - b[3]
+    return -1.0
+
+
+def _horizontal_overlap_ratio(a: list, b: list) -> float:
+    """더 좁은 쪽 폭을 기준으로 한 가로 겹침 비율(0~1)."""
+    inter = min(a[2], b[2]) - max(a[0], b[0])
+    if inter <= 0:
+        return 0.0
+    narrower_width = min(a[2] - a[0], b[2] - b[0])
+    return inter / narrower_width if narrower_width > 0 else 0.0
+
+
+# 라벨(캡션)에 매칭되지 못한 인접 사각형을 흡수할 때 허용하는 최대 세로 간격.
+# "(a) DeiT.", "(b) TimeSformer." 처럼 여러 행(row)의 서브패널로 구성된 큰
+# 그림은 캡션과 맨 아래 패널까지의 거리는 멀어도(캡션 매칭용 40pt를 훌쩍
+# 넘음), 패널들 자기들끼리는 촘촘히 붙어 있으므로 이 값은 캡션 매칭
+# 임계값(40pt)과 동일하게 맞춘다.
+_PANEL_ABSORB_MAX_GAP = 40.0
+_PANEL_ABSORB_MIN_OVERLAP = 0.5
+
+
 def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
     """
     PDF의 각 페이지에서 실제 그림/이미지(Figure) 및 테이블(Table)의 영역 정보를 추출합니다.
@@ -861,6 +888,36 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
                 g[3] = max(g[3], clipped[3])
             else:
                 label_groups[label] = {"rect": clipped, "text": match["text"]}
+
+        # 4-1. 캡션과 멀리 떨어져 있어(예: 여러 행(row)의 서브패널로 구성된 큰
+        # 그림에서 맨 윗 패널) 라벨 매칭에는 실패했지만, 이미 라벨이 붙은
+        # 사각형과 촘촘히 붙어 있는(세로 간격이 작고 가로로 많이 겹치는)
+        # 미매칭 사각형은 같은 그림의 일부로 보고 흡수한다. 한 번 흡수하면
+        # 그룹의 bbox가 커져 다음 패널과도 새로 인접할 수 있으므로 더 이상
+        # 흡수할 것이 없을 때까지 반복한다.
+        changed = True
+        while changed and unlabeled_rects:
+            changed = False
+            still_unlabeled = []
+            for u in unlabeled_rects:
+                absorbed = False
+                for g in label_groups.values():
+                    rect = g["rect"]
+                    gap = _vertical_gap(rect, u)
+                    if gap < 0 or gap > _PANEL_ABSORB_MAX_GAP:
+                        continue
+                    if _horizontal_overlap_ratio(rect, u) < _PANEL_ABSORB_MIN_OVERLAP:
+                        continue
+                    rect[0] = min(rect[0], u[0])
+                    rect[1] = min(rect[1], u[1])
+                    rect[2] = max(rect[2], u[2])
+                    rect[3] = max(rect[3], u[3])
+                    absorbed = True
+                    changed = True
+                    break
+                if not absorbed:
+                    still_unlabeled.append(u)
+            unlabeled_rects = still_unlabeled
 
         def _emit(rect: list, label: Optional[str], caption_text: Optional[str]) -> None:
             # 여백(Padding) 8포인트 적용하여 차트 라벨이나 테이블 테두리가 잘리지 않도록 안전 확보

--- a/backend/tests/test_pdf_parser_images.py
+++ b/backend/tests/test_pdf_parser_images.py
@@ -54,6 +54,47 @@ def test_multi_panel_figure_merges_into_single_labeled_region(tmp_path):
     assert entry_right_pct >= (right_rect.x1 / page_width) * 100 - 1
 
 
+def test_stacked_panel_figure_absorbs_distant_unlabeled_panel(tmp_path):
+    """"(a) DeiT.", "(b) TimeSformer."처럼 여러 행(row)의 서브패널이 위아래로
+    쌓인 큰 그림은, 맨 아래 패널만 캡션과 가까워(40pt 이내) 매칭되고 맨 위
+    패널은 캡션까지의 총 거리가 멀어 매칭에 실패할 수 있다. 이 경우에도
+    아래 패널(라벨 있음)과 위 패널(라벨 없음) 사이 간격 자체는 좁으므로,
+    위 패널이 흡수되어 최종적으로 그림 전체를 포함하는 하나의 bbox가
+    나와야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    # 위쪽 패널(라벨 없음이 될 것) - 캡션과는 멀리 떨어져 있음
+    top_rect = fitz.Rect(50, 50, 500, 200)
+    page.draw_rect(top_rect, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(60, 100), fitz.Point(480, 150), color=(0, 0, 0), width=1)
+    page.insert_text((260, 215), "(a) Panel A.", fontsize=8)
+
+    # 아래쪽 패널(캡션과 가까워 라벨이 매칭될 것) - 위쪽 패널과는 20pt 간격
+    bottom_rect = fitz.Rect(50, 220, 500, 400)
+    page.draw_rect(bottom_rect, color=(0, 0, 0), width=1.5)
+    page.draw_line(fitz.Point(60, 300), fitz.Point(480, 350), color=(0, 0, 0), width=1)
+    page.insert_text((260, 415), "(b) Panel B.", fontsize=8)
+
+    page.insert_text((50, 435), "Figure 3: Stacked panels showing two related results.", fontsize=9)
+
+    path = tmp_path / "stacked_panel.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    fig3_entries = [r for r in result if r.get("label") == "Figure 3"]
+    assert len(fig3_entries) == 1, f"Figure 3이 하나로 합쳐져야 하는데: {fig3_entries}"
+
+    entry = fig3_entries[0]
+    page_height = 842
+    entry_top_pct = entry["top"]
+    entry_bottom_pct = entry["top"] + entry["height"]
+    # 합쳐진 bbox가 위쪽 패널의 위 끝부터 아래쪽 패널의 아래 끝까지 모두 포함해야 함
+    assert entry_top_pct <= (top_rect.y0 / page_height) * 100 + 1
+    assert entry_bottom_pct >= (bottom_rect.y1 / page_height) * 100 - 1
+
+
 def test_unrelated_unlabeled_regions_are_not_merged(tmp_path):
     """캡션에 매칭되지 않는(라벨이 없는) 영역들은 서로 다른 그림/표의 잔여
     조각일 수 있으므로 하나로 합쳐지면 안 되고, 감지된 개수만큼 개별


### PR DESCRIPTION
# Summary
## 1. 원인
- #140에서 좌/우로 나란히 배치된 서브패널(같은 캡션에 동시 매칭되는 경우)을 하나로 합치도록 고쳤지만, "(a) DeiT.", "(b) TimeSformer."처럼 여러 행(row)의 서브패널이 위아래로 쌓인 그림은 여전히 문제가 있었음
- 이런 그림은 맨 아래 패널만 캡션과 가까워(40pt 이내 거리) 매칭되고, 맨 위 패널은 캡션까지의 총 거리가 훨씬 멀어(패널 자체 높이만큼) 매칭에 실패해 라벨 없이 버려짐
- 결과적으로 호버 오버레이에 아래쪽 패널만 나오고 위쪽 패널 전체가 잘려나감 (`ask/fig2.png` vs `ask/fig2_hover.png`로 재현 확인 - Uniformer.pdf의 Figure 2에서 DeiT 파트 전체가 잘리고 TimeSformer 파트만 보임)

## 2. 수정 (`backend/services/pdf_parser.py`)
- 라벨 매칭 이후 흡수(absorb) 패스 추가: 라벨이 매칭된 사각형과 세로 간격이 좁고(40pt 이내) 가로로 많이 겹치는(50% 이상) 미매칭 사각형을 같은 그림의 일부로 보고 흡수해 하나의 bbox로 합침
- 흡수는 반복 적용되어(더 이상 흡수할 게 없을 때까지) 3개 이상의 행으로 쌓인 그림도 처리 가능
- 라벨이 없는 사각형끼리는 서로 합치지 않음 - 서로 다른 그림/표의 잔여 조각일 수 있으므로 신중하게 "이미 라벨이 붙은 그룹에 흡수"되는 경우만 처리

## 3. 테스트
- `backend/tests/test_pdf_parser_images.py`에 상하로 쌓인 패널이 흡수되어 하나로 합쳐지는지 검증하는 테스트 추가

## Test plan
- [x] `pytest tests/test_pdf_parser_images.py` 3개 전부 통과
- [x] `pytest` 전체 스위트 127개 전부 통과 (회귀 없음)
- [x] 실제 버그 재현 문서(Uniformer.pdf Figure 2)로 재확인 - 수정 후 DeiT+TimeSformer 두 블록이 모두 포함된 하나의 bbox로 합쳐지고, 크롭 이미지가 원본 그림 전체(`ask/fig2.png`)와 동일하게 나오는 것을 렌더링 이미지로 시각 확인
- [x] 라이브러리 전체 문서(53개) 대상 `extract_pdf_images` 전수 실행 - 크래시 없음, 과도한 흡수(오버머지) 의심 사례 없음(유일하게 세로 89%를 넘는 항목은 이번 수정과 무관한 기존의 큰 표였음을 확인)