### PR TITLE
feat: main 브랜치 자동 배포 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to Server
+
+# main에 push(=PR 병합 포함)될 때마다 이 서버(orion-gz-network)에 등록된
+# self-hosted runner가 배포 전용 클론(/home/ubuntu/deploy/EasyPaper)을
+# origin/main으로 동기화하고 easypaper.service를 재기동한다.
+#
+# 이 디렉터리는 개발자가 로컬에서 편집하는 작업 디렉토리와는 완전히
+# 분리되어 있어(별도 클론), 로컬 작업 중인 커밋되지 않은 변경과 절대
+# 충돌하지 않는다. 문서 DB/업로드/라이브러리 등 영속 데이터도
+# /home/ubuntu/data/easypaper/(배포 디렉토리와도 별개)에 있어 이 배포
+# 클론을 아무리 초기화해도 데이터 유실이 없다.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, easypaper]
+    steps:
+      - name: Sync deploy clone to origin/main
+        working-directory: /home/ubuntu/deploy/EasyPaper
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+
+      - name: Install backend dependencies
+        working-directory: /home/ubuntu/deploy/EasyPaper/backend
+        run: .venv/bin/pip install -r requirements.txt
+
+      - name: Build frontend
+        working-directory: /home/ubuntu/deploy/EasyPaper/frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Restart easypaper.service
+        run: sudo systemctl restart easypaper
+
+      - name: Health check
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8000/ >/dev/null; then
+              echo "healthcheck OK"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "healthcheck FAILED after 30s"
+          sudo journalctl -u easypaper.service --no-pager -n 50
+          exit 1


### PR DESCRIPTION
# Summary
## 1. CI 자동 배포 워크플로우 추가
- `.github/workflows/deploy.yml`: main에 push(PR 병합 포함)될 때마다 self-hosted runner가 배포 클론을 origin/main으로 동기화하고 백엔드 의존성 설치, 프론트엔드 빌드, `systemctl restart easypaper`, 헬스체크를 수행
- 배포 대상은 개발 작업 디렉토리(`/home/ubuntu/programming/projects/EasyPaper`)와 완전히 분리된 전용 클론(`/home/ubuntu/deploy/EasyPaper`) - 로컬에서 편집 중인 커밋되지 않은 변경과 절대 충돌하지 않음

## 2. 서버 인프라 변경 (이 레포 코드 변경 아님, 참고용)
- GitHub Actions self-hosted runner를 이 서버(orion-gz-network)에 systemd 서비스로 설치/등록
- 영속 데이터(easypaper.db, uploads/, cache/, library/, .env, translation_prompt.txt)를 개발 디렉토리도 배포 디렉토리도 아닌 전용 위치(`/home/ubuntu/data/easypaper/`)로 1회성 이동 - 코드/배포 디렉토리를 나중에 지우거나 재생성해도 데이터에 영향 없음
- `/etc/systemd/system/easypaper.service`(레포에 커밋되지 않는 서버 로컬 설정)를 새 배포 클론 경로 + 새 데이터 경로를 가리키도록 갱신, 컷오버 완료 및 데이터 무결성 확인 완료