### PR TITLE
perf: 서버/앱 재시작 시 세션 복원을 지연 로딩 + 디스크 캐싱으로 개선

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -285,6 +285,17 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
     
     return {"message": "시스템 설정이 성공적으로 변경되었습니다."}
 
+@router.post("/settings/clear-pages-cache")
+async def clear_pages_cache(current_user: str = Depends(get_current_user)):
+    """모든 문서의 PDF 텍스트 추출 결과 디스크 캐시(extract_pages() 결과)를
+    삭제합니다. 이 캐시는 서버/앱 재시작 후 문서를 다시 열 때 PDF를 매번
+    재파싱하지 않도록 저장해두는 것으로, 지워도 다음 열람 시 자동으로
+    다시 채워지므로(ensure_session) 데이터 손실은 없습니다."""
+    from services.cache import clear_all_pages_cache
+    count, freed_bytes = clear_all_pages_cache()
+    return {"cleared_files": count, "freed_bytes": freed_bytes}
+
+
 @router.get("/settings/ollama-status")
 async def ollama_status(current_user: str = Depends(get_current_user)):
     """Ollama CLI가 이 서버에 설치되어 있는지, 설정된 호스트가 로컬인지 확인합니다."""

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -35,7 +35,11 @@ def ensure_session(session_id: str) -> bool:
             return False
             
     try:
-        pages = extract_pages(pdf_path)
+        from services.cache import get_cached_pages, save_pages_cache
+        pages = get_cached_pages(session_id, pdf_path)
+        if pages is None:
+            pages = extract_pages(pdf_path)
+            save_pages_cache(session_id, pdf_path, pages)
         sessions[session_id] = {
             "pdf_path": pdf_path,
             "filename": doc["filename"],

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -9,7 +9,7 @@ from services.auth import get_current_user
 from config import UPLOAD_DIR, MAX_FILE_SIZE_MB
 from services.pdf_parser import extract_pages, get_pdf_metadata
 from services.library import save_document, get_document, get_pdf_path as lib_pdf_path, list_documents
-from services.translation_job import start_job, resume_incomplete_jobs
+from services.translation_job import start_job, resume_incomplete_jobs, get_job_status
 from models.schemas import UploadResponse
 
 router = APIRouter()
@@ -67,27 +67,28 @@ def require_session_owner(session_id: str, current_user: str) -> dict:
 
 
 def restore_sessions_from_library():
-    """서버 시작 시 라이브러리의 문서들을 세션으로 복원하고 미완료 잡을 재개합니다."""
+    """서버 시작 시 미완료 번역 잡이 있는 문서만 세션으로 복원하고 잡을 재개합니다.
+
+    예전에는 라이브러리의 모든 문서를 매번 세션으로 복원했다(각 PDF를
+    처음부터 다시 extract_pages()로 텍스트 추출). 이러면 서버 기동 시간이
+    문서 수에 비례해 늘어나는데, Tauri 데스크톱 앱은 앱을 켤 때마다
+    백엔드 프로세스가 재시작되므로 이 지연을 매번 겪게 되고, 배포 서버도
+    문서가 쌓일수록 CI 헬스체크(재시작 후 30초 이내 응답) 타임아웃을
+    넘기기 시작했다.
+
+    부팅 시점에 실제로 필요한 건 "재개해야 할 미완료 번역 잡이 있는
+    문서"뿐이다 - 그 외 문서는 ensure_session()이 실제로 열람되는 시점에
+    그때 한 번만 추출해 캐싱하므로(require_session_owner 경유) 미리
+    준비해둘 필요가 없다. job_status.json 존재 여부만 확인하는 건 PDF를
+    열지 않는 가벼운 파일 I/O라 문서 수가 많아도 부담이 없다.
+    """
     for doc in list_documents():
         doc_id = doc["id"]
-        pdf_path = lib_pdf_path(doc_id)
-        if not pdf_path:
-            continue
-        try:
-            pages = extract_pages(pdf_path)
-            sessions[doc_id] = {
-                "pdf_path": pdf_path,
-                "filename": doc["filename"],
-                "pages": pages,
-                "total_pages": doc["total_pages"],
-                "metadata": doc.get("metadata", {}),
-                "from_library": True,
-                "username": doc.get("username", "admin"),
-            }
-        except Exception:
-            pass
+        job = get_job_status(doc_id)
+        if job and job.get("status") == "running":
+            ensure_session(doc_id)
 
-    # 미완료 번역 잡 재개
+    # 미완료 번역 잡 재개 (위에서 세션이 복원된 문서만 대상)
     resume_incomplete_jobs(sessions)
 
 

--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -76,3 +76,60 @@ def clear_session_cache(session_id: str) -> None:
     for fname in os.listdir(CACHE_DIR):
         if fname.startswith(session_id):
             os.remove(os.path.join(CACHE_DIR, fname))
+
+
+_PAGES_CACHE_SUFFIX = "_pages_extract.json"
+
+
+def _pages_cache_path(doc_id: str) -> str:
+    return os.path.join(CACHE_DIR, f"{doc_id}{_PAGES_CACHE_SUFFIX}")
+
+
+def get_cached_pages(doc_id: str, pdf_path: str) -> Optional[list]:
+    """PDF에서 추출한 페이지 텍스트(extract_pages 결과)의 디스크 캐시를
+    반환합니다. 캐시가 없거나, 원본 PDF의 mtime/크기가 캐시 저장 당시와
+    달라졌다면(파일이 교체된 경우 등) None을 반환해 재추출을 유도합니다.
+    """
+    path = _pages_cache_path(doc_id)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        stat = os.stat(pdf_path)
+        if data.get("mtime") != stat.st_mtime or data.get("size") != stat.st_size:
+            return None
+        return data.get("pages")
+    except Exception:
+        return None
+
+
+def save_pages_cache(doc_id: str, pdf_path: str, pages: list) -> None:
+    """extract_pages() 결과를 디스크에 캐싱해, 다음 서버 재시작 이후
+    첫 열람 시에도 PDF를 다시 파싱하지 않고 즉시 불러올 수 있게 합니다."""
+    try:
+        stat = os.stat(pdf_path)
+        atomic_write_text(_pages_cache_path(doc_id), json.dumps({
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+            "pages": pages,
+        }, ensure_ascii=False))
+    except Exception:
+        pass
+
+
+def clear_all_pages_cache() -> "tuple[int, int]":
+    """모든 문서의 페이지 추출 캐시 파일을 삭제합니다.
+    (삭제한 파일 개수, 확보한 바이트 수)를 반환합니다."""
+    count = 0
+    freed_bytes = 0
+    for fname in os.listdir(CACHE_DIR):
+        if fname.endswith(_PAGES_CACHE_SUFFIX):
+            path = os.path.join(CACHE_DIR, fname)
+            try:
+                freed_bytes += os.path.getsize(path)
+                os.remove(path)
+                count += 1
+            except Exception:
+                pass
+    return count, freed_bytes

--- a/backend/tests/test_clear_pages_cache_endpoint.py
+++ b/backend/tests/test_clear_pages_cache_endpoint.py
@@ -1,0 +1,27 @@
+"""POST /settings/clear-pages-cache 테스트 - 설정 화면에서 PDF 텍스트 추출
+디스크 캐시를 정리하는 엔드포인트."""
+
+from services.cache import save_pages_cache
+
+
+def test_clear_pages_cache_removes_files_and_reports_stats(test_client, isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 300)
+    save_pages_cache("doc-1", str(pdf_path), [{"page_num": 1, "text": "a"}])
+    save_pages_cache("doc-2", str(pdf_path), [{"page_num": 1, "text": "b"}])
+
+    res = test_client.post("/api/settings/clear-pages-cache")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cleared_files"] == 2
+    assert body["freed_bytes"] > 0
+
+    from services.cache import get_cached_pages
+    assert get_cached_pages("doc-1", str(pdf_path)) is None
+
+
+def test_clear_pages_cache_is_a_no_op_when_nothing_cached(test_client, isolated_dirs):
+    res = test_client.post("/api/settings/clear-pages-cache")
+    assert res.status_code == 200
+    assert res.json() == {"cleared_files": 0, "freed_bytes": 0}

--- a/backend/tests/test_pages_cache.py
+++ b/backend/tests/test_pages_cache.py
@@ -1,0 +1,66 @@
+"""services/cache.py의 페이지 추출 결과 디스크 캐시(get_cached_pages /
+save_pages_cache / clear_all_pages_cache) 테스트.
+
+서버(또는 Tauri 앱 백엔드) 재시작 후 문서를 다시 열 때 PDF를 매번
+재파싱하지 않도록, extract_pages() 결과를 디스크에 캐싱해두는 기능이다."""
+
+import os
+
+from services.cache import get_cached_pages, save_pages_cache, clear_all_pages_cache
+
+
+def _make_pdf(path, size_bytes=200):
+    with open(path, "wb") as f:
+        f.write(b"%PDF-1.4 fake" + b"\0" * size_bytes)
+
+
+def test_cache_miss_when_never_saved(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    assert get_cached_pages("doc-1", str(pdf_path)) is None
+
+
+def test_saved_pages_are_returned_on_cache_hit(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    pages = [{"page_num": 1, "text": "hello"}]
+
+    save_pages_cache("doc-1", str(pdf_path), pages)
+
+    assert get_cached_pages("doc-1", str(pdf_path)) == pages
+
+
+def test_cache_invalidated_when_pdf_content_changes(isolated_dirs, tmp_path):
+    """PDF가 (같은 경로에서) 다른 내용으로 교체되면(mtime/크기 변경),
+    오래된 캐시를 그대로 신뢰하지 않고 재추출을 유도해야 한다."""
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path, size_bytes=200)
+    save_pages_cache("doc-1", str(pdf_path), [{"page_num": 1, "text": "old"}])
+
+    # 파일 크기와 mtime이 모두 바뀌도록 다시 씀
+    import time
+    time.sleep(0.01)
+    _make_pdf(pdf_path, size_bytes=500)
+
+    assert get_cached_pages("doc-1", str(pdf_path)) is None
+
+
+def test_clear_all_pages_cache_removes_only_pages_cache_files(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    save_pages_cache("doc-1", str(pdf_path), [{"page_num": 1, "text": "a"}])
+    save_pages_cache("doc-2", str(pdf_path), [{"page_num": 1, "text": "b"}])
+
+    # 다른 종류의 캐시 파일(번역 캐시)은 영향을 받으면 안 됨
+    from services.cache import save_translation_cache
+    save_translation_cache("doc-1", 1, "번역 결과")
+
+    count, freed_bytes = clear_all_pages_cache()
+
+    assert count == 2
+    assert freed_bytes > 0
+    assert get_cached_pages("doc-1", str(pdf_path)) is None
+    assert get_cached_pages("doc-2", str(pdf_path)) is None
+
+    from services.cache import get_cached_translation
+    assert get_cached_translation("doc-1", 1) == "번역 결과", "번역 캐시는 지워지면 안 됨"

--- a/backend/tests/test_session_restore_lazy.py
+++ b/backend/tests/test_session_restore_lazy.py
@@ -1,0 +1,103 @@
+"""routers.upload.restore_sessions_from_library()의 지연 복원 동작 테스트.
+
+서버 재시작 시 라이브러리의 모든 문서를 미리 세션으로 복원하면(각 PDF를
+extract_pages()로 재추출) 문서 수에 비례해 부팅 시간이 늘어나는 문제가
+있었다. 이제는 진행 중인 번역 잡이 있는 문서만 즉시 복원하고, 나머지는
+ensure_session()이 실제로 열람될 때 지연 복원하도록 바뀌었다 - 이 선택
+로직만 검증한다(잡 재개 자체의 비동기 실행은 기존 resume_incomplete_jobs의
+책임이라 범위 밖).
+"""
+
+import json
+import os
+
+import fitz
+import pytest
+
+import routers.upload as upload_module
+from services.translation_job import _job_path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_fake_sessions():
+    """routers.upload.sessions는 프로세스 전역 dict라 테스트 간 오염을 막기
+    위해 테스트 후 반드시 정리한다."""
+    yield
+    upload_module.sessions.clear()
+
+
+def _create_doc(isolated_dirs, doc_id, monkeypatch):
+    """isolated_dirs 위에 최소한의 실제 PDF 문서를 라이브러리에 저장한다."""
+    import services.translation_job as translation_job
+
+    # translation_job.py는 config.LIBRARY_DIR를 자기 모듈 전역으로 직접
+    # 바인딩해 쓰므로(services.library.LIBRARY_DIR와는 별개 심볼),
+    # job_status.json 경로가 isolated_dirs와 일치하도록 별도로 패치해야 한다.
+    monkeypatch.setattr(translation_job, "LIBRARY_DIR", str(isolated_dirs["library_dir"]))
+
+    tmp_pdf = isolated_dirs["upload_dir"] / f"{doc_id}.pdf"
+    doc = fitz.open()
+    doc.new_page(width=595, height=842)
+    doc.save(str(tmp_pdf))
+    doc.close()
+
+    isolated_dirs["library"].save_document(
+        doc_id, f"{doc_id}.pdf", str(tmp_pdf), 1, {}, username="testuser"
+    )
+
+
+def _write_job_status(doc_id, status, isolated_dirs):
+    path = _job_path(doc_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"status": status, "options": {}}, f)
+
+
+def test_only_documents_with_running_job_are_restored_eagerly(isolated_dirs, monkeypatch):
+    _create_doc(isolated_dirs, "doc-running", monkeypatch)
+    _create_doc(isolated_dirs, "doc-idle", monkeypatch)
+    _write_job_status("doc-running", "running", isolated_dirs)
+    _write_job_status("doc-idle", "completed", isolated_dirs)
+
+    # resume_incomplete_jobs 자체(비동기 태스크 스케줄링, LLM 스트리밍)는
+    # 이 테스트의 범위가 아니므로 no-op으로 대체하고 호출 여부/인자만 확인한다.
+    calls = []
+    monkeypatch.setattr(
+        upload_module, "resume_incomplete_jobs", lambda sessions: calls.append(dict(sessions))
+    )
+
+    upload_module.restore_sessions_from_library()
+
+    assert "doc-running" in upload_module.sessions, "진행 중인 잡이 있는 문서는 즉시 복원되어야 함"
+    assert upload_module.sessions["doc-running"]["pages"], "복원된 세션에는 추출된 페이지가 있어야 함"
+    assert "doc-idle" not in upload_module.sessions, (
+        "완료된 잡만 있는 문서는 부팅 시 미리 복원되면 안 됨(열람 시 지연 복원)"
+    )
+
+    assert len(calls) == 1
+    assert list(calls[0].keys()) == ["doc-running"]
+
+
+def test_document_without_any_job_status_is_not_restored_eagerly(isolated_dirs, monkeypatch):
+    _create_doc(isolated_dirs, "doc-untouched", monkeypatch)
+    # job_status.json 자체가 없는 경우 (번역을 한 번도 시작하지 않은 문서)
+
+    monkeypatch.setattr(upload_module, "resume_incomplete_jobs", lambda sessions: None)
+
+    upload_module.restore_sessions_from_library()
+
+    assert "doc-untouched" not in upload_module.sessions
+
+
+def test_ensure_session_still_lazily_restores_idle_document_on_demand(isolated_dirs, monkeypatch):
+    """restore_sessions_from_library()가 건너뛴 문서도, 실제로 열람되면
+    ensure_session()을 통해 정상적으로(지연) 복원되어야 한다."""
+    _create_doc(isolated_dirs, "doc-idle", monkeypatch)
+    _write_job_status("doc-idle", "completed", isolated_dirs)
+
+    monkeypatch.setattr(upload_module, "resume_incomplete_jobs", lambda sessions: None)
+    upload_module.restore_sessions_from_library()
+    assert "doc-idle" not in upload_module.sessions
+
+    assert upload_module.ensure_session("doc-idle") is True
+    assert "doc-idle" in upload_module.sessions

--- a/backend/tests/test_session_restore_lazy.py
+++ b/backend/tests/test_session_restore_lazy.py
@@ -101,3 +101,24 @@ def test_ensure_session_still_lazily_restores_idle_document_on_demand(isolated_d
 
     assert upload_module.ensure_session("doc-idle") is True
     assert "doc-idle" in upload_module.sessions
+
+
+def test_ensure_session_reuses_disk_cache_across_simulated_restart(isolated_dirs, monkeypatch):
+    """재부팅(프로세스 재시작)해도 디스크 캐시가 있으면 PDF를 다시 파싱하지
+    않아야 한다. 인메모리 sessions dict를 비워 재부팅을 흉내낸 뒤, extract_pages를
+    호출하면 실패하도록 만들어 캐시가 실제로 재사용되는지 검증한다."""
+    _create_doc(isolated_dirs, "doc-idle", monkeypatch)
+
+    assert upload_module.ensure_session("doc-idle") is True
+    cached_pages = upload_module.sessions["doc-idle"]["pages"]
+
+    # 재부팅 시뮬레이션: 인메모리 세션만 사라지고, 디스크 캐시는 남아있음
+    upload_module.sessions.clear()
+
+    def _fail_if_called(pdf_path):
+        raise AssertionError("디스크 캐시가 있는데도 extract_pages()가 다시 호출됨")
+
+    monkeypatch.setattr(upload_module, "extract_pages", _fail_if_called)
+
+    assert upload_module.ensure_session("doc-idle") is True
+    assert upload_module.sessions["doc-idle"]["pages"] == cached_pages

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -656,6 +656,10 @@
             <button type="button" id="clear-cache-btn" class="btn btn-secondary" style="width: 100%; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>브라우저 번역 캐시 비우기
             </button>
+            <button type="button" id="clear-pages-cache-btn" class="btn btn-secondary" style="width: 100%; margin-top: 8px; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>서버 PDF 추출 캐시 비우기
+            </button>
+            <p style="font-size: 11px; color: var(--text-secondary); margin: 6px 0 0; line-height: 1.5;">서버(또는 앱) 재시작 후 문서를 처음 열 때 빠르게 뜨도록 저장해두는 캐시입니다. 비워도 데이터가 사라지지 않고, 다음에 열람할 때 자동으로 다시 채워집니다.</p>
           </div>
           
           <div class="form-actions" style="margin-top: 15px;">

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -548,6 +548,25 @@ export async function clearTranslationCacheAPI(sessionId) {
 }
 
 /**
+ * 모든 문서의 PDF 텍스트 추출 결과 디스크 캐시를 삭제합니다(서버/앱 재시작
+ * 후 첫 열람 속도를 위한 캐시 - 지워도 다음 열람 시 자동으로 다시 채워짐).
+ */
+export async function clearPagesCacheAPI() {
+  const res = await fetch(`${API_BASE}/settings/clear-pages-cache`, {
+    method: 'POST'
+  })
+  if (!res.ok) {
+    try {
+      const err = await res.json()
+      throw new Error(err.detail || '캐시 삭제 실패')
+    } catch {
+      throw new Error('캐시 삭제 실패')
+    }
+  }
+  return res.json()
+}
+
+/**
  * 특정 문서의 이전 채팅 히스토리를 반환합니다.
  */
 export async function getChatHistoryAPI(sessionId) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
 import { icon } from './icons.js'
@@ -141,6 +141,7 @@ const settingDisableInsights = $('setting-disable-insights')
 const settingDisableCitationOverlay = $('setting-disable-citation-overlay')
 const settingDisableFigureOverlay = $('setting-disable-figure-overlay')
 const clearCacheBtn       = $('clear-cache-btn')
+const clearPagesCacheBtn  = $('clear-pages-cache-btn')
 const settingAccentSwatches = $('setting-accent-swatches')
 const settingAccentPicker   = $('setting-accent-picker')
 const settingAccentHex      = $('setting-accent-hex')
@@ -3266,6 +3267,22 @@ clearCacheBtn.addEventListener('click', async () => {
     location.reload()
   }
 })
+
+// 서버 측 PDF 텍스트 추출 결과 캐시 비우기 (재시작 후 첫 열람 가속용 - 지워도
+// 다음 열람 시 자동으로 다시 채워지므로 데이터 손실 없음)
+if (clearPagesCacheBtn) {
+  clearPagesCacheBtn.addEventListener('click', async () => {
+    const ok = await showCustomConfirm('서버에 저장된 PDF 텍스트 추출 캐시를 모두 삭제하시겠습니까?\n(문서를 다시 열면 그때 자동으로 다시 생성되므로 안전합니다.)', { title: '서버 캐시 비우기', confirmText: '삭제', danger: true })
+    if (!ok) return
+    try {
+      const result = await clearPagesCacheAPI()
+      const freedMb = ((result.freed_bytes || 0) / (1024 * 1024)).toFixed(1)
+      showToast(`캐시 파일 ${result.cleared_files || 0}개를 삭제했습니다. (${freedMb}MB 확보)`, 'success')
+    } catch (err) {
+      showToast(err.message || '캐시 삭제에 실패했습니다.', 'error')
+    }
+  })
+}
 
 // 계정 및 비밀번호 변경 제출
 changeCredentialsForm.addEventListener('submit', async (e) => {


### PR DESCRIPTION
# Summary
## 1. 부팅 시 전체 문서 세션 복원 제거 (지연 로딩)
- `restore_sessions_from_library()`가 기존엔 라이브러리의 **모든** 문서를 매번 `extract_pages()`로 재추출해 세션 메모리를 채웠음. 문서 수에 비례해 부팅 시간이 늘어나는 구조라, Tauri 데스크톱 앱은 실행할 때마다 이 지연을 매번 겪고, 배포 서버도 문서가 쌓이면서 CI 헬스체크(재시작 후 30초) 타임아웃을 넘기기 시작함(실제 배포 실패로 재현됨)
- 부팅 시점엔 **진행 중인 번역 잡이 있는 문서만** `job_status.json` 확인 후 즉시 복원하도록 변경. 나머지 문서는 기존에 이미 있던 `ensure_session()`의 지연 로딩 경로(실제 열람 시 그때 복원)를 그대로 사용
- 부팅 시간이 더 이상 라이브러리 크기에 비례하지 않고, 진행 중인 잡 개수(보통 0~1개)에만 비례함

## 2. PDF 텍스트 추출 결과 디스크 캐싱
- 1번만으로는 부팅은 빨라지지만, 재시작 후 문서를 **처음 여는 시점**엔 여전히 `extract_pages()`가 처음부터 다시 돌았음(인메모리 세션이 프로세스 재시작 시 초기화되므로)
- `services/cache.py`에 `get_cached_pages`/`save_pages_cache`/`clear_all_pages_cache` 추가 - `extract_pages()` 결과를 디스크에 캐싱해, 재부팅 이후 첫 열람도 즉시 뜨도록 함
- PDF 파일의 mtime/크기가 캐시 저장 시점과 달라지면 자동으로 무효화되어 재추출됨(캐시 손상/파일 교체 등 방어)

## 3. 설정에서 캐시 정리 기능 추가
- 설정 > 일반 설정에 "서버 PDF 추출 캐시 비우기" 버튼 추가 (`POST /api/settings/clear-pages-cache`)
- 확인 다이얼로그 → API 호출 → 삭제된 파일 수/확보 용량을 토스트로 표시
- 캐시를 비워도 다음 열람 시 자동으로 다시 채워지므로 데이터 손실 없음

## Test plan
- [x] 신규 백엔드 테스트 10개 (지연 복원 선택 로직 3개, 디스크 캐시 히트/미스/무효화/정리 4개, "재부팅 시뮬레이션 후 extract_pages가 호출되면 실패" 회귀 테스트 1개, HTTP 엔드포인트 2개) 전부 통과
- [x] `pytest tests/` 전체 169개 통과 (기존에도 실패하던 무관한 1개 제외)
- [x] Playwright로 설정 화면에서 버튼 렌더링, 클릭 → 확인 다이얼로그 → API 호출 → 토스트 표시까지 실제 브라우저 구동 검증 + 스크린샷 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)