### PR TITLE
fix: 로그인 무차별 대입(brute-force) 방어 추가

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,9 +1,17 @@
-from fastapi import APIRouter, Response, HTTPException, status, Depends
+from fastapi import APIRouter, Request, Response, HTTPException, status, Depends
 from fastapi.responses import StreamingResponse
 import json
 import httpx
 from pydantic import BaseModel
-from services.auth import verify_password, hash_password, create_session_token, get_current_user
+from services.auth import (
+    verify_password,
+    hash_password,
+    create_session_token,
+    get_current_user,
+    get_login_lockout_remaining,
+    record_failed_login,
+    reset_login_attempts,
+)
 from config import (
     get_app_username,
     get_app_password_hash,
@@ -72,16 +80,29 @@ class ChangeCredentialsRequest(BaseModel):
     new_password: str
 
 @router.post("/auth/login")
-async def login(response: Response, data: LoginRequest):
+async def login(request: Request, response: Response, data: LoginRequest):
     from services.auth import SESSION_TTL_DEFAULT_SECONDS, SESSION_TTL_REMEMBER_SECONDS
     from services.db import get_user
+
+    lockout_remaining = get_login_lockout_remaining(request)
+    if lockout_remaining > 0:
+        retry_after = int(lockout_remaining) + 1
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"로그인 시도가 너무 많습니다. {retry_after}초 후 다시 시도해주세요.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     user = get_user(data.username)
 
     if not user or not verify_password(user["password_hash"], data.password):
+        record_failed_login(request)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="아이디 또는 비밀번호가 올바르지 않습니다."
         )
+
+    reset_login_attempts(request)
 
     # "로그인 상태 유지"를 체크하면 훨씬 긴 만료 기간의 세션 쿠키를 발급해,
     # 다음에 앱을 열 때 자동으로 로그인된 상태로 시작하게 한다(비밀번호를

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -27,6 +27,59 @@ def hash_password(password: str) -> str:
     key = hashlib.pbkdf2_hmac('sha256', password.encode('utf-8'), salt, 100000)
     return f"{salt.hex()}:{key.hex()}"
 
+
+# ─────────────────────────────────────────────────────────
+#  로그인 무차별 대입(brute-force) 방어
+# ─────────────────────────────────────────────────────────
+# self-host 배포(리버스 프록시 뒤 네트워크 노출)를 명시적으로 지원하는 앱인데
+# 로그인 시도 횟수 제한이 전혀 없어, 비밀번호를 admin/admin에서 바꾼 뒤에도
+# 무제한으로 대입 공격이 가능했다. Redis 등 별도 인프라 없이(단일 관리자
+# 계정, 인메모리 세션과 동일한 수준의 영속성이면 충분) 클라이언트 IP 기준
+# 슬라이딩 윈도우 잠금을 둔다 - 서버 재시작 시 초기화되는 건 감내 가능한
+# 트레이드오프(재시작 자체가 이미 관리자 권한이 필요한 드문 이벤트).
+LOGIN_MAX_ATTEMPTS = 5
+LOGIN_WINDOW_SECONDS = 15 * 60
+LOGIN_LOCKOUT_SECONDS = 5 * 60
+
+# IP -> {"count": 실패 횟수, "first_at": 첫 실패 시각, "locked_until": 잠금 해제 시각}
+_login_failures: dict[str, dict] = {}
+
+
+def _client_ip(request: Request) -> str:
+    # 리버스 프록시(NPM 등) 뒤에서는 request.client.host가 프록시 자신의
+    # 주소로 잡혀 모든 클라이언트가 하나로 묶일 수 있지만, X-Forwarded-For는
+    # 프록시를 신뢰할 수 있다는 보장 없이는 클라이언트가 임의로 위조해
+    # 잠금을 우회할 수 있는 값이라 그대로 신뢰하지 않는다. 지금은 요청의
+    # 실제 커넥션 주소만 기준으로 삼는다.
+    return request.client.host if request.client else "unknown"
+
+
+def get_login_lockout_remaining(request: Request) -> float:
+    """현재 요청의 클라이언트가 잠겨 있으면 남은 초를, 아니면 0을 반환합니다."""
+    state = _login_failures.get(_client_ip(request))
+    if not state:
+        return 0.0
+    remaining = state.get("locked_until", 0) - time.time()
+    return remaining if remaining > 0 else 0.0
+
+
+def record_failed_login(request: Request) -> None:
+    """로그인 실패를 기록하고, 임계치를 넘으면 잠급니다."""
+    ip = _client_ip(request)
+    now = time.time()
+    state = _login_failures.get(ip)
+    if not state or now - state["first_at"] > LOGIN_WINDOW_SECONDS:
+        state = {"count": 0, "first_at": now, "locked_until": 0.0}
+    state["count"] += 1
+    if state["count"] >= LOGIN_MAX_ATTEMPTS:
+        state["locked_until"] = now + LOGIN_LOCKOUT_SECONDS
+    _login_failures[ip] = state
+
+
+def reset_login_attempts(request: Request) -> None:
+    """로그인 성공 시 해당 클라이언트의 실패 기록을 초기화합니다."""
+    _login_failures.pop(_client_ip(request), None)
+
 SESSION_TTL_DEFAULT_SECONDS = 7 * 24 * 3600
 # "로그인 상태 유지"를 체크했을 때 쓰는 훨씬 긴 만료 기간 - 매번 다시
 # 로그인하지 않아도 되는 "자동 로그인" 효과를 기존의 안전한 HttpOnly

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -11,9 +11,19 @@ from services.auth import (
     create_session_token,
     verify_session_token,
     get_current_user,
+    get_login_lockout_remaining,
+    record_failed_login,
+    reset_login_attempts,
+    LOGIN_MAX_ATTEMPTS,
     SESSION_TTL_DEFAULT_SECONDS,
     SESSION_TTL_REMEMBER_SECONDS,
 )
+
+
+class FakeRequest:
+    """request.client.host만 흉내내는 최소 페이크(라우터의 Request 대신 사용)."""
+    def __init__(self, ip="1.2.3.4"):
+        self.client = type("Client", (), {"host": ip})()
 
 
 def test_hash_password_produces_verifiable_hash():
@@ -92,3 +102,52 @@ async def test_get_current_user_still_requires_cookie_when_skip_login_disabled(m
 
     with pytest.raises(HTTPException):
         await get_current_user(FakeRequest())
+
+
+def test_login_lockout_starts_unlocked():
+    req = FakeRequest("10.0.0.1")
+    assert get_login_lockout_remaining(req) == 0
+
+
+def test_record_failed_login_locks_out_after_max_attempts():
+    req = FakeRequest("10.0.0.2")
+    for _ in range(LOGIN_MAX_ATTEMPTS - 1):
+        record_failed_login(req)
+        assert get_login_lockout_remaining(req) == 0, "임계치 도달 전에는 잠기면 안 된다"
+
+    record_failed_login(req)
+    assert get_login_lockout_remaining(req) > 0, "임계치에 도달하면 잠겨야 한다"
+
+
+def test_reset_login_attempts_clears_lockout():
+    req = FakeRequest("10.0.0.3")
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        record_failed_login(req)
+    assert get_login_lockout_remaining(req) > 0
+
+    reset_login_attempts(req)
+    assert get_login_lockout_remaining(req) == 0, "로그인 성공(초기화) 후에는 잠금이 풀려야 한다"
+
+
+def test_login_lockout_is_scoped_per_client_ip():
+    attacker = FakeRequest("10.0.0.4")
+    bystander = FakeRequest("10.0.0.5")
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        record_failed_login(attacker)
+
+    assert get_login_lockout_remaining(attacker) > 0
+    assert get_login_lockout_remaining(bystander) == 0, \
+        "다른 IP의 실패 시도가 무관한 클라이언트를 잠그면 안 된다"
+
+
+def test_login_lockout_expires_after_window(monkeypatch):
+    import services.auth as auth_module
+
+    req = FakeRequest("10.0.0.6")
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        record_failed_login(req)
+    assert get_login_lockout_remaining(req) > 0
+
+    real_time = time.time
+    monkeypatch.setattr(auth_module.time, "time", lambda: real_time() + auth_module.LOGIN_LOCKOUT_SECONDS + 1)
+    assert get_login_lockout_remaining(req) == 0, "잠금 시간이 지나면 다시 시도할 수 있어야 한다"


### PR DESCRIPTION
# Summary
## 1. 로그인 브루트포스 방어 추가
- `POST /auth/login`에 시도 횟수 제한이 전혀 없어, self-host로 네트워크에 노출된 배포에서 비밀번호를 무제한 대입 공격할 수 있었음(기본 계정 admin/admin 경고는 있었지만 커스텀 비밀번호로 바꾼 뒤에도 무제한 시도 가능)
- `services/auth.py`에 클라이언트 IP 기준 인메모리 슬라이딩 윈도우 잠금 추가 - 15분 내 5회 실패 시 5분간 429(Retry-After 헤더 포함)로 잠금, 로그인 성공 시 해당 IP의 실패 기록 초기화
- 별도 인프라(Redis 등) 없이 기존 인메모리 세션과 동일한 수준의 영속성으로 구현(서버 재시작 시 초기화되는 트레이드오프 감내)
- `routers/auth.py`의 `/auth/login`에 연결
- `tests/test_auth_service.py`에 단위 테스트 6개 추가(잠금 임계치, IP별 격리, 잠금 해제, 시간 경과 후 해제 등)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>