### PR TITLE
fix: 앱 버전의 -beta.N 접미사가 Windows MSI 빌드를 깨뜨리던 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.1-beta.1"
+version = "0.1.1"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,12 @@
+# version: 릴리스마다 반드시 이전 배포본보다 큰 값으로 올려야 Tauri
+# updater가 새 버전을 감지한다(git 태그 이름과 무관 - updater는 이 값만
+# 본다). "-beta.N" 같은 비숫자 prerelease 접미사는 붙이지 말 것 - Windows
+# MSI(WiX) 번들러가 숫자로만 이루어진 prerelease만 허용해 빌드 자체가
+# 실패한다("optional pre-release identifier ... must be numeric-only").
+# 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.1-beta.1"
+version = "0.1.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
## Summary
- `v0.1.1-beta.1`로 릴리스를 시도했더니 Windows MSI(WiX) 번들러가 `optional pre-release identifier ... must be numeric-only and cannot be greater than 65535 for msi target` 에러로 빌드 실패 (macOS/Linux는 정상 빌드됨)
- WiX는 semver의 임의 prerelease 문자열(`-beta.N`)을 지원하지 않음
- 버전을 순수 숫자 `0.1.1`로 변경 - "베타" 표시는 git 태그/릴리스 노트에서만 하고, 앱 내장 버전은 항상 숫자만 증가
- 재발 방지를 위해 `Cargo.toml`에 제약 설명 주석 추가
- 실패했던 `v0.1.1-beta.1` 태그/릴리스(Windows 에셋 누락된 불완전 상태)는 삭제 완료

## Test plan
- [ ] `v0.1.1` 태그 push 시 Windows/Linux/macOS 3개 플랫폼 모두 정상 빌드되는지 확인