### PR TITLE
fix: start.bat PowerShell 정규식 따옴표 이스케이프 오류 수정

### DIFF
--- a/scripts/bat/start.bat
+++ b/scripts/bat/start.bat
@@ -11,7 +11,7 @@ for /f "usebackq delims=" %%R in (`powershell -NoProfile -Command ^
     "$idx = Join-Path '%REPO_ROOT%' 'frontend\dist\index.html'; " ^
     "if (-not (Test-Path $idx)) { 'BUILD'; exit }; " ^
     "$missing = $false; " ^
-    "(Select-String -Path $idx -Pattern '\"(/assets/[^\"]+\.(js|css))\"' -AllMatches).Matches | ForEach-Object { " ^
+    "(Select-String -Path $idx -Pattern '\x22(/assets/[^\x22]+\.(js|css))\x22' -AllMatches).Matches | ForEach-Object { " ^
     "  $p = Join-Path '%REPO_ROOT%' ('frontend\dist' + $_.Groups[1].Value.Replace('/', '\')); " ^
     "  if (-not (Test-Path $p)) { $missing = $true } " ^
     "}; " ^


### PR DESCRIPTION
## Summary
- `scripts/bat/start.bat`의 프론트엔드 빌드 산출물 검증용 PowerShell 정규식에서, cmd.exe가 `\"`를 이스케이프로 인식하지 못해 따옴표가 조기 종료되고 PowerShell -Command 인자가 잘려 실행되는 문제 수정
- 리터럴 큰따옴표를 `\x22` hex escape로 대체해 배치 인자 문자열 안에 실제 `"` 문자가 섞이지 않도록 변경 (cmd/PowerShell 양쪽에서 정상 동작)

Fixes #164

## Test plan
- [ ] Windows에서 `scripts\bat\start.bat` 실행 시 오류 없이 정상 기동되는지 확인
- [ ] frontend/dist가 최신이 아닐 때 자동 리빌드 로직(BUILD 분기)이 여전히 정상 동작하는지 확인