### PR TITLE
feat: 데스크톱 앱 업데이트 확인 주기 설정 추가 및 macOS/Windows 실행 방법 문서화

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -59,7 +59,22 @@ jobs:
           {
             echo "notes<<RELEASE_NOTES_EOF"
             echo "자동 생성된 릴리스입니다. 코드사이닝(macOS 공증/Windows Authenticode)이"
-            echo "아직 적용되지 않아 설치 시 운영체제 보안 경고가 뜰 수 있습니다."
+            echo "아직 적용되지 않아 설치 시 운영체제 보안 경고가 뜹니다. 아래 실행 방법을"
+            echo "꼭 확인해주세요."
+            echo ""
+            echo "## 실행 방법"
+            echo ""
+            echo "**macOS**: 앱이 완전히 서명되지 않은 상태라 최신 macOS(Ventura 이후)에서는"
+            echo "우클릭 → 열기로 우회되지 않고 \"앱이 손상되었기 때문에 열 수 없습니다\" 라는"
+            echo "오해의 소지가 있는 메시지가 뜹니다. 실제로 파일이 손상된 게 아니라 다운로드"
+            echo "시 붙는 quarantine 속성 때문이니, 터미널에서 아래 명령으로 지운 뒤 다시"
+            echo "실행하세요."
+            echo '```bash'
+            echo "xattr -cr /Applications/EasyPaper.app"
+            echo '```'
+            echo ""
+            echo "**Windows**: \"Windows의 PC 보호\" 화면에서 **추가 정보 → 실행**을 선택하면"
+            echo "정상적으로 설치됩니다."
             echo ""
             echo "## 변경 사항"
             commits=$(git log "$range" --no-merges --pretty=format:'%s' | grep -E '^(feat|fix|perf)(\(.+\))?:' || true)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,14 @@ Tauri 기반 네이티브 앱으로, Python/Node.js 설치 없이 바로 실행�
 2. 설치 후 앱을 실행하면 첫 화면에서 AI 엔진(Ollama/Gemini/Claude/OpenAI/CLI) 온보딩 마법사가 안내합니다.
 3. 이후 새 버전이 배포되면 앱이 자동으로 감지하여, 설정 화면의 버튼 한 번으로 업데이트를 내려받고 설치할 수 있습니다.
 
-> ⚠️ 아직 macOS 공증(Notarization)·Windows Authenticode 코드사이닝을 적용하지 않아, 설치 시 운영체제 보안 경고가 뜰 수 있습니다. macOS는 앱 아이콘을 우클릭 → **열기**, Windows는 "Windows의 PC 보호" 화면에서 **추가 정보 → 실행**을 선택하면 정상적으로 설치됩니다.
+> ⚠️ 아직 macOS 공증(Notarization)·Windows Authenticode 코드사이닝을 적용하지 않아, 설치 시 운영체제 보안 경고가 뜹니다. 아래 안내를 따라주세요.
+>
+> **macOS**: 앱이 완전히 서명되지 않은 상태라 최신 macOS(Ventura 이후)에서는 우클릭 → 열기로 우회되지 않고 **"앱이 손상되었기 때문에 열 수 없습니다"** 라는 오해의 소지가 있는 메시지가 뜹니다. 실제로 파일이 손상된 게 아니라 다운로드 시 붙는 quarantine 속성 때문이니, 터미널에서 아래 명령으로 지운 뒤 다시 실행하세요.
+> ```bash
+> xattr -cr /Applications/EasyPaper.app
+> ```
+>
+> **Windows**: "Windows의 PC 보호" 화면에서 **추가 정보 → 실행**을 선택하면 정상적으로 설치됩니다.
 
 ### 2. 소스에서 웹 앱으로 직접 실행하기
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -899,7 +899,15 @@
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>데스크탑 앱 업데이트:</strong><br>
               아래 버튼을 누르면 새 버전이 있는지 확인합니다. 새 버전이 있으면 다운로드 후 설치하고 앱을 자동으로 재시작합니다.
             </div>
-            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 10px; margin-bottom: 12px;">
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="font-size: 12.5px; color: var(--text-secondary); white-space: nowrap;">자동 업데이트 확인</span>
+                <select id="setting-tauri-update-check-interval" class="form-select" style="width: auto; min-width: 110px;">
+                  <option value="daily">매일</option>
+                  <option value="weekly">매주</option>
+                  <option value="never">사용 안 함</option>
+                </select>
+              </div>
               <span id="tauri-current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
             <div id="tauri-update-notes-box" class="update-changelog-box hidden" style="margin-bottom: 12px;">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1550,7 +1550,7 @@ async function checkAuthentication() {
       })
     } else {
       loadTauriAppVersion()
-      checkTauriUpdate({ silent: true })
+      maybeCheckTauriUpdateIfDue()
       startTauriUpdatePolling()
     }
   } else {
@@ -2679,21 +2679,57 @@ const tauriUpdateStatus = $('tauri-update-status')
 const tauriUpdateNotesBox = $('tauri-update-notes-box')
 const tauriUpdateVersionLine = $('tauri-update-version-line')
 const tauriUpdateNotes = $('tauri-update-notes')
+const settingTauriUpdateCheckInterval = $('setting-tauri-update-check-interval')
 
 let pendingTauriUpdate = null
 // 같은 버전으로는 팝업을 한 세션에 한 번만 띄운다 - "나중에"를 눌러도
 // 주기적 재확인 때마다 같은 안내가 반복해서 뜨는 것을 막기 위함.
 let lastNotifiedTauriUpdateVersion = null
 
+// 데스크탑판 자동 업데이트 확인 주기 설정. 웹(git 기반) 배포판은 서버 쪽
+// DB에 last_checked_at을 저장하지만(getUpdateCheckConfigAPI), 데스크탑은
+// 사용자별 로컬 앱 설정이라 서버에 저장할 이유가 없어 localStorage를 쓴다.
+const TAURI_UPDATE_CHECK_STORAGE_KEY = 'easypaper_tauri_update_check_interval'
+const TAURI_UPDATE_LAST_CHECKED_STORAGE_KEY = 'easypaper_tauri_update_last_checked_at'
+
+function getTauriUpdateCheckInterval() {
+  return localStorage.getItem(TAURI_UPDATE_CHECK_STORAGE_KEY) || 'weekly'
+}
+
+if (settingTauriUpdateCheckInterval) {
+  settingTauriUpdateCheckInterval.value = getTauriUpdateCheckInterval()
+  settingTauriUpdateCheckInterval.addEventListener('change', () => {
+    localStorage.setItem(TAURI_UPDATE_CHECK_STORAGE_KEY, settingTauriUpdateCheckInterval.value)
+  })
+  globalSettingsBtn.addEventListener('click', () => {
+    settingTauriUpdateCheckInterval.value = getTauriUpdateCheckInterval()
+  })
+}
+
 // 로그인 시 1회 체크로는 앱을 오래 켜둔 사용자가 새 버전을 놓칠 수 있어,
-// 앱이 열려 있는 동안 주기적으로도 백그라운드 재확인을 한다.
+// 앱이 열려 있는 동안에도 재확인이 필요하다. 그렇다고 설정된 간격(매일/매주)
+// 그대로 setInterval을 걸면 앱을 그 간격보다 짧게 켰다 껐다 하는 사용자는
+// 영영 체크가 안 도는 문제가 생기므로, 웹의 maybeAutoCheckForUpdate와 동일한
+// 방식을 쓴다 - 짧은 주기(1시간)로 깨어나 "마지막 확인 이후 설정된 간격이
+// 지났는지"만 가볍게 확인하고, 지났을 때만 실제 업데이트 체크를 수행한다.
 // checkAuthentication()이 (재로그인 등으로) 여러 번 실행될 수 있으므로
 // 타이머가 중복 생성되지 않도록 항상 기존 것을 먼저 정리한다.
-const TAURI_UPDATE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6시간
+const TAURI_UPDATE_DUE_CHECK_TICK_MS = 60 * 60 * 1000 // 1시간
 let tauriUpdatePollingTimer = null
+
+async function maybeCheckTauriUpdateIfDue() {
+  const interval = getTauriUpdateCheckInterval()
+  if (interval === 'never') return
+  const intervalMs = UPDATE_CHECK_INTERVAL_MS[interval] || UPDATE_CHECK_INTERVAL_MS.weekly
+  const lastCheckedAt = Number(localStorage.getItem(TAURI_UPDATE_LAST_CHECKED_STORAGE_KEY) || 0)
+  const dueNow = !lastCheckedAt || (Date.now() - lastCheckedAt) >= intervalMs
+  if (!dueNow) return
+  await checkTauriUpdate({ silent: true })
+}
+
 function startTauriUpdatePolling() {
   if (tauriUpdatePollingTimer) clearInterval(tauriUpdatePollingTimer)
-  tauriUpdatePollingTimer = setInterval(() => checkTauriUpdate({ silent: true }), TAURI_UPDATE_POLL_INTERVAL_MS)
+  tauriUpdatePollingTimer = setInterval(maybeCheckTauriUpdateIfDue, TAURI_UPDATE_DUE_CHECK_TICK_MS)
 }
 
 if (isTauriDesktop && tauriUpdateSection) {
@@ -2719,6 +2755,7 @@ function resetTauriUpdateState() {
 
 async function checkTauriUpdate({ silent = false } = {}) {
   if (!isTauriDesktop) return
+  localStorage.setItem(TAURI_UPDATE_LAST_CHECKED_STORAGE_KEY, String(Date.now()))
   resetTauriUpdateState()
   if (!silent && tauriUpdateCheckBtn) {
     tauriUpdateCheckBtn.disabled = true


### PR DESCRIPTION
# Summary
## 1. 데스크톱 앱 업데이트 확인 주기 설정 추가
- 기존에는 앱 실행 중 백그라운드 재확인 간격이 6시간으로 고정되어 있던 문제 수정
- 설정 화면(앱 업데이트 섹션)에 웹 배포판과 동일한 "매일/매주/사용 안 함" 드롭다운(`setting-tauri-update-check-interval`) 추가 (`frontend/index.html`)
- 설정값은 서버가 아닌 로컬 앱 전용 값이라 `localStorage`(`easypaper_tauri_update_check_interval`)에 저장 (`frontend/src/main.js`)
- 웹의 `maybeAutoCheckForUpdate`와 동일한 패턴으로 `maybeCheckTauriUpdateIfDue()` 추가: 1시간마다 깨어나 "마지막 확인(`easypaper_tauri_update_last_checked_at`) 이후 설정된 간격이 지났는지"만 가볍게 검사하고, 지났을 때만 실제 `checkTauriUpdate({ silent: true })`를 수행
- 로그인 시 무조건 체크하던 것을 `maybeCheckTauriUpdateIfDue()` 호출로 교체해 "사용 안 함" 설정이 로그인 시점 체크에도 적용되도록 함

## 2. macOS/Windows 실행 방법 문서화
- 실사용 중 macOS에서 "앱이 손상되었기 때문에 열 수 없습니다" 오류 발생을 확인 - 완전히 서명되지 않은 앱이라 최신 macOS(Ventura 이후)에서는 우클릭 → 열기로 우회되지 않고 `xattr -cr` 명령이 필요함
- `README.md`의 기존 안내(우클릭 → 열기로 해결된다는 부정확한 내용)를 정확한 `xattr -cr /Applications/EasyPaper.app` 안내로 수정
- `.github/workflows/tauri-release.yml`의 릴리스 노트 생성 스텝을 수정해, 매 릴리스마다 변경 로그와 별개로 "## 실행 방법" 섹션(macOS `xattr` 안내 + Windows SmartScreen 우회 안내)이 고정으로 포함되도록 함