### PR TITLE
fix: 데스크톱 앱 버전을 0.1.1-beta.1로 올려 업데이터 감지 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1-beta.1",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.1.1-beta.1"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.1.1-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.1",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
## Summary
- `v0.1.0-beta.1`~`beta.5`까지 git 태그 이름만 바뀌었을 뿐, `tauri.conf.json`/`Cargo.toml`/`package.json`의 실제 앱 버전은 계속 `0.1.0`으로 고정되어 있었음
- Tauri 업데이터는 git 태그가 아니라 앱에 내장된 semver 버전으로 신규 여부를 비교하므로, 모든 릴리스의 `latest.json`이 동일한 `version: "0.1.0"`을 가리켜 지금까지 업데이트 감지가 원천적으로 불가능했음 (실제로 `beta.1`과 `beta.5`의 `latest.json`을 비교해 확인)
- 베이스 버전을 `0.1.1`로 올려야 기존 설치본(`0.1.0`)보다 확실히 "더 높은" 버전으로 비교됨 (같은 베이스에 `-beta.N` prerelease만 붙이면 semver상 오히려 더 낮게 취급되어 여전히 감지 안 됨)
- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`을 `0.1.1-beta.1`로 통일

## Test plan
- [ ] `v0.1.1-beta.1` 릴리스 후 `latest.json`의 `version`이 `0.1.1-beta.1`인지 확인
- [ ] 기존 베타(0.1.0) 설치본에서 앱 업데이트 확인 시 새 버전이 정상적으로 감지되는지 확인