### PR TITLE
fix: 세로로 붙은 표들이 서로의 캡션에 잘못 매칭되어 오버레이가 과도하게 크롭되던 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -669,6 +669,16 @@ def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Dict[
     캡션은 보통 그림 바로 아래, 표는 바로 위에 위치하므로 상하 인접 캡션을 모두
     후보로 보되, 가로 범위가 겹치고 세로 거리가 가장 짧은 것을 채택합니다.
 
+    단, 이 상/하 허용은 각 캡션의 종류(Table/Figure)에 맞는 방향으로만
+    적용해야 한다. 두 표가 세로로 가깝게 붙어 있으면(예: TABLE III 바로
+    아래 TABLE IV), 위쪽 표(TABLE III) 입장에서 자기 자신의 캡션(위쪽)보다
+    아래에 있는 TABLE IV의 캡션이 절대 거리상 오히려 더 가까운 경우가
+    있다. 방향을 구분하지 않고 최소 거리만으로 고르면 위쪽 표가 아래쪽
+    표의 캡션에 잘못 매칭되어, label_groups 병합 단계에서 두 표가 하나의
+    bbox로 합쳐져 버린다(실제로 합성 PDF로 재현됨 - TABLE III와 TABLE IV가
+    하나의 "Table IV" 오버레이로 크롭되는 버그). Table 캡션은 위에 있을
+    때만, Figure 캡션은 아래에 있을 때만 후보로 인정한다.
+
     벡터 그래픽으로 그려진 다이어그램은 (숨겨진 배경 사각형 등으로 인해) 감지된
     bbox가 실제 그림 내용보다 아래/위로 더 뻗어 있어 캡션 줄과 겹쳐버리는
     경우가 있다. 이 경우 캡션을 후보에서 완전히 제외하면 매칭 자체가 실패하므로,
@@ -685,20 +695,31 @@ def _match_caption_for_rect(rect: list, captions: List[Dict[str, Any]]) -> Dict[
         overlap = min(x1, cx1) - max(x0, cx0)
         if overlap <= 0:
             continue
+        is_table_caption = cap["label"].startswith("Table")
         clip_y0 = None
         clip_y1 = None
-        if cy0 >= y1:
-            dist = cy0 - y1  # 캡션이 아래에 있는 경우 (Figure)
-        elif cy1 <= y0:
-            dist = y0 - cy1  # 캡션이 위에 있는 경우 (Table)
-        elif cy0 >= y1 - edge_margin:
-            # 사각형 하단 가장자리 부근까지 캡션이 파고든 경우 - 사실상 바로
-            # 아래에 있는 캡션으로 보고 인정하되, 캡션 시작 지점에서 잘라낸다
-            dist = 0.0
-            clip_y1 = cy0
+        if cy1 <= y0:
+            # 캡션이 사각형 위에 있는 경우 - Table 관례에만 부합
+            if not is_table_caption:
+                continue
+            dist = y0 - cy1
+        elif cy0 >= y1:
+            # 캡션이 사각형 아래에 있는 경우 - Figure 관례에만 부합
+            if is_table_caption:
+                continue
+            dist = cy0 - y1
         elif cy1 <= y0 + edge_margin:
+            # 사각형 상단 가장자리 부근까지 캡션이 파고든 경우 - 사실상 바로
+            # 위에 있는 캡션으로 보고 인정(Table 방향)하되, 캡션 끝 지점에서 잘라낸다
+            if not is_table_caption:
+                continue
             dist = 0.0
             clip_y0 = cy1
+        elif cy0 >= y1 - edge_margin:
+            if is_table_caption:
+                continue
+            dist = 0.0
+            clip_y1 = cy0
         else:
             continue  # 사각형 중심부까지 깊이 겹치는 캡션은 대상에서 제외
         if dist > 40.0:
@@ -978,13 +999,23 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
         # 미매칭 사각형은 같은 그림의 일부로 보고 흡수한다. 한 번 흡수하면
         # 그룹의 bbox가 커져 다음 패널과도 새로 인접할 수 있으므로 더 이상
         # 흡수할 것이 없을 때까지 반복한다.
+        #
+        # 이 흡수는 Figure 전용이다 - Table은 항상 하나의 완결된 그리드라
+        # 서브패널을 다시 이어붙일 필요가 없고, 페이지 폭 전체를 차지하는
+        # 표(Table III 등) 바로 아래 40pt 이내에 있는, 전혀 무관한 다른
+        # 표/그림(예: 옆 칸에 나란히 놓인 Table IV의 차트)까지 "가로로 많이
+        # 겹친다"는 이유로 잘못 흡수해버리는 문제가 있었다 - 겹침 비율이
+        # 더 좁은 쪽(흡수 대상) 폭 기준이라, 폭이 넓은 표는 그 아래 있는
+        # 어떤 좁은 요소와도 쉽게 "많이 겹치는" 것으로 계산되기 때문이다.
         changed = True
         while changed and unlabeled_rects:
             changed = False
             still_unlabeled = []
             for u in unlabeled_rects:
                 absorbed = False
-                for g in label_groups.values():
+                for label, g in label_groups.items():
+                    if label.startswith("Table"):
+                        continue
                     rect = g["rect"]
                     gap = _vertical_gap(rect, u)
                     if gap < 0 or gap > _PANEL_ABSORB_MAX_GAP:

--- a/backend/tests/test_pdf_parser_images.py
+++ b/backend/tests/test_pdf_parser_images.py
@@ -95,6 +95,96 @@ def test_stacked_panel_figure_absorbs_distant_unlabeled_panel(tmp_path):
     assert entry_bottom_pct >= (bottom_rect.y1 / page_height) * 100 - 1
 
 
+def test_upper_table_does_not_match_lower_tables_caption(tmp_path):
+    """세로로 가깝게 붙은 두 표(예: TABLE III 바로 아래 TABLE IV)가 있으면,
+    위쪽 표(TABLE III) 입장에서 자기 자신의 캡션(위쪽)보다 아래쪽 표
+    (TABLE IV)의 캡션이 절대 거리상 오히려 더 가까울 수 있다. 방향을
+    구분하지 않고 최소 거리만으로 캡션을 고르면 위쪽 표가 아래쪽 표의
+    캡션에 잘못 매칭되어, 두 표가 하나의 bbox로 합쳐져 버리는 버그가
+    있었다(Table IV를 클릭하면 TABLE III까지 통째로 크롭되어 보임).
+    Table 캡션은 표 위에 있을 때만 후보로 인정해야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    # TABLE III: 캡션이 표 위 지점에 있음(자기 자신과의 거리는 40pt 이내로,
+    # 그러나 TABLE IV 캡션과의 거리(아래 참고)보다는 더 멀게)
+    page.insert_text((250, 45), "TABLE III", fontsize=9)
+    page.draw_line(fitz.Point(50, 75), fitz.Point(545, 75), color=(0, 0, 0), width=1)
+    page.insert_text((60, 90), "datasets methods average kappa", fontsize=7)
+    page.draw_line(fitz.Point(50, 100), fitz.Point(545, 100), color=(0, 0, 0), width=1)
+    page.insert_text((60, 112), "Conformer 88.19 0.7155", fontsize=7)
+    page.draw_line(fitz.Point(50, 155), fitz.Point(545, 155), color=(0, 0, 0), width=1)
+
+    # TABLE IV: TABLE III 바로 아래, 폭이 더 좁은 표. TABLE III 사각형에서
+    # TABLE IV 캡션까지의 거리가 TABLE III 자신의 캡션까지 거리보다 오히려 더 짧다.
+    page.insert_text((150, 180), "TABLE IV", fontsize=9)
+    page.draw_line(fitz.Point(50, 218), fitz.Point(290, 218), color=(0, 0, 0), width=1)
+    page.insert_text((60, 232), "datasets methods accuracy kappa", fontsize=7)
+    page.draw_line(fitz.Point(50, 240), fitz.Point(290, 240), color=(0, 0, 0), width=1)
+    page.insert_text((60, 252), "Conformer 95.30 0.9295", fontsize=7)
+    page.draw_line(fitz.Point(50, 315), fitz.Point(290, 315), color=(0, 0, 0), width=1)
+
+    path = tmp_path / "adjacent_tables.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    labels = sorted(r.get("label") or "" for r in result)
+    assert labels == ["Table III", "Table IV"], f"두 표가 별도 항목으로 남아야 하는데: {result}"
+
+    table3 = next(r for r in result if r["label"] == "Table III")
+    table4 = next(r for r in result if r["label"] == "Table IV")
+    page_height = 842
+    # Table III의 크롭 범위가 Table IV 영역(y=218 이후)까지 침범하면 안 된다
+    table3_bottom_pct = table3["top"] + table3["height"]
+    assert table3_bottom_pct < (218 / page_height) * 100
+
+
+def test_wide_table_does_not_absorb_unrelated_figure_below(tmp_path):
+    """페이지 폭 전체를 차지하는 표(Table) 바로 아래 40pt 이내에, 그 표와는
+    무관하게 옆 칸에 나란히 놓인 다른 그림/차트가 있을 수 있다. 서브패널
+    흡수 로직(_PANEL_ABSORB_*)은 겹침 비율을 더 좁은 쪽(흡수 대상) 폭
+    기준으로 계산하므로, 폭이 넓은 표는 그 아래 있는 어떤 좁은 요소와도
+    "가로로 많이 겹치는" 것으로 오판되어 무관한 그림까지 표 안으로
+    흡수해버리는 버그가 있었다. 이 흡수는 Figure 전용으로 제한되어야
+    하고, Table은 무관한 아래쪽 요소를 흡수하면 안 된다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    # 페이지 폭 전체를 차지하는 표
+    page.insert_text((250, 45), "Table 1", fontsize=9)
+    page.draw_line(fitz.Point(50, 75), fitz.Point(545, 75), color=(0, 0, 0), width=1)
+    page.insert_text((60, 90), "datasets methods average kappa", fontsize=7)
+    page.draw_line(fitz.Point(50, 100), fitz.Point(545, 100), color=(0, 0, 0), width=1)
+    page.draw_line(fitz.Point(50, 155), fitz.Point(545, 155), color=(0, 0, 0), width=1)
+
+    # 표 바로 아래(39pt 간격), 표 폭의 오른쪽 절반에만 걸치는 무관한 차트
+    # (자기 캡션은 이 페이지에 없음 - 다른 페이지의 Figure에 속한다고 가정)
+    chart_rect = fitz.Rect(330, 194, 545, 340)
+    page.draw_rect(chart_rect, color=(0, 0, 0), width=1.2)
+    page.draw_line(fitz.Point(340, 330), fitz.Point(500, 210), color=(0.3, 0.3, 0.8), width=3)
+
+    path = tmp_path / "wide_table_unrelated_chart.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    table_entries = [r for r in result if r.get("label") == "Table 1"]
+    assert len(table_entries) == 1
+    table_entry = table_entries[0]
+
+    page_height = 842
+    table_bottom_pct = table_entry["top"] + table_entry["height"]
+    # 표의 크롭 범위가 차트 시작 지점(y=194) 아래까지 뻗어나가면 안 된다
+    assert table_bottom_pct < (194 / page_height) * 100 + 2, (
+        f"Table 1이 무관한 차트를 흡수해 크롭 범위가 커짐: {table_entry}"
+    )
+
+    # 차트는 별도의 라벨 없는 항목으로 남아야 한다
+    unlabeled = [r for r in result if not r.get("label")]
+    assert len(unlabeled) == 1
+
+
 def test_unrelated_unlabeled_regions_are_not_merged(tmp_path):
     """캡션에 매칭되지 않는(라벨이 없는) 영역들은 서로 다른 그림/표의 잔여
     조각일 수 있으므로 하나로 합쳐지면 안 되고, 감지된 개수만큼 개별


### PR DESCRIPTION
## Summary
- 사용자 제보(ask/table_4_overlay.png): "Table IV" 참조를 클릭하면 바로 위 TABLE III와 오른쪽의 무관한 차트까지 통째로 크롭되어 보임
- **원인 1**: `_match_caption_for_rect`가 캡션 위치가 위/아래 중 어느 쪽이든 절대 거리만으로 가장 가까운 것을 채택했다. TABLE III 바로 아래 TABLE IV가 붙어 있으면, TABLE III 사각형 입장에서 자기 캡션(위쪽)보다 TABLE IV 캡션(아래쪽)이 오히려 더 가까운 경우가 있어 잘못 매칭되고, `label_groups` 병합 단계에서 두 표가 하나의 bbox로 합쳐짐 → Table 캡션은 위에 있을 때만, Figure 캡션은 아래에 있을 때만 후보로 인정하도록 방향 제한
- **원인 2**: 4-1 "서브패널 흡수" 로직(`_PANEL_ABSORB_*`)의 겹침 비율 계산이 더 좁은 쪽(흡수 대상) 폭 기준이라, 페이지 폭 전체를 차지하는 Table 아래 40pt 이내의 무관한 요소(옆 칸 차트 등)까지 오판 흡수함 → 이 흡수를 Figure 라벨 그룹에만 적용하도록 제한
- 합성 PDF로 두 문제 모두 재현 확인 후 수정, 회귀 방지 테스트 2개 추가

## Test plan
- [x] `backend/tests/test_pdf_parser_images.py` 전체 통과 (신규 2개 포함, 5 passed)
- [x] 합성 PDF로 실제 재현 및 수정 확인