### PR TITLE
fix: 업로드 파일 크기 제한을 스트리밍 방식으로 검사

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -112,18 +112,32 @@ async def upload_pdf(
     os.makedirs(session_dir, exist_ok=True)
     pdf_path = os.path.join(session_dir, "document.pdf")
 
-    # 파일 저장
-    content = await file.read()
-    file_size_mb = len(content) / (1024 * 1024)
+    # 파일 저장 (스트리밍) - await file.read()로 전체를 한 번에 읽으면 크기
+    # 제한 검사가 이미 전체 파일을 메모리에 다 올린 "다음"에야 이루어져,
+    # MAX_FILE_SIZE_MB를 아무리 작게 잡아도 공격자가 매우 큰 파일을 계속
+    # 올려 메모리를 고갈시키는 DoS 벡터가 된다. 청크 단위로 읽어 디스크에
+    # 바로 쓰면서, 누적 크기가 한도를 넘는 순간 더 읽지 않고 즉시 중단한다.
+    CHUNK_SIZE = 1024 * 1024  # 1MB
+    max_bytes = MAX_FILE_SIZE_MB * 1024 * 1024
+    total_bytes = 0
+    try:
+        async with aiofiles.open(pdf_path, "wb") as f:
+            while True:
+                chunk = await file.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                total_bytes += len(chunk)
+                if total_bytes > max_bytes:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"파일 크기가 {MAX_FILE_SIZE_MB}MB를 초과합니다."
+                    )
+                await f.write(chunk)
+    except HTTPException:
+        shutil.rmtree(session_dir, ignore_errors=True)
+        raise
 
-    if file_size_mb > MAX_FILE_SIZE_MB:
-        raise HTTPException(
-            status_code=413,
-            detail=f"파일 크기가 {MAX_FILE_SIZE_MB}MB를 초과합니다."
-        )
-
-    async with aiofiles.open(pdf_path, "wb") as f:
-        await f.write(content)
+    file_size_mb = total_bytes / (1024 * 1024)
 
     # PDF 파싱
     try:

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -1,0 +1,50 @@
+"""POST /api/upload의 파일 크기 제한이 스트리밍 도중에(전체를 메모리에
+읽어들이기 전에) 적용되는지 확인하는 회귀 테스트.
+
+이전에는 await file.read()로 전체 파일을 먼저 메모리에 다 올린 "다음"에야
+MAX_FILE_SIZE_MB를 검사해서, 한도를 아무리 작게 잡아도 큰 업로드가 메모리를
+전부 소비한 뒤에야 거부되는 DoS 벡터였다.
+"""
+
+import fitz
+import routers.upload as upload_module
+
+
+def _minimal_pdf_bytes() -> bytes:
+    doc = fitz.open()
+    doc.new_page()
+    return doc.tobytes()
+
+
+def test_upload_rejects_oversized_file_without_buffering_it_all(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    # 한도를 아주 작게(약 1KB) 잡아, 몇 KB짜리 업로드도 초과하도록 만든다
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 0.001)
+
+    oversized_content = b"%PDF-1.4\n" + (b"A" * 20_000)
+
+    res = test_client.post(
+        "/api/upload",
+        files={"file": ("big.pdf", oversized_content, "application/pdf")},
+    )
+
+    assert res.status_code == 413
+    # 거부된 업로드는 세션 디렉토리를 남기지 않아야 한다
+    assert list(upload_dir.iterdir()) == []
+
+
+def test_upload_accepts_file_within_size_limit(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
+
+    res = test_client.post(
+        "/api/upload",
+        files={"file": ("small.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["filename"] == "small.pdf"
+    assert body["session_id"] in upload_module.sessions


### PR DESCRIPTION
# Summary
## 1. 업로드 크기 제한 검사를 스트리밍 방식으로 변경
- `POST /upload`가 `await file.read()`로 파일 전체를 메모리에 다 읽은 "다음"에야 `MAX_FILE_SIZE_MB`를 검사해서, 한도를 아무리 작게 잡아도 큰 업로드가 메모리를 전부 소비한 뒤에야 거부되는 DoS 벡터였음(self-host로 네트워크에 노출된 배포에서 특히 위험)
- 1MB 청크 단위로 읽어 디스크에 바로 쓰면서 누적 크기가 한도를 넘는 순간 즉시 중단하도록 수정, 거부 시 세션 디렉토리 정리
- 회귀 테스트 2개 추가(한도 초과 시 413 + 디렉토리 미생성, 한도 내 정상 업로드)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>