### PR TITLE
fix: macOS 데스크탑 앱 업데이트 설치 시 모듈 임포트 실패 오류 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2852,6 +2852,15 @@ async function installTauriUpdate() {
   if (updateAvailableActions) updateAvailableActions.style.display = 'none'
 
   try {
+    // 이 페이지 자체가 로컬 백엔드 sidecar(127.0.0.1:*)가 서빙하는 정적
+    // 파일이라, 아래에서 sidecar를 죽이고 나면 그 시점까지 한 번도 로드된
+    // 적 없는 청크(dynamic import)는 더 이상 네트워크로 가져올 수 없다.
+    // relaunch()에 필요한 plugin-process는 지금까지 쓰인 적이 없으므로
+    // sidecar를 죽이기 전에 미리 import해 브라우저가 청크를 확보해 두게
+    // 한다 - 순서를 바꾸지 않으면 "Importing a module script failed" 오류로
+    // 설치가 실패한다.
+    const { relaunch } = await import('@tauri-apps/plugin-process')
+
     // Windows 설치 프로그램이 파일을 덮어쓰기 전에 백엔드 sidecar를 먼저
     // 종료해야 한다 - 계속 떠 있으면 PyInstaller 런타임이 로드한 DLL(예:
     // MSVCP140.dll)을 OS가 잠그고 있어서 "Error opening file for writing"
@@ -2886,7 +2895,6 @@ async function installTauriUpdate() {
       }
     })
 
-    const { relaunch } = await import('@tauri-apps/plugin-process')
     await relaunch()
   } catch (err) {
     setTauriUpdateStatusText('설치 실패: ' + (err.message || err), '#ef4444')


### PR DESCRIPTION
# Summary
## 1. macOS 자동 업데이트 설치 시 "Importing a module script failed" 오류 수정
- Tauri 메인 창은 앱에 번들된 정적 자원이 아니라 로컬 백엔드 sidecar(`http://127.0.0.1:{port}`)가 서빙하는 프론트엔드 페이지를 로드함
- 기존 `installTauriUpdate()`는 파일 잠금 해제를 위해 `kill_backend_sidecar`로 백엔드를 먼저 종료한 뒤, 재시작에 필요한 `@tauri-apps/plugin-process`를 그 이후에 동적 import함
- 이 모듈은 그 전까지 한 번도 로드된 적 없는 lazy chunk라 브라우저가 처음 fetch를 시도하는데, 이미 서버가 죽은 상태라 요청이 실패해 "Importing a module script failed" 오류로 설치가 중단됨
- `@tauri-apps/plugin-process` 동적 import를 sidecar 종료 이전으로 옮겨, 백엔드가 살아있는 동안 미리 청크를 확보하도록 순서 변경 (`frontend/src/main.js`)

## Test plan
- [x] `npm run build`로 프론트엔드 정상 빌드 확인
- [ ] macOS 데스크탑 앱에서 실제 업데이트 설치 후 재시작 확인