### PR TITLE
fix: 평문 비밀번호 비교를 타이밍 세이프하게 수정

### DIFF
--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -7,8 +7,11 @@ from config import get_app_password, get_app_username, get_skip_login, SECRET_KE
 
 def verify_password(stored_password_hash: str, provided_password: str) -> bool:
     # 1. 만약 평문 비밀번호(APP_PASSWORD)가 설정되어 있다면 즉시 비교
+    # (== 대신 compare_digest로 비교 - 문자열 조기 종료 비교는 앞글자부터
+    # 하나씩 맞춰가는 타이밍 공격에 이론상 노출된다. 비ASCII 비밀번호도
+    # 지원하도록 bytes로 인코딩해 비교한다.)
     app_pwd = get_app_password()
-    if app_pwd and provided_password == app_pwd:
+    if app_pwd and hmac.compare_digest(provided_password.encode('utf-8'), app_pwd.encode('utf-8')):
         return True
 
     # 2. 해시 기반 검증 수행 (하위 호환 및 보안 권장 사양)

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -37,6 +37,15 @@ def test_verify_password_rejects_wrong_password():
     assert verify_password(h, "wrong-password") is False
 
 
+def test_verify_password_accepts_configured_plaintext_password(monkeypatch):
+    """APP_PASSWORD(평문)가 설정된 경우의 비교 경로 - compare_digest로 bytes 비교하도록
+    바뀌었으므로 정상적으로 동작하는지, 비ASCII(한글) 비밀번호도 지원하는지 확인."""
+    import services.auth as auth_module
+    monkeypatch.setattr(auth_module, "get_app_password", lambda: "비밀번호123!")
+    assert verify_password("unused-hash", "비밀번호123!") is True
+    assert verify_password("unused-hash", "wrong") is False
+
+
 def test_verify_password_rejects_malformed_hash():
     assert verify_password("not-a-valid-hash", "anything") is False
 


### PR DESCRIPTION
# Summary
## 1. verify_password 평문 비교 타이밍 세이프 처리
- APP_PASSWORD(평문) 비교 경로가 Python `==`를 사용해 이론상 문자열 조기 종료 타이밍 공격에 노출되어 있었음(해시 비교 쪽은 이미 `hmac.compare_digest` 사용 중)
- `hmac.compare_digest`로 통일하고, 비ASCII(한글 등) 비밀번호도 지원하도록 UTF-8 bytes로 인코딩 후 비교
- 회귀 테스트 1개 추가(한글 비밀번호 포함)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>