### PR TITLE
fix: 번역 로딩 중 메모 위치 튐 현상 수정 및 메모 색상별 하이라이트 적용

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -535,6 +535,9 @@ async function initScrollViewer() {
         } catch (err) {
           console.warn(`Failed to lazy load translation for page ${pageNum}:`, err)
           delete state.translationCache[pageNum]
+          // 번역 로딩 실패 시 폴백 세그멘테이션 상태로 메모가 계속 숨겨져 있지
+          // 않도록, 이미 그려진 문장 분할 기준으로 메모를 다시 그려준다.
+          renderPageMemos(pageNum)
         }
       }
 
@@ -553,6 +556,7 @@ async function initScrollViewer() {
         }).catch(err => {
           if (state.sessionId === currentSessionId) {
             delete state.translationCache[nextPage]
+            renderPageMemos(nextPage)
           }
         })
       }
@@ -5718,6 +5722,9 @@ function renderPageMemos(pageNum) {
   }
   pageWrapper.querySelectorAll('.pdf-sentence-has-memo').forEach(el => {
     el.classList.remove('pdf-sentence-has-memo', 'pdf-sentence-has-memo-hidden')
+    Array.from(el.classList).forEach(cls => {
+      if (cls.startsWith('color-')) el.classList.remove(cls)
+    })
     delete el.dataset.memoId
   })
 
@@ -5782,7 +5789,10 @@ function renderPageMemos(pageNum) {
           const memoRects = getSentenceRects(memoSRange, vtmForMemo, memoTextLayer)
           memoRects.forEach(r => {
             const box = document.createElement('div')
-            box.className = isHiddenIndividually ? 'sentence-memo-box hidden-memo' : 'sentence-memo-box'
+            const colorClass = `color-${memo.color || 'default'}`
+            box.className = isHiddenIndividually
+              ? `sentence-memo-box hidden-memo ${colorClass}`
+              : `sentence-memo-box ${colorClass}`
             box.style.left = `${r.left}px`
             box.style.top = `${r.top}px`
             box.style.width = `${r.width}px`
@@ -5803,7 +5813,7 @@ function renderPageMemos(pageNum) {
         const { pdfElements } = getMappedElementsAndIndices(sentenceEl, pageNum, memo.sentenceIdx)
         if (pdfElements) {
           pdfElements.forEach(el => {
-            el.classList.add('pdf-sentence-has-memo')
+            el.classList.add('pdf-sentence-has-memo', `color-${memo.color || 'default'}`)
             if (isHiddenIndividually) {
               // 클릭 시 되살리기는 pageWrapper에 위임된 리스너(위 참고)가 처리한다 -
               // 이 요소는 재렌더링 때마다 파괴되지 않고 남아있어 직접 리스너를
@@ -6870,6 +6880,17 @@ window.onTextLayerRendered = (textLayerDiv, pageNum) => {
   renderImageOverlayLayer(textLayerDiv, pageNum)
   renderCitationOverlayLayer(textLayerDiv, pageNum)
   renderFigureRefOverlayLayer(textLayerDiv, pageNum)
+
+  // 이미 번역된 적이 있는 페이지인데 아직 번역 문장 데이터(state.translationSentences)가
+  // 로드되지 않았다면, 방금 위에서 실행한 세그멘테이션은 정규식 기반 폴백
+  // (splitIntoSentences) 결과다. 번역 캐시가 로드되면 alignSentencesToText로 다시
+  // 세그멘테이션되며 문장 인덱스가 달라질 수 있어, 지금 메모를 그리면 잘못된 위치에
+  // 표시됐다가 번역 로딩 완료 시 원래 위치로 튀어 보인다. 이 경우엔 그리지 않고
+  // renderTransContent → reRenderPageAnnotations에서 최종 위치로 한 번만 그리게 한다.
+  const pendingRetranslationSegmentation =
+    state.translatedPages.has(pageNum) &&
+    !(state.translationSentences[pageNum] && state.translationSentences[pageNum].length)
+  if (pendingRetranslationSegmentation) return
 
   // Render floating memos
   renderPageMemos(pageNum)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3739,6 +3739,48 @@ body.light-theme .pdf-sentence.pdf-sentence-has-memo:hover {
   background-color: rgba(99, 102, 241, 0.16) !important;
 }
 
+/* 메모 색상별 원문 문장 하이라이트 - 플로팅 메모 카드/커넥터 라인과 동일한 팔레트 */
+.pdf-sentence.pdf-sentence-has-memo.color-yellow {
+  background-color: rgba(234, 179, 8, 0.18) !important;
+  border-bottom-color: rgba(234, 179, 8, 0.6) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-yellow:hover {
+  background-color: rgba(234, 179, 8, 0.28) !important;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-yellow {
+  background-color: rgba(234, 179, 8, 0.1) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-green {
+  background-color: rgba(16, 185, 129, 0.18) !important;
+  border-bottom-color: rgba(16, 185, 129, 0.6) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-green:hover {
+  background-color: rgba(16, 185, 129, 0.28) !important;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-green {
+  background-color: rgba(16, 185, 129, 0.1) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-blue {
+  background-color: rgba(59, 130, 246, 0.18) !important;
+  border-bottom-color: rgba(59, 130, 246, 0.6) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-blue:hover {
+  background-color: rgba(59, 130, 246, 0.28) !important;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-blue {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-red {
+  background-color: rgba(244, 63, 94, 0.18) !important;
+  border-bottom-color: rgba(244, 63, 94, 0.6) !important;
+}
+.pdf-sentence.pdf-sentence-has-memo.color-red:hover {
+  background-color: rgba(244, 63, 94, 0.28) !important;
+}
+body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-red {
+  background-color: rgba(244, 63, 94, 0.1) !important;
+}
+
 /* ── Floating Markdown Memo Styles ── */
 .floating-memo {
   position: absolute;
@@ -4381,6 +4423,48 @@ body.light-theme .sentence-memo-box {
 }
 .sentence-memo-box.hidden-memo:hover {
   background-color: rgba(245, 158, 11, 0.32);
+}
+
+/* 메모 색상별 하이라이트 상자 - 플로팅 메모 카드/커넥터 라인과 동일한 팔레트 */
+.sentence-memo-box.color-yellow {
+  background-color: rgba(234, 179, 8, 0.18);
+  border-bottom-color: rgba(234, 179, 8, 0.6);
+}
+.sentence-memo-box.color-yellow.hidden-memo:hover {
+  background-color: rgba(234, 179, 8, 0.32);
+}
+body.light-theme .sentence-memo-box.color-yellow {
+  background-color: rgba(234, 179, 8, 0.14);
+}
+.sentence-memo-box.color-green {
+  background-color: rgba(16, 185, 129, 0.18);
+  border-bottom-color: rgba(16, 185, 129, 0.6);
+}
+.sentence-memo-box.color-green.hidden-memo:hover {
+  background-color: rgba(16, 185, 129, 0.32);
+}
+body.light-theme .sentence-memo-box.color-green {
+  background-color: rgba(16, 185, 129, 0.14);
+}
+.sentence-memo-box.color-blue {
+  background-color: rgba(59, 130, 246, 0.18);
+  border-bottom-color: rgba(59, 130, 246, 0.6);
+}
+.sentence-memo-box.color-blue.hidden-memo:hover {
+  background-color: rgba(59, 130, 246, 0.32);
+}
+body.light-theme .sentence-memo-box.color-blue {
+  background-color: rgba(59, 130, 246, 0.14);
+}
+.sentence-memo-box.color-red {
+  background-color: rgba(244, 63, 94, 0.18);
+  border-bottom-color: rgba(244, 63, 94, 0.6);
+}
+.sentence-memo-box.color-red.hidden-memo:hover {
+  background-color: rgba(244, 63, 94, 0.32);
+}
+body.light-theme .sentence-memo-box.color-red {
+  background-color: rgba(244, 63, 94, 0.14);
 }
 
 /* 독립 수식 호버 상자 */


### PR DESCRIPTION
# Summary
## 1. 번역 로딩 중 메모 위치가 잠깐 어긋났다가 돌아오는 버그 수정
- `window.onTextLayerRendered`(frontend/src/main.js)에서 페이지 리로드 직후 pdf.js 텍스트 레이어가 먼저 렌더될 때, 아직 `state.translationSentences`가 도착하지 않아 정규식 기반 폴백 분할(`splitIntoSentences`)로 세그멘테이션된 상태로 `renderPageMemos`를 호출하던 부분 수정
- 이미 번역된 적 있는 페이지인데 `translationSentences`가 아직 로드되지 않은 과도기 상태(`pendingRetranslationSegmentation`)에는 `renderPageMemos` 호출을 건너뛰도록 처리 - 번역 로드 완료 후 `renderTransContent` → `reRenderPageAnnotations`가 `alignSentencesToText`로 재세그멘테이션한 최종 위치로 한 번만 그리도록 함
- 번역 로딩이 실패하는 경우를 대비해 `initScrollViewer`의 `catch` 블록(현재 페이지/다음 페이지 프리페칭)에서 `renderPageMemos`를 호출해, 메모 하이라이트가 영영 그려지지 않는 회귀를 방지

## 2. 메모 하이라이트 색상이 메모 색상에 반영되지 않던 문제 수정
- `memo.color` 필드가 플로팅 카드/커넥터 라인에는 반영되어 있었지만, 본문 텍스트 하이라이트(`.sentence-memo-box`, `.pdf-sentence-has-memo`)에는 반영되지 않고 하드코딩된 amber/indigo 색만 쓰이던 부분 수정
- `renderPageMemos`(frontend/src/main.js)에서 하이라이트 박스/스팬 생성 시 `color-${memo.color || 'default'}` 클래스를 추가
- `style.css`에 카드/커넥터 라인과 동일한 팔레트(`yellow #eab308`, `green #10b981`, `blue #3b82f6`, `red #f43f5e`)로 `.sentence-memo-box.color-*`, `.pdf-sentence-has-memo.color-*` 규칙 추가 (라이트 테마 변형 포함)
- 재렌더링 시 이전 색상 클래스가 잔존하지 않도록 `.pdf-sentence-has-memo` 클리어 로직에 `color-*` 클래스 제거 추가

## Test plan
- `npx vite build` 통과 확인
- `node --check frontend/src/main.js` 문법 검증 통과
🤖 Generated with [Claude Code](https://claude.com/claude-code)