### PR TITLE
feat: 라이브러리에 AI 어시스턴트/논문 비교 채팅 세션 조회 기능 추가

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -6,7 +6,13 @@ from typing import List
 
 from routers.upload import sessions, ensure_session, require_session_owner
 from services.llm_client import stream_chat
-from services.db import db_save_chat_message, db_get_chat_history
+from services.db import (
+    db_save_chat_message,
+    db_get_chat_history,
+    db_list_assistant_chat_sessions,
+    db_upsert_compare_session,
+    db_list_compare_chat_sessions,
+)
 from services.library import get_document as lib_get_document
 from services.auth import get_current_user
 
@@ -165,6 +171,7 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
         paper_blocks.append(f"\n\n===== 논문 {idx}: {title} =====\n{paper_text}")
 
     compare_id = _build_compare_id(doc_ids)
+    db_upsert_compare_session(compare_id, current_user, doc_ids)
     titles_list = "\n".join(f"- 논문 {i}: {t}" for i, t in enumerate(titles, start=1))
     combined_context = "".join(paper_blocks)
 
@@ -229,6 +236,22 @@ async def get_compare_chat_history(doc_ids: str, current_user: str = Depends(get
     compare_id = _build_compare_id(ids)
     history = db_get_chat_history(compare_id)
     return {"history": history, "compare_id": compare_id}
+
+
+@router.get("/chat/sessions")
+async def get_chat_sessions(current_user: str = Depends(get_current_user)):
+    """현재 사용자가 AI 어시스턴트(단일 논문) 기능으로 나눈 채팅 세션 목록을
+    최근 대화 순으로 반환합니다."""
+    sessions = db_list_assistant_chat_sessions(current_user)
+    return {"sessions": sessions}
+
+
+@router.get("/chat/compare-sessions")
+async def get_compare_chat_sessions(current_user: str = Depends(get_current_user)):
+    """현재 사용자가 논문 비교 기능으로 나눈 채팅 세션 목록을 최근 대화 순으로
+    반환합니다."""
+    sessions = db_list_compare_chat_sessions(current_user)
+    return {"sessions": sessions}
 
 
 @router.get("/chat/{session_id}/history")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -100,6 +100,21 @@ def init_db():
         )
         """)
 
+        # 7. compare_sessions 테이블 (논문 비교 채팅 세션 id ↔ 비교 대상 문서
+        #    id 목록 매핑). chats.doc_id에 쓰이는 "cmp_"+hash 값은 원본
+        #    doc_ids 조합을 역산할 수 없는 단방향 해시라서, 라이브러리에서
+        #    "이 비교 세션이 어떤 논문들의 비교인지"를 보여주려면 이 매핑을
+        #    별도로 저장해둬야 한다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS compare_sessions (
+            id TEXT PRIMARY KEY,
+            username TEXT NOT NULL,
+            doc_ids TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """)
+
         conn.commit()
         
     # 기본 관리자 계정 초기 생성
@@ -389,6 +404,93 @@ def db_clear_chat_history(doc_id: str) -> None:
         cursor = conn.cursor()
         cursor.execute("DELETE FROM chats WHERE doc_id = ?", (doc_id,))
         conn.commit()
+
+
+def db_list_assistant_chat_sessions(username: str) -> List[Dict[str, Any]]:
+    """사용자가 AI 어시스턴트(단일 논문) 기능으로 대화한 채팅 세션 목록을,
+    최근 대화 시각 역순으로 반환합니다. 비교 채팅(doc_id가 "cmp_"로 시작)은
+    제외하고, 휴지통에 있거나 삭제된 문서의 대화도 제외합니다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT d.id AS doc_id, d.filename, d.metadata, MAX(c.created_at) AS last_message_at
+            FROM chats c
+            JOIN documents d ON d.id = c.doc_id
+            WHERE d.username = ? AND d.is_deleted = 0 AND c.doc_id NOT LIKE 'cmp\\_%' ESCAPE '\\'
+            GROUP BY c.doc_id
+            ORDER BY last_message_at DESC
+            """,
+            (username,)
+        )
+        sessions = []
+        for r in cursor.fetchall():
+            row = dict(r)
+            metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+            title = metadata.get("title") or row["filename"]
+            sessions.append({
+                "doc_id": row["doc_id"],
+                "title": title,
+                "last_message_at": row["last_message_at"],
+            })
+        return sessions
+
+
+def db_upsert_compare_session(compare_id: str, username: str, doc_ids: List[str]) -> None:
+    """비교 채팅 세션 id와 그 대상 문서 id 목록의 매핑을 저장/갱신합니다."""
+    now = datetime.now(timezone.utc).isoformat()
+    doc_ids_json = json.dumps(doc_ids, ensure_ascii=False)
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO compare_sessions (id, username, doc_ids, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at
+            """,
+            (compare_id, username, doc_ids_json, now, now)
+        )
+        conn.commit()
+
+
+def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
+    """사용자가 논문 비교 기능으로 대화한 채팅 세션 목록을, 최근 대화 시각
+    역순으로 반환합니다. 각 세션의 doc_ids에 연결된 문서 제목도 함께 담습니다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, doc_ids, updated_at FROM compare_sessions WHERE username = ? ORDER BY updated_at DESC",
+            (username,)
+        )
+        rows = cursor.fetchall()
+
+        sessions = []
+        for r in rows:
+            row = dict(r)
+            doc_ids = json.loads(row["doc_ids"])
+
+            titles = []
+            for doc_id in doc_ids:
+                cursor.execute(
+                    "SELECT filename, metadata FROM documents WHERE id = ? AND username = ?",
+                    (doc_id, username)
+                )
+                doc_row = cursor.fetchone()
+                if not doc_row:
+                    titles.append("(삭제된 논문)")
+                    continue
+                doc = dict(doc_row)
+                metadata = json.loads(doc["metadata"]) if doc["metadata"] else {}
+                titles.append(metadata.get("title") or doc["filename"])
+
+            sessions.append({
+                "id": row["id"],
+                "doc_ids": doc_ids,
+                "titles": titles,
+                "last_message_at": row["updated_at"],
+            })
+        return sessions
+
 
 # ── 페이지 인사이트 (키워드/단어, 요약) ─────────────────────────────────────────
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,13 +90,14 @@
       <div class="library-tabs-container">
         <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>보관함</button>
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
+        <button id="lib-tab-chat" class="library-tab-btn" data-tab="chat"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>채팅</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
       <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
 
       <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
-      <div style="position: relative; margin-bottom: 14px;">
+      <div id="library-search-box" style="position: relative; margin-bottom: 14px;">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
         <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
         <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
@@ -120,6 +121,15 @@
           <p>저장된 논문이 없습니다</p>
           <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>
         </div>
+      </div>
+
+      <!-- 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 채팅 세션 목록) -->
+      <div id="library-chat-section" class="hidden">
+        <div class="chat-session-subtabs">
+          <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트 대화</button>
+          <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교 대화</button>
+        </div>
+        <div id="chat-session-list" class="chat-session-list"></div>
       </div>
     </div>
     <!-- 우하단 휴지통 비우기 플로팅 버튼 -->

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -617,6 +617,24 @@ export async function getCompareChatHistoryAPI(docIds) {
 }
 
 /**
+ * AI 어시스턴트(단일 논문) 채팅 세션 목록을 반환합니다.
+ */
+export async function getChatSessionsAPI() {
+  const res = await fetch(`${API_BASE}/chat/sessions`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('채팅 세션 목록 로드 실패')
+  return res.json()
+}
+
+/**
+ * 논문 비교 채팅 세션 목록을 반환합니다.
+ */
+export async function getCompareChatSessionsAPI() {
+  const res = await fetch(`${API_BASE}/chat/compare-sessions`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('비교 채팅 세션 목록 로드 실패')
+  return res.json()
+}
+
+/**
  * Antigravity CLI 사용량 통계 조회
  */
 export async function getAgyUsageAPI() {

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -37,6 +37,7 @@ const PATHS = {
   image: '<rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>',
   search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
   externalLink: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
+  compare: '<path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
@@ -24,7 +24,7 @@ window.fetch = async function (...args) {
 
 // ── 상태 ──────────────────────────────────────────
 const state = {
-  currentLibraryTab: 'archive', // 'archive' (보관함) 또는 'history' (히스토리)
+  currentLibraryTab: 'archive', // 'archive'(보관함) / 'history'(히스토리) / 'trash'(휴지통) / 'chat'(채팅)
   previousLibraryTab: 'archive', // 휴지통 진입 전 이전 탭 기억용
   currentDocId: null,
   currentDocMetadata: {},
@@ -184,8 +184,14 @@ const libraryCountBadge = $('library-count-badge')
 const libTabArchive     = $('lib-tab-archive')
 const libTabHistory     = $('lib-tab-history')
 const libTabTrash       = $('lib-tab-trash')
+const libTabChat        = $('lib-tab-chat')
 const libEmptyTrashBtn  = $('lib-empty-trash-btn')
 const libraryStatsContainer = $('library-stats-container')
+const librarySearchBox  = $('library-search-box')
+const libraryChatSection = $('library-chat-section')
+const chatSubtabAssistant = $('chat-subtab-assistant')
+const chatSubtabCompare   = $('chat-subtab-compare')
+const chatSessionList     = $('chat-session-list')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
 const compareSelectBar      = $('compare-select-bar')
@@ -3337,11 +3343,12 @@ async function loadLibraryCount() {
 function updateTabUI(activeTab) {
   state.currentLibraryTab = activeTab
   activeCategoryFilter = 'ALL'
-  
+
   if (libTabArchive) libTabArchive.classList.toggle('active', activeTab === 'archive')
   if (libTabHistory) libTabHistory.classList.toggle('active', activeTab === 'history')
   if (libTabTrash) libTabTrash.classList.toggle('active', activeTab === 'trash')
-  
+  if (libTabChat) libTabChat.classList.toggle('active', activeTab === 'chat')
+
   if (libEmptyTrashBtn) {
     if (activeTab === 'trash') {
       libEmptyTrashBtn.classList.remove('hidden')
@@ -3350,18 +3357,28 @@ function updateTabUI(activeTab) {
     }
   }
 
-  // 휴지통 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
+  // 휴지통/채팅 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
   if (libUploadBtn) {
-    if (activeTab === 'trash') {
+    if (activeTab === 'trash' || activeTab === 'chat') {
       libUploadBtn.classList.add('hidden')
     } else {
       libUploadBtn.classList.remove('hidden')
     }
   }
   if (libCompareToggleBtn) {
-    libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash')
+    libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash' || activeTab === 'chat')
   }
   setCompareSelectMode(false)
+
+  // 채팅 탭은 문서 그리드 대신 채팅 세션 목록을 보여주므로, 검색/필터 등
+  // 논문 목록 전용 UI는 숨긴다.
+  const isChatTab = activeTab === 'chat'
+  if (libraryGrid) libraryGrid.classList.toggle('hidden', isChatTab)
+  if (libraryChatSection) libraryChatSection.classList.toggle('hidden', !isChatTab)
+  if (librarySearchBox) librarySearchBox.classList.toggle('hidden', isChatTab)
+  if (librarySearchStatus && isChatTab) librarySearchStatus.classList.add('hidden')
+  if (libraryFilterRow) libraryFilterRow.classList.toggle('hidden', isChatTab)
+  if (libraryStatsContainer && isChatTab) libraryStatsContainer.classList.add('hidden')
 
   renderLibrary()
 }
@@ -3386,6 +3403,12 @@ if (libTabTrash) {
       state.previousLibraryTab = state.currentLibraryTab
       updateTabUI('trash')
     }
+  })
+}
+if (libTabChat) {
+  libTabChat.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'chat') return
+    updateTabUI('chat')
   })
 }
 
@@ -3745,6 +3768,11 @@ if (compareBackBtn) {
 }
 
 async function renderLibrary() {
+  if (state.currentLibraryTab === 'chat') {
+    await renderChatSessions()
+    return
+  }
+
   // 탭 전환 등으로 목록을 새로 불러올 때는 검색 상태를 초기화한다 - 검색
   // 결과가 다른 탭의 목록과 뒤섞여 보이는 것을 방지
   if (librarySearchInput) librarySearchInput.value = ''
@@ -3861,6 +3889,101 @@ async function renderLibrary() {
     console.error(err)
     libraryGrid.innerHTML = `<div class="lib-empty"><p style="color:var(--error)">라이브러리 불러오기 실패</p></div>`
   }
+}
+
+// ── 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 대화 목록) ────────────────
+let chatSessionSubtab = 'assistant' // 'assistant' 또는 'compare'
+
+function updateChatSubtabUI() {
+  if (chatSubtabAssistant) chatSubtabAssistant.classList.toggle('active', chatSessionSubtab === 'assistant')
+  if (chatSubtabCompare) chatSubtabCompare.classList.toggle('active', chatSessionSubtab === 'compare')
+}
+
+function formatChatSessionTime(isoString) {
+  if (!isoString) return ''
+  return new Date(isoString).toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+async function renderChatSessions() {
+  updateChatSubtabUI()
+  if (!chatSessionList) return
+  chatSessionList.innerHTML = `<div class="lib-empty"><p>불러오는 중...</p></div>`
+
+  try {
+    if (chatSessionSubtab === 'assistant') {
+      const data = await getChatSessionsAPI()
+      renderAssistantChatSessions(data.sessions || [])
+    } else {
+      const data = await getCompareChatSessionsAPI()
+      renderCompareChatSessions(data.sessions || [])
+    }
+  } catch (err) {
+    console.error('채팅 세션 목록 로드 실패:', err)
+    chatSessionList.innerHTML = `<div class="lib-empty"><p style="color:var(--error)">채팅 세션을 불러오지 못했습니다</p></div>`
+  }
+}
+
+if (chatSubtabAssistant) {
+  chatSubtabAssistant.addEventListener('click', () => {
+    if (chatSessionSubtab === 'assistant') return
+    chatSessionSubtab = 'assistant'
+    renderChatSessions()
+  })
+}
+if (chatSubtabCompare) {
+  chatSubtabCompare.addEventListener('click', () => {
+    if (chatSessionSubtab === 'compare') return
+    chatSessionSubtab = 'compare'
+    renderChatSessions()
+  })
+}
+
+function renderAssistantChatSessions(sessions) {
+  if (sessions.length === 0) {
+    chatSessionList.innerHTML = `<div class="lib-empty"><p>AI 어시스턴트와 나눈 대화가 없습니다</p></div>`
+    return
+  }
+  chatSessionList.innerHTML = ''
+  sessions.forEach(session => {
+    const item = document.createElement('div')
+    item.className = 'chat-session-item'
+    item.innerHTML = `
+      <div class="chat-session-item-icon">${icon('messageCircle', 17)}</div>
+      <div class="chat-session-item-body">
+        <div class="chat-session-item-title">${escapeHtml(session.title)}</div>
+        <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
+      </div>
+    `
+    item.addEventListener('click', () => {
+      location.hash = `#viewer?id=${encodeURIComponent(session.doc_id)}&chat=1`
+    })
+    chatSessionList.appendChild(item)
+  })
+}
+
+function renderCompareChatSessions(sessions) {
+  if (sessions.length === 0) {
+    chatSessionList.innerHTML = `<div class="lib-empty"><p>논문 비교 대화가 없습니다</p></div>`
+    return
+  }
+  chatSessionList.innerHTML = ''
+  sessions.forEach(session => {
+    const item = document.createElement('div')
+    item.className = 'chat-session-item'
+    const titleText = (session.titles || []).join(' · ')
+    item.innerHTML = `
+      <div class="chat-session-item-icon">${icon('compare', 17)}</div>
+      <div class="chat-session-item-body">
+        <div class="chat-session-item-title">${escapeHtml(titleText)}</div>
+        <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
+      </div>
+    `
+    item.addEventListener('click', () => {
+      const idsParam = session.doc_ids.map(id => encodeURIComponent(id)).join(',')
+      location.hash = `#compare?ids=${idsParam}`
+    })
+    chatSessionList.appendChild(item)
+  })
 }
 
 let currentLibraryDocs = []
@@ -7090,6 +7213,22 @@ function toggleChatSidebar() {
   }
 }
 
+// 라이브러리의 채팅 세션 조회 목록에서 AI 어시스턴트 대화를 클릭해 들어올 때
+// 처럼, 이미 사이드바가 열려 있는지와 무관하게 "펼쳐진 상태"를 보장해야 하는
+// 경우 사용한다 (toggleChatSidebar는 매번 상태를 반전시켜 이미 열려 있으면
+// 오히려 닫혀버린다).
+function openChatSidebar() {
+  if (!state.sessionId || !chatSidebar) return
+  if (!chatSidebar.classList.contains('hidden')) return
+  chatSidebar.classList.remove('hidden')
+  if (chatResizer) chatResizer.classList.remove('hidden')
+  chatToggleBtn.classList.add('active')
+  chatInput.focus()
+  setTimeout(() => {
+    chatMessages.scrollTop = chatMessages.scrollHeight
+  }, 100)
+}
+
 function resetChatUI() {
   chatMessages.innerHTML = `<div class="chat-message assistant"><div class="message-bubble">안녕하세요! 이 논문의 내용에 대해 궁금한 점을 질문하시면 해당 분야의 전문가로서 답변해 드립니다.<br><br><strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong><ul><li>이 논문의 핵심 연구 내용과 기여도를 요약해줘.</li><li>본문에서 제안하는 알고리즘/방법론의 상세 과정을 설명해줘.</li><li>실험 결과에서 제시된 주요 수치와 의의는 무엇이야?</li></ul></div></div>`
   chatInput.value = ''
@@ -9749,16 +9888,20 @@ async function handleRouting() {
     console.log("[Router] handleRouting triggered. Current hash:", hash)
     
     if (hash.startsWith('#viewer?id=')) {
-      const docId = hash.split('?id=')[1]
+      const params = new URLSearchParams(hash.slice('#viewer?'.length))
+      const docId = params.get('id')
+      const wantChatOpen = params.get('chat') === '1'
       if (docId) {
         if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
           console.log("[Router] Viewer already active for document:", docId)
+          if (wantChatOpen) openChatSidebar()
           return
         }
         console.log("[Router] Routing to viewer for document:", docId)
         const doc = await fetchLibraryDoc(docId)
         if (doc) {
           await openFromLibrary(doc, false)
+          if (wantChatOpen) openChatSidebar()
           return
         }
       }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4943,3 +4943,83 @@ body.light-theme .figure-preview-tooltip {
 #lib-tab-trash:active {
   transform: scale(0.95);
 }
+
+/* ── 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 대화 목록) ── */
+.chat-session-subtabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+.chat-session-subtab-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: 8px 16px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 12px;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  font-family: var(--font-sans);
+}
+.chat-session-subtab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.chat-session-subtab-btn.active {
+  color: #fff;
+  background: var(--control-accent);
+  border-color: var(--control-accent);
+}
+
+.chat-session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-session-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.chat-session-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px -4px rgba(0, 0, 0, 0.35);
+  border-color: var(--accent-mid);
+}
+.chat-session-item-icon {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent-mid) 14%, var(--bg-elevated));
+  color: var(--accent-mid);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.chat-session-item-body {
+  flex: 1;
+  min-width: 0;
+}
+.chat-session-item-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-session-item-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}


### PR DESCRIPTION
# Summary
## 1. 채팅 세션 조회용 백엔드 API 및 DB 추가
- `backend/services/db.py`: 논문 비교 채팅 세션 id ↔ 비교 대상 문서 id 목록 매핑을 저장하는 `compare_sessions` 테이블 추가 (기존 `chats.doc_id`의 `cmp_`+hash 값은 원본 doc_ids 조합을 역산할 수 없어 별도 저장 필요)
- `db_list_assistant_chat_sessions(username)`: AI 어시스턴트(단일 논문) 채팅 세션 목록을 논문 제목 + 최근 대화 시각과 함께 조회 (휴지통/삭제된 문서 제외)
- `db_upsert_compare_session(compare_id, username, doc_ids)`, `db_list_compare_chat_sessions(username)`: 비교 채팅 세션 목록을 참여 논문 제목들과 함께 조회
- `backend/routers/chat.py`: `chat_compare_stream`에서 비교 세션 매핑을 upsert하도록 연결, `GET /api/chat/sessions`(어시스턴트), `GET /api/chat/compare-sessions`(비교) 엔드포인트 추가

## 2. 라이브러리 화면에 "채팅" 탭 추가
- `frontend/index.html`: 보관함/히스토리 옆에 `lib-tab-chat` 탭 버튼과, "AI 어시스턴트 대화" / "논문 비교 대화" 서브탭 + 세션 리스트 마크업(`library-chat-section`) 추가
- `frontend/src/style.css`: 서브탭 버튼, 세션 리스트 아이템 스타일 추가
- `frontend/src/icons.js`: 비교 세션 아이콘(`compare`) 추가

## 3. 채팅 세션 목록 렌더링 및 클릭 이동 로직
- `frontend/src/api.js`: `getChatSessionsAPI`, `getCompareChatSessionsAPI` 클라이언트 함수 추가
- `frontend/src/main.js`:
  - `updateTabUI`에 `chat` 탭 분기 추가 (문서 그리드/검색/필터 숨기고 채팅 세션 섹션 노출)
  - `renderChatSessions`/`renderAssistantChatSessions`/`renderCompareChatSessions`로 두 종류의 세션을 각각 논문 제목 타이틀로 리스트업
  - AI 어시스턴트 세션 클릭 시 `#viewer?id=<id>&chat=1`로 이동하며 뷰어의 채팅 사이드바가 자동으로 펼쳐지도록 `openChatSidebar()` 추가 및 `handleRouting`에서 `chat=1` 쿼리 파싱 지원
  - 비교 세션 클릭 시 기존 `#compare?ids=...` 라우트로 이동

## 테스트
- 격리된 테스트용 backend/frontend(8001/5180 포트)를 띄우고 Playwright로 로그인 → 채팅 탭 클릭 → 두 서브탭 전환 → 세션 클릭까지 직접 구동해 스크린샷으로 확인
- 테스트 중 생성한 임시 DB 데이터/파일/프로세스는 모두 정리함