### PR TITLE
fix: 캐시/잡 상태 파일을 원자적으로 쓰도록 변경

### DIFF
--- a/backend/services/atomic_io.py
+++ b/backend/services/atomic_io.py
@@ -1,0 +1,25 @@
+"""파일을 원자적으로(all-or-nothing) 쓰기 위한 공용 헬퍼.
+
+캐시/잡 상태 파일들을 open(path, "w")로 바로 덮어쓰면, 쓰는 도중 프로세스가
+비정상 종료(정전, 강제 kill 등)될 경우 파일이 잘려나간 상태의 깨진 JSON으로
+남을 수 있다. 같은 파일시스템 안에서의 os.replace()는 원자적이라는 보장을
+이용해, 임시 파일에 다 쓴 뒤 원래 경로로 교체하는 방식으로 이 문제를 막는다.
+"""
+
+import os
+
+
+def atomic_write_text(path: str, content: str, encoding: str = "utf-8") -> None:
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    tmp_path = f"{path}.tmp-{os.getpid()}"
+    try:
+        with open(tmp_path, "w", encoding=encoding) as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -2,6 +2,7 @@ import json
 import os
 from typing import Optional
 from config import CACHE_DIR
+from services.atomic_io import atomic_write_text
 
 
 def _cache_path(session_id: str, page_num: int, suffix: str = "") -> str:
@@ -62,14 +63,12 @@ def save_translation_cache(session_id: str, page_num: int, translation: str, suf
         try:
             data = json.loads(translation)
             if isinstance(data, dict) and "translation" in data:
-                with open(path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False)
+                atomic_write_text(path, json.dumps(data, ensure_ascii=False))
                 return
         except Exception:
             pass
-            
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump({"translation": translation}, f, ensure_ascii=False)
+
+    atomic_write_text(path, json.dumps({"translation": translation}, ensure_ascii=False))
 
 
 def clear_session_cache(session_id: str) -> None:

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from config import LIBRARY_DIR
+from services.atomic_io import atomic_write_text
 from services.chunker import split_into_chunks, align_sentences, tag_source_text, parse_tagged_translation
 from services.llm_client import stream_translation
 from services.library import save_translation, get_translation, get_document
@@ -38,9 +39,7 @@ def _load_job(session_id: str) -> Optional[dict]:
 
 def _save_job(session_id: str, job: dict) -> None:
     path = _job_path(session_id)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(job, f, ensure_ascii=False, indent=2)
+    atomic_write_text(path, json.dumps(job, ensure_ascii=False, indent=2))
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/tests/test_atomic_io.py
+++ b/backend/tests/test_atomic_io.py
@@ -1,0 +1,27 @@
+"""services/atomic_io.py 단위 테스트."""
+
+import os
+
+from services.atomic_io import atomic_write_text
+
+
+def test_atomic_write_text_creates_file_with_content(tmp_path):
+    path = str(tmp_path / "sub" / "file.json")
+    atomic_write_text(path, '{"a": 1}')
+    with open(path, "r", encoding="utf-8") as f:
+        assert f.read() == '{"a": 1}'
+
+
+def test_atomic_write_text_overwrites_existing_file(tmp_path):
+    path = str(tmp_path / "file.txt")
+    atomic_write_text(path, "first")
+    atomic_write_text(path, "second")
+    with open(path, "r", encoding="utf-8") as f:
+        assert f.read() == "second"
+
+
+def test_atomic_write_text_leaves_no_temp_file_behind(tmp_path):
+    path = str(tmp_path / "file.txt")
+    atomic_write_text(path, "content")
+    remaining = os.listdir(tmp_path)
+    assert remaining == ["file.txt"], f"임시 파일이 정리되지 않고 남아있다: {remaining}"


### PR DESCRIPTION
# Summary
## 1. 캐시/잡 상태 파일 원자적 쓰기
- `services/cache.py`(번역 파일 캐시)와 `services/translation_job.py`(잡 상태 `job_status.json`)가 `open(path, "w")`로 파일을 직접 덮어써서, 쓰는 도중 프로세스가 비정상 종료(정전, 강제 kill 등)되면 파일이 잘려나간 상태의 깨진 JSON으로 남을 수 있었음
- `services/atomic_io.py`에 공용 `atomic_write_text()` 헬퍼 추가(임시 파일에 쓴 뒤 `os.replace()`로 교체 - 같은 파일시스템 내에서 원자적임이 보장됨)하고 두 곳에 적용
- 단위 테스트 3개 추가

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>