### PR TITLE
fix: 세션/문서 기반 엔드포인트에 소유자 검증 일관되게 적용

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -57,11 +57,8 @@ async def startup_event():
 @app.get("/api/pdf-file/{session_id}")
 async def serve_pdf(session_id: str, username: str = Depends(get_current_user)):
     """PDF 파일을 직접 서빙합니다."""
-    if not upload.ensure_session(session_id):
-        from fastapi import HTTPException
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-    pdf_path = upload.sessions[session_id]["pdf_path"]
-    return FileResponse(pdf_path, media_type="application/pdf")
+    session = upload.require_session_owner(session_id, username)
+    return FileResponse(session["pdf_path"], media_type="application/pdf")
 
 
 # 프론트엔드 정적 파일 서빙 (빌드된 dist 폴더)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -4,7 +4,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from typing import List
 
-from routers.upload import sessions, ensure_session
+from routers.upload import sessions, ensure_session, require_session_owner
 from services.llm_client import stream_chat
 from services.db import db_save_chat_message, db_get_chat_history
 from services.library import get_document as lib_get_document
@@ -55,16 +55,13 @@ def _dedupe_preserve_order(items: List[str]) -> List[str]:
     return list(dict.fromkeys(items))
 
 @router.post("/chat/stream")
-async def chat_stream(data: ChatRequest):
+async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current_user)):
     """
     논문 내용을 기반으로 AI 전문가와 챗을 진행하고 실시간 스트리밍 답변을 반환합니다.
     """
     session_id = data.session_id
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+    session = require_session_owner(session_id, current_user)
 
-    session = sessions[session_id]
-    
     # 세션 내의 모든 페이지에서 텍스트 수집
     pages = session.get("pages", [])
     paper_text = ""
@@ -235,9 +232,8 @@ async def get_compare_chat_history(doc_ids: str, current_user: str = Depends(get
 
 
 @router.get("/chat/{session_id}/history")
-async def get_chat_history(session_id: str):
+async def get_chat_history(session_id: str, current_user: str = Depends(get_current_user)):
     """특정 문서의 이전 채팅 히스토리를 반환합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+    require_session_owner(session_id, current_user)
     history = db_get_chat_history(session_id)
     return {"history": history}

--- a/backend/routers/insight.py
+++ b/backend/routers/insight.py
@@ -1,8 +1,9 @@
 import json
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 
-from routers.upload import sessions, ensure_session
+from routers.upload import require_session_owner
+from services.auth import get_current_user
 from services.llm_client import stream_page_insight
 from services.library import save_page_insight, get_page_insight
 
@@ -17,7 +18,8 @@ async def get_page_insight_stream(
     page_num: int,
     kind: str,
     target_lang: str = "한국어",
-    force: bool = False
+    force: bool = False,
+    current_user: str = Depends(get_current_user)
 ):
     """
     특정 페이지의 키워드/단어 설명(kind=keywords) 또는 요약(kind=summary)을
@@ -27,10 +29,7 @@ async def get_page_insight_stream(
     if kind not in VALID_KINDS:
         raise HTTPException(status_code=400, detail=f"kind는 {VALID_KINDS} 중 하나여야 합니다.")
 
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-
-    session = sessions[session_id]
+    session = require_session_owner(session_id, current_user)
     total_pages = session["total_pages"]
 
     if page_num < 1 or page_num > total_pages:

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -10,7 +10,7 @@ from services.translation_job import (
     cancel_job,
 )
 from services.auth import get_current_user
-from routers.upload import sessions, ensure_session
+from routers.upload import require_session_owner
 
 router = APIRouter()
 
@@ -23,8 +23,9 @@ class RestartJobRequest(BaseModel):
 
 
 @router.get("/jobs/{session_id}/status")
-async def job_status(session_id: str):
+async def job_status(session_id: str, current_user: str = Depends(get_current_user)):
     """잡 진행 상황을 반환합니다."""
+    require_session_owner(session_id, current_user)
     job = get_job_status(session_id)
     if not job:
         raise HTTPException(status_code=404, detail="잡을 찾을 수 없습니다.")
@@ -39,9 +40,11 @@ async def get_page_translation(
     style: str = "academic",
     ignore_math: bool = False,
     ignore_table: bool = True,
-    ignore_refs: bool = False
+    ignore_refs: bool = False,
+    current_user: str = Depends(get_current_user)
 ):
     """특정 페이지의 번역 MD 내용 및 매핑 데이터를 반환합니다."""
+    require_session_owner(session_id, current_user)
     suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
     
     from services.library import get_translation_full
@@ -67,9 +70,11 @@ async def download_translation(
     style: str = "academic",
     ignore_math: bool = False,
     ignore_table: bool = True,
-    ignore_refs: bool = False
+    ignore_refs: bool = False,
+    current_user: str = Depends(get_current_user)
 ):
     """전체 번역 MD 파일을 다운로드합니다."""
+    require_session_owner(session_id, current_user)
     suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
     path = get_full_md_path(session_id, suffix)
     if not path:
@@ -88,10 +93,7 @@ async def restart_translation_job(
     current_user: str = Depends(get_current_user)
 ):
     """주어진 옵션으로 번역 작업을 중단하고 새로 재시작합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-        
-    session = sessions[session_id]
+    session = require_session_owner(session_id, current_user)
     pages = session["pages"]
     
     job = start_job(
@@ -112,9 +114,8 @@ async def cancel_translation_job(
     current_user: str = Depends(get_current_user)
 ):
     """현재 진행 중인 번역 작업을 취소(중단)합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-        
+    require_session_owner(session_id, current_user)
+
     cancelled = cancel_job(session_id)
     return {"message": "번역 작업이 취소되었습니다." if cancelled else "진행 중인 번역 작업이 없습니다."}
 

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 
-from routers.upload import sessions, ensure_session
+from routers.upload import require_session_owner
+from services.auth import get_current_user
 from services.chunker import split_into_chunks, align_sentences, tag_source_text, parse_tagged_translation
 from services.llm_client import stream_translation, check_ollama_health
 from services.cache import get_cached_translation, save_translation_cache, get_cached_translation_full
@@ -20,16 +21,14 @@ async def translate_page(
     style: str = "academic",
     ignore_math: bool = False,
     ignore_table: bool = True,
-    ignore_refs: bool = False
+    ignore_refs: bool = False,
+    current_user: str = Depends(get_current_user)
 ):
     """
     특정 페이지를 번역하고 SSE 스트리밍으로 반환합니다.
     이미 동일한 옵션으로 번역된 페이지는 캐시에서 즉시 반환합니다.
     """
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-
-    session = sessions[session_id]
+    session = require_session_owner(session_id, current_user)
     total_pages = session["total_pages"]
 
     if page_num < 1 or page_num > total_pages:
@@ -221,12 +220,9 @@ async def get_providers_availability():
 
 
 @router.get("/translation-status/{session_id}")
-async def translation_status(session_id: str):
+async def translation_status(session_id: str, current_user: str = Depends(get_current_user)):
     """세션의 번역 완료 페이지 목록을 반환합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-
-    session = sessions[session_id]
+    session = require_session_owner(session_id, current_user)
     total_pages = session["total_pages"]
 
     from services.cache import get_cached_translation
@@ -244,11 +240,10 @@ async def translation_status(session_id: str):
 
 
 @router.post("/translate/{session_id}/clear-cache")
-async def clear_translation_cache(session_id: str):
+async def clear_translation_cache(session_id: str, current_user: str = Depends(get_current_user)):
     """세션의 모든 번역 캐시와 라이브러리 번역 저장본 및 잡 상태를 지웁니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-        
+    require_session_owner(session_id, current_user)
+
     # 1. 파일 캐시 삭제
     from services.cache import clear_session_cache
     clear_session_cache(session_id)

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -50,6 +50,22 @@ def ensure_session(session_id: str) -> bool:
         return False
 
 
+def require_session_owner(session_id: str, current_user: str) -> dict:
+    """세션이 존재하고 현재 로그인한 사용자 소유인지 확인합니다.
+
+    library.py의 _require_owned_document와 동일한 이유로, 다른 사용자의
+    세션은 존재 여부조차 알려주지 않도록(403이 아니라) 존재하지 않는
+    경우와 동일하게 404로 응답한다. jobs.py/main.py의 세션 기반
+    엔드포인트에서도 재사용한다.
+    """
+    if not ensure_session(session_id):
+        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+    session = sessions[session_id]
+    if session.get("username") != current_user:
+        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+    return session
+
+
 def restore_sessions_from_library():
     """서버 시작 시 라이브러리의 문서들을 세션으로 복원하고 미완료 잡을 재개합니다."""
     for doc in list_documents():
@@ -153,12 +169,9 @@ async def upload_pdf(
 
 
 @router.get("/session/{session_id}")
-async def get_session(session_id: str):
+async def get_session(session_id: str, current_user: str = Depends(get_current_user)):
     """세션 정보를 반환합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-
-    session = sessions[session_id]
+    session = require_session_owner(session_id, current_user)
     return {
         "session_id": session_id,
         "filename": session["filename"],
@@ -168,17 +181,16 @@ async def get_session(session_id: str):
 
 
 @router.delete("/session/{session_id}")
-async def delete_session(session_id: str):
+async def delete_session(session_id: str, current_user: str = Depends(get_current_user)):
     """세션 및 업로드 파일을 삭제합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
+    require_session_owner(session_id, current_user)
 
     session = sessions.pop(session_id)
     session_dir = os.path.dirname(session["pdf_path"])
-    
+
     from services.library import delete_chat_sessions
     delete_chat_sessions(session_id)
-    
+
     shutil.rmtree(session_dir, ignore_errors=True)
 
     from services.cache import clear_session_cache
@@ -188,8 +200,7 @@ async def delete_session(session_id: str):
 
 
 @router.get("/pdf/{session_id}")
-async def get_pdf_path(session_id: str):
+async def get_pdf_path(session_id: str, current_user: str = Depends(get_current_user)):
     """세션의 PDF 파일 경로를 반환합니다."""
-    if not ensure_session(session_id):
-        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다.")
-    return {"pdf_path": sessions[session_id]["pdf_path"]}
+    session = require_session_owner(session_id, current_user)
+    return {"pdf_path": session["pdf_path"]}

--- a/backend/tests/test_session_ownership.py
+++ b/backend/tests/test_session_ownership.py
@@ -1,0 +1,81 @@
+"""세션 기반 엔드포인트(upload/jobs/translate/insight/chat)들이 다른 사용자의
+세션에 접근하는 것을 막는지 확인하는 회귀 테스트.
+
+test_client 픽스처는 get_current_user를 "testuser"로 고정하므로, "otheruser"
+소유의 세션을 만들어두고 testuser로 접근했을 때 404가 나는지 검증한다
+(문서의 존재 여부 자체를 노출하지 않기 위해 403이 아니라 404로 통일).
+"""
+
+import pytest
+
+import routers.upload as upload_module
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_fake_sessions():
+    yield
+    for key in list(upload_module.sessions.keys()):
+        if key.startswith("own-test-"):
+            del upload_module.sessions[key]
+
+
+def _inject_session(session_id, username, text="Sample paper text."):
+    upload_module.sessions[session_id] = {
+        "pdf_path": f"/x/{session_id}.pdf",
+        "filename": f"{session_id}.pdf",
+        "pages": [{"page_num": 1, "text": text}],
+        "total_pages": 1,
+        "metadata": {},
+        "from_library": True,
+        "username": username,
+    }
+
+
+def test_get_session_rejects_other_users_session(test_client):
+    _inject_session("own-test-1", "otheruser")
+    res = test_client.get("/api/session/own-test-1")
+    assert res.status_code == 404
+
+
+def test_get_session_allows_owner(test_client):
+    _inject_session("own-test-2", "testuser")
+    res = test_client.get("/api/session/own-test-2")
+    assert res.status_code == 200
+
+
+def test_delete_session_rejects_other_users_session(test_client):
+    _inject_session("own-test-3", "otheruser")
+    res = test_client.delete("/api/session/own-test-3")
+    assert res.status_code == 404
+    # 삭제되지 않고 그대로 남아 있어야 한다
+    assert "own-test-3" in upload_module.sessions
+
+
+def test_get_pdf_path_rejects_other_users_session(test_client):
+    _inject_session("own-test-4", "otheruser")
+    res = test_client.get("/api/pdf/own-test-4")
+    assert res.status_code == 404
+
+
+def test_translation_status_rejects_other_users_session(test_client):
+    _inject_session("own-test-5", "otheruser")
+    res = test_client.get("/api/translation-status/own-test-5")
+    assert res.status_code == 404
+
+
+def test_chat_history_rejects_other_users_session(test_client):
+    _inject_session("own-test-6", "otheruser")
+    res = test_client.get("/api/chat/own-test-6/history")
+    assert res.status_code == 404
+
+
+def test_job_status_rejects_other_users_session(test_client):
+    _inject_session("own-test-7", "otheruser")
+    res = test_client.get("/api/jobs/own-test-7/status")
+    assert res.status_code == 404
+
+
+def test_job_cancel_rejects_other_users_session(test_client):
+    _inject_session("own-test-8", "otheruser")
+    res = test_client.post("/api/jobs/own-test-8/cancel")
+    assert res.status_code == 404


### PR DESCRIPTION
# Summary
## 1. 세션 기반 엔드포인트 소유자 검증 누락 수정
- `library.py`(문서 API)는 매 요청마다 `_require_owned_document`로 소유자를 확인하지만, `upload.py`/`jobs.py`/`translate.py`/`chat.py`/`insight.py`의 `session_id` 기반 엔드포인트는 로그인 여부만 확인하고 실제 소유자인지는 확인하지 않았음
- `session_id`가 UUID라 실용적 위험은 낮지만, 다중 사용자 환경에서 다른 사용자 세션 UUID를 알면 그대로 조회/삭제/다운로드가 가능한 구멍
- `upload.py`에 `require_session_owner()` 공용 헬퍼 추가(존재하지 않는 경우와 구분 없이 404로 통일 - library.py의 `_require_owned_document`와 동일한 정책) 후 다음 라우터들에 일관 적용:
  - `upload.py`: GET/DELETE `/session/{id}`, GET `/pdf/{id}`
  - `jobs.py`: GET `/jobs/{id}/status`, `/page/{n}`, `/download`, POST `/restart`, `/cancel`
  - `translate.py`: GET `/translate/{id}/{page}`, `/translation-status/{id}`, POST `/translate/{id}/clear-cache`
  - `chat.py`: POST `/chat/stream`, GET `/chat/{id}/history`
  - `insight.py`: GET `/insight/{id}/{page}`
  - `main.py`: GET `/api/pdf-file/{id}`
- 회귀 테스트 8개 추가(`test_session_ownership.py`) - 다른 사용자 세션 접근 시 404, 본인 세션은 정상 접근

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>