### PR TITLE
chore: 데스크톱 앱 버전을 0.1.7로 올림

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -289,6 +289,7 @@ function showLogin() {
   stopLibraryPolling()
   viewerScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   loginScreen.classList.add('active')
   // 글로벌 테마 토글 표시, 로그아웃 및 설정 버튼 숨김
   const globalToggle = $('global-theme-toggle')
@@ -300,6 +301,7 @@ function showViewer() {
   stopLibraryPolling()
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   viewerScreen.classList.add('active')
   // 글로벌 테마 토글 숨김 (뷰어 상단바 테마 버튼 사용)
   const globalToggle = $('global-theme-toggle')
@@ -3375,6 +3377,7 @@ async function showLibraryScreen(shouldPushState = true) {
   }
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   libraryScreen.classList.add('active')
   // 글로벌 테마 토글, 로그아웃, 설정 버튼 표시
   const globalToggle = $('global-theme-toggle')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.6"
+version = "0.1.7"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
# Summary
## 1. 데스크톱 앱 버전 0.1.6 → 0.1.7 업그레이드
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`의 version 필드를 0.1.7로 동기화
- 방금 머지된 "업데이트 발견 시 팝업 알림 + 주기적 재확인"(PR #187) 기능을 실제 배포하기 위한 버전업