### PR TITLE
chore: tauri-desktop-spike 워크플로우 정식 지원 이후 역할 정리

### DIFF
--- a/.github/workflows/tauri-desktop-spike.yml
+++ b/.github/workflows/tauri-desktop-spike.yml
@@ -1,7 +1,12 @@
-name: Tauri Desktop Spike
+name: Tauri Sidecar Smoke Test
 
 # 수동 트리거만 사용 - 기존 웹 배포(systemd/Docker) 파이프라인에는 전혀
-# 개입하지 않는다. feature/tauri-desktop-spike 브랜치의 실현 가능성 검증용.
+# 개입하지 않는다. tauri-desktop-spike 브랜치는 main에 병합되어 데스크탑
+# 지원이 정식화됐고(tauri-release.yml이 실제 서명/배포까지 담당), 이
+# 워크플로우는 그 무거운 릴리스 빌드 없이도 "PyInstaller sidecar가 정상
+# 기동해 응답하는지 + Rust가 컴파일되는지"를 빠르게 확인하는 스모크
+# 테스트로 계속 남겨둔다(tauri-release.yml에는 이 healthcheck/cargo
+# check 단계가 없음).
 on:
   workflow_dispatch: {}
 


### PR DESCRIPTION
# Summary
## 1. spike 워크플로우 이름/설명을 실제 역할에 맞게 갱신
- `tauri-desktop-spike.yml`이 `feature/tauri-desktop-spike` 브랜치의 "실현 가능성 검증용"이라는 옛 설명을 그대로 달고 있었음 - 그 브랜치는 이미 main에 병합돼 데스크탑 지원이 정식화됐고, 실제 릴리스 빌드는 `tauri-release.yml`이 전담하게 됨.
- 다만 이 워크플로우는 `tauri-release.yml`에는 없는 "PyInstaller sidecar 단독 기동 healthcheck + `cargo check`" 스텝(빠른 사전 점검용, 서명/번들링 없이 실행)을 갖고 있어 삭제하지 않고 유지 - 워크플로우 이름을 `Tauri Sidecar Smoke Test`로 바꾸고 상단 주석을 지금 상태에 맞게 갱신.
- 파일명/트리거/잡 구조는 변경하지 않음. 다른 문서에서 이 워크플로우를 이름으로 참조하는 곳이 없음을 grep으로 확인.

## 참고
- 조사 과정에서 발견한 또 다른 stale 주석(`src-tauri/src/lib.rs`의 "pubkey도 스파이크용 임시 키"라는 설명 - 실제로는 `6e38eae`에서 이미 실배포 키로 교체됨)은 이 브랜치에서 다루지 않음. `feature/tauri-update-flow`(#147) 브랜치가 해당 블록 전체를 실제 업데이트 다운로드/설치 플로우로 교체하면서 자연스럽게 제거되므로, 여기서 같은 줄을 건드리면 두 브랜치 병합 시 불필요한 충돌만 생김.

## Test plan
- [ ] YAML 파싱 확인 - 완료
- [ ] `workflow_dispatch`로 실행해 기존과 동일하게 동작하는지 확인(로직 변경 없음, 이름/주석만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)