### PR TITLE
fix: 릴리스 CI 파이프라인 개선 (자동 게시 / macOS Intel / 커밋 기반 노트)

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,11 +1,17 @@
 name: Tauri Release
 
-# 태그 push(v*) 또는 수동 트리거로 win/mac-arm64/linux 3개 플랫폼을 빌드해
-# GitHub Release(초안)에 업로드하고, Tauri updater가 읽는 latest.json도
+# 태그 push(v*) 또는 수동 트리거로 win/mac-arm64/mac-x64/linux 4개 플랫폼을
+# 빌드해 GitHub Release에 업로드하고, Tauri updater가 읽는 latest.json도
 # 함께 생성한다. TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)로 업데이트 페이로드에
 # 서명하지만, OS 코드사이닝(macOS 공증/Windows Authenticode)은 아직 하지
 # 않으므로 설치 시 Gatekeeper/SmartScreen 경고가 뜬다 - 유료 인증서 발급
 # 후 별도로 추가 필요.
+#
+# v* 태그 push는 빌드가 끝나면 릴리스를 즉시 게시(draft=false)한다 - 실제
+# 배포 트리거이므로 사람이 다시 "Publish" 버튼을 누르지 않아도 updater
+# 엔드포인트(releases/latest/download/latest.json)가 바로 응답하게 하기
+# 위함. workflow_dispatch(수동 테스트 빌드)는 실수로 공개 릴리스가 되지
+# 않도록 계속 초안(draft)으로 남긴다.
 on:
   push:
     tags:
@@ -26,9 +32,42 @@ jobs:
             name: windows
           - os: macos-14
             name: macos-arm64
+          - os: macos-13
+            name: macos-x64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # 태그 push 시점의 "직전 태그"를 찾아 릴리스 노트를 커밋 메시지로
+          # 자동 생성하려면 태그 히스토리 전체가 필요하다(기본 얕은 클론은
+          # 태그를 안 가져옴).
+          fetch-depth: 0
+
+      - name: Generate release notes from commits since previous tag
+        id: relnotes
+        shell: bash
+        run: |
+          current_tag="${{ github.ref_type == 'tag' && github.ref_name || '' }}"
+          prev_tag=$(git tag --list 'v*' --sort=-creatordate | grep -vFx "$current_tag" | head -n1 || true)
+          range=HEAD
+          if [ -n "$prev_tag" ]; then
+            range="$prev_tag..HEAD"
+          fi
+
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            echo "자동 생성된 릴리스입니다. 코드사이닝(macOS 공증/Windows Authenticode)이"
+            echo "아직 적용되지 않아 설치 시 운영체제 보안 경고가 뜰 수 있습니다."
+            echo ""
+            echo "## 변경 사항"
+            commits=$(git log "$range" --no-merges --pretty=format:'%s' | grep -E '^(feat|fix|perf)(\(.+\))?:' || true)
+            if [ -n "$commits" ]; then
+              echo "$commits" | sed 's/^/- /'
+            else
+              echo "- 세부 변경 내역 없음"
+            fi
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v5
         with:
@@ -83,8 +122,8 @@ jobs:
         with:
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v0.0.0-manual{0}', github.run_number) }}
           releaseName: "EasyPaper Desktop ${{ github.ref_type == 'tag' && github.ref_name || 'manual build' }}"
-          releaseBody: |
-            자동 생성된 릴리스입니다. 코드사이닝(macOS 공증/Windows Authenticode)이
-            아직 적용되지 않아 설치 시 운영체제 보안 경고가 뜰 수 있습니다.
-          releaseDraft: true
+          releaseBody: ${{ steps.relnotes.outputs.notes }}
+          # 태그 push만 즉시 게시하고, workflow_dispatch 수동 빌드는 검토 전
+          # 실수로 공개되지 않도록 초안으로 남긴다.
+          releaseDraft: ${{ github.ref_type != 'tag' }}
           prerelease: false


### PR DESCRIPTION
# Summary
## 1. v* 태그 push 시 릴리스 자동 게시
- `releaseDraft`가 항상 `true`라 빌드 완료 후 사람이 수동으로 GitHub에서 "Publish"를 눌러야만 updater 엔드포인트(`releases/latest/download/latest.json`)가 응답했음. 실제로 현재 저장소 릴리스(`v0.0.0-manual2`)도 draft 상태라 지금은 404가 나는 상태였음 (`gh api`로 확인).
- `releaseDraft: ${{ github.ref_type != 'tag' }}` — 실제 배포용 태그 push는 즉시 게시, `workflow_dispatch`(수동 테스트 빌드)는 실수로 공개되지 않도록 계속 draft 유지.

## 2. macOS Intel(x86_64) 빌드 추가
- 매트릭스에 `macos-13`(Intel) 러너 추가. 기존에는 `macos-14`(Apple Silicon)만 빌드해 Intel Mac 사용자는 설치가 불가능했음.
- 백엔드 sidecar 빌드/복사 스크립트(`backend/packaging/build.sh`, `src-tauri/scripts/copy-sidecar.sh`)에 아키텍처 하드코딩이 없어 추가 수정 없이 그대로 동작함을 확인.

## 3. 릴리스 노트 자동 생성
- 고정 문구("자동 생성된 릴리스입니다...") 대신, 직전 `v*` 태그 이후의 `feat`/`fix`/`perf` conventional commit 메시지를 모아 `releaseBody`에 자동으로 채움.
- 태그 히스토리 조회를 위해 `actions/checkout`에 `fetch-depth: 0` 추가.
- 이전 `v*` 태그가 없는 첫 배포에서는 전체 히스토리를 대상으로 하므로 노트가 길어질 수 있음(현재 저장소엔 아직 `v*` 태그가 없어 확인됨).

## 참고
- bash 로직(직전 태그 탐색, conventional commit 필터링)은 로컬에서 실제 저장소 히스토리로 시뮬레이션해 검증함.
- 이 환경에 `actionlint`가 없어 YAML 문법만 `python3 -c "import yaml..."`로 검증했고, 실제 워크플로우 실행 결과는 CI에서 확인 필요.

## Test plan
- [ ] YAML 파싱 확인 - 완료
- [ ] `workflow_dispatch`로 수동 실행 → draft 릴리스 생성 및 4개 플랫폼(win/linux/mac-arm64/mac-x64) 빌드 성공 확인
- [ ] 실제 `v*` 태그 push → 릴리스가 draft 없이 바로 게시되는지, `latest.json` 엔드포인트가 200을 반환하는지 확인
- [ ] 릴리스 노트에 커밋 메시지가 올바르게 채워지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)