### PR TITLE
fix: PDF 원문 드래그 선택 중 reference/fig/table/eq 오버레이 노출 방지

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6378,6 +6378,9 @@ function positionFigurePreviewTooltip() {
 // targets: documentImages 항목 배열(1개 이상 - "Figures 1 and 2"처럼 여러 개를
 // 한 번에 가리키는 표기는 각각을 세로로 쌓아 보여준다)
 async function showFigurePreviewTooltip(targets, boxEl) {
+  // 텍스트 드래그 선택 중에 마우스가 마커 박스 위를 스쳐 지나가도(mouseenter)
+  // 미리보기가 뜨지 않도록 막는다 - 다른 호버 오버레이들과 동일한 가드.
+  if (state.isSelectionDragging) return
   if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
   figurePreviewBoxEl = boxEl
   figurePreviewCurrentTargets = targets
@@ -6520,6 +6523,9 @@ function positionCitationTooltip() {
 }
 
 function showCitationTooltip(docId, refNum, refText, boxEl) {
+  // 텍스트 드래그 선택 중에 마우스가 마커 박스 위를 스쳐 지나가도(mouseenter)
+  // 미리보기가 뜨지 않도록 막는다 - 다른 호버 오버레이들과 동일한 가드.
+  if (state.isSelectionDragging) return
   if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
   citationTooltipDocId = docId
   citationTooltipRefNum = refNum


### PR DESCRIPTION
# Summary
## 1. PDF 원문 드래그 선택 중 참조 오버레이가 뜨던 버그 수정
- 드래그 선택 상태(`state.isSelectionDragging`)는 이미 있었고 문장 호버(번역 대조) 오버레이에는 적용돼 있었지만, 인용 참조(reference) 및 그림/표/수식(fig/table/eq) 참조 마커 박스의 `mouseenter` → `showCitationTooltip()` / `showFigurePreviewTooltip()` 호출 경로에는 체크가 빠져 있어, 텍스트 드래그 선택 중 마우스가 마커 박스 위를 지나가면 오버레이가 뜨던 문제 해결
- `frontend/src/main.js`의 `showCitationTooltip()`, `showFigurePreviewTooltip()` 함수 진입부에 `if (state.isSelectionDragging) return` 가드 추가 (다른 호버 오버레이들과 동일한 기존 패턴에 맞춤)
- 클릭으로 여는 동작은 `mouseup` 시점에 플래그가 이미 해제되므로 영향 없음

## Test plan
- [x] `npx esbuild`로 구문 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)