### PR TITLE
feat: 어시스턴트 모델을 번역 모델과 동일하게 사용하는 체크박스 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -714,7 +714,12 @@
           <div style="border-top: 1px solid var(--border); padding-top: 15px; margin-top: 15px;">
             <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>AI 어시스턴트 (Chat) 설정</h4>
             <div class="form-group">
-              <label>어시스턴트 AI 제공업체 및 모델</label>
+              <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; font-size: 13px; font-weight: 500; color: var(--text-secondary);">
+                <span>어시스턴트 AI 제공업체 및 모델</span>
+                <label class="checkbox-label" style="font-weight: 400; font-size: 12.5px;">
+                  <input type="checkbox" id="setting-chat-same-as-trans" /> 번역 모델과 동일한 모델 사용
+                </label>
+              </div>
               <div id="setting-chat-provider"></div>
             </div>
           </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -149,6 +149,7 @@ const settingOllamaHost    = $('setting-ollama-host')
 const settingOpenAIKey     = $('setting-openai-key')
 const settingGeminiKey     = $('setting-gemini-key')
 const settingClaudeKey     = $('setting-claude-key')
+const settingChatSameAsTrans = $('setting-chat-same-as-trans')
 
 // (provider/model selects are now custom ProviderModelPicker instances – see below)
 
@@ -2008,13 +2009,33 @@ const chatSidebarPicker = new ProviderModelPicker($('chat-sidebar-provider'), {
 
 const settingTransPicker = new ProviderModelPicker($('setting-trans-provider'), {
   compact: false,
-  onChange: () => updateSettingsUIVisibility()
+  onChange: () => applyChatSameAsTransUI()
 })
 
 const settingChatPicker = new ProviderModelPicker($('setting-chat-provider'), {
   compact: false,
   onChange: () => updateSettingsUIVisibility()
 })
+
+// "번역 모델과 동일한 모델 사용" 체크박스: 켜져 있으면 어시스턴트 선택기를
+// 잠그고 번역 모델 값을 그대로 따라가게 한다.
+function applyChatSameAsTransUI() {
+  const chatProviderEl = $('setting-chat-provider')
+  const checked = !!(settingChatSameAsTrans && settingChatSameAsTrans.checked)
+  if (checked) {
+    const { provider, model } = settingTransPicker.getValue()
+    settingChatPicker.setValue(provider, model)
+  }
+  if (chatProviderEl) {
+    chatProviderEl.style.opacity = checked ? '0.5' : ''
+    chatProviderEl.style.pointerEvents = checked ? 'none' : ''
+  }
+  updateSettingsUIVisibility()
+}
+
+if (settingChatSameAsTrans) {
+  settingChatSameAsTrans.addEventListener('change', applyChatSameAsTransUI)
+}
 
 const POPULAR_MODELS = {} // kept for backward compat
 
@@ -2147,7 +2168,13 @@ async function refreshSystemSettings() {
     settingTransPicker.setValue(sys.trans_provider || 'antigravity', sys.trans_model)
     chatSidebarPicker.setValue(sys.chat_provider || 'antigravity', sys.chat_model)
     settingChatPicker.setValue(sys.chat_provider || 'antigravity', sys.chat_model)
-    
+
+    if (settingChatSameAsTrans) {
+      settingChatSameAsTrans.checked = !!sys.trans_model &&
+        sys.chat_provider === sys.trans_provider && sys.chat_model === sys.trans_model
+    }
+    applyChatSameAsTransUI()
+
     const promptTemplate = $('setting-prompt-template')
     if (promptTemplate) {
       promptTemplate.value = sys.translation_prompt_template || promptTemplate.value
@@ -2165,12 +2192,15 @@ async function refreshSystemSettings() {
 async function changeProviderAndModel(type, newProvider, newModel) {
   try {
     const sys = await getSystemSettingsAPI()
+    // "번역 모델과 동일한 모델 사용"이 켜져 있으면 번역 모델을 바꿀 때
+    // 어시스턴트 모델도 함께 따라가게 한다.
+    const syncChatToTrans = type === 'trans' && !!(settingChatSameAsTrans && settingChatSameAsTrans.checked)
     const payload = {
       ollama_host: sys.ollama_host || '',
       trans_provider: type === 'trans' ? newProvider : (sys.trans_provider || 'antigravity'),
       trans_model: type === 'trans' ? newModel : (sys.trans_model || ''),
-      chat_provider: type === 'chat' ? newProvider : (sys.chat_provider || 'antigravity'),
-      chat_model: type === 'chat' ? newModel : (sys.chat_model || ''),
+      chat_provider: (type === 'chat' || syncChatToTrans) ? newProvider : (sys.chat_provider || 'antigravity'),
+      chat_model: (type === 'chat' || syncChatToTrans) ? newModel : (sys.chat_model || ''),
       openai_api_key: sys.openai_api_key || '',
       gemini_api_key: sys.gemini_api_key || '',
       claude_api_key: sys.claude_api_key || '',
@@ -2180,6 +2210,10 @@ async function changeProviderAndModel(type, newProvider, newModel) {
     // sync settings pickers
     if (type === 'trans') {
       settingTransPicker.setValue(newProvider, newModel)
+      if (syncChatToTrans) {
+        settingChatPicker.setValue(newProvider, newModel)
+        chatSidebarPicker.setValue(newProvider, newModel)
+      }
     } else {
       settingChatPicker.setValue(newProvider, newModel)
     }
@@ -2487,8 +2521,12 @@ systemSettingsForm.addEventListener('submit', async (e) => {
   e.preventDefault()
   
   const { provider: transProvider, model: transModel } = settingTransPicker.getValue()
-  const { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
-  
+  let { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
+  if (settingChatSameAsTrans && settingChatSameAsTrans.checked) {
+    chatProvider = transProvider
+    chatModel = transModel
+  }
+
   if (!transModel) {
     showToast('번역 모델을 선택해주세요.', 'error')
     return
@@ -2530,8 +2568,12 @@ if (advancedSettingsForm) {
     e.preventDefault()
     
     const { provider: transProvider, model: transModel } = settingTransPicker.getValue()
-    const { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
-    
+    let { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
+    if (settingChatSameAsTrans && settingChatSameAsTrans.checked) {
+      chatProvider = transProvider
+      chatModel = transModel
+    }
+
     if (!transModel) {
       showToast('번역 모델을 선택해주세요.', 'error')
       return


### PR DESCRIPTION
# Summary
## 1. "번역 모델과 동일한 모델 사용" 체크박스 추가
- 설정 모달 "모델 설정" 탭의 "AI 어시스턴트 (Chat) 설정" 영역에 체크박스(`#setting-chat-same-as-trans`) 추가
- 체크 시 어시스턴트 모델 선택기(`#setting-chat-provider`)가 잠기고(pointer-events: none, 반투명 처리), 번역 모델 선택값을 그대로 복사해서 사용
- `applyChatSameAsTransUI()` 함수로 체크박스 on/off 및 번역 모델 변경 시 동기화 처리
- 설정 모달을 열 때(`refreshSystemSettings`) 서버에 저장된 trans/chat 값이 서로 같으면 체크박스를 자동으로 켜진 상태로 복원
- 상단 퀵 선택기(`viewer-trans-provider`)로 번역 모델을 바꾸는 경우(`changeProviderAndModel`)에도 체크박스가 켜져 있으면 어시스턴트 모델이 함께 갱신되도록 처리 — 그렇지 않으면 설정 모달을 열지 않고 번역 모델만 바꿨을 때 "동일 모델" 상태가 깨짐
- `system-settings-form`/`advanced-settings-form` 저장 시에도 체크박스가 켜져 있으면 어시스턴트 값을 번역 값으로 강제 일치

## Test plan
- [x] `npm run build` 성공 확인
- [x] Playwright로 브라우저에서 실제 동작 확인: 체크 시 어시스턴트 선택기 값이 번역 모델과 즉시 동일해지고 잠김(pointer-events: none), 해제 시 다시 독립적으로 선택 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)