### PR TITLE
feat: 정보 탭에 GitHub 저장소 카드 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -835,6 +835,30 @@
       <!-- 정보 탭 -->
       <div id="tab-info" class="tab-pane">
         <div class="modal-form">
+          <div class="form-group">
+            <label>EasyPaper 프로젝트</label>
+            <div style="background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-md); padding: 14px 16px; margin-bottom: 12px;">
+              <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 12px;">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" style="flex-shrink: 0; color: var(--text-primary);"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.238 1.838 1.238 1.07 1.834 2.809 1.304 3.495.997.108-.775.42-1.305.763-1.605-2.665-.303-5.467-1.334-5.467-5.93 0-1.31.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23a11.5 11.5 0 0 1 3.003-.404c1.02.005 2.047.138 3.005.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.814 1.103.814 2.222 0 1.606-.015 2.898-.015 3.293 0 .32.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                <div style="min-width: 0;">
+                  <div style="font-size: 14px; font-weight: 600; color: var(--text-primary);">orion-gz / EasyPaper</div>
+                  <div style="font-size: 12px; color: var(--text-secondary); margin-top: 2px;">학술 PDF 논문을 AI로 번역하고, 논문 내용을 바탕으로 바로 대화하는 통합 웹 서비스</div>
+                </div>
+              </div>
+              <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                <a href="https://github.com/orion-gz/EasyPaper" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 4px; padding: 8px 14px; font-size: 12.5px;">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>저장소 방문
+                </a>
+                <a href="https://github.com/orion-gz/EasyPaper/issues" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 4px; padding: 8px 14px; font-size: 12.5px;">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>버그 제보
+                </a>
+                <a href="https://github.com/orion-gz/EasyPaper/pulls" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 4px; padding: 8px 14px; font-size: 12.5px;">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M11 18H8a2 2 0 0 1-2-2V9"/></svg>기여하기
+                </a>
+              </div>
+            </div>
+          </div>
+
           <div id="system-update-section" class="form-group">
             <label>시스템 업데이트 (System Update)</label>
             <div style="background: rgba(139, 92, 246, 0.1); border-left: 4px solid var(--accent-mid); padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">


### PR DESCRIPTION
# Summary
## 1. 정보 탭에 GitHub 저장소 카드 추가
- 시스템 업데이트 섹션 바로 위에 "EasyPaper 프로젝트" 카드 신설
- GitHub 로고, 저장소명(orion-gz/EasyPaper), 한 줄 설명 표시
- "저장소 방문"(https://github.com/orion-gz/EasyPaper), "버그 제보"(Issues), "기여하기"(Pull Requests) 바로가기 링크 추가 - 모두 `target="_blank" rel="noopener noreferrer"`로 새 탭에서 안전하게 열림

## Test plan
- [x] `npm run build` 성공 확인
- [x] Playwright로 정보 탭 진입 후 카드 렌더링 및 각 링크의 href/target/rel 값 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)