### PR TITLE
fix: Figure/Table/Equation 참조 번호가 로마 숫자인 경우 오버레이 매칭 실패 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -596,11 +596,21 @@ def render_cover_image(pdf_path: str, output_path: str, top_fraction: float = 0.
         doc.close()
 
 
-_CAPTION_RE = re.compile(r"^\s*(Fig(?:ure)?|Table)\.?\s*(\d+)\b\.?\s*[:.\-]?\s*", re.IGNORECASE)
-# 수식 번호: 줄 끝에 "(3)"처럼 소괄호 숫자만 단독으로 오는 경우만 인정한다. 인용
-# 연도("...(2020)")와 헷갈리지 않도록 자릿수를 1~3자리로 제한한다(수식 번호가
-# 999개를 넘는 논문은 사실상 없음. 반면 연도는 항상 4자리라 자동으로 배제됨).
-_EQUATION_LINE_RE = re.compile(r"\((\d{1,3})\)\s*$")
+# 일부 논문은 Figure/Table/수식 번호를 아라비아 숫자 대신 로마 숫자(I, II, III, IV...)로
+# 매긴다(부록 표/수식에 흔함). "IVX" 같은 무효한 조합은 배제하고 정식 로마 숫자
+# 표기(1~3999)만 인정하도록 표준 로마 숫자 검증 패턴을 사용한다. 맨 앞의
+# lookahead((?=[MDCLXVI]))는 그룹이 전부 빈 문자열로만 매칭되어 공백 문자열이
+# "로마 숫자"로 인정되는 것을 막기 위함이다.
+_ROMAN_NUMERAL_RE = r"(?=[MDCLXVI])M{0,4}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})"
+_CAPTION_RE = re.compile(
+    rf"^\s*(Fig(?:ure)?|Table)\.?\s*(\d+|{_ROMAN_NUMERAL_RE})\b\.?\s*[:.\-]?\s*", re.IGNORECASE
+)
+# 수식 번호: 줄 끝에 "(3)"처럼 소괄호 숫자(또는 로마 숫자)만 단독으로 오는 경우만
+# 인정한다. 인용 연도("...(2020)")와 헷갈리지 않도록 자릿수를 1~3자리로 제한한다
+# (수식 번호가 999개를 넘는 논문은 사실상 없음. 반면 연도는 항상 4자리라 자동으로
+# 배제됨). 로마 숫자는 대문자만 인정한다(re.IGNORECASE를 안 씀) - 본문에
+# 흔한 "(i)", "(ii)" 같은 소문자 열거 표기를 수식 번호로 오인하지 않기 위함이다.
+_EQUATION_LINE_RE = re.compile(rf"\((\d{{1,3}}|{_ROMAN_NUMERAL_RE})\)\s*$")
 
 
 def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
@@ -631,10 +641,18 @@ def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
             if not plain_text:
                 continue
             m = _CAPTION_RE.match(plain_text)
-            if not m:
+            # 로마 숫자 대안 분기(_ROMAN_NUMERAL_RE)는 lookahead만으로는 빈 문자열
+            # 매칭을 완전히 막지 못한다 - "Table Introduction..."처럼 로마 숫자
+            # 글자(I/V/X/L/C/D/M)로 시작하는 일반 단어가 뒤따르면 숫자 그룹이
+            # 빈 문자열로 매칭되고도 \b 경계 조건은 통과해버린다. group(2)가
+            # 비어 있으면 실제 캡션이 아니므로 명시적으로 걸러낸다.
+            if not m or not m.group(2):
                 continue
             kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"
-            number = m.group(2)
+            # 로마 숫자는 대소문자 상관없이 매칭되지만("fig. iv"도 허용), 프론트엔드의
+            # 본문 참조 매칭과 항상 같은 대문자 표기로 라벨을 맞춰야 한다(대문자
+            # 로마 숫자가 관례이므로 digit은 그대로 두고 로마 숫자만 사실상 영향받음).
+            number = m.group(2).upper()
             caption_text = " ".join(t for t in line_texts[i:] if t).strip()
             captions.append({
                 "label": f"{kind} {number}",
@@ -726,7 +744,7 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
             if not line_text:
                 continue
             m = _EQUATION_LINE_RE.search(line_text)
-            if m:
+            if m and m.group(1):
                 candidates.append((bbox, m.group(1)))
 
     equations = []

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6414,10 +6414,22 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
 // 오버레이와 동일한 원칙으로, 백엔드가 좌표+라벨을 뽑아낸(=documentImages에
 // 실제로 존재하는) 대상을 가리키는 표기만 호버 가능한 박스로 그린다.
 //
+// 일부 논문은 Figure/Table/수식 번호를 아라비아 숫자 대신 로마 숫자(I, II, III...)로
+// 매긴다(부록 표/수식에 흔함). backend(pdf_parser.py)의 _ROMAN_NUMERAL_RE와 동일한
+// 표준 로마 숫자(1~3999) 검증 패턴 - "IVX" 같은 무효한 조합은 배제한다. 맨 앞의
+// lookahead는 그룹이 전부 빈 문자열로 매칭되어 공백이 "로마 숫자"로 인정되는 것을 막는다.
+const ROMAN_NUMERAL_SRC = '(?=[MDCLXVI])M{0,4}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})'
+const ROMAN_NUMERAL_TOKEN_RE = new RegExp(`^${ROMAN_NUMERAL_SRC}$`, 'i')
+
 // 복수형(Figures/Figs/Tables)과 "Figs. 3-5", "Figures 1 and 2", "Table 1, 2"
 // 처럼 여러 개를 한 번에 가리키는 표기도 지원하기 위해, 키워드 뒤에 오는
-// 숫자 나열 전체를 그룹으로 캡처한 뒤 parseFigureTableNumberList로 펼친다.
-const FIGURE_TABLE_REF_RE = /\b(Figures?|Figs?|Tables?|Equations?|Eqns?|Eqs?)\.?\s*\(?\s*((?:\d+\s*(?:(?:[-–,]|and|&)\s*)+)*\d+)\b\)?/gi
+// 숫자(또는 로마 숫자) 나열 전체를 그룹으로 캡처한 뒤 parseFigureTableNumberList로 펼친다.
+const FIGURE_TABLE_NUM_SRC = `(?:\\d+|${ROMAN_NUMERAL_SRC})`
+const FIGURE_TABLE_REF_RE = new RegExp(
+  `\\b(Figures?|Figs?|Tables?|Equations?|Eqns?|Eqs?)\\.?\\s*\\(?\\s*` +
+  `((?:${FIGURE_TABLE_NUM_SRC}\\s*(?:(?:[-–,]|and|&)\\s*)+)*${FIGURE_TABLE_NUM_SRC})\\b\\)?`,
+  'gi'
+)
 
 function normalizeFigureTableKind(keyword) {
   const kw = keyword.toLowerCase()
@@ -6426,8 +6438,10 @@ function normalizeFigureTableKind(keyword) {
   return 'Equation'
 }
 
-// "1", "1, 2", "3-5", "1 and 2", "1, 2 and 3" 같은 숫자 나열을 개별 번호
-// 목록으로 펼친다 (본문 인용 파싱의 parseCitationNumbers와 동일한 원칙).
+// "1", "1, 2", "3-5", "1 and 2", "1, 2 and 3", "I", "I and II" 같은 숫자(아라비아
+// 또는 로마) 나열을 개별 번호 목록으로 펼친다 (본문 인용 파싱의 parseCitationNumbers와
+// 동일한 원칙). 로마 숫자는 범위("I-III") 표기는 흔치 않아 지원하지 않고, backend가
+// 라벨을 항상 대문자로 저장하므로(_find_page_captions) 매칭을 위해 대문자로 맞춘다.
 function parseFigureTableNumberList(text) {
   const nums = []
   const normalized = text.replace(/&/g, ',').replace(/\band\b/gi, ',')
@@ -6441,10 +6455,11 @@ function parseFigureTableNumberList(text) {
       if (end >= start && end - start <= 50) {
         for (let n = start; n <= end; n++) nums.push(String(n))
       }
-    } else {
-      const single = trimmed.match(/^\d+$/)
-      if (single) nums.push(single[0])
+      return
     }
+    const single = trimmed.match(/^\d+$/)
+    if (single) { nums.push(single[0]); return }
+    if (ROMAN_NUMERAL_TOKEN_RE.test(trimmed)) nums.push(trimmed.toUpperCase())
   })
   return nums
 }
@@ -6466,6 +6481,10 @@ function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
   FIGURE_TABLE_REF_RE.lastIndex = 0
   let match
   while ((match = FIGURE_TABLE_REF_RE.exec(vtm.fullText)) !== null) {
+    // 로마 숫자 대안 분기는 lookahead만으로 빈 문자열 매칭을 완전히 막지 못해
+    // "Table Introduction..."처럼 로마 숫자 글자로 시작하는 일반 단어도 숫자 그룹이
+    // 빈 문자열로 매칭될 수 있다 - 이런 경우는 실제 참조 표기가 아니므로 건너뛴다.
+    if (!match[2]) continue
     const kind = normalizeFigureTableKind(match[1])
     const numbers = parseFigureTableNumberList(match[2])
     const targets = numbers


### PR DESCRIPTION
# Summary
## 1. 로마 숫자 번호 지원 추가
- `backend/services/pdf_parser.py`의 `_CAPTION_RE`(Figure/Table 캡션 매칭)와 `_EQUATION_LINE_RE`(수식 번호 매칭)가 아라비아 숫자(`\d+`)만 인식하던 것을 표준 로마 숫자(1~3999) 패턴도 함께 인식하도록 수정
- `frontend/src/main.js`의 `FIGURE_TABLE_REF_RE`(본문 중 "Figure I", "Table II", "Eq. (III)" 같은 참조 표기 감지)와 `parseFigureTableNumberList`도 동일하게 로마 숫자 지원 추가
- 수식 번호(`_EQUATION_LINE_RE`)는 대문자 로마 숫자만 인정(`re.IGNORECASE` 미적용) - 본문에 흔한 "(i)", "(ii)" 같은 소문자 열거 표기를 수식 번호로 오인하지 않도록 함
- 백엔드 캡션 라벨과 프론트엔드 참조 번호를 모두 대문자로 정규화해 대소문자 표기 차이와 무관하게 매칭되도록 함

## 2. 로마 숫자 정규식의 빈 매칭 취약점 방어
- 로마 숫자 패턴의 lookahead만으로는 빈 문자열 매칭을 완전히 막지 못해, "Table Introduction..."처럼 로마 숫자 글자(I/V/X/L/C/D/M)로 시작하는 일반 단어 뒤에서도 숫자 그룹이 빈 문자열로 매칭되고 단어 경계 조건은 통과해버리는 것을 발견
- `_find_page_captions`, `_find_page_equations`(백엔드)와 `renderFigureRefOverlayLayer`(프론트엔드)에 캡처된 번호가 비어 있으면 실제 참조가 아닌 것으로 건너뛰는 방어 코드 추가

## Test plan
- [x] 합성 PDF로 "Figure IV", "Table II", "Eq. (III)" 캡션/수식 번호가 정상 추출되는지 확인
- [x] 로마 숫자 글자로 시작하는 일반 단어("Table Introduction...")가 오탐되지 않는지 확인 (백엔드/프론트엔드 모두)
- [x] 기존 아라비아 숫자 표기("Table 3", "Figs. 1 and 2")가 계속 정상 동작하는지 확인
- [x] `npm run build` 정상 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)