### PR TITLE
feat: 레퍼런스 오버레이 인용 표기 감지 범위 확장

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -9,6 +9,10 @@
 "첫 저자 성(소문자) + 연도"를 키로 쓴다(예: "vaswani2017") - 프론트엔드의
 본문 인용 표기 매칭(main.js의 parseAuthorYearKeys)과 반드시 같은 키 형식을
 써야 한다.
+
+대괄호 스타일은 순수 숫자(`[12]`)뿐 아니라 alpha 스타일 BibTeX가 흔히 쓰는
+"저자 이니셜+연도" 키워드 키(`[BCV13]`, `[LBH+15]`, `[Dev86]` 등)도 그대로
+키로 인정한다 - 프론트엔드의 CITATION_MARKER_RE도 동일한 키 형식을 감지한다.
 """
 
 import re
@@ -22,7 +26,7 @@ _HEADER_PREFIX_RE = re.compile(
     r"참\s*고\s*문\s*헌)\b",
     re.IGNORECASE,
 )
-_BRACKET_ENTRY_RE = re.compile(r"^\s*\[(\d{1,3})\]\s*(.+)")
+_BRACKET_ENTRY_RE = re.compile(r"^\s*\[([A-Za-z0-9][A-Za-z0-9+\-]{0,9})\]\s*(.+)")
 _PLAIN_NUMBERED_ENTRY_RE = re.compile(r"^\s*(\d{1,3})[.)]\s+(.+)")
 
 # (Author, Year) 스타일 항목의 시작 줄 판별용 - "Surname, Initial..." 형태로

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -145,6 +145,20 @@ def test_parses_header_with_space_separated_drop_cap():
     assert refs == {"1": "Some Author. A paper title. 2020."}
 
 
+def test_parses_keyword_style_bracket_references():
+    """일부 논문(특히 VAE류)은 저자 이니셜+연도 키워드를 대괄호 키로 쓴다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "[BCV13] Y. Bengio, A. Courville, and P. Vincent. Representation "
+        "learning: A review and new perspectives. 2013.\n\n"
+        "[Dev86] G. E. Deville. Some early paper. 1986."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"BCV13", "Dev86"}
+    assert "Bengio" in refs["BCV13"]
+    assert "Deville" in refs["Dev86"]
+
+
 def test_author_year_keeps_first_entry_on_duplicate_key():
     """같은 저자가 같은 해에 여러 편(2020a/2020b 등)이면 먼저 나온 항목만 유지한다."""
     pages = [{"page_num": 1, "text": (

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-aciJFm3h.js"></script>
+  <script type="module" crossorigin src="/assets/index-BEU-LFL0.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ca9Rsbe5.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -48,6 +48,7 @@ const state = {
   quotedText: null,            // AI 질문 시 인용구 보관용
   documentImages: [],          // 문서 내 이미지 좌표 목록
   referenceMap: {},            // 참고문헌 번호 -> 원문 텍스트 맵
+  referencesHeaderPageNum: null, // References/참고문헌 섹션이 시작되는 페이지 번호(감지 전엔 null)
   quotedImage: null,           // AI 질문 시 인용 이미지 보관용 (Base64)
   quotedImagePage: null,       // AI 질문 시 인용 이미지의 페이지 번호
   pendingFigureQuote: null,    // 클릭 후 AI 질문 전 대기중인 인용 이미지 정보
@@ -325,7 +326,8 @@ function resetState() {
     sessionId: null, filename: null, title: null, totalPages: 0, currentPage: 1,
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
     chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null,
-    activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: [], referenceMap: {}
+    activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: [], referenceMap: {},
+    referencesHeaderPageNum: null
   })
   if (typeof toggleCropMode === 'function') toggleCropMode(false)
   viewerScrollContainer.innerHTML = ''
@@ -6309,23 +6311,38 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
   inner.appendChild(layer)
 }
 
-// 본문 인용 표기 두 스타일을 지원한다:
+// 본문 인용 표기 세 스타일을 지원한다:
 // 1) 번호 인용: [12], [12, 13], [12-14]
-// 2) 저자-연도 인용: (Smith, 2020), (Smith et al., 2020), (Smith & Jones, 2020),
+// 2) 키워드 인용(alpha 스타일 BibTeX): [BCV13], [BCV13, Dev86] - 저자 이니셜+
+//    연도 형태의 키(예: VAE 논문의 [BCV13], [Dev86])도 순수 숫자와 동일하게
+//    대괄호 토큰으로 취급한다. 백엔드 reference_parser.py의 _BRACKET_ENTRY_RE도
+//    동일한 키 형식을 파싱한다.
+// 3) 저자-연도 인용: (Smith, 2020), (Smith et al., 2020), (Smith & Jones, 2020),
 //    (Smith, 2020; Jones, 2019) 등 - 백엔드 reference_parser.py의
 //    _parse_author_year_entries와 동일하게 "저자 성(소문자)+연도"를 키로 매칭한다.
-const CITATION_MARKER_RE = /\[\s*\d{1,3}(?:\s*[,\-–]\s*\d{1,3})*\s*\]/g
+//
+// 대괄호 안 토큰 하나(숫자 또는 "BCV13"류 키워드 키, 최대 10자)를 가리키는
+// 조각 - 실제로 참고문헌 목록에 있는 키인지는 아래 addCitationBox 호출부에서
+// refMap 존재 여부로 걸러내므로, 여기서는 폭넓게 잡아도 오탐이 화면에 나타나지
+// 않는다(존재하지 않는 키는 그냥 클릭 불가능한 채로 무시됨).
+const CITATION_TOKEN_SRC = '[A-Za-z0-9][A-Za-z0-9+\\-]{0,9}'
+const CITATION_MARKER_RE = new RegExp(
+  `\\[\\s*${CITATION_TOKEN_SRC}(?:\\s*,\\s*${CITATION_TOKEN_SRC})*\\s*\\]`, 'g'
+)
 // 여는 괄호 바로 뒤 대문자로 시작하고, 닫는 괄호 전 20자 이내에 4자리 연도가
 // 있어야 인용으로 인정한다(오탐 방지 - 그냥 "(그림 2020년 기준)" 같은 일반
 // 괄호 문구가 걸리지 않도록 대문자 시작 + 연도 둘 다 요구).
 const CITATION_AUTHOR_YEAR_MARKER_RE = /\([A-ZÀ-Ö][^()]{2,160}?\d{4}[a-z]?[^()]{0,20}\)/g
 
-// "[12, 14-16]" 형태의 대괄호 안 내용을 개별 참고문헌 번호 목록으로 펼친다
+// "[12, 14-16]", "[BCV13, Dev86]" 형태의 대괄호 안 내용을 개별 참고문헌
+// 키 목록으로 펼친다. 숫자 범위("14-16")만 확장 대상이고, 키워드 키는
+// 범위 개념이 없으므로 토큰 그대로 유지한다.
 function parseCitationNumbers(bracketText) {
   const inner = bracketText.slice(1, -1)
   const nums = []
   inner.split(',').forEach(part => {
-    const range = part.trim().match(/^(\d{1,3})\s*[-–]\s*(\d{1,3})$/)
+    const trimmed = part.trim()
+    const range = trimmed.match(/^(\d{1,3})\s*[-–]\s*(\d{1,3})$/)
     if (range) {
       const start = parseInt(range[1], 10)
       const end = parseInt(range[2], 10)
@@ -6333,13 +6350,28 @@ function parseCitationNumbers(bracketText) {
       if (end >= start && end - start <= 50) {
         for (let n = start; n <= end; n++) nums.push(String(n))
       }
-    } else {
-      const single = part.trim().match(/^\d{1,3}$/)
-      if (single) nums.push(single[0])
+      return
     }
+    const token = trimmed.match(new RegExp(`^${CITATION_TOKEN_SRC}$`))
+    if (token) nums.push(token[0])
   })
   return nums
 }
+
+// 참고문헌 목록 항목 자체의 "시작 표기"를 찾기 위한 정규식들(대괄호가 없는
+// 스타일 전용 - 대괄호 스타일은 위 CITATION_MARKER_RE가 위치와 무관하게 이미
+// 잡아낸다). References 섹션 안에서만 적용되므로(위 renderCitationOverlayLayer
+// 참고), 본문 절 번호("2. Introduction")나 서술형 인용("Smith (2020)는...")과
+// 헷갈릴 걱정 없이 폭넓게 잡아도 된다.
+//
+// 번호형: "12. Author..." / "12) Author..." - 백엔드의 _PLAIN_NUMBERED_ENTRY_RE와
+// 동일한 형태를, 뒤에 대문자(또는 한글)로 시작하는 저자명이 이어질 때만 인정한다.
+const REF_ENTRY_PLAIN_NUMBER_RE = /\b(\d{1,3})[.)]\s+(?=[A-Z가-힣])/g
+// 저자-연도형: "Author, A. ... (2020)." - 백엔드의 _AUTHOR_YEAR_ENTRY_START_RE
+// (성+쉼표로 시작) 와 _YEAR_RE(괄호 안 4자리 연도)를 하나로 합친 형태. 본문
+// 인용 표기와 달리 연도가 그 자체로 괄호에 싸여 있고 저자 이름은 괄호 밖에
+// 있는 문헌 목록 서식(APA류)을 겨냥한다.
+const REF_ENTRY_AUTHOR_YEAR_RE = /\b([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+),\s[^()]{0,160}?\((\d{4})[a-z]?\)/g
 
 // "(Smith, 2020; Jones et al., 2019)" 형태를 세미콜론 기준으로 나눠 각각에서
 // 앞쪽 저자 성과 끝쪽 연도만 앵커로 뽑는다(공저자 나열/"et al." 등 그 사이
@@ -6356,6 +6388,28 @@ function parseAuthorYearKeys(parenText) {
     }
   })
   return keys
+}
+
+// References/Bibliography/참고문헌 섹션 헤더 판별 - 백엔드 reference_parser.py의
+// _HEADER_PREFIX_RE와 같은 키워드를 인정한다(문단 시작 위치에서만 - 본문 중간에
+// "...자세한 내용은 References를 참고하라" 같은 일반 문장이 섹션 시작으로
+// 오인되지 않도록 fullText 시작 또는 문단 구분자 \n\n 뒤에서만 매칭한다).
+const REFERENCES_HEADER_RE = /(?:^|\n\n)\s*\**\s*(?:References|Bibliography|참고문헌)\b/i
+
+// vtm.fullText에서 References 헤더를 찾아 이 페이지를 문서의 참고문헌 섹션
+// 시작 페이지로 state에 기록한다. 페이지는 스크롤에 따라 순서 없이(뒤늦게)
+// 렌더링될 수 있어, 이미 더 이른 페이지 번호가 기록돼 있으면 덮어쓰지 않는다.
+// 반환값은 "이 페이지에서 참고문헌 섹션이 시작하는 문자 오프셋"이다:
+// 아직 섹션을 못 찾았거나 이 페이지가 섹션 이전이면 -1, 헤더가 있던 페이지보다
+// 뒤 페이지면(전체가 참고문헌 섹션) 0, 헤더가 있는 페이지 자신이면 헤더 위치.
+function detectReferencesSectionStart(vtm, pageNum) {
+  const m = REFERENCES_HEADER_RE.exec(vtm.fullText)
+  if (m && (state.referencesHeaderPageNum === null || pageNum < state.referencesHeaderPageNum)) {
+    state.referencesHeaderPageNum = pageNum
+  }
+  if (state.referencesHeaderPageNum === null || pageNum < state.referencesHeaderPageNum) return -1
+  if (pageNum > state.referencesHeaderPageNum) return 0
+  return m ? m.index : 0
 }
 
 // 본문 인용 표기 오버레이 - 참고문헌 목록에 실제로 존재하는 항목을 가리키는
@@ -6377,6 +6431,8 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
 
   const docId = state.currentDocId
   if (!docId) return
+
+  const referencesSectionStart = detectReferencesSectionStart(vtm, pageNum)
 
   const addCitationBox = (charStart, charEnd, refKey) => {
     const rects = getSentenceRects({ charStart, charEnd }, vtm, textLayerDiv)
@@ -6419,6 +6475,33 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
     const keys = parseAuthorYearKeys(match[0]).filter(k => refMap[k])
     if (keys.length === 0) continue
     addCitationBox(match.index, match.index + match[0].length, keys[0])
+  }
+
+  // 참고문헌 목록 자체(대괄호가 없는 스타일)에도 오버레이를 건다 - 위 두
+  // 정규식은 대괄호 인용([12]) 또는 괄호로 묶인 저자-연도 인용((Smith, 2020))만
+  // 잡아내는데, 참고문헌 목록의 각 항목 시작 표기는 스타일에 따라 그 어느
+  // 쪽에도 안 걸리는 경우가 있다("12. Author..." 같은 번호형, "Author, A.
+  // (2020). Title..." 같은 저자-연도형). 참고문헌 목록을 훑어보다가 바로 그
+  // 자리에서 원문 링크/Scholar 검색을 쓸 수 있도록, References 헤더 이후
+  // 영역에서만 이 두 표기도 추가로 인용 표기로 인정한다(섹션 밖에서 걸면
+  // "2. Introduction" 같은 절 번호나 "Smith (2020)는..." 같은 서술형 문장까지
+  // 오탐될 위험이 크다).
+  if (referencesSectionStart >= 0) {
+    REF_ENTRY_PLAIN_NUMBER_RE.lastIndex = 0
+    while ((match = REF_ENTRY_PLAIN_NUMBER_RE.exec(vtm.fullText)) !== null) {
+      if (match.index < referencesSectionStart) continue
+      const num = match[1]
+      if (!refMap[num]) continue
+      addCitationBox(match.index, match.index + match[0].length, num)
+    }
+
+    REF_ENTRY_AUTHOR_YEAR_RE.lastIndex = 0
+    while ((match = REF_ENTRY_AUTHOR_YEAR_RE.exec(vtm.fullText)) !== null) {
+      if (match.index < referencesSectionStart) continue
+      const key = `${match[1].toLowerCase()}${match[2]}`
+      if (!refMap[key]) continue
+      addCitationBox(match.index, match.index + match[0].length, key)
+    }
   }
 }
 


### PR DESCRIPTION
# Summary
## 1. 백엔드 참고문헌 파싱 - 대괄호 키를 영숫자까지 확장
- `backend/services/reference_parser.py`의 `_BRACKET_ENTRY_RE`를 숫자 전용(`[12]`)에서 영숫자 조합 키([BCV13], [Dev86], [LBH+15] 등)까지 인식하도록 확장
- 저자 이니셜+연도 키워드 스타일(alpha BibTeX 스타일)을 쓰는 논문의 참고문헌 목록도 정상적으로 `referenceMap`에 파싱됨
- `backend/tests/test_reference_parser.py`에 키워드 스타일 대괄호 파싱 테스트 추가

## 2. 프론트엔드 본문 인용 오버레이 - 키워드 스타일 대괄호 인용 감지 추가
- `CITATION_MARKER_RE`, `parseCitationNumbers`를 확장해 `[BCV13]`, `[BCV13, Dev86]` 같은 키워드형 대괄호 인용도 감지
- 실제 `referenceMap`에 존재하는 키만 클릭 가능한 오버레이로 그리는 기존 원칙(오탐 방지)은 그대로 유지
- 저자-연도 인용(`(Gloret et al., 2011)`, `(Loshchilov & Hutter, 2017)` 등)은 기존 로직이 이미 정상 동작함을 확인

## 3. 참고문헌 섹션 자체에도 오버레이 동작하도록 개선
- `References`/`Bibliography`/`참고문헌` 헤더 위치를 페이지 렌더 시점에 감지해 `state.referencesHeaderPageNum`에 기록하는 `detectReferencesSectionStart()` 추가
- 참고문헌 섹션 내부에서만 적용되는 두 정규식(`REF_ENTRY_PLAIN_NUMBER_RE`: 대괄호 없는 번호형 "12. Author...", `REF_ENTRY_AUTHOR_YEAR_RE`: 저자-연도형 "Author, A. (2020).")을 추가해, 참고문헌 목록의 항목 자체에서도 호버/클릭으로 원문 링크 찾기·Google Scholar 검색을 바로 쓸 수 있도록 함
- 본문 절 번호("2. Introduction")나 서술형 인용과 혼동되지 않도록 References 헤더 이후 영역에서만 적용

## Test plan
- [x] `pytest backend/tests/test_reference_parser.py` 15개 전부 통과
- [x] `npx vite build` 성공
- [x] 정규식 로직 격리 검증 스크립트로 4가지 인용 스타일 + 섹션 헤더 감지 + 참고문헌 항목 오버레이 18개 케이스 확인
- [x] `npx playwright test tests/e2e/citation-links.spec.js` 4개 전부 통과(회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)