### PR TITLE
chore: 데스크톱 앱 버전을 0.1.5로 올림

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
# Summary
## 1. 데스크톱 앱 버전 0.1.4 → 0.1.5
- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`의 버전을 0.1.5로 일괄 갱신
- 이번 릴리스에는 다음 두 건이 포함됨:
  - #181 라이브러리 화면 번역 진행률 프로그레스 바 미갱신 문제 수정
  - #182 레퍼런스 오버레이가 다양한 본문 인용 표기([BCV13]류 키워드 인용 포함)와 참고문헌 목록 항목 자체를 감지하도록 개선

## Test plan
- [x] 버전 문자열 4개 파일 모두 0.1.5로 일치하는지 확인 (Cargo.lock의 다른 크레이트 버전과 혼동하지 않도록 `name = "app"` 항목만 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)