### PR TITLE
fix: 메모 위치 튐 현상이 재발하던 원인(segmentPdfElements 내부 렌더 호출) 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9260,7 +9260,17 @@ function segmentPdfElements(container, pageNum) {
       // 잘못 참조하는 죽은 코드(renderMemoOverlay)가 대신 호출되고 있어서,
       // 이 함수를 호출하는 경로 중 memo 재호출을 별도로 챙기지 않는 곳에서는
       // 메모 하이라이트가 그대로 사라진 채 복구되지 않는 버그가 있었다.
-      renderPageMemos(pageNum);
+      //
+      // 다만 이미 번역된 적 있는 페이지인데 아직 번역 문장 데이터가 로드되지
+      // 않아 위 2단계에서 정규식 기반 폴백(splitIntoSentences)으로 분할한
+      // 상태라면, 여기서 그리는 위치는 번역이 로드된 뒤 alignSentencesToText로
+      // 재분할되면서 곧 달라진다. 이 상태로 지금 그리면 메모가 잘못된 위치에
+      // 표시됐다가 번역 로딩 완료 시 원래 위치로 튀어 보이므로, 이 경우엔
+      // 건너뛰고 최종(정렬된) 세그멘테이션이 나온 뒤에만 그린다.
+      const usedFallbackSegmentation = !(sentences && sentences.length > 0)
+      if (!(usedFallbackSegmentation && state.translatedPages.has(pageNum))) {
+        renderPageMemos(pageNum);
+      }
     }
   } catch (err) {
     console.warn(`segmentPdfElements failed for p.${pageNum}:`, err);


### PR DESCRIPTION
# Summary
## 1. #199에서 놓쳤던 실제 렌더링 경로 수정
- 직전 PR(#199)에서는 `window.onTextLayerRendered`의 마지막 `renderPageMemos` 호출만 조건부로 건너뛰도록 막았으나, 실제로 폴백 세그멘테이션 결과로 메모를 그리는 지점은 `segmentElementIntoSentences('pdf-sentence')` → `segmentPdfElements` 내부(frontend/src/main.js)에 별도로 존재했음 - 이 함수가 문장 분할을 마친 직후 자체적으로 `renderPageMemos(pageNum)`를 호출하고 있어서, `onTextLayerRendered`의 가드는 이미 한 번 잘못된 위치에 그려진 뒤에 실행되는 중복 호출만 막을 뿐 실제 튐 현상은 막지 못했음
- `segmentPdfElements`에서 문장 정렬에 쓰인 `sentences`(`state.translationSentences[pageNum]`) 변수를 그대로 활용해, 이미 번역된 적 있는 페이지인데 아직 번역 문장 데이터가 없어 정규식 기반 폴백(`splitIntoSentences`)으로 분할된 경우 `renderPageMemos` 호출을 건너뛰도록 수정 - 번역이 로드되어 `alignSentencesToText`로 최종 재세그멘테이션될 때만 메모를 그리도록 함

## Test plan
- `npx vite build` 통과 확인
- `node --check frontend/src/main.js` 문법 검증 통과
🤖 Generated with [Claude Code](https://claude.com/claude-code)