### PR TITLE
fix: 2단 레이아웃 논문에서 참고문헌 파싱이 대부분 실패하던 문제 수정

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -13,10 +13,18 @@
 대괄호 스타일은 순수 숫자(`[12]`)뿐 아니라 alpha 스타일 BibTeX가 흔히 쓰는
 "저자 이니셜+연도" 키워드 키(`[BCV13]`, `[LBH+15]`, `[Dev86]` 등)도 그대로
 키로 인정한다 - 프론트엔드의 CITATION_MARKER_RE도 동일한 키 형식을 감지한다.
+
+번호형(대괄호/평문) 항목 경계는 줄바꿈이 아니라 "항목 시작 표기" 자체를
+전체 텍스트에서 직접 찾아 판정한다(아래 _extract_marker_entries 참고) -
+2단 레이아웃 논문에서 실제로 관찰된 문제: pdf_parser.py의 블록 추출 결과가
+참고문헌 항목 경계와 줄바꿈이 전혀 일치하지 않는 경우가 흔하다(항목 하나가
+줄바꿈으로 쪼개지거나, 서로 다른 두 항목이 줄바꿈 없이 한 줄에 붙어버림).
 """
 
 import re
 from typing import Dict, List, Optional
+
+from services.pdf_parser import _INDENT_SENTINEL
 
 # 헤더 단어의 글자 사이에 공백을 허용한다 - 드롭캡(첫 글자만 별도 폰트/굵기)
 # 렌더링 시 "**R** **EFERENCES**"처럼 글자 사이에 공백이 끼어드는 경우까지
@@ -26,8 +34,26 @@ _HEADER_PREFIX_RE = re.compile(
     r"참\s*고\s*문\s*헌)\b",
     re.IGNORECASE,
 )
-_BRACKET_ENTRY_RE = re.compile(r"^\s*\[([A-Za-z0-9][A-Za-z0-9+\-]{0,9})\]\s*(.+)")
+# 대괄호 키는 순수 숫자([12]) 또는 "저자 이니셜+연도" 꼴([BCV13], [Dev86],
+# [LBH+15])만 인정하고, 숫자가 전혀 없는 순수 알파벳 키는 거부한다 -
+# 참고문헌 항목 안에는 "... 2021. [Online]. Available: ..." 처럼 서지
+# 매체를 나타내는 대괄호 표기([Online], [Internet], [Software] 등)가 실제로
+# 흔히 등장하는데, 이런 단어들이 새 항목의 시작으로 오인되면 그 뒤 진짜
+# 항목들이 전부 직전 항목에 잘못 흡수되어 버린다.
+_BRACKET_KEY_RE = re.compile(r"\d{1,3}|[A-Za-z]{1,6}\+?\d{2,4}[a-z]?")
+_BRACKET_ENTRY_RE = re.compile(r"^\s*\[(" + _BRACKET_KEY_RE.pattern + r")\]\s*(.+)")
 _PLAIN_NUMBERED_ENTRY_RE = re.compile(r"^\s*(\d{1,3})[.)]\s+(.+)")
+
+# 아래 두 정규식은 줄 시작(^)에 앵커하지 않고 텍스트 전체에서 "항목이 시작하는
+# 지점" 자체를 찾는 데 쓴다(_extract_marker_entries) - 매치와 매치 사이 구간을
+# 그대로 항목 텍스트로 잘라내므로, 항목 중간에 줄바꿈이 끼어 있든 두 항목이
+# 줄바꿈 없이 붙어 있든 항목 경계를 정확히 잡아낼 수 있다.
+_BRACKET_MARKER_RE = re.compile(r"\[(" + _BRACKET_KEY_RE.pattern + r")\]")
+# 평문 번호형은 대괄호보다 오탐 위험이 크다(항목 안에 흔한 "vol. 12," 같은
+# 숫자+마침표와 구분이 안 됨) - 뒤에 대문자/한글이 바로 이어질 때만 후보로
+# 인정하고, _extract_marker_entries에서 1부터 정확히 연속되는 번호만 채택해
+# 우연히 일치하는 페이지/연도 숫자를 걸러낸다.
+_PLAIN_NUMBERED_MARKER_RE = re.compile(r"(?:^|\s)(\d{1,3})[.)]\s+(?=[A-Z가-힣])")
 
 # (Author, Year) 스타일 항목의 시작 줄 판별용 - "Surname, Initial..." 형태로
 # 시작하는 줄을 새 항목의 시작으로 본다. 실제로 참고문헌 항목인지는 flush 시점에
@@ -88,6 +114,12 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
         return {}
 
     combined_text = "\n".join(p.get("text", "") or "" for p in pages[ref_start_page_idx:])
+    # pdf_parser.py가 들여쓰기된 문단 앞에 붙이는 내부 마커(_INDENT_SENTINEL) -
+    # 원래는 chunker.py가 번역 파이프라인에서 소비하는 표시인데, 참고문헌
+    # 목록의 줄바꿈된 항목(첫 줄은 안 들여써지고 이어지는 줄은 들여써지는
+    # hanging indent 서식)도 이 표시가 붙은 채로 들어와, 그대로 두면 툴팁에
+    # 보이는 참고문헌 원문에 눈에 안 보이는 문자가 섞여 나온다.
+    combined_text = combined_text.replace(_INDENT_SENTINEL, "")
     lines = combined_text.split("\n")
 
     start_idx = 0
@@ -100,35 +132,46 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
             start_idx = idx
             break
     body_lines = lines[start_idx:]
+    # 항목 경계 탐지는 줄바꿈에 기대지 않는다(아래 _extract_marker_entries
+    # 참고) - 여기서는 그냥 하나의 문자열로 이어붙이기만 한다.
+    body_text = "\n".join(body_lines)
 
-    entries: Dict[str, str] = {}
-    current_num = None
-    current_parts: List[str] = []
-
-    def flush():
-        if current_num is not None:
-            text = re.sub(r"\s+", " ", " ".join(current_parts)).strip()
-            if text:
-                entries[current_num] = text[:_MAX_ENTRY_LENGTH]
-
-    for raw_line in body_lines:
-        line = raw_line.strip()
-        if not line:
-            continue
-
-        m = _BRACKET_ENTRY_RE.match(line) or _PLAIN_NUMBERED_ENTRY_RE.match(line)
-        if m:
-            flush()
-            current_num = m.group(1)
-            current_parts = [m.group(2)]
-        elif current_num is not None:
-            current_parts.append(line)
-
-    flush()
-
+    entries = _extract_marker_entries(body_text, _BRACKET_MARKER_RE)
+    if not entries:
+        entries = _extract_marker_entries(body_text, _PLAIN_NUMBERED_MARKER_RE, sequential=True)
     if not entries:
         entries = _parse_author_year_entries(body_lines)
 
+    return entries
+
+
+def _extract_marker_entries(text: str, marker_re: "re.Pattern", sequential: bool = False) -> Dict[str, str]:
+    """텍스트 전체에서 marker_re에 매칭되는 "항목 시작 표기"를 전부 찾아,
+    연속된 두 매치 사이 구간을 항목 텍스트로 잘라낸다.
+
+    sequential=True(평문 번호형)이면 오탐 방지를 위해 1부터 정확히
+    연속되는 번호(1, 2, 3, ...)만 항목 시작으로 채택한다 - 실제 참고문헌
+    번호는 항상 이렇게 증가하므로, 항목 본문 안의 우연한 숫자(페이지·연도
+    등)를 걸러내는 데 이 제약만으로 충분하다.
+    """
+    matches = list(marker_re.finditer(text))
+    if sequential:
+        filtered = []
+        expected = 1
+        for m in matches:
+            if int(m.group(1)) != expected:
+                continue
+            filtered.append(m)
+            expected += 1
+        matches = filtered
+
+    entries: Dict[str, str] = {}
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        entry_text = re.sub(r"\s+", " ", text[start:end]).strip()
+        if entry_text and m.group(1) not in entries:
+            entries[m.group(1)] = entry_text[:_MAX_ENTRY_LENGTH]
     return entries
 
 

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -145,6 +145,59 @@ def test_parses_header_with_space_separated_drop_cap():
     assert refs == {"1": "Some Author. A paper title. 2020."}
 
 
+def test_parses_entries_packed_on_one_line_without_separators():
+    """2단 레이아웃 PDF의 블록 추출 결과, 서로 다른 여러 항목이 줄바꿈 없이
+    한 줄에 이어 붙는 경우가 실제로 관찰된다(예: 실제 EEG Conformer 논문의
+    참고문헌 목록). 항목 경계가 줄바꿈이 아니라 "[N]" 표기 자체로 판정되어야
+    이런 경우에도 각 항목이 올바르게 분리된다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "[1] J. Jin et al., “A novel framework,” IEEE Trans., vol. 30, "
+        "pp. 20–29, 2022. [2] B. Liu et al., “Improving SSVEP-BCI,” "
+        "IEEE Trans., vol. 29, pp. 1998–2007, 2021. [3] J. W. Li et al., "
+        "“Single-channel selection,” J. Biomed., vol. 26, 2022."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"1", "2", "3"}
+    assert "Jin" in refs["1"] and "Liu" not in refs["1"]
+    assert "Liu" in refs["2"] and "Single-channel" not in refs["2"]
+    assert "Single-channel" in refs["3"]
+
+
+def test_parses_entry_split_across_hanging_indent_continuation_line():
+    """hanging indent 서식(첫 줄은 안 들여쓰고 이어지는 줄만 들여쓰는 참고문헌
+    표기)에서, 실제 pdf_parser.py가 들여쓰기된 이어지는 줄 앞에 내부 마커
+    (_INDENT_SENTINEL)를 붙여 반환한다 - 참고문헌 파싱 결과에는 이 마커가
+    노출되지 않아야 하고, 항목도 하나로 정상 병합되어야 한다."""
+    from services.pdf_parser import _INDENT_SENTINEL
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "[1] J. Jin et al., “A novel classification framework using the graph\n\n"
+        f"{_INDENT_SENTINEL}representations of electroencephalogram,” IEEE Trans., 2022. "
+        "[2] B. Liu et al., “Second entry,” 2021."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"1", "2"}
+    assert _INDENT_SENTINEL not in refs["1"]
+    assert "representations of electroencephalogram" in refs["1"]
+
+
+def test_bracket_bibliographic_medium_marker_is_not_treated_as_new_entry():
+    """"[Online]", "[Internet]" 같은 서지 매체 표기 대괄호는 참고문헌 항목
+    안에 실제로 흔히 등장하는데, 숫자가 없는 순수 알파벳 키라 새 항목의
+    시작으로 오인되면 안 된다(오인되면 그 뒤 진짜 항목이 전부 잘못 흡수됨)."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "[22] Y. Song et al., “Transformer-based learning,” Jun. 2021. "
+        "[Online]. Available: https://arxiv.org/abs/2106.11170 "
+        "[23] S. Bagchi and D. Bathula, “EEG-ConvTransformer,” 2022."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"22", "23"}
+    assert "Online" in refs["22"]  # 항목 텍스트 안에는 그대로 남아 있어야 함
+    assert "Bagchi" in refs["23"]
+
+
 def test_parses_keyword_style_bracket_references():
     """일부 논문(특히 VAE류)은 저자 이니셜+연도 키워드를 대괄호 키로 쓴다."""
     pages = [{"page_num": 1, "text": (

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BEU-LFL0.js"></script>
+  <script type="module" crossorigin src="/assets/index-Ir7J-XCg.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ca9Rsbe5.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6387,13 +6387,21 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
 //    (Smith, 2020; Jones, 2019) 등 - 백엔드 reference_parser.py의
 //    _parse_author_year_entries와 동일하게 "저자 성(소문자)+연도"를 키로 매칭한다.
 //
-// 대괄호 안 토큰 하나(숫자 또는 "BCV13"류 키워드 키, 최대 10자)를 가리키는
-// 조각 - 실제로 참고문헌 목록에 있는 키인지는 아래 addCitationBox 호출부에서
-// refMap 존재 여부로 걸러내므로, 여기서는 폭넓게 잡아도 오탐이 화면에 나타나지
-// 않는다(존재하지 않는 키는 그냥 클릭 불가능한 채로 무시됨).
-const CITATION_TOKEN_SRC = '[A-Za-z0-9][A-Za-z0-9+\\-]{0,9}'
+// 대괄호 안 토큰 하나 - 순수 숫자(1~3자리) 또는 "BCV13"류 키워드 키(영문
+// 1~6자 + 선택적 "+" + 숫자 2~4자리 + 선택적 소문자 접미사)만 인정한다.
+// 백엔드 reference_parser.py의 _BRACKET_KEY_RE와 반드시 같은 모양을 유지할
+// 것 - 숫자가 전혀 없는 순수 알파벳 키(예: 참고문헌 항목 안에 흔한
+// "[Online]", "[Internet]" 같은 서지 매체 표기)까지 토큰으로 인정하면,
+// 우연히 refMap에 같은 이름의 키가 있는 경우(드물지만 가능) 엉뚱한 곳에
+// 오버레이가 걸릴 여지가 생긴다. 실제로 참고문헌 목록에 있는 키인지는 아래
+// addCitationBox 호출부에서 refMap 존재 여부로 한 번 더 걸러진다.
+const CITATION_TOKEN_SRC = '(?:\\d{1,3}|[A-Za-z]{1,6}\\+?\\d{2,4}[a-z]?)'
+// 대괄호 목록의 항목 하나는 위 단일 키이거나, 숫자 범위("12-14")일 수 있다 -
+// 범위는 CITATION_TOKEN_SRC 모양에 안 맞으므로(하이픈 포함) 마커 탐지
+// 단계에서 별도 대안으로 허용해두고, 실제 펼치기는 parseCitationNumbers가 한다.
+const CITATION_LIST_ITEM_SRC = `(?:\\d{1,3}\\s*[-–]\\s*\\d{1,3}|${CITATION_TOKEN_SRC})`
 const CITATION_MARKER_RE = new RegExp(
-  `\\[\\s*${CITATION_TOKEN_SRC}(?:\\s*,\\s*${CITATION_TOKEN_SRC})*\\s*\\]`, 'g'
+  `\\[\\s*${CITATION_LIST_ITEM_SRC}(?:\\s*,\\s*${CITATION_LIST_ITEM_SRC})*\\s*\\]`, 'g'
 )
 // 여는 괄호 바로 뒤 대문자로 시작하고, 닫는 괄호 전 20자 이내에 4자리 연도가
 // 있어야 인용으로 인정한다(오탐 방지 - 그냥 "(그림 2020년 기준)" 같은 일반


### PR DESCRIPTION
# Summary
## 1. 참고문헌 목록 항목 경계를 줄바꿈이 아닌 항목 시작 표기 자체로 판정
- 사용자가 실제 논문(EEG Conformer, IEEE 2단 레이아웃)에서 본문 인용 `[37]`에 호버가 안 된다고 제보 → 조사 결과 46개 참고문헌 중 단 3개(`1`, `9`, `28`)만 파싱되고 있었음이 확인됨(`[37]`은 그 증상 중 하나였을 뿐)
- 원인: `pdf_parser.py`의 블록 추출 결과가 2단 레이아웃 논문에서 참고문헌 항목 경계와 줄바꿈이 전혀 일치하지 않음 - 항목 하나가 hanging indent로 인해 중간에 줄바꿈되거나, 서로 다른 두 항목이 줄바꿈 없이 한 줄에 붙어버리는 경우가 흔함
- `backend/services/reference_parser.py`를 `^` 줄 시작 앵커링 방식에서, 전체 텍스트에서 "항목 시작 표기"(`[N]` 또는 `N.`) 자체를 정규식으로 찾아 매치 사이 구간을 항목 텍스트로 잘라내는 방식(`_extract_marker_entries`)으로 재작성
- 평문 번호형(`12. Author...`)은 오탐 위험이 커서, 1부터 정확히 연속되는 번호만 항목으로 채택하도록 시퀀스 검증 추가
- 대괄호 키 패턴에 숫자 포함을 필수 조건으로 좁힘(`_BRACKET_KEY_RE`) - 참고문헌 항목 안에 흔한 `[Online]`, `[Internet]` 같은 서지 매체 표기가 새 항목 시작으로 오인되지 않도록 함
- 프론트엔드 `CITATION_TOKEN_SRC`(main.js)도 동일한 패턴으로 좁혀 백엔드와 일관성 유지, `[12-14]` 범위 인용은 별도 대안으로 계속 지원

## 2. 참고문헌 원문에 내부 마커 문자가 노출되던 문제 수정
- `pdf_parser.py`가 들여쓰기된 문단 앞에 붙이는 내부 표시 문자(`_INDENT_SENTINEL`, ``)가 hanging indent 참고문헌 항목의 이어지는 줄에도 그대로 붙어, 인용 툴팁에 보이지 않는 문자가 섞여 나오던 문제를 함께 수정(파싱 전 제거)

## Test plan
- [x] `pytest backend/tests/test_reference_parser.py` - 기존 15개 + 신규 3개(2단 레이아웃 줄바꿈 없는 연속 항목, hanging indent 항목 분리, `[Online]` 오탐 방지) 전부 통과
- [x] 백엔드 전체 테스트 스위트 156개 통과(1개 무관한 사전 존재 환경 이슈 제외, 원본 코드에서도 동일하게 실패함을 확인)
- [x] 실제로 제보된 논문 PDF로 재현 - 수정 전 3/46 → 수정 후 46/46 참고문헌 정상 파싱, `[37]` 포함
- [x] Playwright로 실제 PDF를 앱에 로드해 `[37]`에 대한 `.citation-marker-box`가 실제로 렌더링됨을 확인
- [x] `tests/e2e/citation-links.spec.js` 기존 4개 전부 통과(회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)