### PR TITLE
feat: 캡처 즉시 인용 및 참조 미리보기 툴팁 리사이즈 기능 추가

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -51,7 +51,6 @@ const state = {
   referencesHeaderPageNum: null, // References/참고문헌 섹션이 시작되는 페이지 번호(감지 전엔 null)
   quotedImage: null,           // AI 질문 시 인용 이미지 보관용 (Base64)
   quotedImagePage: null,       // AI 질문 시 인용 이미지의 페이지 번호
-  pendingFigureQuote: null,    // 클릭 후 AI 질문 전 대기중인 인용 이미지 정보
   activeHighlightColor: '#eab308', // 기본 하이라이트 노란색
   activeUnderlineColor: '#ef4444',  // 기본 밑줄 빨간색
   isCropMode: false,           // 영역 캡처 모드 여부
@@ -344,7 +343,7 @@ function resetState() {
   Object.assign(state, {
     sessionId: null, filename: null, title: null, totalPages: 0, currentPage: 1,
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
-    chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null, pendingFigureQuote: null,
+    chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null,
     activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: [], referenceMap: {},
     referencesHeaderPageNum: null
   })
@@ -6481,16 +6480,12 @@ function createSelectionMenu() {
 
   menu.querySelector('.ask-ai-btn').addEventListener('click', (e) => {
     e.preventDefault(); e.stopPropagation();
-    if (state.pendingFigureQuote) {
-      askAIAssistantImage(state.pendingFigureQuote.base64Img, state.pendingFigureQuote.pageNum)
-    } else {
-      const selection = window.getSelection()
-      const text = extractSelectionText(selection).trim()
-      if (text) {
-        askAIAssistant(text)
-      }
-      selection.removeAllRanges()
+    const selection = window.getSelection()
+    const text = extractSelectionText(selection).trim()
+    if (text) {
+      askAIAssistant(text)
     }
+    selection.removeAllRanges()
     hideSelectionMenu()
   })
 
@@ -7052,7 +7047,6 @@ function hideSelectionMenu() {
     selectionMenu.classList.add('hidden')
     selectionMenu.querySelectorAll('.expand-wrapper').forEach(w => w.classList.remove('expanded'))
   }
-  state.pendingFigureQuote = null
   state.hoverSelectionDisabled = true
   if (sentenceHoverTimer) {
     clearTimeout(sentenceHoverTimer)
@@ -7330,17 +7324,16 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
 
       try {
         const base64Img = cropFigureFromCanvas(canvas, imgPercent)
-        state.pendingFigureQuote = {
-          pageNum: pageNum,
-          imgPercent: imgPercent,
-          base64Img: base64Img
-        }
-
-        // Show selection menu
-        const rect = overlay.getBoundingClientRect()
-        showSelectionMenu(rect, false) // false = hide annotation options
+        // 감지된 박스를 클릭하면 곧장 채팅 인용으로 넣어 바로 질문을 타이핑할
+        // 수 있게 한다 - 자유 드래그 캡처 도구(아래 initCropTool)와 동일한
+        // 패턴. 예전에는 클릭 시 작은 선택 메뉴를 띄우고 그 안의 "AI에게
+        // 질문" 버튼을 한 번 더 눌러야 했는데, 이 메뉴엔 그 버튼 하나뿐이라
+        // 불필요한 중간 단계였다.
+        toggleCropMode(false)
+        askAIAssistantImage(base64Img, pageNum)
       } catch (err) {
         console.error("그림 크롭 실패:", err)
+        showToast("캡처에 실패했습니다.", "error")
       }
     })
 
@@ -7668,17 +7661,36 @@ let figurePreviewTooltipEl = null
 let figurePreviewHideTimer = null
 let figurePreviewBoxEl = null
 let figurePreviewRequestId = 0
+// 리사이즈 드래그 도중, 아직 커지지 않은 박스 경계를 커서가 순간적으로
+// 벗어나 mouseleave가 튀는 경우가 있다 - 드래그 중엔 hide 스케줄 자체를
+// 완전히 무시해 박스가 리사이즈 도중 사라지는 것을 막는다.
+let figurePreviewIsResizing = false
 
 // showFigurePreviewTooltip이 마지막으로 그린 targets 배열 - 툴팁 안 개별
 // 항목을 클릭했을 때 어느 페이지로 이동할지 idx로 되찾기 위해 보관한다.
 let figurePreviewCurrentTargets = []
 
+// 이미지가 실제 그림/표보다 작아 보인다는 피드백에 따라, 참조 호버
+// 미리보기 툴팁 자체를 사용자가 드래그로 키울 수 있게 한다. 한 번 조절한
+// 크기는 localStorage에 저장해 다음 호버부터도 유지된다.
+const _FIGURE_PREVIEW_SIZE_KEY = 'easypaper_figure_preview_size'
+const _FIGURE_PREVIEW_MIN_WIDTH = 220
+const _FIGURE_PREVIEW_MIN_HEIGHT = 140
+
 function getOrCreateFigurePreviewTooltip() {
   if (figurePreviewTooltipEl) return figurePreviewTooltipEl
   const el = document.createElement('div')
   el.className = 'figure-preview-tooltip hidden'
-  el.innerHTML = `<div class="figure-preview-tooltip-items"></div>`
+  el.innerHTML = `<div class="figure-preview-tooltip-items"></div><div class="figure-preview-tooltip-resize-handle" title="드래그하여 크기 조절"></div>`
   document.body.appendChild(el)
+
+  try {
+    const saved = JSON.parse(localStorage.getItem(_FIGURE_PREVIEW_SIZE_KEY) || 'null')
+    if (saved && saved.w >= _FIGURE_PREVIEW_MIN_WIDTH && saved.h >= _FIGURE_PREVIEW_MIN_HEIGHT) {
+      el.style.width = `${saved.w}px`
+      el.style.height = `${saved.h}px`
+    }
+  } catch {}
 
   el.addEventListener('mouseenter', () => {
     if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
@@ -7696,12 +7708,45 @@ function getOrCreateFigurePreviewTooltip() {
     scrollToPage(viewerScrollContainer, target.page)
   })
 
+  el.querySelector('.figure-preview-tooltip-resize-handle').addEventListener('mousedown', (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const startX = e.clientX
+    const startY = e.clientY
+    const startWidth = el.offsetWidth
+    const startHeight = el.offsetHeight
+    el.classList.add('resizing')
+    figurePreviewIsResizing = true
+    if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
+
+    const onMove = (moveEvent) => {
+      const newWidth = Math.max(_FIGURE_PREVIEW_MIN_WIDTH, startWidth + (moveEvent.clientX - startX))
+      const newHeight = Math.max(_FIGURE_PREVIEW_MIN_HEIGHT, startHeight + (moveEvent.clientY - startY))
+      el.style.width = `${newWidth}px`
+      el.style.height = `${newHeight}px`
+    }
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      el.classList.remove('resizing')
+      figurePreviewIsResizing = false
+      localStorage.setItem(_FIGURE_PREVIEW_SIZE_KEY, JSON.stringify({ w: el.offsetWidth, h: el.offsetHeight }))
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  })
+
   figurePreviewTooltipEl = el
   return el
 }
 
 function positionFigurePreviewTooltip() {
   if (!figurePreviewTooltipEl || !figurePreviewBoxEl) return
+  // 사용자가 리사이즈 핸들을 드래그하는 도중에는 위치를 다시 계산하지 않는다 -
+  // 그 사이 이미지 로딩이 끝나 재배치가 걸리면(아래 showFigurePreviewTooltip의
+  // imgEl.onload) 커서 아래에서 박스가 튀어 리사이즈가 끊기는 문제가 있었다.
+  if (figurePreviewTooltipEl.classList.contains('resizing')) return
   const rect = figurePreviewBoxEl.getBoundingClientRect()
   const tw = figurePreviewTooltipEl.offsetWidth || 280
   const th = figurePreviewTooltipEl.offsetHeight || 160
@@ -7767,6 +7812,7 @@ function hideFigurePreviewTooltip() {
 }
 
 function scheduleFigurePreviewTooltipHide() {
+  if (figurePreviewIsResizing) return
   if (figurePreviewHideTimer) clearTimeout(figurePreviewHideTimer)
   figurePreviewHideTimer = setTimeout(hideFigurePreviewTooltip, 220)
 }
@@ -11228,4 +11274,3 @@ document.querySelectorAll('.onboarding-pull-model-btn').forEach((btn) => {
     )
   })
 })
-

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4646,7 +4646,13 @@ body.light-theme .figure-ref-marker-box:hover {
 .figure-preview-tooltip {
   position: fixed;
   z-index: 200;
-  max-width: min(420px, calc(100vw - 16px));
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  min-width: 220px;
+  min-height: 140px;
+  max-width: min(90vw, 900px);
+  max-height: min(90vh, 900px);
   background: rgba(23, 20, 38, 0.97);
   color: var(--text-primary);
   border: 1px solid var(--border-strong);
@@ -4657,6 +4663,10 @@ body.light-theme .figure-ref-marker-box:hover {
   -webkit-backdrop-filter: blur(6px);
   animation: fadeInTooltip 0.15s cubic-bezier(0.16, 1, 0.3, 1);
 }
+.figure-preview-tooltip.resizing {
+  animation: none;
+  user-select: none;
+}
 body.light-theme .figure-preview-tooltip {
   background: rgba(255, 255, 255, 0.98);
   border-color: var(--border-strong);
@@ -4665,9 +4675,36 @@ body.light-theme .figure-preview-tooltip {
 .figure-preview-tooltip.hidden {
   display: none;
 }
+/* items 영역만 스크롤을 담당하게 해서(flex 자식), 리사이즈 핸들은 내부
+   스크롤 위치와 무관하게 항상 툴팁 바깥쪽 모서리에 고정된다 */
 .figure-preview-tooltip-items {
-  max-height: 70vh;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
+}
+.figure-preview-tooltip-resize-handle {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 14px;
+  height: 14px;
+  cursor: nwse-resize;
+  opacity: 0.45;
+  transition: opacity 0.15s ease-in-out;
+}
+.figure-preview-tooltip-resize-handle:hover,
+.figure-preview-tooltip.resizing .figure-preview-tooltip-resize-handle {
+  opacity: 1;
+}
+.figure-preview-tooltip-resize-handle::after {
+  content: '';
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--text-secondary);
+  border-bottom: 2px solid var(--text-secondary);
 }
 .figure-preview-tooltip-item + .figure-preview-tooltip-item {
   margin-top: 12px;
@@ -4696,9 +4733,7 @@ body.light-theme .figure-preview-tooltip {
 }
 .figure-preview-tooltip-img {
   display: block;
-  max-width: 100%;
-  max-height: min(50vh, 420px);
-  width: auto;
+  width: 100%;
   height: auto;
   border-radius: 4px;
   border: 1px solid var(--border-strong);


### PR DESCRIPTION
# Summary
## 1. 영역 캡처 모드 - 감지 박스 클릭 시 곧장 채팅 인용으로
- 기존엔 감지된 그림/표 점선 박스를 클릭하면 작은 선택 메뉴가 뜨고, 그 안의 "AI에게 질문" 버튼을 한 번 더 눌러야 채팅에 인용이 들어갔음. 이 메뉴엔 그 버튼 하나뿐이라 불필요한 중간 단계였음
- 클릭 시 곧장 `askAIAssistantImage()`를 호출해 채팅 사이드바를 열고 인용 이미지를 채운 뒤 바로 질문을 타이핑할 수 있게 함 - 자유 드래그 캡처 도구(`initCropTool`)와 동일한 패턴으로 통일
- 더 이상 쓰이지 않는 `state.pendingFigureQuote` 관련 코드(상태 선언, 선택 메뉴의 분기 처리, reset 로직) 제거

## 2. Figure/Table/Equation 참조 미리보기 툴팁 리사이즈
- 본문 "Figure 1"/"Table 2" 등 참조 표기 호버 시 뜨는 미리보기 이미지가 표/그림 실물보다 작아 보인다는 피드백에 따라, 툴팁 자체를 모서리 핸들 드래그로 키울 수 있게 함
- 미리보기 이미지가 `max-height: min(50vh, 420px)` 등으로 별도 고정되어 있던 것을 `width:100%; height:auto`로 바꿔, 툴팁을 키우면 이미지도 함께 커지도록 함
- 조절한 크기는 `localStorage`(`easypaper_figure_preview_size`)에 저장돼 다음 호버부터도 유지됨
- 리사이즈를 위해 툴팁 레이아웃을 flex 구조로 재구성(내부 스크롤은 `.figure-preview-tooltip-items`가 전담, 리사이즈 핸들은 스크롤과 무관하게 항상 바깥쪽 모서리에 고정)

## 3. 구현 중 발견한 레이스 컨디션 수정
- 리사이즈 드래그로 박스가 빠르게 커지는 동안, 아직 커지지 않은 이전 경계를 커서가 순간적으로 벗어나 `mouseleave`가 발동 → 220ms 뒤 툴팁이 사라지는 문제가 있었음(실제로 Playwright 드래그 시뮬레이션으로 재현/확인)
- 리사이즈 드래그 중에는 hide 스케줄 자체를 무시하도록 `figurePreviewIsResizing` 플래그 가드 추가

## Test plan
- [x] Playwright로 실제 브라우저 구동: 캡처 박스 클릭 → 채팅 사이드바/인용 이미지 즉시 표시, 캡처 모드 자동 해제, 예전 선택 메뉴는 뜨지 않음을 확인
- [x] Playwright로 미리보기 툴팁 리사이즈 핸들 드래그 → 크기 증가 및 `localStorage` 저장 확인, 드래그 전/중/후 스크린샷으로 시각 확인
- [x] 기존 e2e 스위트(28개) 재실행 - 새로 깨진 테스트 없음(실패한 5개는 변경사항을 스태시하고 재현해 이 브랜치와 무관한 사전 존재 이슈임을 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)