### PR TITLE
fix: Windows 자동 업데이트 설치 시 sidecar DLL 잠금으로 실패하던 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DZZgg9Y0.js"></script>
+  <script type="module" crossorigin src="/assets/index-aciJFm3h.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ca9Rsbe5.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2753,6 +2753,20 @@ async function installTauriUpdate() {
   if (tauriUpdateCheckBtn) tauriUpdateCheckBtn.disabled = true
 
   try {
+    // Windows 설치 프로그램이 파일을 덮어쓰기 전에 백엔드 sidecar를 먼저
+    // 종료해야 한다 - 계속 떠 있으면 PyInstaller 런타임이 로드한 DLL(예:
+    // MSVCP140.dll)을 OS가 잠그고 있어서 "Error opening file for writing"
+    // 오류로 설치가 멈춘다. downloadAndInstall의 진행 콜백은 await하지
+    // 않고 그냥 호출되므로, 'Finished' 이벤트 시점에 죽이면 설치 시작과
+    // 경쟁 상태가 생길 수 있다 - 다운로드 시작 전에 미리 종료해 둔다
+    // (다운로드 자체는 sidecar 없이도 문제없이 동작한다).
+    try {
+      const { invoke } = await import('@tauri-apps/api/core')
+      await invoke('kill_backend_sidecar')
+    } catch (killErr) {
+      console.warn('sidecar 종료 실패(무시하고 설치 계속):', killErr)
+    }
+
     let downloadedBytes = 0
     let totalBytes = 0
     await pendingTauriUpdate.downloadAndInstall((event) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -149,6 +149,18 @@ fn kill_sidecar(state: &tauri::State<SidecarState>) {
     }
 }
 
+/// 프론트엔드가 Tauri updater로 새 버전을 다운로드·설치하기 직전에 호출한다.
+/// PyInstaller onedir sidecar가 계속 떠 있으면 자신이 로드한 DLL(예:
+/// MSVCP140.dll)을 OS 레벨에서 잠그고 있어서, Windows 설치 프로그램이 같은
+/// 경로에 새 버전 파일을 덮어쓰지 못하고 "Error opening file for writing"
+/// 오류로 멈춘다 - 자동 업데이트로 설치를 시작하기 전에 sidecar를 먼저
+/// 종료해 파일 잠금을 풀어줘야 한다.
+#[tauri::command]
+fn kill_backend_sidecar(state: tauri::State<SidecarState>) {
+    log::info!("update install requested, killing sidecar to release locked files");
+    kill_sidecar(&state);
+}
+
 /// 앱 시작에 필요한 필수 자원(리소스 디렉토리, sidecar 프로세스 등)을 얻지
 /// 못했을 때 쓴다. 이런 실패는 대부분 백신이 sidecar 바이너리를 격리했거나
 /// 디스크 권한 문제처럼 사용자가 직접 손댈 수 없는 환경 문제라 복구를
@@ -175,6 +187,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .manage(SidecarState(Mutex::new(None)))
+        .invoke_handler(tauri::generate_handler![kill_backend_sidecar])
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(


### PR DESCRIPTION
## Summary
- 사용자 제보: Windows에서 앱 내 자동 업데이트 설치 중 `Error opening file for writing: ...\_internal\MSVCP140.dll` 오류로 설치가 중단됨 (ask/image.png 스크린샷)
- 원인: `installTauriUpdate()`가 `downloadAndInstall()`로 새 버전을 받고 설치하는 동안, 백엔드 PyInstaller onedir sidecar 프로세스가 여전히 실행 중이라 자신이 로드한 DLL을 OS가 잠그고 있었음. `kill_sidecar`는 지금까지 창 닫기/앱 종료 시에만 호출됐고 업데이트 설치 흐름에서는 전혀 호출되지 않았음
- `src-tauri/src/lib.rs`에 `kill_backend_sidecar` 커맨드 추가, `installTauriUpdate()`가 `downloadAndInstall()` 호출 **전에**(진행 콜백 안에서 호출하면 await되지 않아 설치 시작과 경쟁 상태가 생길 수 있어, 다운로드 시작 전에 미리 종료) 이를 호출하도록 수정

## Test plan
- [ ] Windows에서 실제 자동 업데이트 설치 시 sidecar가 먼저 종료되고 설치가 파일 잠금 오류 없이 끝까지 완료되는지 확인
- [x] `npm run build` 정상 통과 확인