### PR TITLE
fix: SKIP_LOGIN 경고 문구에 강력한 관리 기능 노출 명시

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -329,7 +329,12 @@ def update_credentials_in_env(new_username: str, new_password_hash: str):
 # 있는 개인/로컬 환경(예: 다른 사람이 접근할 수 없는 개인 PC의 Tauri
 # 데스크탑 앱)에서 매번 로그인하는 번거로움을 없애기 위한 설정이다 - 켜면
 # 이 서버에 네트워크로 접근 가능한 모든 사람이 인증 없이 전체 기능을 쓸
-# 수 있게 되므로, 계정 설정 화면에서 명시적으로 켜야만 활성화된다.
+# 수 있게 되므로, 계정 설정 화면에서 명시적으로 켜야만 활성화된다. "전체
+# 기능"에는 /settings/update(git pull + 재빌드 + 서버 재시작)와
+# /settings/install-*(Ollama/Claude Code/Codex/Antigravity 원격 설치
+# 스크립트 실행)처럼 서버에 소프트웨어를 설치·재시작시킬 수 있는 관리
+# 기능도 포함되므로, 단순 조회 권한보다 훨씬 강력한 노출이라는 점에
+# 유의해야 한다.
 SKIP_LOGIN = os.getenv("SKIP_LOGIN", "false").strip().lower() == "true"
 
 def get_skip_login() -> bool:
@@ -368,8 +373,12 @@ if SKIP_LOGIN:
         "\n" + "!" * 70 +
         "\n[보안 경고] 로그인 없이 사용 설정이 켜져 있습니다.\n"
         "이 서버에 네트워크로 접근 가능한 모든 사람이 인증 없이 전체 기능을\n"
-        "쓸 수 있습니다. 신뢰할 수 있는 개인/로컬 환경이 아니라면 설정에서\n"
-        "즉시 꺼주세요.\n"
+        "쓸 수 있습니다. 여기에는 논문 열람뿐 아니라 git pull + 재빌드 후\n"
+        "서버 자동 재시작(시스템 업데이트), Ollama/Claude Code/Codex/\n"
+        "Antigravity CLI 원격 설치 스크립트 실행(curl|bash, PowerShell\n"
+        "irm|iex) 등 서버에 임의 소프트웨어를 설치하고 프로세스를 재시작할\n"
+        "수 있는 관리 기능까지 전부 포함됩니다. 신뢰할 수 있는 개인/로컬\n"
+        "환경이 아니라면 설정에서 즉시 꺼주세요.\n"
         + "!" * 70 + "\n"
     )
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -784,6 +784,7 @@
             <h3 style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>로그인 생략</h3>
             <div style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid #ef4444; padding: 12px 14px; border-radius: var(--radius-sm); margin-bottom: 12px; font-size: 12.5px; color: var(--text-primary); line-height: 1.6;">
               <strong>보안 경고:</strong> 켜면 이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있습니다.
+              여기에는 논문 열람뿐 아니라 시스템 업데이트(서버 재시작)와 Ollama/CLI 원격 설치처럼 서버에 소프트웨어를 설치·재시작시킬 수 있는 관리 기능도 포함됩니다.
               다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.
             </div>
             <label style="display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer;">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3155,7 +3155,7 @@ if (settingSkipLoginCheckbox) {
     const wantsEnabled = settingSkipLoginCheckbox.checked
     if (wantsEnabled) {
       const ok = await showCustomConfirm(
-        '이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있게 됩니다.\n다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.\n계속하시겠습니까?',
+        '이 서버에 네트워크로 접근 가능한 모든 사람이 로그인 없이 전체 기능을 쓸 수 있게 됩니다.\n여기에는 시스템 업데이트(서버 재시작)와 Ollama/CLI 원격 설치처럼 서버에 소프트웨어를 설치·재시작시킬 수 있는 관리 기능도 포함됩니다.\n다른 사람이 접근할 수 없는 개인 PC/로컬 환경에서만 켜세요.\n계속하시겠습니까?',
         { title: '로그인 생략 켜기', confirmText: '켜기', danger: true }
       )
       if (!ok) {


### PR DESCRIPTION
# Summary
## 1. SKIP_LOGIN 경고 문구 보강
- 로그인 생략(SKIP_LOGIN) 활성화 시 논문 열람뿐 아니라 `/settings/update`(git pull + 재빌드 + 서버 재시작)와 `/settings/install-*`(Ollama/Claude Code/Codex/Antigravity 원격 설치 스크립트 실행)처럼 서버에 소프트웨어를 설치·재시작시킬 수 있는 관리 기능까지 전부 무인증으로 노출된다는 점이 기존 "전체 기능 사용 가능" 문구만으로는 충분히 전달되지 않았음
- 서버 시작 시 콘솔 경고(`config.py`), 코드 주석, 설정 화면 정적 경고 박스(`index.html`), 로그인 생략 켜기 확인 다이얼로그(`main.js`) 4곳의 문구를 모두 구체화
- `npm run build` 정상 빌드, 백엔드 테스트 142 passed 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>