### PR TITLE
fix: 채팅 세션 탭 이름 정리 및 논문 열람 성능 개선

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -126,8 +126,8 @@
       <!-- 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 채팅 세션 목록) -->
       <div id="library-chat-section" class="hidden">
         <div class="chat-session-subtabs">
-          <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트 대화</button>
-          <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교 대화</button>
+          <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트</button>
+          <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교</button>
         </div>
         <div id="chat-session-list" class="chat-session-list"></div>
       </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3954,8 +3954,20 @@ function renderAssistantChatSessions(sessions) {
         <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
       </div>
     `
-    item.addEventListener('click', () => {
-      location.hash = `#viewer?id=${encodeURIComponent(session.doc_id)}&chat=1`
+    item.addEventListener('click', async () => {
+      // location.hash를 바꿔서 라우터(handleRouting)를 거치게 하면, 이 앱에서는
+      // hashchange와 popstate가 함께 발생해 handleRouting이 같은 문서를 두 번
+      // 라우팅하며 문서 조회(fetchLibraryDoc) 요청도 중복으로 나가 체감 로딩이
+      // 늘어진다. 라이브러리 카드의 "열기" 버튼처럼 문서를 직접 한 번만 불러와
+      // 바로 열어서 이 지연을 없앤다.
+      try {
+        const doc = await fetchLibraryDoc(session.doc_id)
+        await openFromLibrary(doc)
+        openChatSidebar()
+      } catch (err) {
+        console.error('채팅 세션에서 논문 열기 실패:', err)
+        showToast('논문을 불러오지 못했습니다.', 'error')
+      }
     })
     chatSessionList.appendChild(item)
   })
@@ -3978,9 +3990,17 @@ function renderCompareChatSessions(sessions) {
         <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
       </div>
     `
-    item.addEventListener('click', () => {
-      const idsParam = session.doc_ids.map(id => encodeURIComponent(id)).join(',')
-      location.hash = `#compare?ids=${idsParam}`
+    item.addEventListener('click', async () => {
+      // 이유는 위 renderAssistantChatSessions와 동일 - 라우터를 거치지 않고
+      // 문서들을 직접 불러와 바로 비교 화면을 연다.
+      try {
+        const docs = await Promise.all(session.doc_ids.map(id => fetchLibraryDoc(id)))
+        if (!docs.every(Boolean)) throw new Error('일부 논문을 찾을 수 없습니다.')
+        await openCompareScreen(docs)
+      } catch (err) {
+        console.error('채팅 세션에서 비교 화면 열기 실패:', err)
+        showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
+      }
     })
     chatSessionList.appendChild(item)
   })


### PR DESCRIPTION
# Summary
## 1. 채팅 세션 탭 이름에서 "대화" 문구 제거
- `frontend/index.html`: "AI 어시스턴트 대화" → "AI 어시스턴트", "논문 비교 대화" → "논문 비교"로 서브탭 라벨 수정

## 2. 채팅 세션 클릭 시 논문 열람 속도 개선
- 기존에는 세션 클릭 시 `location.hash`를 변경해 라우터(`handleRouting`)를 거치도록 했는데, 이 앱에서는 hash 변경 시 `hashchange`와 `popstate`가 함께 발생해 `handleRouting`이 같은 문서를 두 번 라우팅하며 `GET /api/library/{doc_id}` 요청도 중복으로 나가고 있었음 (Playwright로 재현: 클릭 1회당 handleRouting 2회 호출 확인)
- `frontend/src/main.js`의 `renderAssistantChatSessions`/`renderCompareChatSessions` 클릭 핸들러를 라이브러리 카드의 "열기" 버튼과 동일한 방식(문서를 직접 한 번만 조회 후 `openFromLibrary`/`openCompareScreen` 직접 호출)으로 변경해 중복 요청 제거
- 문서를 불러오지 못하는 경우에 대한 에러 토스트 처리 추가

## 테스트
- 격리된 테스트 backend/frontend를 띄우고 Playwright로 직접 확인
  - 탭 라벨이 "AI 어시스턴트" / "논문 비교"로 정확히 표시됨
  - 세션 클릭 시 `/api/library/{doc_id}` 요청이 기존 2회 → 1회로 줄어듦
  - 채팅 사이드바 자동 오픈 등 기존 동작은 그대로 유지됨
- 테스트 중 생성한 임시 DB 데이터/파일/프로세스는 모두 정리함