### PR TITLE
fix: 논문 비교 선택 모드에서 열기 버튼 클릭 시 뷰어로 이동해버리는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4128,7 +4128,14 @@ function wireDocItemEvents(container, doc, displayTitle) {
 
   const openBtn = container.querySelector('.doc-open-btn')
   if (openBtn) {
-    openBtn.addEventListener('click', (e) => { e.stopPropagation(); openFromLibrary(doc) })
+    openBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      // 편집/삭제/미리보기 버튼은 비교 선택 모드에서 CSS(pointer-events: none)로
+      // 막혀있지만, "열기" 버튼은 카드 풋터에 별도로 배치되어 그 대상에서 빠져있다.
+      // 막지 않으면 선택 모드 중 클릭 시 선택 대신 뷰어로 즉시 이동해버린다.
+      if (compareSelectMode) { toggleDocCompareSelection(container, doc); return }
+      openFromLibrary(doc)
+    })
   }
 
   const deleteBtn = container.querySelector('.doc-delete-btn')

--- a/frontend/tests/e2e/compare-chat.spec.js
+++ b/frontend/tests/e2e/compare-chat.spec.js
@@ -77,3 +77,24 @@ test('선택하지 않은 상태에서는 비교 채팅 시작 버튼이 비활�
   await expect(page.locator('#compare-select-bar')).toHaveClass(/hidden/)
   await expect(page.locator('.doc-card-compare-check').first()).not.toBeVisible()
 })
+
+// 비교 선택 모드에서는 카드를 클릭하면 선택 상태만 토글되어야 한다. "열기" 버튼은
+// 편집/삭제 등 다른 카드 액션과 달리 pointer-events: none 규칙에서 빠져 있어,
+// 클릭 시 선택 대신 뷰어 화면으로 바로 이동해버리는 버그가 있었다.
+test('비교 선택 모드에서 열기 버튼을 눌러도 뷰어로 이동하지 않고 선택만 토글된다', async ({ page }) => {
+  const docs = [
+    { id: 'doc-1', filename: 'a.pdf', total_pages: 1, metadata: { title: 'Paper A' }, translated_pages: [] },
+    { id: 'doc-2', filename: 'b.pdf', total_pages: 1, metadata: { title: 'Paper B' }, translated_pages: [] },
+  ]
+  await mockBaseRoutes(page, { documents: docs })
+
+  await gotoApp(page)
+  await page.click('#lib-compare-toggle-btn')
+
+  const firstCard = page.locator('.doc-card').first()
+  await firstCard.locator('.doc-open-btn').click({ force: true })
+
+  await expect(page.locator('#compare-select-count')).toHaveText('1/5개 선택됨')
+  await expect(page.locator('#library-screen')).toHaveClass(/active/)
+  await expect(page.locator('#viewer-screen')).not.toHaveClass(/active/)
+})


### PR DESCRIPTION
# Summary
## 1. 비교 선택 모드에서 "열기" 버튼이 선택 대신 뷰어 이동을 유발하던 버그 수정
- 라이브러리 카드/리스트의 편집·삭제·미리보기 버튼(`.doc-card-zone-actions`, `.doc-icon-actions`)은 비교 선택 모드(`.compare-select-mode`)일 때 CSS로 `pointer-events: none` 처리되어 클릭이 막히지만, "열기" 버튼(`.doc-open-btn`)은 카드 풋터에 별도 배치되어 이 규칙에서 빠져 있었음
- 그 결과 논문 비교를 위해 선택 모드에 진입한 상태에서 "열기" 버튼을 누르면, 선택이 아니라 곧바로 뷰어 화면으로 이동해버려 진행 중이던 비교 선택이 중단되는 문제가 있었음
- `frontend/src/main.js`의 `wireDocItemEvents` 내 `.doc-open-btn` 클릭 핸들러에 `compareSelectMode` 가드를 추가해, 선택 모드일 때는 카드 본문 클릭과 동일하게 `toggleDocCompareSelection`을 호출하도록 수정

## 2. 재발 방지 테스트 추가
- `frontend/tests/e2e/compare-chat.spec.js`에 비교 선택 모드에서 "열기" 버튼을 눌러도 뷰어로 이동하지 않고 선택 카운트만 증가하는지 확인하는 케이스 추가
- 수정 전 코드로 되돌려 해당 테스트가 실제로 실패함을 확인 후, 수정 적용 시 통과함을 검증함

## Test plan
- [x] `pytest backend/tests/test_chat_compare.py` (9 passed) — 백엔드 비교 채팅 로직은 변경하지 않았으며 회귀 없음 확인
- [x] `playwright test tests/e2e/compare-chat.spec.js` (3 passed, 신규 케이스 포함)
- [x] 전체 프론트엔드 e2e 스위트 실행 — 비교 기능과 무관한 `update-notifications.spec.js`의 기존 실패 5건은 수정 전 코드에서도 동일하게 재현되어 본 브랜치와 무관함을 확인함(별도 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)