### PR TITLE
feat: 논문 뷰어에 메모 접기/숨기기/전체 숨기기 기능 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -273,6 +273,9 @@
           <button id="export-btn" class="icon-btn" title="번역본 내보내기">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
           </button>
+          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          </button>
         </div>
 
         <div class="toolbar-divider"></div>

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -38,6 +38,9 @@ const PATHS = {
   search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
   externalLink: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
   compare: '<path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/>',
+  chevronUp: '<path d="m18 15-6-6-6 6"/>',
+  chevronDown: '<path d="m6 9 6 6 6-6"/>',
+  eyeOff: '<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -234,6 +234,7 @@ const zoomOutBtn        = $('zoom-out-btn')
 const zoomLabel         = $('zoom-level')
 const syncScrollBtn     = $('sync-scroll-btn')
 const exportBtn         = $('export-btn')
+const memosHideAllBtn   = $('memos-hide-all-btn')
 const retranslateBtn    = $('retranslate-btn')
 const captureAreaBtn    = $('capture-area-btn')
 const cancelTransBtn    = $('cancel-trans-btn')
@@ -4651,6 +4652,8 @@ async function openFromLibrary(doc, shouldPushState = true) {
       history.pushState({ screen: 'viewer', docId: doc.id }, '', `#viewer?id=${doc.id}`)
     }
     state.sessionId  = doc.id
+    allMemosHidden = loadAllMemosHiddenState(doc.id)
+    updateMemosHideAllBtnUI()
     loadDocumentImages(doc.id)
     loadDocumentReferences(doc.id)
     state.filename   = doc.filename
@@ -5370,6 +5373,47 @@ function saveMemos(sessionId, memos) {
   localStorage.setItem(key, JSON.stringify(memos))
 }
 
+// 툴바의 "전체 숨기기" 토글 - 개별 memo.hidden 필드와는 별개로, 문서를 보는 동안만
+// 켜고 끄는 순수 화면 표시 상태(번역창 접기의 isTransPaneCollapsed와 동일한 패턴).
+// 문서(세션)별로 마지막 상태를 기억해두되, 각 메모의 저장된 내용에는 손대지 않는다.
+let allMemosHidden = false
+
+function getAllMemosHiddenKey(sessionId) {
+  return `easypaper_memos_all_hidden_${sessionId}`
+}
+
+function loadAllMemosHiddenState(sessionId) {
+  if (!sessionId) return false
+  return localStorage.getItem(getAllMemosHiddenKey(sessionId)) === 'true'
+}
+
+function updateMemosHideAllBtnUI() {
+  if (!memosHideAllBtn) return
+  memosHideAllBtn.classList.toggle('active', allMemosHidden)
+  memosHideAllBtn.title = allMemosHidden
+    ? '숨긴 메모 모두 표시'
+    : '작성된 모든 메모 숨기기 (하이라이트만 표시)'
+}
+
+function redrawAllPageMemos() {
+  document.querySelectorAll('.pdf-page-wrapper').forEach(wrapper => {
+    const pageNum = parseInt(wrapper.dataset.page, 10)
+    if (!isNaN(pageNum)) renderPageMemos(pageNum)
+  })
+}
+
+if (memosHideAllBtn) {
+  memosHideAllBtn.addEventListener('click', () => {
+    allMemosHidden = !allMemosHidden
+    if (state.sessionId) {
+      localStorage.setItem(getAllMemosHiddenKey(state.sessionId), String(allMemosHidden))
+    }
+    updateMemosHideAllBtnUI()
+    redrawAllPageMemos()
+    showToast(allMemosHidden ? '모든 메모가 숨겨졌습니다.' : '숨겼던 메모를 모두 표시합니다.', 'info')
+  })
+}
+
 function updateMemoConnectorLine(pageWrapper, memo) {
   let svg = pageWrapper.querySelector('.memo-connector-svg')
   if (!svg) {
@@ -5491,21 +5535,54 @@ function renderPageMemos(pageNum) {
     clearOverlayBoxes(overlay, 'sentence-memo-box')
   }
   pageWrapper.querySelectorAll('.pdf-sentence-has-memo').forEach(el => {
-    el.classList.remove('pdf-sentence-has-memo')
+    el.classList.remove('pdf-sentence-has-memo', 'pdf-sentence-has-memo-hidden')
+    delete el.dataset.memoId
   })
+
+  // 폴백(VTM 미사용) 경로에서 숨겨진 메모의 하이라이트 클릭 시 다시 보이기.
+  // .pdf-sentence 스팬은 이 함수가 다시 호출돼도 파괴/재생성되지 않고 그대로
+  // 남아있는 요소라, 매번 element에 직접 리스너를 추가하면 재렌더링될 때마다
+  // 리스너가 계속 쌓인다. 그래서 pageWrapper 하나당 한 번만 위임 리스너를 걸고,
+  // 클릭 시점에 최신 memo 목록을 다시 읽어서 처리한다.
+  if (!pageWrapper.dataset.memoRevealBound) {
+    pageWrapper.dataset.memoRevealBound = '1'
+    pageWrapper.addEventListener('click', (e) => {
+      const target = e.target.closest('.pdf-sentence-has-memo-hidden')
+      if (!target || !target.dataset.memoId) return
+      e.stopPropagation()
+      const pNum = parseInt(pageWrapper.dataset.page, 10)
+      const allMemosObj = loadMemos(state.sessionId)
+      const memos = allMemosObj[`page_${pNum}`] || []
+      const targetMemo = memos.find(m => m.id === target.dataset.memoId)
+      if (targetMemo) {
+        targetMemo.hidden = false
+        saveMemos(state.sessionId, allMemosObj)
+        renderPageMemos(pNum)
+      }
+    })
+  }
 
   if (!state.sessionId) return
   const allMemos = loadMemos(state.sessionId)
   const pageMemos = allMemos[`page_${pageNum}`] || []
 
   pageMemos.forEach(memo => {
-    const memoEl = document.createElement('div')
-    memoEl.className = `floating-memo color-${memo.color || 'default'}`
-    memoEl.setAttribute('data-id', memo.id)
-    memoEl.style.left = `${memo.x}%`
-    memoEl.style.top = `${memo.y}%`
+    // 개별 "숨기기"(memo.hidden) 또는 툴바의 "전체 숨기기"(allMemosHidden) 중
+    // 하나라도 켜져 있으면 카드는 그리지 않고 PDF 본문의 하이라이트만 남긴다.
+    // 전체 숨기기는 순수 화면 표시 상태라 하이라이트를 클릭해도 개별 메모만
+    // 되살아나지 않도록, "클릭해서 다시 보이기"는 개별 숨김에만 적용한다.
+    const isHiddenIndividually = !!memo.hidden
+    const isHidden = isHiddenIndividually || allMemosHidden
 
-    // VTM 기반 메모 하이라이트 (비파괴 시스템)
+    const revealHiddenMemo = () => {
+      memo.hidden = false
+      const allMemosObj = loadMemos(state.sessionId)
+      allMemosObj[`page_${pageNum}`] = pageMemos
+      saveMemos(state.sessionId, allMemosObj)
+      renderPageMemos(pageNum)
+    }
+
+    // VTM 기반 메모 하이라이트 (비파괴 시스템) - 카드 표시 여부와 무관하게 항상 그린다
     const vtmForMemo = state.virtualTextMaps && state.virtualTextMaps[pageNum]
     const memoSentenceRanges = state.pdfPageSentences && state.pdfPageSentences[pageNum]
     let sentenceText = memo.sentenceText || ''
@@ -5521,7 +5598,19 @@ function renderPageMemos(pageNum) {
         if (memoTextLayer) {
           const memoOverlay = getOrCreateOverlay(pageWrapper)
           const memoRects = getSentenceRects(memoSRange, vtmForMemo, memoTextLayer)
-          renderSentenceOverlay(memoOverlay, memoRects, 'sentence-memo-box')
+          memoRects.forEach(r => {
+            const box = document.createElement('div')
+            box.className = isHiddenIndividually ? 'sentence-memo-box hidden-memo' : 'sentence-memo-box'
+            box.style.left = `${r.left}px`
+            box.style.top = `${r.top}px`
+            box.style.width = `${r.width}px`
+            box.style.height = `${r.height}px`
+            if (isHiddenIndividually) {
+              box.title = '숨겨진 메모 다시 표시'
+              box.addEventListener('click', (e) => { e.stopPropagation(); revealHiddenMemo() })
+            }
+            memoOverlay.appendChild(box)
+          })
         }
       }
     } else {
@@ -5531,10 +5620,28 @@ function renderPageMemos(pageNum) {
         sentenceText = sentenceEl.textContent.trim()
         const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, memo.sentenceIdx)
         if (pdfElements) {
-          pdfElements.forEach(el => el.classList.add('pdf-sentence-has-memo'))
+          pdfElements.forEach(el => {
+            el.classList.add('pdf-sentence-has-memo')
+            if (isHiddenIndividually) {
+              // 클릭 시 되살리기는 pageWrapper에 위임된 리스너(위 참고)가 처리한다 -
+              // 이 요소는 재렌더링 때마다 파괴되지 않고 남아있어 직접 리스너를
+              // 달면 호출될 때마다 중복으로 쌓이기 때문
+              el.classList.add('pdf-sentence-has-memo-hidden')
+              el.dataset.memoId = memo.id
+              el.title = '숨겨진 메모 다시 표시'
+            }
+          })
         }
       }
     }
+
+    if (isHidden) return // 카드/커넥터는 그리지 않고 하이라이트만 남긴다
+
+    const memoEl = document.createElement('div')
+    memoEl.className = `floating-memo color-${memo.color || 'default'}${memo.collapsed ? ' collapsed' : ''}`
+    memoEl.setAttribute('data-id', memo.id)
+    memoEl.style.left = `${memo.x}%`
+    memoEl.style.top = `${memo.y}%`
 
     let isEditing = !memo.content.trim()
 
@@ -5626,6 +5733,18 @@ function renderPageMemos(pageNum) {
 
         actions.querySelector('.edit-btn').addEventListener('click', (e) => {
           e.stopPropagation()
+          if (memo.collapsed) {
+            memo.collapsed = false
+            memoEl.classList.remove('collapsed')
+            const collapseBtnEl = memoEl.querySelector('.collapse-btn')
+            if (collapseBtnEl) {
+              collapseBtnEl.innerHTML = icon('chevronUp', 12)
+              collapseBtnEl.title = '메모 접기'
+            }
+            const allMemosObj = loadMemos(state.sessionId)
+            allMemosObj[`page_${pageNum}`] = pageMemos
+            saveMemos(state.sessionId, allMemosObj)
+          }
           isEditing = true
           updateCardContent()
         })
@@ -5665,12 +5784,44 @@ function renderPageMemos(pageNum) {
           <span class="color-dot blue ${memo.color === 'blue' ? 'selected' : ''}" data-color="blue" title="파랑"></span>
           <span class="color-dot red ${memo.color === 'red' ? 'selected' : ''}" data-color="red" title="빨강"></span>
         </div>
+        <div class="floating-memo-toggles">
+          <button class="floating-memo-action-btn collapse-btn" title="${memo.collapsed ? '메모 펼치기' : '메모 접기'}">
+            ${icon(memo.collapsed ? 'chevronDown' : 'chevronUp', 12)}
+          </button>
+          <button class="floating-memo-action-btn hide-btn" title="메모 숨기기 (하이라이트만 표시)">
+            ${icon('eyeOff', 12)}
+          </button>
+        </div>
         <div class="floating-memo-actions"></div>
       </div>
       <div class="floating-memo-body"></div>
     `
 
     updateCardContent()
+
+    const collapseBtn = memoEl.querySelector('.collapse-btn')
+    collapseBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      memo.collapsed = !memo.collapsed
+      const allMemosObj = loadMemos(state.sessionId)
+      allMemosObj[`page_${pageNum}`] = pageMemos
+      saveMemos(state.sessionId, allMemosObj)
+
+      memoEl.classList.toggle('collapsed', memo.collapsed)
+      collapseBtn.innerHTML = icon(memo.collapsed ? 'chevronDown' : 'chevronUp', 12)
+      collapseBtn.title = memo.collapsed ? '메모 펼치기' : '메모 접기'
+      setTimeout(() => updateMemoConnectorLine(pageWrapper, memo), 0)
+    })
+
+    const hideBtn = memoEl.querySelector('.hide-btn')
+    hideBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      memo.hidden = true
+      const allMemosObj = loadMemos(state.sessionId)
+      allMemosObj[`page_${pageNum}`] = pageMemos
+      saveMemos(state.sessionId, allMemosObj)
+      renderPageMemos(pageNum)
+    })
 
     const body = memoEl.querySelector('.floating-memo-body')
     body.addEventListener('click', (e) => {
@@ -5690,8 +5841,8 @@ function renderPageMemos(pageNum) {
         colorDots.forEach(d => d.classList.remove('selected'))
         dot.classList.add('selected')
         
-        memoEl.className = `floating-memo color-${selectedColor}`
-        
+        memoEl.className = `floating-memo color-${selectedColor}${memo.collapsed ? ' collapsed' : ''}`
+
         memo.color = selectedColor
         const allMemosObj = loadMemos(state.sessionId)
         allMemosObj[`page_${pageNum}`] = pageMemos

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4006,6 +4006,19 @@ body.light-theme .custom-confirm-modal {
 .floating-memo:hover .floating-memo-color-picker {
   opacity: 1;
 }
+
+.floating-memo-toggles {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-right: 4px;
+}
+
+/* 접기 상태: 헤더(제목 탭)만 남기고 본문은 숨긴다 */
+.floating-memo.collapsed .floating-memo-body {
+  display: none;
+}
+
 .color-dot {
   width: 10px;
   height: 10px;
@@ -4358,6 +4371,16 @@ body.light-theme .sentence-active-box {
 }
 body.light-theme .sentence-memo-box {
   background-color: rgba(245, 158, 11, 0.14);
+}
+/* 숨겨진 메모의 하이라이트 - 클릭하면 메모 카드가 다시 나타난다 (부모
+   .pdf-highlight-overlay는 pointer-events:none이지만 이 상자만 auto로
+   되돌려 클릭을 받는다 - .citation-marker-box와 동일한 패턴) */
+.sentence-memo-box.hidden-memo {
+  pointer-events: auto !important;
+  cursor: pointer;
+}
+.sentence-memo-box.hidden-memo:hover {
+  background-color: rgba(245, 158, 11, 0.32);
 }
 
 /* 독립 수식 호버 상자 */


### PR DESCRIPTION
# Summary
## 1. 메모 개별 접기 기능
- `frontend/src/main.js`의 `renderPageMemos`: 각 메모 카드 헤더에 접기 토글 버튼(`.collapse-btn`) 추가
- `memo.collapsed` 필드를 memo 객체에 추가해 `saveMemos`로 영속화, `.floating-memo.collapsed .floating-memo-body { display: none }`(`frontend/src/style.css`)로 제목(헤더)만 남기고 본문을 숨김
- 색상 변경 시 `memoEl.className`을 통째로 덮어쓰던 기존 코드가 `collapsed` 클래스를 날리던 문제를 함께 수정
- 접힌 상태에서 "편집" 버튼을 누르면 자동으로 펼쳐지도록 처리(접힌 채로는 textarea가 보이지 않아 편집이 막히는 문제 방지)

## 2. 메모 개별 숨기기 기능
- 메모 카드 헤더에 숨기기 버튼(`.hide-btn`) 추가 - 클릭 시 `memo.hidden = true`로 저장하고 카드 전체를 그리지 않음
- PDF 본문의 하이라이트(VTM 경로의 `.sentence-memo-box`, 폴백 경로의 `.pdf-sentence-has-memo`)는 그대로 유지해 "메모가 있었다"는 표시만 남김
- 숨겨진 메모의 하이라이트를 클릭하면 다시 카드가 나타나도록 처리
  - VTM 경로: 하이라이트 박스가 렌더링마다 새로 생성되므로 직접 리스너 연결
  - 폴백 경로(`.pdf-sentence` 스팬)는 재렌더링돼도 파괴되지 않고 남아있는 요소라, 매번 리스너를 새로 달면 계속 쌓이는 문제가 있어 `pageWrapper` 단위로 한 번만 위임 리스너를 걸어 처리

## 3. 툴바 "전체 숨기기" 토글 추가
- `frontend/index.html`: 뷰어 툴바(`action-group`)에 `#memos-hide-all-btn` 아이콘 버튼 추가
- 개별 `memo.hidden`과는 별개로, 문서를 보는 동안만 켜고 끄는 순수 화면 표시 상태(번역창 접기와 동일한 패턴)로 구현 - 문서(세션)별로 마지막 상태를 localStorage에 기억
- 켜져 있으면 모든 메모 카드가 숨겨지고 하이라이트만 남음

## 4. 기타
- `frontend/src/icons.js`: `chevronUp`/`chevronDown`/`eyeOff` 아이콘 추가

## 테스트
- 격리된 테스트 backend/frontend를 띄우고 실제 논문(PDF)을 업로드해 Playwright로 직접 검증
  - 접기 → 본문(body) 숨겨짐 / 펼치기 → 다시 보임
  - 개별 숨기기 → 카드 사라지고(count 0) 하이라이트만 남음(hidden-memo count 1) → 하이라이트 클릭 → 카드 복원(count 1)
  - 툴바 "전체 숨기기" → 모든 카드 사라짐 + 버튼 active 표시 → 다시 클릭 → 복원
  - localStorage에 `collapsed`/`hidden` 필드가 정상적으로 영속화됨을 확인
- 테스트 중 생성한 임시 DB 데이터/파일/프로세스는 모두 정리함