### PR TITLE
feat: 감지된 그림/표 오버레이 박스를 드래그로 크기 조절할 수 있는 기능 추가

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7192,17 +7192,92 @@ function cropFigureFromCanvas(canvas, imgPercent) {
   return tempCanvas.toDataURL('image/png')
 }
 
+// 감지된 그림/표 오버레이 박스의 모서리 핸들을 드래그해 영역을 직접 조절할 수
+// 있게 한다. 자동 감지 bbox가 실제 표/그림보다 너무 크거나 작게 잡히는
+// 경우(레이아웃이 특이한 논문 등)가 있어, 캡처 전에 사용자가 직접 보정할
+// 수 있어야 한다. imgPercent는 state.documentImages 안의 객체를 그대로
+// 참조하므로, 여기서 좌표를 갱신하면 이후 클릭 시 크롭(cropFigureFromCanvas)과
+// 참조 오버레이 미리보기(renderFigureCrop)에도 그대로 반영된다.
+const _FIGURE_OVERLAY_MIN_SIZE_PCT = 3
+
+function _attachFigureOverlayResizeHandles(overlay, imgPercent, inner) {
+  const corners = ['nw', 'ne', 'sw', 'se']
+
+  corners.forEach(pos => {
+    const handle = document.createElement('div')
+    handle.className = `pdf-figure-overlay-handle pdf-figure-overlay-handle-${pos}`
+
+    // 핸들에서 시작된 클릭이 overlay의 click 리스너(크롭 트리거)까지
+    // 버블링되지 않도록 막는다 - 드래그 없이 핸들만 클릭했을 때 의도치
+    // 않게 캡처가 실행되는 것을 방지.
+    handle.addEventListener('click', (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+    })
+
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const containerRect = inner.getBoundingClientRect()
+      // 드래그하는 동안 고정되어야 할 반대쪽 모서리 (예: nw를 끌면 se가 고정점)
+      const fixedX = pos.includes('w') ? imgPercent.left + imgPercent.width : imgPercent.left
+      const fixedY = pos.includes('n') ? imgPercent.top + imgPercent.height : imgPercent.top
+
+      overlay.classList.add('resizing')
+      document.body.style.userSelect = 'none'
+
+      const onMove = (moveEvent) => {
+        let mx = ((moveEvent.clientX - containerRect.left) / containerRect.width) * 100
+        let my = ((moveEvent.clientY - containerRect.top) / containerRect.height) * 100
+        mx = Math.max(0, Math.min(100, mx))
+        my = Math.max(0, Math.min(100, my))
+
+        let width = Math.max(_FIGURE_OVERLAY_MIN_SIZE_PCT, Math.abs(mx - fixedX))
+        let height = Math.max(_FIGURE_OVERLAY_MIN_SIZE_PCT, Math.abs(my - fixedY))
+        let left = mx < fixedX ? fixedX - width : fixedX
+        let top = my < fixedY ? fixedY - height : fixedY
+
+        left = Math.max(0, Math.min(left, 100 - width))
+        top = Math.max(0, Math.min(top, 100 - height))
+
+        imgPercent.left = left
+        imgPercent.top = top
+        imgPercent.width = width
+        imgPercent.height = height
+
+        overlay.style.left = `${left}%`
+        overlay.style.top = `${top}%`
+        overlay.style.width = `${width}%`
+        overlay.style.height = `${height}%`
+      }
+
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        overlay.classList.remove('resizing')
+        document.body.style.userSelect = ''
+      }
+
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+    })
+
+    overlay.appendChild(handle)
+  })
+}
+
 function renderImageOverlayLayer(textLayerDiv, pageNum) {
   const pageImages = (state.documentImages || []).filter(img => img.page === pageNum)
   const inner = textLayerDiv.parentElement
   if (!inner) return
-  
+
   // Remove existing layer if any
   const oldLayer = inner.querySelector('.pdf-image-overlay-layer')
   if (oldLayer) oldLayer.remove()
-  
+
   if (pageImages.length === 0) return
-  
+
   const layer = document.createElement('div')
   layer.className = 'pdf-image-overlay-layer'
   layer.style.position = 'absolute'
@@ -7212,7 +7287,7 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
   layer.style.height = '100%'
   layer.style.pointerEvents = 'none'
   layer.style.zIndex = '3'
-  
+
   pageImages.forEach((imgPercent, idx) => {
     const overlay = document.createElement('div')
     overlay.className = 'pdf-figure-overlay'
@@ -7225,17 +7300,17 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
     overlay.style.height = `${imgPercent.height}%`
     overlay.style.pointerEvents = 'auto'
     overlay.style.cursor = 'pointer'
-    
+
     overlay.addEventListener('click', (e) => {
       e.preventDefault()
       e.stopPropagation()
-      
+
       // Clear text selection
       window.getSelection().removeAllRanges()
-      
+
       const canvas = inner.querySelector('canvas')
       if (!canvas) return
-      
+
       try {
         const base64Img = cropFigureFromCanvas(canvas, imgPercent)
         state.pendingFigureQuote = {
@@ -7243,7 +7318,7 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
           imgPercent: imgPercent,
           base64Img: base64Img
         }
-        
+
         // Show selection menu
         const rect = overlay.getBoundingClientRect()
         showSelectionMenu(rect, false) // false = hide annotation options
@@ -7251,10 +7326,12 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
         console.error("그림 크롭 실패:", err)
       }
     })
-    
+
+    _attachFigureOverlayResizeHandles(overlay, imgPercent, inner)
+
     layer.appendChild(overlay)
   })
-  
+
   inner.appendChild(layer)
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3298,6 +3298,45 @@ body.light-theme .chat-quote-area {
   box-shadow: 0 0 3px rgba(126, 196, 232, 0.3);
 }
 
+/* 드래그 중에는 transition을 꺼서 마우스 움직임에 박스가 지연 없이 붙어오게 함 */
+.pdf-figure-overlay.resizing {
+  transition: none !important;
+}
+
+/* ── 감지된 그림/표 오버레이 크기 조절 핸들 ── */
+.pdf-figure-overlay-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  margin: -5px;
+  border-radius: 50%;
+  background: rgba(126, 196, 232, 0.9);
+  border: 1.5px solid #fff;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+  z-index: 4;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out, transform 0.1s ease-in-out;
+}
+
+.pdf-figure-overlay:hover .pdf-figure-overlay-handle,
+.pdf-figure-overlay.resizing .pdf-figure-overlay-handle {
+  opacity: 1;
+}
+
+.pdf-figure-overlay-handle:hover {
+  transform: scale(1.3);
+}
+
+.pdf-figure-overlay-handle-nw { top: 0; left: 0; cursor: nwse-resize; }
+.pdf-figure-overlay-handle-ne { top: 0; left: 100%; cursor: nesw-resize; }
+.pdf-figure-overlay-handle-sw { top: 100%; left: 0; cursor: nesw-resize; }
+.pdf-figure-overlay-handle-se { top: 100%; left: 100%; cursor: nwse-resize; }
+
+body.light-theme .pdf-figure-overlay-handle {
+  border-color: #fff;
+}
+
 /* ── Capture Crop Mode Styling ── */
 #viewer-scroll-container.crop-mode .pdf-page-inner {
   cursor: crosshair !important;
@@ -3357,7 +3396,6 @@ body.light-theme .message-quote-img {
 }
 
 #viewer-scroll-container.crop-mode .textLayer,
-#viewer-scroll-container.crop-mode .pdf-figure-overlay,
 #viewer-scroll-container.crop-mode .pdf-sentence {
   pointer-events: none !important;
   user-select: none !important;


### PR DESCRIPTION
# Summary
## 1. 오버레이 박스 리사이즈 핸들 추가
- 영역 캡처 모드(`#viewer-scroll-container.crop-mode`)에서 자동 감지된 그림/표 점선 박스(`.pdf-figure-overlay`)에 모서리 리사이즈 핸들 4개(nw/ne/sw/se)를 추가
- 자동 감지 bbox가 실제 그림/표보다 너무 크거나 작게 잡히는 경우(레이아웃이 특이한 논문 등), 캡처 전에 사용자가 직접 크기를 보정할 수 있음
- `_attachFigureOverlayResizeHandles()`: 드래그 중인 모서리의 반대쪽 모서리를 고정점으로 두고, 마우스 위치 기준으로 left/top/width/height를 재계산(최소 크기 3%, 페이지 경계 클램프 적용)
- 조절된 좌표는 `state.documentImages` 안의 원본 객체(`imgPercent`)에 직접 반영되므로, 크롭(`cropFigureFromCanvas`)과 본문 참조 오버레이 미리보기(`renderFigureCrop`)에도 그대로 적용됨(별도 동기화 불필요)
- 핸들 자체 클릭은 `stopPropagation`으로 박스의 크롭 트리거(click 리스너)까지 버블링되지 않도록 처리 - 드래그 없이 핸들만 클릭했을 때 의도치 않게 캡처가 실행되는 것 방지

## 2. 선행 버그 수정: crop-mode에서 감지 박스 클릭(캡처)이 막혀 있던 문제
- `style.css`에 `#viewer-scroll-container.crop-mode` 관련 규칙이 실수로 중복 작성되어 있었는데, 그중 하나가 `.pdf-figure-overlay`에도 `pointer-events: none !important`를 걸고 있었음
- 감지 박스는 애초에 crop-mode일 때만 보이는데(`.pdf-image-overlay-layer`가 기본 `display:none`), 바로 그 상태에서 클릭이 막혀 있어 "박스 클릭 → 크롭" 기능 자체가 사실상 죽어 있었음
- 리사이즈 핸들이 정상 동작하려면 이 선행 버그부터 고쳐야 해서 함께 수정(중복 규칙에서 `.pdf-figure-overlay` 셀렉터만 제거)

## 3. 스타일 추가
- `.pdf-figure-overlay-handle`: 반투명 하늘색 원형 핸들, 박스 호버 시에만 표시(평소엔 opacity:0)
- `.pdf-figure-overlay.resizing`: 드래그 중 CSS transition을 꺼서 마우스 움직임에 박스가 지연 없이 붙어오게 함

## Test plan
- [x] Playwright로 실제 브라우저 구동: 영역 캡처 모드 진입 → 감지 박스 호버 시 핸들 노출 확인 → se 핸들 드래그로 박스 크기 증가 및 반대쪽(nw) 모서리 고정 확인 → 콘솔 에러 없음 확인
- [x] 드래그 전/중 스크린샷으로 시각적 확인 (핸들 렌더링, 박스 크기 변화)
- [x] `node --check src/main.js` 문법 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)