### PR TITLE
fix: Windows Antigravity 설치 성공 오탐 실패 수정

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -426,15 +426,23 @@ def _resolve_cli_path(configured_path: str, bare_command: str) -> str:
     if found:
         return found
 
-    # Codex의 공식 Windows 설치 스크립트(install.ps1)는 ~/.local/bin이 아니라
-    # %LOCALAPPDATA%\Programs\OpenAI\Codex\bin에 설치한다 - CODEX_PATH
-    # 기본값(~/.local/bin/codex)과 실제 설치 위치가 OS별로 다른 유일한
-    # 경우라 별도로 확인한다.
-    if bare_command == "codex" and platform.system() == "Windows":
+    # Codex/Antigravity의 공식 Windows 설치 스크립트는 ~/.local/bin이 아니라
+    # 각각 %LOCALAPPDATA%\Programs\OpenAI\Codex\bin, %LOCALAPPDATA%\agy\bin에
+    # 설치한다 - *_PATH 기본값(~/.local/bin/...)과 실제 설치 위치가 OS별로
+    # 다른 경우라 별도로 확인한다. 이 확인이 없으면 설치 스크립트가 exit
+    # code 0으로 정상 종료해도 바이너리를 못 찾아 "성공했는데 실패로 표시"되는
+    # 모순이 생긴다(설치 직후 PATH 레지스트리 브로드캐스트는 이미 떠 있는
+    # 백엔드 프로세스의 os.environ["PATH"]는 갱신하지 못하므로 shutil.which도
+    # 도움이 안 된다).
+    if platform.system() == "Windows":
         localappdata = os.environ.get("LOCALAPPDATA", "")
         if localappdata:
-            candidate = os.path.join(localappdata, "Programs", "OpenAI", "Codex", "bin", "codex.exe")
-            if os.path.exists(candidate):
+            windows_candidates = {
+                "codex": os.path.join(localappdata, "Programs", "OpenAI", "Codex", "bin", "codex.exe"),
+                "agy": os.path.join(localappdata, "agy", "bin", "agy.exe"),
+            }
+            candidate = windows_candidates.get(bare_command)
+            if candidate and os.path.exists(candidate):
                 return candidate
 
     return bare_command

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -65,6 +65,24 @@ def test_resolve_cli_path_finds_codex_at_windows_localappdata(monkeypatch, tmp_p
     assert resolved == str(exe_path)
 
 
+def test_resolve_cli_path_finds_agy_at_windows_localappdata(monkeypatch, tmp_path):
+    """Antigravity의 공식 Windows 설치 스크립트(install.cmd)는 AGY_PATH 기본값
+    (~/.local/bin/agy)이 아니라 %LOCALAPPDATA%\\agy\\bin에 설치한다 - 이 위치를
+    확인하지 않으면 설치 스크립트가 exit code 0으로 정상 종료해도 바이너리를
+    찾지 못해 성공을 실패로 잘못 표시하는 버그가 재발한다."""
+    localappdata = tmp_path / "LocalAppData"
+    bin_dir = localappdata / "agy" / "bin"
+    bin_dir.mkdir(parents=True)
+    exe_path = bin_dir / "agy.exe"
+    exe_path.write_text("")
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
+    resolved = config._resolve_cli_path("/nonexistent/agy", "agy")
+    assert resolved == str(exe_path)
+
+
 def test_resolve_cli_path_windows_codex_fallback_not_applied_to_other_clis(monkeypatch, tmp_path):
     """Windows LOCALAPPDATA 폴백은 codex 전용이다 - agy/claude에 잘못 적용되지
     않아야 한다."""


### PR DESCRIPTION
## Summary
- Windows에서 Antigravity(agy) CLI 설치 스크립트(install.cmd)가 exit code 0으로 정상 종료했는데도, `_resolve_cli_path`가 agy의 실제 Windows 설치 위치(`%LOCALAPPDATA%\agy\bin\agy.exe`)를 몰라서 "설치됨" 판정에 실패해 `설치 스크립트가 오류 코드 0로 종료되었습니다` 라는 모순된 에러가 표시되던 문제 수정
- codex에 이미 있던 `%LOCALAPPDATA%` Windows 폴백 패턴을 agy에도 동일하게 적용 (`backend/config.py`)
- 회귀 방지 테스트 `test_resolve_cli_path_finds_agy_at_windows_localappdata` 추가

## Test plan
- [x] `backend/tests/test_config_cross_platform.py` 관련 테스트 통과 확인 (신규 agy 테스트 포함, 14 passed)
- [ ] Windows에서 온보딩/설정 화면의 Antigravity 설치 버튼으로 실제 설치 성공 판정이 정상 표시되는지 확인