### PR TITLE
fix: 번역 완료 시 메모 하이라이트가 사라지던 버그 수정 및 주석 리스트 펼쳐보기 추가

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -935,13 +935,15 @@ function renderTransContent(pageNum, text, cached = false) {
   const textLayerDiv = document.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"] .textLayer`)
   if (textLayerDiv) {
     segmentElementIntoSentences(textLayerDiv, pageNum, 'pdf-sentence')
-    
-    // 주석(Annotation) 하이라이트 복원
+
+    // 주석(하이라이트/언더라인) 및 메모 하이라이트 복원 - 위 재세그멘테이션으로
+    // VirtualTextMap/문장 매핑이 통째로 새로 만들어지기 때문에, 이 페이지에 저장된
+    // 하이라이트/언더라인이 없더라도(메모만 있는 경우) 반드시 다시 그려줘야 한다.
+    // 예전에는 annotations[page_N]이 있을 때만 재렌더링해서, 메모만 있고 하이라이트/
+    // 언더라인은 없는 페이지에서 번역 로딩이 끝나면 메모 하이라이트가 사라지는
+    // 버그가 있었다.
     if (state.sessionId) {
-      const annotations = loadAnnotations(state.sessionId)
-      if (annotations[`page_${pageNum}`]) {
-        reRenderPageAnnotations(textLayerDiv, pageNum)
-      }
+      reRenderPageAnnotations(textLayerDiv, pageNum)
     }
   }
   
@@ -4144,26 +4146,45 @@ function renderAnnotationItems(items) {
     const item = document.createElement('div')
     item.className = 'chat-session-item'
 
-    let iconHtml, snippet, iconBg
+    let iconHtml, fullText, iconBg
     if (entry.memo) {
       iconHtml = icon('messageCircle', 17)
-      snippet = truncateForList(entry.memo.content, 70) || truncateForList(entry.memo.sentenceText, 70) || '(내용 없음)'
+      fullText = (entry.memo.content && entry.memo.content.trim()) || entry.memo.sentenceText || '(내용 없음)'
       iconBg = ''
     } else {
       const isHighlight = annotationBrowserSubtab === 'highlight'
       iconHtml = icon(isHighlight ? 'highlighter' : 'underline', 17)
-      snippet = truncateForList(entry.annotation.text, 70) || '(내용 없음)'
+      fullText = entry.annotation.text || '(내용 없음)'
       iconBg = entry.annotation.color ? `background:${hexToRgba(entry.annotation.color, 0.22)};color:${entry.annotation.color}` : ''
     }
+
+    const shortText = truncateForList(fullText, 70)
+    const canExpand = fullText.trim().length > shortText.replace(/\.\.\.$/, '').length
 
     item.innerHTML = `
       <div class="chat-session-item-icon" style="${iconBg}">${iconHtml}</div>
       <div class="chat-session-item-body">
         <div class="chat-session-item-title">${escapeHtml(docTitle)} · ${pageNum}페이지</div>
-        <div class="chat-session-item-meta">${escapeHtml(snippet)}</div>
+        <div class="chat-session-item-meta annotation-item-meta">${escapeHtml(shortText)}</div>
       </div>
+      ${canExpand ? `<button class="annotation-expand-btn" title="전체 내용 보기">${icon('chevronDown', 12)}</button>` : ''}
     `
     item.addEventListener('click', () => openAnnotationTarget(doc, pageNum))
+
+    if (canExpand) {
+      const expandBtn = item.querySelector('.annotation-expand-btn')
+      const metaEl = item.querySelector('.annotation-item-meta')
+      let expanded = false
+      expandBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        expanded = !expanded
+        metaEl.textContent = expanded ? fullText : shortText
+        metaEl.classList.toggle('expanded', expanded)
+        expandBtn.innerHTML = icon(expanded ? 'chevronUp' : 'chevronDown', 12)
+        expandBtn.title = expanded ? '접기' : '전체 내용 보기'
+      })
+    }
+
     annotationList.appendChild(item)
   })
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5046,3 +5046,28 @@ body.light-theme .figure-preview-tooltip {
   color: var(--text-muted);
   margin-top: 4px;
 }
+.annotation-item-meta.expanded {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.annotation-expand-btn {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.annotation-expand-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-mid);
+  background: var(--bg-hover);
+}


### PR DESCRIPTION
# Summary
## 1. 메모 "숨기기" 후 하이라이트가 사라지는 버그 수정
- `renderTransContent`(`frontend/src/main.js`)에서 페이지 번역이 완료되면 PDF 텍스트 레이어를 재세그멘테이션(`segmentElementIntoSentences`)해 VirtualTextMap/문장 매핑을 새로 만드는데, 그 직후 메모 하이라이트를 다시 그려주는 `reRenderPageAnnotations` 호출이 **해당 페이지에 하이라이트/언더라인 주석이 있을 때만** 실행되도록 조건이 걸려 있었음
- 그 결과 하이라이트/언더라인 없이 메모만 있는 페이지에서는, 번역이 완료되는 순간(또는 메모를 숨긴 직후 번역이 막 완료되는 타이밍) 메모 카드/하이라이트가 새 VirtualTextMap 기준으로 다시 그려지지 않아 사라져 보였음(새로고침하면 초기 로드 시점엔 이미 번역이 끝나 있어 정상적으로 보임)
- 조건을 제거하고 `reRenderPageAnnotations`를 항상 호출하도록 수정 - 저장된 하이라이트/언더라인이 없는 경우 `applyAnnotationsFromOffsets`가 그냥 no-op이라 부작용 없음

## 2. 라이브러리 "주석" 조회 리스트에 펼쳐보기 기능 추가
- 메모/하이라이트/언더라인 미리보기가 70자로 잘려서 전체 내용을 볼 수 없었던 문제 개선
- 잘린 내용이 있는 항목에만 펼치기 버튼을 추가해, 클릭하면 항목 전체로 이동하지 않고 그 자리에서 전체 내용을 펼쳐볼 수 있도록 함 (다시 클릭하면 접힘)

## 테스트
- 격리된 테스트 backend/frontend를 띄우고 실제 논문을 업로드해 검증
  - 번역 완료 재세그멘테이션 시퀀스를 실제로 재현해, 수정 전 로직이면 사라졌을 숨겨진 메모의 하이라이트가 수정 후에는 두 번 반복 실행해도 그대로 유지됨을 확인
  - 실제 Ollama 로컬 모델로 번역 잡을 돌려 재현 흐름도 함께 확인
  - 라이브러리 "주석" 탭에서 긴 메모는 펼치기 버튼이 나타나 전체 내용이 펼쳐지고, 짧은 메모는 버튼이 없음을 확인 - 펼치기 클릭 시 페이지 이동 없이 라이브러리 화면에 그대로 머무름을 확인
- 테스트 중 생성한 임시 DB 데이터/파일/프로세스는 모두 정리함