### PR TITLE
feat: 오버레이 캡션에 원문 볼드 서식 유지

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -88,6 +88,27 @@ def _is_bold_span(span: dict) -> bool:
     return bool(span.get("flags", 0) & _BOLD_FLAG) or "bold" in span.get("font", "").lower()
 
 
+def _spans_to_bold_markdown(spans: List[dict]) -> str:
+    """한 줄(line)의 span 목록을 이어붙이되, 볼드로 표시된 구간은 마크다운
+    (**...**)으로 감싼다. 본문 텍스트(_build_block_text_and_indent)뿐 아니라
+    Figure/Table 캡션 추출(_find_page_captions)에서도 원문의 볼드 서식을
+    그대로 프론트엔드까지 전달하기 위해 공용으로 쓰인다."""
+    parts = []
+    for span in spans:
+        t = span.get("text", "")
+        if not t:
+            continue
+        if _is_bold_span(span) and t.strip():
+            # 앞뒤 공백은 마크다운 표시 밖으로 빼서 "** text **"처럼 어색해지지 않게 함
+            lead = t[:len(t) - len(t.lstrip())]
+            trail = t[len(t.rstrip()):]
+            core = t.strip()
+            parts.append(f"{lead}**{core}**{trail}")
+        else:
+            parts.append(t)
+    return "".join(parts)
+
+
 def _build_block_text_and_indent(block: dict) -> tuple[str, bool]:
     """dict 모드 블록 하나에서 줄 단위로 텍스트를 조립합니다.
     볼드로 표시된 글자 구간은 번역 후에도 살아남도록 마크다운(**...**)으로 감싸고,
@@ -98,20 +119,7 @@ def _build_block_text_and_indent(block: dict) -> tuple[str, bool]:
         spans = line.get("spans", [])
         if not spans:
             continue
-        parts = []
-        for span in spans:
-            t = span.get("text", "")
-            if not t:
-                continue
-            if _is_bold_span(span) and t.strip():
-                # 앞뒤 공백은 마크다운 표시 밖으로 빼서 "** text **"처럼 어색해지지 않게 함
-                lead = t[:len(t) - len(t.lstrip())]
-                trail = t[len(t.rstrip()):]
-                core = t.strip()
-                parts.append(f"{lead}**{core}**{trail}")
-            else:
-                parts.append(t)
-        line_text = "".join(parts)
+        line_text = _spans_to_bold_markdown(spans)
         if line_text.strip():
             line_texts.append(line_text)
             line_x0s.append(line["bbox"][0])
@@ -604,6 +612,12 @@ def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
     캡션 패턴인 경우만 인정해 본문 중간에 우연히 나오는 경우를 배제한다.
     캡션 전문은 매칭된 줄부터 블록 끝까지의 텍스트를 이어붙여 구성한다
     (캡션이 보통 그 블록에서 끝까지 이어지는 독립된 문단이기 때문).
+
+    반환되는 캡션 전문에는 원문에서 볼드로 표시된 구간이 마크다운(**...**)으로
+    표시되어 있다(프론트엔드가 오버레이 캡션을 렌더링할 때 볼드로 되살린다).
+    다만 "Figure 1" 캡션 패턴 매칭(_CAPTION_RE)은 라벨 자체가 볼드로 표시되는
+    경우가 흔해(예: "**Figure 1.** ...") 마크다운 표시가 섞이면 정규식이
+    실패하므로, 매칭 전용으로 별표를 제거한 버전을 따로 만들어 사용한다.
     """
     captions = []
     blocks = page.get_text("dict")["blocks"]
@@ -611,14 +625,12 @@ def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
         lines = b.get("lines")
         if not lines:
             continue
-        line_texts = [
-            "".join(span.get("text", "") for span in ln.get("spans", [])).strip()
-            for ln in lines
-        ]
-        for i, line_text in enumerate(line_texts):
-            if not line_text:
+        line_texts = [_spans_to_bold_markdown(ln.get("spans", [])).strip() for ln in lines]
+        plain_line_texts = [re.sub(r"\*+", "", t) for t in line_texts]
+        for i, plain_text in enumerate(plain_line_texts):
+            if not plain_text:
                 continue
-            m = _CAPTION_RE.match(line_text)
+            m = _CAPTION_RE.match(plain_text)
             if not m:
                 continue
             kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4401,6 +4401,14 @@ function escapeHtml(str) {
   return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')
 }
 
+// PDF 원문에서 볼드로 표시된 구간은 backend(pdf_parser.py의 _spans_to_bold_markdown)가
+// 마크다운(**...**)으로 감싸서 넘겨준다 - Figure/Table 캡션, 참고문헌 원문 등
+// 오버레이 툴팁에 원문 그대로의 볼드 서식을 되살릴 때 이 함수로 변환한다.
+// (formatTranslationHtml과 동일하게 escapeHtml 이후에 ** -> <strong> 치환)
+function renderBoldText(str) {
+  return escapeHtml(str).replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
+}
+
 // marked.parse()는 마크다운 소스에 섞인 raw HTML(<script>, onerror= 등)을 그대로
 // 통과시킨다. AI 채팅 응답/메모/체인지로그처럼 우리가 직접 작성하지 않은 텍스트를
 // marked로 렌더링한 뒤 innerHTML에 꽂아넣는 모든 지점에서는, 악성 PDF의
@@ -6558,7 +6566,7 @@ async function showFigurePreviewTooltip(targets, boxEl) {
       <div class="figure-preview-tooltip-label">${escapeHtml(t.label)} · p.${t.page}</div>
       <div class="figure-preview-tooltip-loading">${icon('refreshCw', 14, 'style="vertical-align:-2px;margin-right:4px"')}불러오는 중...</div>
       <img class="figure-preview-tooltip-img hidden" alt="" />
-      ${t.caption ? `<div class="figure-preview-tooltip-caption">${escapeHtml(t.caption)}</div>` : ''}
+      ${t.caption ? `<div class="figure-preview-tooltip-caption">${renderBoldText(t.caption)}</div>` : ''}
     </div>
   `).join('')
 
@@ -6697,7 +6705,7 @@ function showCitationTooltip(docId, refNum, refText, boxEl) {
   citationTooltipBoxEl = boxEl
 
   const tooltip = getOrCreateCitationTooltip()
-  tooltip.querySelector('.citation-tooltip-text').textContent = refText
+  tooltip.querySelector('.citation-tooltip-text').innerHTML = renderBoldText(refText)
   const resultEl = tooltip.querySelector('.citation-tooltip-result')
   resultEl.className = 'citation-tooltip-result hidden'
   resultEl.innerHTML = ''


### PR DESCRIPTION
# Summary
## 1. Figure/Table 캡션 볼드 서식 보존
- `backend/services/pdf_parser.py`의 `_find_page_captions`가 캡션 span의 텍스트만 이어붙이고 볼드 여부를 무시하던 부분 수정
- 본문 텍스트 추출(`_build_block_text_and_indent`)에서 쓰던 볼드 → 마크다운(`**...**`) 변환 로직을 `_spans_to_bold_markdown` 공용 함수로 추출해 캡션 추출에도 재사용
- 캡션 라벨("Figure 1" 등) 자체가 볼드인 경우가 흔해, `_CAPTION_RE` 매칭은 별표를 제거한 버전으로 별도 수행하도록 처리

## 2. 참고문헌(인용) 오버레이 텍스트 볼드 렌더링
- 참고문헌 목록 파싱(`reference_parser.py`)이 사용하는 페이지 텍스트는 기존에도 볼드를 `**...**`로 보존하고 있었으나, 프론트엔드에서 `textContent`로만 표시해 마크다운 표시가 그대로 노출되던 문제 수정

## 3. 프론트엔드 렌더링
- `frontend/src/main.js`에 `renderBoldText()` 헬퍼 추가 (`escapeHtml` 이후 `**...**` → `<strong>` 변환, XSS 안전)
- Figure/Table/Equation 참조 미리보기 툴팁의 캡션(`figure-preview-tooltip-caption`)과 인용 참고문헌 툴팁(`citation-tooltip-text`) 렌더링에 적용

## Test plan
- [x] 합성 PDF로 볼드 span이 포함된 Figure 캡션 추출 시 `**...**` 마크다운으로 보존되는지 확인
- [x] 합성 PDF로 볼드 span이 포함된 참고문헌 항목 추출 시 `**...**` 마크다운으로 보존되는지 확인
- [x] `renderBoldText()`가 `**...**`를 `<strong>`으로 변환하고 HTML 특수문자를 이스케이프하는지 확인
- [x] `npm run build` 정상 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)