### PR TITLE
fix: Windows에서 agy.exe 프롬프트가 cmd /c 재파싱으로 잘리던 문제 수정

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -78,9 +78,23 @@ def windows_safe_exec_args(cmd):
     설치되어 있어도 "[WinError 2] 지정된 파일을 찾을 수 없습니다" 오류로
     실행 자체가 실패한다. Windows에서는 cmd.exe를 경유해 PATHEXT 확장자
     검색·해석을 맡기는 방식으로 이를 우회한다 (macOS/Linux는 기존과 동일).
+
+    단, agy(Antigravity)의 공식 Windows 설치본은 .cmd 셔임이 아니라 실제
+    agy.exe 네이티브 바이너리다(get_agy_path의 %LOCALAPPDATA%\\agy\\bin
+    폴백 참고). 이런 .exe까지 cmd /c로 감싸면, cmd.exe가 전달받은 인자
+    문자열을 자기 방식대로 다시 파싱하면서 인자 안의 개행 문자(\\n)를
+    명령 경계로 오인해 그 뒤 내용을 통째로 잘라버린다 - 실제로 번역
+    프롬프트(안내문 뒤에 \\n\\n으로 이어지는 원문 본문)를 --print 인자로
+    넘기면 agy가 안내문만 받고 원문 본문은 통째로 사라져, "번역할 텍스트를
+    알려주세요"만 반복 응답하는 버그로 이어졌다. .exe는 CreateProcess가
+    셸 없이 바로 실행할 수 있으므로 cmd.exe 경유 자체가 불필요하다 -
+    .cmd/.bat 래퍼(확장자가 .exe가 아닌 경우)만 cmd /c로 감싼다.
     """
     import platform
     if platform.system() == "Windows":
+        exe_path = cmd[0] if cmd else ""
+        if isinstance(exe_path, str) and exe_path.lower().endswith(".exe"):
+            return list(cmd)
         return ["cmd", "/c"] + list(cmd)
     return list(cmd)
 

--- a/backend/tests/test_config_cross_platform.py
+++ b/backend/tests/test_config_cross_platform.py
@@ -29,6 +29,29 @@ def test_windows_safe_exec_args_passthrough_on_posix(monkeypatch):
     assert result == ["claude", "--print", "hello"]
 
 
+def test_windows_safe_exec_args_does_not_wrap_native_exe(monkeypatch):
+    """agy(Antigravity)의 공식 Windows 설치본은 .cmd 셔임이 아니라 실제
+    agy.exe 네이티브 바이너리다. 이런 .exe까지 cmd /c로 감싸면 cmd.exe가
+    인자 문자열(개행이 포함된 멀티라인 번역 프롬프트)을 자기 방식대로 다시
+    파싱하면서 개행 이후 내용을 통째로 잘라버려, 실제 번역할 원문이 CLI에
+    전달되지 않는 버그로 이어졌다 - .exe는 cmd.exe 경유 없이 CreateProcess가
+    직접 실행할 수 있으므로 감싸면 안 된다."""
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    exe_path = "C:\\Users\\test\\AppData\\Local\\agy\\bin\\agy.exe"
+    multiline_prompt = "instructions\n\nactual text to translate"
+    result = config.windows_safe_exec_args([exe_path, "--print", multiline_prompt])
+    assert result == [exe_path, "--print", multiline_prompt]
+
+
+def test_windows_safe_exec_args_still_wraps_non_exe_on_windows(monkeypatch):
+    """claude/codex처럼 npm으로 설치되어 .cmd/.bat 래퍼로 배포되는(확장자가
+    .exe가 아닌) 경우는 여전히 cmd /c로 감싸야 CreateProcess가 실행할 수
+    있다 - .exe 우회 처리가 이 기존 케이스를 깨뜨리지 않는지 확인."""
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    result = config.windows_safe_exec_args(["claude.cmd", "--print", "hello"])
+    assert result == ["cmd", "/c", "claude.cmd", "--print", "hello"]
+
+
 def test_resolve_cli_path_prefers_existing_configured_path(tmp_path):
     real_binary = tmp_path / "claude"
     real_binary.write_text("#!/bin/sh\n")


### PR DESCRIPTION
## Summary
- Windows에서 Antigravity(`agy`)로 번역을 시도하면 CLI가 "번역할 텍스트를 알려주세요" 같은 응답만 반복하던 문제의 원인을 발견 및 수정
- `agy`의 공식 Windows 설치본은 `.cmd` 셔임이 아니라 실제 `agy.exe` 네이티브 바이너리인데, `windows_safe_exec_args`가 모든 Windows CLI 호출을 무조건 `cmd /c`로 감싸고 있었음
- `.exe`까지 `cmd.exe`를 경유하면, cmd.exe가 전달받은 인자 문자열을 자기 방식대로 다시 파싱하면서 번역 프롬프트 안내문 뒤의 개행(`\n\n`)을 명령 경계로 오인해 그 뒤에 이어지는 실제 번역 원문을 통째로 잘라버림 → agy는 안내문만 받고 실제 텍스트는 전혀 받지 못함
- `cmd[0]`이 `.exe`로 끝나면 `cmd.exe` 경유 없이 CreateProcess가 직접 실행하도록 수정하고, `.cmd`/`.bat` 래퍼(claude/codex npm 셔임 등)만 기존대로 `cmd /c`로 감싸도록 조건 추가 (`backend/config.py`)
- 회귀 방지 테스트 2개 추가 (`.exe`는 감싸지 않음 / 비-`.exe`는 여전히 감쌈)

## Test plan
- [x] `backend/tests/test_config_cross_platform.py` 관련 테스트 통과 확인 (신규 2개 포함)
- [ ] Windows에서 Antigravity로 실제 번역 시도 시 원문이 정상적으로 CLI에 전달되고 번역 결과가 나오는지 확인