### PR TITLE
fix: 번역 진행 상황 폴링이 겹쳐 실행되는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -972,45 +972,58 @@ function updateProgressMiniRaw(done, total, isRunning = true) {
 function startJobPolling(sessionId) {
   if (state.pollingTimer) clearInterval(state.pollingTimer)
 
+  // 완료된 페이지 수가 많거나 네트워크가 느리면 poll() 한 번의 실행이
+  // 5초를 넘길 수 있는데, setInterval은 이전 실행이 끝났는지와 무관하게
+  // 매번 새로 poll()을 호출한다. 그러면 두 호출이 같은 페이지에 대해
+  // 동시에 getPageTranslation을 중복 요청/렌더링하게 되므로, 이전 poll()이
+  // 아직 진행 중이면 이번 tick은 건너뛴다.
+  let pollInFlight = false
+
   async function poll() {
     if (!state.sessionId || state.sessionId !== sessionId) return
-    const job = await getJobStatus(sessionId)
-    if (!job) return
+    if (pollInFlight) return
+    pollInFlight = true
+    try {
+      const job = await getJobStatus(sessionId)
+      if (!job) return
 
-    for (const pageNum of (job.completed_pages || [])) {
-      if (state.translatedPages.has(pageNum)) continue
-      const data = await getPageTranslation(sessionId, pageNum, getTranslationOptions())
-      if (data?.translation) {
-        state.translationCache[pageNum] = data.translation
-        state.translationSentences[pageNum] = data.sentences || []
-        state.translatedPages.add(pageNum)
-        state.translatingPages.delete(pageNum)
-        renderTransContent(pageNum, data.translation, false)
+      for (const pageNum of (job.completed_pages || [])) {
+        if (state.translatedPages.has(pageNum)) continue
+        const data = await getPageTranslation(sessionId, pageNum, getTranslationOptions())
+        if (data?.translation) {
+          state.translationCache[pageNum] = data.translation
+          state.translationSentences[pageNum] = data.sentences || []
+          state.translatedPages.add(pageNum)
+          state.translatingPages.delete(pageNum)
+          renderTransContent(pageNum, data.translation, false)
+        }
       }
-    }
 
-    const done  = state.translatedPages.size
-    const total = job.total_pages || state.totalPages
-    const isRunning = job.status === 'running' || job.status === 'pending'
-    updateProgressMiniRaw(done, total, isRunning)
+      const done  = state.translatedPages.size
+      const total = job.total_pages || state.totalPages
+      const isRunning = job.status === 'running' || job.status === 'pending'
+      updateProgressMiniRaw(done, total, isRunning)
 
-    if (job.status === 'running') {
-      translateSpinner.classList.remove('hidden')
-      translateStatusText.textContent = `백그라운드 번역 중 (${done}/${total}p)`
-      cancelTransBtn.classList.remove('hidden')
-      resumeTransBtn.classList.add('hidden')
-    } else {
-      translateSpinner.classList.add('hidden')
-      translateStatusText.textContent =
-        job.status === 'completed' ? `번역 완료 ✓ (${done}/${total}p)` : `상태: ${job.status}`
-      cancelTransBtn.classList.add('hidden')
-      if (job.status !== 'completed') {
-        resumeTransBtn.classList.remove('hidden')
-      } else {
+      if (job.status === 'running') {
+        translateSpinner.classList.remove('hidden')
+        translateStatusText.textContent = `백그라운드 번역 중 (${done}/${total}p)`
+        cancelTransBtn.classList.remove('hidden')
         resumeTransBtn.classList.add('hidden')
+      } else {
+        translateSpinner.classList.add('hidden')
+        translateStatusText.textContent =
+          job.status === 'completed' ? `번역 완료 ✓ (${done}/${total}p)` : `상태: ${job.status}`
+        cancelTransBtn.classList.add('hidden')
+        if (job.status !== 'completed') {
+          resumeTransBtn.classList.remove('hidden')
+        } else {
+          resumeTransBtn.classList.add('hidden')
+        }
+        clearInterval(state.pollingTimer)
+        state.pollingTimer = null
       }
-      clearInterval(state.pollingTimer)
-      state.pollingTimer = null
+    } finally {
+      pollInFlight = false
     }
   }
 


### PR DESCRIPTION
# Summary
## 1. 번역 진행 폴링 오버랩 방지
- `startJobPolling`의 `poll()`이 완료 페이지 수만큼 `getPageTranslation`을 순차 `await`하는데, `setInterval(poll, 5000)`은 이전 실행이 끝났는지와 무관하게 5초마다 새로 `poll()`을 호출함
- 네트워크가 느리거나 완료 페이지가 많아 한 번의 실행이 5초를 넘기면 두 `poll()`이 동시에 같은 페이지에 대해 `getPageTranslation`을 중복 요청·중복 렌더링할 수 있었음
- 이전 `poll()`이 아직 진행 중이면 이번 tick을 건너뛰는 `pollInFlight` 플래그 추가
- `npm run build` 정상 빌드 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>