### PR TITLE
fix: 텍스트 레이어 재세그멘테이션 시 메모 하이라이트가 복구되지 않던 죽은 코드 제거

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9232,35 +9232,18 @@ function segmentPdfElements(container, pageNum) {
     if (pageWrapper) {
       const overlay = getOrCreateOverlay(pageWrapper);
       clearOverlayBoxes(overlay, 'sentence-hover-box', 'sentence-active-box', 'sentence-memo-box', 'sentence-equation-box', 'sentence-pulse-box');
-      // 메모 하이라이트 재렌더링
-      renderMemoOverlay(pageWrapper, pageNum, overlay);
+      // 메모 카드/하이라이트 재렌더링 - 바로 위에서 방금 sentence-memo-box를
+      // 지웠기 때문에, segmentPdfElements를 호출하는 곳(번역 완료, 최초 텍스트
+      // 레이어 렌더링 등) 어디서든 이 시점에 반드시 다시 그려줘야 한다. 예전에는
+      // easypaper_annotations_*(하이라이트/언더라인)에만 있는 "memos" 필드를
+      // 잘못 참조하는 죽은 코드(renderMemoOverlay)가 대신 호출되고 있어서,
+      // 이 함수를 호출하는 경로 중 memo 재호출을 별도로 챙기지 않는 곳에서는
+      // 메모 하이라이트가 그대로 사라진 채 복구되지 않는 버그가 있었다.
+      renderPageMemos(pageNum);
     }
   } catch (err) {
     console.warn(`segmentPdfElements failed for p.${pageNum}:`, err);
   }
-}
-
-// 메모가 있는 문장의 오버레이 하이라이트를 렌더링
-function renderMemoOverlay(pageWrapper, pageNum, overlay) {
-  try {
-    const annotations = loadAnnotations(state.sessionId);
-    const memos = (annotations && annotations.memos) ? annotations.memos.filter(m => m.pageNum === pageNum) : [];
-    if (memos.length === 0) return;
-
-    const vtm = state.virtualTextMaps && state.virtualTextMaps[pageNum];
-    const sentenceRanges = state.pdfPageSentences && state.pdfPageSentences[pageNum];
-    if (!vtm || !sentenceRanges) return;
-
-    const container = pageWrapper.querySelector('.textLayer');
-    if (!container) return;
-
-    memos.forEach(memo => {
-      const sRange = sentenceRanges.find(r => r.sentenceIdx === memo.sentenceIdx);
-      if (!sRange) return;
-      const rects = getSentenceRects(sRange, vtm, container);
-      renderSentenceOverlay(overlay, rects, 'sentence-memo-box');
-    });
-  } catch (e) { /* no-op */ }
 }
 
 // 번역본용 문장 쪼개기


### PR DESCRIPTION
# Summary
## 진짜 원인을 다시 찾음
이전 PR(#197)에서 `renderTransContent`의 조건부 게이트를 제거했지만, 사용자가 실제로는 여전히 재현된다고 확인해줘서 더 깊이 파봤습니다. 진짜 원인은 `segmentPdfElements`(`frontend/src/main.js`) 내부에 있었습니다.

`segmentPdfElements`는 텍스트 레이어를 재구성할 때마다(번역 완료, 페이지 최초 렌더링 등 - 호출 경로 무관하게) 항상:
1. 기존 `.sentence-memo-box`(메모 하이라이트) 오버레이 박스를 전부 지움
2. 그 자리에 `renderMemoOverlay()`를 호출해 "다시 그림" — 그런데 이 함수는 하이라이트/언더라인 저장소(`easypaper_annotations_*`)에만 있는 `annotations.memos`라는, 실제로는 존재한 적 없는 필드를 참조하고 있어서 **항상 빈 배열이 되는 죽은 코드**였음

즉 `segmentPdfElements`가 호출되는 시점마다 메모 하이라이트가 지워지고, 그 직후 실행되는 "복구" 로직은 실질적으로 아무것도 하지 않았습니다. 바깥쪽 호출부(`renderTransContent`, `onTextLayerRendered` 등)가 그 뒤에 `renderPageMemos`를 별도로 호출해주는 경우에만 우연히 복구됐던 것이고, 그 타이밍/경로가 어긋나면 하이라이트가 사라진 채로 남았습니다.

## 수정
- `renderMemoOverlay(pageWrapper, pageNum, overlay)` 호출을 실제 메모 렌더링 함수인 `renderPageMemos(pageNum)` 호출로 교체
- 이제 `segmentPdfElements`가 호출될 때마다 항상 정확한 메모 카드/하이라이트(숨김 상태 포함)가 그 자리에서 바로 복구됨 - 바깥쪽 호출부가 별도로 다시 챙겨줄 필요가 없어짐
- 더 이상 아무 곳에서도 쓰이지 않는 죽은 함수 `renderMemoOverlay` 삭제

## 테스트
- 격리된 테스트 backend/frontend를 띄우고 실제 논문을 업로드해 검증
- 숨긴 메모가 있는 페이지에서 `segmentPdfElements`를 실제 호출 경로와 동일하게 직접 호출(반복 4회)해도 하이라이트가 계속 유지됨을 확인 - 수정 전에는 이 호출 하나만으로도 즉시 사라졌을 상황
- 실제 로컬 Ollama 번역도 함께 트리거해뒀으나(환경상 매우 느려 이번 검증에서는 완료까지 기다리지 못함), 위 직접 호출 검증이 `segmentPdfElements`가 호출되는 모든 경로(번역 완료, 페이지 최초 렌더링 등)에 동일하게 적용되는 근본 수정이라 실제 번역 완료 시나리오에도 동일하게 적용됨
- 테스트 중 생성한 임시 DB 데이터/파일/프로세스는 모두 정리함