### PR TITLE
fix: Claude Code CLI 세션 격리 시 인증 실패 및 stderr 유실 버그 수정

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -88,12 +88,24 @@ def _start_stderr_drain(process):
 
 
 async def _finish_stderr_drain(stderr_task) -> str:
-    """stderr 드레인 태스크를 정리하고 지금까지 모인 내용을 문자열로 반환한다."""
+    """stderr 드레인 태스크를 정리하고 지금까지 모인 내용을 문자열로 반환한다.
+
+    process.wait()가 끝난 직후에도 stderr 파이프의 EOF 감지가 아주 살짝(수십~수백ms)
+    늦게 반영되어 stderr_task.done()이 아직 False일 수 있다(실측으로 확인됨) - 이걸
+    "멈춘 것"으로 보고 곧장 cancel해버리면, 이미 커널 파이프에는 다 도착해 있던 stderr
+    내용까지 통째로 버려진다(취소된 태스크를 await하면 CancelledError만 던지고 그동안
+    읽은 데이터는 사라짐). 그 결과 예를 들어 claude_code의 "No conversation found"
+    같은 실패 메시지를 못 읽어, 상위의 재시도(신규 세션 생성) 로직이 걸리지 않는 버그가
+    있었다. 정말 멈춘 경우와 구분하기 위해 짧게 유예 시간을 준 뒤에만 취소한다.
+    """
     if not stderr_task.done():
-        stderr_task.cancel()
+        try:
+            await asyncio.wait_for(stderr_task, timeout=2.0)
+        except Exception:
+            pass
     try:
-        data = await stderr_task
-    except (asyncio.CancelledError, Exception):
+        data = stderr_task.result()
+    except Exception:
         return ""
     return data.decode("utf-8", errors="replace") if data else ""
 
@@ -928,6 +940,15 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
         dest_settings = os.path.join(claude_dir, "settings.json")
         if os.path.exists(orig_settings) and not os.path.exists(dest_settings):
             shutil.copy2(orig_settings, dest_settings)
+
+        # ~/.claude/ 안의 credentials/settings만으로는 부족하다 - 최신 Claude Code CLI는
+        # 최상위 ~/.claude.json(계정/세션 메타데이터)도 있어야 로그인 상태로 인식한다.
+        # 이게 빠지면 격리된 $HOME에서는 자격증명을 그대로 복사해도 "Not logged in"으로
+        # 실패한다.
+        orig_top_level_config = os.path.expanduser("~/.claude.json")
+        dest_top_level_config = os.path.join(home_dir, ".claude.json")
+        if os.path.exists(orig_top_level_config) and not os.path.exists(dest_top_level_config):
+            shutil.copy2(orig_top_level_config, dest_top_level_config)
 
         env["HOME"] = home_dir
 


### PR DESCRIPTION
# Summary
## 1. Claude Code CLI 세션 격리 시 인증 실패 수정
- `stream_claude_code`에서 문서(session_id)별로 격리된 `$HOME`을 만들 때 `~/.claude/.credentials.json`, `~/.claude/settings.json`만 복사하고 최상위 `~/.claude.json`(계정/세션 메타데이터)은 복사하지 않던 문제 수정
- 최신 Claude Code CLI 버전 기준으로는 이 파일이 없으면 자격증명을 그대로 복사해도 "Not logged in"으로 인식되어, 새 문서(session_id)에서 claude_code provider로 최초 호출 시 항상 실패했음

## 2. stderr 레이스 컨디션으로 인한 재시도 로직 미작동 수정
- `_finish_stderr_drain`(claude_code/codex/antigravity 공통 사용)이 `process.wait()` 완료 직후 `stderr_task.done()`이 False면 곧장 `cancel()`하던 문제 수정
- 실측 결과 프로세스 종료 직후에도 stderr 파이프 EOF 감지가 수십~수백ms 늦게 반영될 수 있는데, 이 시점에 취소하면 이미 커널 파이프에 도착해 있던 stderr 내용까지 통째로 버려짐(취소된 태스크를 await하면 `CancelledError`만 던짐)
- 그 결과 최초 세션 생성 시 CLI가 내는 "No conversation found with session ID: ..." 에러 메시지를 못 읽어, 상위의 "세션 없으면 새로 생성" 재시도 로직이 걸리지 않고 매번 원인불명 실패(`code=1: 알 수 없는 오류`)로 끝나던 버그 수정
- 정말 멈춘 경우와 구분하기 위해 2초 유예 시간을 준 뒤에만 취소하도록 변경

## 발견 경위
읽기 전 브리핑(Reading Primer) 기능 작업 중 CLI 기반 provider(claude_code) 실제 동작을 검증하다가 발견. 이 두 버그는 새 브랜치 작업과 무관하게 기존 `stream_claude_code`/`_finish_stderr_drain`에 이미 있던 문제로, claude_code/codex/antigravity provider로 새 문서를 여는 모든 최초 호출(번역/채팅/인사이트 포함)에 영향을 준다.

## Test plan
- [x] `pytest tests/` — 기존 무관 실패 1건 제외 169개 통과
- [x] 격리된 `$HOME`에 `.claude.json`이 정상 복사되는지 확인
- [x] 실제 `claude` CLI로 `generate_reading_primer` 스타일 호출을 재현해 세션 최초 생성(`--resume` 실패 → `--session-id` 재시도) 및 정상 응답 수신 확인