### PR TITLE
chore: 데스크톱 앱 버전을 0.1.10으로 올림 (macOS 업데이트 설치 오류 수정 배포용)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.9"
+version = "0.1.10"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
# Summary
## 1. 버전을 0.1.10으로 상향
- package.json, src-tauri/tauri.conf.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock의 버전을 0.1.9 → 0.1.10으로 통일
- #205(macOS 업데이트 설치 시 모듈 임포트 실패 오류 수정) 배포를 위한 릴리스 태그 준비