### PR TITLE
fix: 비교 채팅에서 라이브러리로 돌아갈 때 compare 화면이 남는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -289,6 +289,7 @@ function showLogin() {
   stopLibraryPolling()
   viewerScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   loginScreen.classList.add('active')
   // 글로벌 테마 토글 표시, 로그아웃 및 설정 버튼 숨김
   const globalToggle = $('global-theme-toggle')
@@ -300,6 +301,7 @@ function showViewer() {
   stopLibraryPolling()
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   viewerScreen.classList.add('active')
   // 글로벌 테마 토글 숨김 (뷰어 상단바 테마 버튼 사용)
   const globalToggle = $('global-theme-toggle')
@@ -3375,6 +3377,7 @@ async function showLibraryScreen(shouldPushState = true) {
   }
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
   libraryScreen.classList.add('active')
   // 글로벌 테마 토글, 로그아웃, 설정 버튼 표시
   const globalToggle = $('global-theme-toggle')


### PR DESCRIPTION
## Summary
- `showLogin()`, `showViewer()`, `showLibraryScreen()`이 `#compare-screen`의 `active` 클래스를 제거하지 않아, 비교 채팅 화면 위에서 다른 화면으로 전환해도 compare 화면이 겹쳐 보이던 문제 수정
- 세 함수 모두 각 화면을 `active`로 전환하기 전에 `if (compareScreen) compareScreen.classList.remove('active')` 추가

Closes #184

## Test plan
- [x] `node -c src/main.js` 문법 검사 통과
- [ ] 브라우저에서 비교 채팅 진입 → 라이브러리/뷰어/로그인 화면으로 이동 시 compare 화면이 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)