### PR TITLE
fix: kill_backend_sidecar ACL 권한 누락으로 업데이트 설치 시 sidecar 종료가 조용히 실패하던 문제 수정

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,13 @@
 fn main() {
-  tauri_build::build()
+  // lib.rs의 kill_backend_sidecar처럼 앱이 직접 정의한 커맨드는 tauri_build::build()의
+  // 기본 설정만으로는 ACL 권한이 전혀 생성되지 않아, capabilities에 아무리 추가해도
+  // "not allowed by ACL"로 항상 막힌다(실제로 이 문제로 업데이트 설치 시 sidecar 종료
+  // 요청이 조용히 실패해 파일 잠금 버그가 재발했다). AppManifest::commands로 이
+  // 커맨드에 대한 allow-kill-backend-sidecar/deny-kill-backend-sidecar 권한이
+  // 자동 생성되도록 명시해야 capabilities/default.json에서 참조할 수 있다.
+  tauri_build::try_build(
+    tauri_build::Attributes::new()
+      .app_manifest(tauri_build::AppManifest::new().commands(&["kill_backend_sidecar"])),
+  )
+  .expect("failed to run tauri-build");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "process:allow-restart",
     "core:window:allow-set-theme",
     "core:window:allow-set-background-color",
-    "opener:default"
+    "opener:default",
+    "allow-kill-backend-sidecar"
   ]
 }


### PR DESCRIPTION
## Summary
- 사용자 제보(ask/image.png): v0.1.2(sidecar 종료 수정 포함, PR #174)에서도 여전히 `Error opening file for writing: ...MSVCP140.dll` 오류로 업데이트 설치가 실패함 (v0.1.3 시점에 재현)
- 원인: `tauri_build::build()`의 기본 설정은 앱이 직접 정의한 커맨드(`kill_backend_sidecar`)에 대해 ACL 권한을 전혀 생성하지 않는다. capabilities에 커맨드 이름을 아무리 추가해도 대응하는 권한 정의 자체가 없으면 Tauri IPC authority가 "not allowed by ACL"로 거부한다 (Tauri 소스코드 `tauri-utils`의 `acl/resolved.rs`, `acl/build.rs` 확인: `AppManifest::commands`로 명시한 커맨드만 `allow-$command`(kebab-case)/`deny-$command` 권한이 자동 생성됨)
- `installTauriUpdate()`의 `invoke('kill_backend_sidecar')` 호출이 매번 조용히 실패했고, try/catch가 이를 삼켜 설치가 sidecar를 죽이지 못한 채 그대로 진행되어 이전과 동일한 DLL 잠금 오류가 재발함
- `build.rs`에서 `AppManifest::commands(&["kill_backend_sidecar"])`로 권한 자동 생성을 명시하고, `capabilities/default.json`에 생성된 `"allow-kill-backend-sidecar"` 권한 추가

## Test plan
- [x] `tauri-desktop-spike.yml`(Tauri Sidecar Smoke Test)을 이 브랜치에서 수동 실행 - Windows/Linux/macOS 3개 플랫폼 모두 `cargo check` 통과 확인
- [ ] 실제 릴리스에서 Windows 자동 업데이트 설치가 DLL 잠금 오류 없이 끝까지 완료되는지 확인