### PR TITLE
feat: 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 기능 추가

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from routers import jobs as jobs_router
 from routers import auth as auth_router
 from routers import agy as agy_router
 from routers import insight as insight_router
+from routers import primer as primer_router
 from services.auth import get_current_user
 
 app = FastAPI(
@@ -42,6 +43,7 @@ app.include_router(library_router.router, prefix="/api", dependencies=[Depends(g
 app.include_router(jobs_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Jobs"])
 app.include_router(agy_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["AGY"])
 app.include_router(insight_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Insight"])
+app.include_router(primer_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Primer"])
 
 
 @app.on_event("startup")

--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.responses import FileResponse
+
+from routers.upload import require_session_owner
+from routers.library import _require_owned_document
+from services.auth import get_current_user
+from services.primer import get_cached_primer, generate_primer
+from services.library import get_primer_figure_path
+
+router = APIRouter()
+
+
+@router.get("/library/{doc_id}/primer")
+async def get_primer(doc_id: str, target_lang: str = "한국어", current_user: str = Depends(get_current_user)):
+    """읽기 전 브리핑 콘텐츠를 반환합니다. 업로드 직후 백그라운드로 이미 생성되어
+    있으면 캐시에서 즉시 반환하고, 아직 없으면(구버전 문서 등) 그 자리에서 생성합니다."""
+    cached = get_cached_primer(doc_id, target_lang=target_lang)
+    if cached:
+        return cached
+
+    session = require_session_owner(doc_id, current_user)
+    return await generate_primer(
+        doc_id,
+        session["pages"],
+        session["metadata"],
+        username=current_user,
+        pdf_path=session["pdf_path"],
+        target_lang=target_lang,
+        session_id=doc_id,
+    )
+
+
+@router.get("/library/{doc_id}/primer-figure")
+async def get_primer_figure(doc_id: str, current_user: str = Depends(get_current_user)):
+    """읽기 전 브리핑에 쓰이는 대표 Figure 크롭 이미지를 서빙합니다."""
+    _require_owned_document(doc_id, current_user)
+    figure_path = get_primer_figure_path(doc_id)
+    if not figure_path:
+        raise HTTPException(status_code=404, detail="Figure 이미지가 없습니다.")
+    return FileResponse(figure_path, media_type="image/png", headers={"Cache-Control": "public, max-age=86400"})

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -1,6 +1,7 @@
 import uuid
 import os
 import shutil
+import asyncio
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from fastapi.responses import JSONResponse
 import aiofiles
@@ -10,6 +11,7 @@ from config import UPLOAD_DIR, MAX_FILE_SIZE_MB
 from services.pdf_parser import extract_pages, get_pdf_metadata
 from services.library import save_document, get_document, get_pdf_path as lib_pdf_path, list_documents
 from services.translation_job import start_job, resume_incomplete_jobs, get_job_status
+from services.primer import generate_primer
 from models.schemas import UploadResponse
 
 router = APIRouter()
@@ -166,16 +168,35 @@ async def upload_pdf(
         "username": current_user,
     }
 
-    # 백그라운드 번역 잡 즉시 시작 (사용자 지정 번역 옵션 바인딩)
-    start_job(
-        session_id,
-        pages,
-        target_lang=target_lang,
-        style=style,
-        ignore_math=ignore_math,
-        ignore_table=ignore_table,
-        ignore_refs=ignore_refs
-    )
+    # 읽기 전 브리핑을 먼저 생성한 뒤 번역 잡을 시작한다. CLI(antigravity/claude_code/
+    # codex) provider는 문서(session_id)당 세션이 하나뿐이라 primer 생성과 번역이 그
+    # 세션을 동시에 쓸 수 없다 - primer를 완료한 뒤에만 번역이 세션을 점유하도록
+    # 순차 실행한다 (API 기반 provider는 세션 개념이 없어 이 순서가 지연을 조금
+    # 더할 뿐 문제가 되지 않는다).
+    async def _run_primer_then_translate():
+        try:
+            await generate_primer(
+                session_id,
+                pages,
+                metadata,
+                username=current_user,
+                pdf_path=pdf_path,
+                target_lang=target_lang,
+                session_id=session_id,
+            )
+        except Exception as e:
+            print(f"[Upload {session_id}] Primer 생성 실패: {e}")
+        start_job(
+            session_id,
+            pages,
+            target_lang=target_lang,
+            style=style,
+            ignore_math=ignore_math,
+            ignore_table=ignore_table,
+            ignore_refs=ignore_refs
+        )
+
+    asyncio.create_task(_run_primer_then_translate())
 
     return UploadResponse(
         session_id=session_id,

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -28,6 +28,9 @@ def _pdf_path(doc_id: str) -> str:
 def _cover_path(doc_id: str) -> str:
     return os.path.join(LIBRARY_DIR, doc_id, "cover.jpg")
 
+def _primer_figure_path(doc_id: str) -> str:
+    return os.path.join(LIBRARY_DIR, doc_id, "primer_figure.png")
+
 
 # ── 문서 저장 ─────────────────────────────────────────────────────────────────
 
@@ -338,6 +341,23 @@ def get_cover_path(doc_id: str) -> Optional[str]:
             print(f"[get_cover_path] 표지 이미지 생성 실패 ({doc_id}): {e}")
             return None
     return cover_path
+
+def get_primer_figure_path(doc_id: str) -> Optional[str]:
+    """읽기 전 브리핑에 쓰이는 대표 Figure 크롭 이미지 경로를 반환합니다. primer 생성
+    파이프라인(save_primer_figure)에서만 생성되므로, 아직 생성되지 않았다면 None."""
+    path = _primer_figure_path(doc_id)
+    return path if os.path.exists(path) else None
+
+
+def save_primer_figure(doc_id: str, pdf_path: str, page_num: int, bbox_percent: dict) -> bool:
+    """primer 생성 파이프라인에서 대표 Figure 영역을 크롭해 캐시합니다."""
+    from services.pdf_parser import render_image_crop
+    try:
+        return render_image_crop(pdf_path, page_num, bbox_percent, _primer_figure_path(doc_id))
+    except Exception as e:
+        print(f"[save_primer_figure] Figure 크롭 실패 ({doc_id}): {e}")
+        return False
+
 
 def update_document_metadata(doc_id: str, metadata: dict) -> None:
     """문서 메타데이터를 업데이트합니다."""

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2,6 +2,7 @@ import asyncio
 import httpx
 import json
 import logging
+import re
 from typing import AsyncGenerator
 from config import (
     get_ollama_host,
@@ -864,6 +865,90 @@ async def stream_page_insight(
         raise RuntimeError("답변 생성 시간이 초과되었습니다.")
     except httpx.HTTPStatusError as e:
         raise RuntimeError(f"Ollama HTTP 오류: {e.response.status_code}")
+
+
+_PRIMER_LINE_RE = re.compile(
+    r'^[\s\-\*>]*\**\s*(HOOK|Q1|Q2|Q3|CHECK1|CHECK2|CHECK3)\**\s*[:.\)]\s*(.+)$',
+    re.IGNORECASE,
+)
+
+
+async def generate_reading_primer(title: str, text: str, target_lang: str = "한국어", session_id: str = None) -> dict:
+    """
+    논문 제목과 도입부(초록 등) 원문으로 "읽기 전 브리핑" 콘텐츠(훅 문장, 예측 질문 3개,
+    읽으면서 확인할 체크리스트 3개)를 생성합니다. 채팅(Chat) 프로바이더/모델 설정을
+    재사용하며, stream_page_insight와 마찬가지로 세션이 지속되는 CLI provider는
+    번역/채팅/인사이트와 동일한 문서당 공유 세션(session_id)을 그대로 사용합니다.
+    """
+    instruction = (
+        f"다음은 학술 논문 '{title}'의 도입부(초록 등) 원문입니다. 이 논문을 읽기 전 독자가 "
+        f"호기심을 갖고 몰입할 수 있도록 아래 형식에 맞춰 {target_lang}로 작성해주세요.\n\n"
+        f"- HOOK: 이 논문이 다루는 문제를 흥미로운 질문 형태로 재구성한 한두 문장. 초록을 "
+        f"그대로 요약하지 말고 \"왜 이 문제가 어려운가/왜 흥미로운가\"를 짚어 궁금증을 유발하세요.\n"
+        f"- Q1/Q2/Q3: 독자가 본문을 읽기 전 스스로 답을 예측해볼 만한 질문 3개. 각각 한 문장.\n"
+        f"- CHECK1/CHECK2/CHECK3: 본문을 읽는 동안 확인하면 좋을 구체적인 포인트(예: 비교 대상, "
+        f"핵심 수치, 한계점 등) 3개. 각각 한 문장.\n\n"
+        f"반드시 아래 형식으로 정확히 7줄만 출력하세요. 다른 설명이나 서론은 절대 추가하지 마세요.\n"
+        f"HOOK: <내용>\nQ1: <내용>\nQ2: <내용>\nQ3: <내용>\nCHECK1: <내용>\nCHECK2: <내용>\nCHECK3: <내용>"
+    )
+    prompt = f"{instruction}\n\n원문:\n{text[:3000]}"
+
+    provider = get_chat_provider()
+    model = get_chat_model()
+
+    tokens = []
+    if provider == "antigravity":
+        async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer"):
+            tokens.append(token)
+    elif provider == "claude_code":
+        async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer"):
+            tokens.append(token)
+    elif provider == "codex":
+        async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="primer"):
+            tokens.append(token)
+    elif provider in ("openai", "gemini", "claude"):
+        messages = [{"role": "user", "content": prompt}]
+        if provider == "openai":
+            async for token in stream_openai(messages, model=model, temperature=0.5):
+                tokens.append(token)
+        elif provider == "gemini":
+            async for token in stream_gemini(messages, model=model, temperature=0.5):
+                tokens.append(token)
+        else:
+            async for token in stream_claude(messages, model=model, temperature=0.5):
+                tokens.append(token)
+    else:
+        # Ollama 폴백
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "options": {"temperature": 0.5},
+        }
+        # 스트리밍 없이 응답을 한 번에 기다리는 호출이라, 로컬 CPU 추론처럼 느린
+        # 환경에서도 끊기지 않도록 다른 ollama 스트리밍 호출들과 동일하게 360초를 준다
+        # (stream_page_insight의 120초는 페이지 단위라 상대적으로 짧아도 되지만, 이
+        # 함수는 문서 전체 도입부를 한 번에 처리해 응답이 더 오래 걸릴 수 있다).
+        async with httpx.AsyncClient(timeout=360.0) as client:
+            resp = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            tokens.append(data.get("message", {}).get("content", ""))
+
+    raw = "".join(tokens)
+    result = {"hook": "", "questions": [], "checklist": []}
+    for line in raw.splitlines():
+        m = _PRIMER_LINE_RE.match(line.strip())
+        if not m:
+            continue
+        key, value = m.group(1).upper(), m.group(2).strip().rstrip('*').strip()
+        if key == "HOOK":
+            result["hook"] = value
+        elif key in ("Q1", "Q2", "Q3"):
+            result["questions"].append(value)
+        else:
+            result["checklist"].append(value)
+    return result
 
 
 async def check_ollama_health() -> dict:

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -574,6 +574,31 @@ def _rect_mostly_inside_any(x0: float, y0: float, x1: float, y1: float, rects: L
     return False
 
 
+def render_image_crop(pdf_path: str, page_num: int, bbox_percent: Dict[str, float], output_path: str, zoom: float = 2.0) -> bool:
+    """
+    지정한 페이지에서 백분율 좌표(bbox_percent: left, top, width, height, extract_pdf_images와
+    동일한 형식)에 해당하는 영역만 잘라 이미지로 렌더링합니다. render_cover_image와 동일한
+    PyMuPDF 크롭 기법을 임의의 페이지/영역에 쓸 수 있도록 일반화한 버전입니다.
+    """
+    doc = fitz.open(pdf_path)
+    try:
+        if page_num < 1 or page_num > doc.page_count:
+            return False
+        page = doc[page_num - 1]
+        rect = page.rect
+        x0 = rect.x0 + rect.width * (bbox_percent["left"] / 100)
+        y0 = rect.y0 + rect.height * (bbox_percent["top"] / 100)
+        x1 = x0 + rect.width * (bbox_percent["width"] / 100)
+        y1 = y0 + rect.height * (bbox_percent["height"] / 100)
+        clip = fitz.Rect(x0, y0, x1, y1)
+        matrix = fitz.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=matrix, clip=clip)
+        pix.save(output_path)
+        return True
+    finally:
+        doc.close()
+
+
 def render_cover_image(pdf_path: str, output_path: str, top_fraction: float = 0.45, zoom: float = 2.0) -> bool:
     """
     라이브러리 카드 미리보기용으로, 1페이지 상단(제목+저자+abstract가 보통 위치하는

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -1,0 +1,199 @@
+"""
+"읽기 전 브리핑(Reading Primer)" 생성 오케스트레이션.
+
+업로드 직후 백그라운드로 실행되어 아래 네 가지를 조합한 결과를 page_insights
+테이블(doc_id, page_num=0, kind="primer")에 캐싱한다:
+  1. 훅 문장 / 예측 질문 3개 / 체크리스트 3개 (LLM, llm_client.generate_reading_primer)
+  2. 대표 Figure 크롭 이미지 (pdf_parser.extract_pdf_images + render_image_crop)
+  3. 내 라이브러리 안에서 이 논문의 참고문헌과 겹치는 논문 매칭 (외부 API 없이 텍스트 매칭)
+  4. 내 라이브러리에 없는 참고문헌 중 최대 3건만 Semantic Scholar로 확장 조회
+"""
+import json
+import re
+from typing import Optional
+
+from services.library import (
+    save_page_insight,
+    get_page_insight,
+    get_pdf_path,
+    save_primer_figure,
+    list_documents,
+)
+from services.reference_parser import extract_reference_list
+from services.llm_client import generate_reading_primer
+
+_EXTERNAL_MATCH_LIMIT = 3
+_EXTERNAL_ATTEMPT_LIMIT = 5
+_LIBRARY_MATCH_THRESHOLD = 0.7
+_STOPWORDS = {
+    "the", "a", "an", "of", "for", "and", "or", "on", "in", "to", "with",
+    "using", "via", "based", "towards", "toward", "from", "into", "at", "by",
+}
+
+
+def _normalize_words(text: str) -> set:
+    words = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return {w for w in words if len(w) > 2 and w not in _STOPWORDS}
+
+
+def _match_library_references(reference_map: dict, doc_id: str, username: str) -> tuple[list, set]:
+    """참고문헌 원문 목록을 내 라이브러리의 다른 논문 제목과 텍스트 매칭한다.
+    외부 API를 쓰지 않아 업로드마다 항상 실행해도 부담이 없다."""
+    candidates = []
+    for doc in list_documents(username=username):
+        if doc["id"] == doc_id:
+            continue
+        title = (doc.get("metadata") or {}).get("title") or doc.get("filename", "")
+        words = _normalize_words(title)
+        if len(words) < 2:
+            continue
+        candidates.append((doc["id"], title, words))
+
+    matches = []
+    matched_doc_ids = set()
+    matched_ref_nums = set()
+    for ref_num, ref_text in reference_map.items():
+        ref_words = _normalize_words(ref_text)
+        if not ref_words:
+            continue
+        for cand_doc_id, title, words in candidates:
+            if cand_doc_id in matched_doc_ids:
+                continue
+            if len(words & ref_words) / len(words) >= _LIBRARY_MATCH_THRESHOLD:
+                matches.append({"ref_num": ref_num, "doc_id": cand_doc_id, "title": title})
+                matched_doc_ids.add(cand_doc_id)
+                matched_ref_nums.add(ref_num)
+                break
+    return matches, matched_ref_nums
+
+
+def _is_plausible_match(ref_text: str, resolved: dict) -> bool:
+    """Semantic Scholar 공개 검색은 API 키 없이 쓰다 보니 지저분한 인용 문자열에
+    엉뚱한 논문을 최상위로 반환하는 경우가 있다(실제로 EEG 논문 테스트에서 안과
+    수술 논문이 매칭된 사례를 확인함). 연도가 인용 원문에 그대로 등장하거나,
+    제목 단어가 인용 원문과 충분히 겹칠 때만 신뢰할 만한 매칭으로 받아들인다."""
+    year = resolved.get("year")
+    if year and str(year) in (ref_text or ""):
+        return True
+    title_words = _normalize_words(resolved.get("title", ""))
+    if not title_words:
+        return False
+    ref_words = _normalize_words(ref_text)
+    return len(title_words & ref_words) / len(title_words) >= 0.5
+
+
+async def _resolve_external_references(reference_map: dict, matched_ref_nums: set) -> list:
+    from services.reference_linker import resolve_reference
+    results = []
+    attempts = 0
+    for ref_num, ref_text in reference_map.items():
+        if len(results) >= _EXTERNAL_MATCH_LIMIT or attempts >= _EXTERNAL_ATTEMPT_LIMIT:
+            break
+        if ref_num in matched_ref_nums:
+            continue
+        attempts += 1
+        resolved = await resolve_reference(ref_text)
+        if resolved and _is_plausible_match(ref_text, resolved):
+            results.append({"ref_num": ref_num, **resolved})
+    return results
+
+
+def _pick_primary_figure(pdf_path: str) -> Optional[dict]:
+    from services.pdf_parser import extract_pdf_images
+    try:
+        images = extract_pdf_images(pdf_path)
+    except Exception as e:
+        print(f"[primer] Figure 추출 실패: {e}")
+        return None
+
+    best = None
+    best_num = None
+    for img in images:
+        label = img.get("label") or ""
+        m = re.match(r"^fig(?:ure)?\.?\s*(\d+)", label, re.IGNORECASE)
+        if not m:
+            continue
+        num = int(m.group(1))
+        if best_num is None or num < best_num:
+            best_num = num
+            best = img
+    return best
+
+
+async def generate_primer(
+    doc_id: str,
+    pages: list,
+    metadata: dict,
+    username: str,
+    pdf_path: str,
+    target_lang: str = "한국어",
+    session_id: str = None,
+) -> dict:
+    """primer 콘텐츠를 생성하고 캐시에 저장한 뒤 결과 dict를 반환한다.
+    실패해도 예외를 던지지 않고 부분 결과를 반환한다 - 업로드 직후 번역 착수를
+    막아서는 안 되는 백그라운드 부가 기능이기 때문이다.
+    """
+    title = metadata.get("title") or ""
+    combined_text = "\n".join(p.get("text", "") for p in pages[:2])
+
+    try:
+        llm_part = await generate_reading_primer(title, combined_text, target_lang=target_lang, session_id=session_id)
+    except Exception as e:
+        print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
+        llm_part = {"hook": "", "questions": [], "checklist": []}
+
+    try:
+        reference_map = extract_reference_list(pages)
+    except Exception as e:
+        print(f"[primer] 참고문헌 파싱 실패 ({doc_id}): {e}")
+        reference_map = {}
+
+    library_matches, matched_ref_nums = [], set()
+    if reference_map:
+        try:
+            library_matches, matched_ref_nums = _match_library_references(reference_map, doc_id, username)
+        except Exception as e:
+            print(f"[primer] 라이브러리 매칭 실패 ({doc_id}): {e}")
+
+    external_matches = []
+    if reference_map:
+        try:
+            external_matches = await _resolve_external_references(reference_map, matched_ref_nums)
+        except Exception as e:
+            print(f"[primer] 외부 참고문헌 조회 실패 ({doc_id}): {e}")
+
+    figure = None
+    try:
+        picked = _pick_primary_figure(pdf_path)
+        if picked and save_primer_figure(doc_id, pdf_path, picked["page"], picked):
+            figure = {"page": picked["page"], "label": picked.get("label")}
+    except Exception as e:
+        print(f"[primer] Figure 크롭 실패 ({doc_id}): {e}")
+
+    result = {
+        "hook": llm_part.get("hook", ""),
+        "questions": llm_part.get("questions", []),
+        "checklist": llm_part.get("checklist", []),
+        "figure": figure,
+        "citation_graph": {
+            "library": library_matches,
+            "external": external_matches,
+        },
+    }
+
+    try:
+        save_page_insight(doc_id, 0, "primer", json.dumps(result, ensure_ascii=False), suffix=target_lang)
+    except Exception as e:
+        print(f"[primer] 캐시 저장 실패 ({doc_id}): {e}")
+
+    return result
+
+
+def get_cached_primer(doc_id: str, target_lang: str = "한국어") -> Optional[dict]:
+    content = get_page_insight(doc_id, 0, "primer", suffix=target_lang)
+    if not content:
+        return None
+    try:
+        return json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -211,6 +211,9 @@
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
+        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기" style="margin-left: 6px;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+        </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
@@ -648,6 +651,9 @@
               <label class="checkbox-label">
                 <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
               </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              </label>
             </div>
           </div>
 
@@ -1007,6 +1013,56 @@
         </div>
       </div>
       <button id="doc-preview-open-btn" class="doc-preview-open-btn">열기</button>
+    </div>
+  </div>
+
+  <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
+  <div id="primer-modal" class="modal-overlay hidden">
+    <div class="primer-content">
+      <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
+
+      <div id="primer-loading" class="primer-loading">
+        <div class="spinner"></div>
+        <p>읽기 전 브리핑을 준비하고 있어요...</p>
+      </div>
+
+      <div id="primer-error" class="primer-error hidden">
+        <p>브리핑을 불러오지 못했습니다.</p>
+      </div>
+
+      <div id="primer-body" class="primer-body hidden">
+        <h2 id="primer-title" class="primer-title"></h2>
+
+        <div id="primer-hook-section" class="primer-section primer-hook-section hidden">
+          <h3>💡 이 논문이 다루는 문제</h3>
+          <p id="primer-hook-text" class="primer-hook-text"></p>
+        </div>
+
+        <div id="primer-questions-section" class="primer-section hidden">
+          <h3>🤔 읽기 전에 스스로 답해보기</h3>
+          <ul id="primer-questions" class="primer-list"></ul>
+        </div>
+
+        <div id="primer-figure-section" class="primer-section primer-figure-section hidden">
+          <h3>🖼️ 핵심 그림 먼저 보기</h3>
+          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+        </div>
+
+        <div id="primer-checklist-section" class="primer-section hidden">
+          <h3>✅ 읽으면서 확인할 것</h3>
+          <ul id="primer-checklist" class="primer-checklist"></ul>
+        </div>
+
+        <div id="primer-graph-section" class="primer-section primer-graph-section hidden">
+          <h3>🔗 이 논문과 연결된 논문</h3>
+          <div id="primer-graph" class="primer-graph"></div>
+        </div>
+      </div>
+
+      <div class="primer-footer">
+        <button id="primer-skip-btn" class="btn btn-secondary">건너뛰기</button>
+        <button id="primer-continue-btn" class="btn btn-primary">읽으러 가기</button>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -43,6 +43,8 @@ const PATHS = {
   eyeOff: '<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/>',
   highlighter: '<path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/>',
   underline: '<path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/>',
+  lightbulb: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>',
+  network: '<rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -122,3 +122,9 @@ export async function deleteLibraryDocPermanently(docId) {
   if (!res.ok) throw new Error('영구 삭제 실패')
   return res.json()
 }
+
+export async function fetchPrimer(docId, targetLang = '한국어') {
+  const res = await fetch(`${API_BASE}/library/${docId}/primer?target_lang=${encodeURIComponent(targetLang)}`)
+  if (!res.ok) throw new Error('읽기 전 브리핑 조회 실패')
+  return res.json()
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -71,6 +71,9 @@ const state = {
   disableCitationOverlay: localStorage.getItem('easypaper_disable_citation_overlay') === 'true',
   // Figure/Table/수식 참조 표기 호버 미리보기를 끌지 여부.
   disableFigureOverlay: localStorage.getItem('easypaper_disable_figure_overlay') === 'true',
+  // 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 게이팅 모달을 끌지 여부. 꺼도
+  // 뷰어 툴바 버튼으로는 언제든 다시 열어볼 수 있다.
+  disablePrimer: localStorage.getItem('easypaper_disable_primer') === 'true',
   // pageNum_kind(예: "3_keywords") → 생성된 텍스트. 탭 재방문 시 재요청 방지용 캐시.
   pageInsightCache: {}
 }
@@ -139,6 +142,7 @@ const settingDisableBookmark = $('setting-disable-bookmark')
 const settingDisableInsights = $('setting-disable-insights')
 const settingDisableCitationOverlay = $('setting-disable-citation-overlay')
 const settingDisableFigureOverlay = $('setting-disable-figure-overlay')
+const settingDisablePrimer = $('setting-disable-primer')
 const clearCacheBtn       = $('clear-cache-btn')
 const clearPagesCacheBtn  = $('clear-pages-cache-btn')
 const settingAccentSwatches = $('setting-accent-swatches')
@@ -267,6 +271,27 @@ const outlineToggleBtn   = $('outline-toggle-btn')
 const outlineSidebar     = $('outline-sidebar')
 const outlineCloseBtn    = $('outline-close-btn')
 const outlineContent     = $('outline-content')
+const viewerPrimerBtn    = $('viewer-primer-btn')
+
+// 읽기 전 브리핑(Reading Primer) 모달
+const primerModal          = $('primer-modal')
+const primerCloseBtn       = $('primer-close-btn')
+const primerLoading        = $('primer-loading')
+const primerError          = $('primer-error')
+const primerBody           = $('primer-body')
+const primerTitle          = $('primer-title')
+const primerHookSection    = $('primer-hook-section')
+const primerHookText       = $('primer-hook-text')
+const primerQuestionsSection = $('primer-questions-section')
+const primerQuestions      = $('primer-questions')
+const primerFigureSection  = $('primer-figure-section')
+const primerFigureImg      = $('primer-figure-img')
+const primerChecklistSection = $('primer-checklist-section')
+const primerChecklist      = $('primer-checklist')
+const primerGraphSection   = $('primer-graph-section')
+const primerGraph          = $('primer-graph')
+const primerSkipBtn        = $('primer-skip-btn')
+const primerContinueBtn    = $('primer-continue-btn')
 const chatInput          = $('chat-input')
 const chatSendBtn        = $('chat-send-btn')
 
@@ -2298,6 +2323,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingDisableInsights.checked = state.disableInsights
   settingDisableCitationOverlay.checked = state.disableCitationOverlay
   settingDisableFigureOverlay.checked = state.disableFigureOverlay
+  settingDisablePrimer.checked = state.disablePrimer
   updateAccentSettingsUI(currentAccentColor)
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
@@ -2558,6 +2584,11 @@ settingDisableFigureOverlay.addEventListener('change', () => {
   state.disableFigureOverlay = settingDisableFigureOverlay.checked
   localStorage.setItem('easypaper_disable_figure_overlay', state.disableFigureOverlay)
   refreshAllPageOverlays()
+})
+
+settingDisablePrimer.addEventListener('change', () => {
+  state.disablePrimer = settingDisablePrimer.checked
+  localStorage.setItem('easypaper_disable_primer', state.disablePrimer)
 })
 
 // 시스템 설정 폼 제출
@@ -4797,6 +4828,163 @@ if (docPreviewOpenBtn) {
   })
 }
 
+// ── 읽기 전 브리핑(Reading Primer) 모달 ──────────────────────
+// mode: 'gate'면 논문을 처음 열 때 뷰어 진입을 가로막는 형태로 뜨며
+// (건너뛰기/읽으러 가기 둘 다 통과), 'toolbar'면 뷰어 툴바에서 언제든
+// 다시 열어보는 형태로 뜬다(닫기 버튼 하나만 노출). 어느 모드든 모달이
+// 닫히는 시점에 resolve되는 프로미스를 반환한다.
+let primerResolve = null
+
+function hidePrimerModal(result) {
+  primerModal.classList.add('hidden')
+  if (primerResolve) {
+    const resolve = primerResolve
+    primerResolve = null
+    resolve(result)
+  }
+}
+
+function renderPrimerCitationGraph(container, citationGraph, mode) {
+  const section = primerGraphSection
+  const libraryMatches = (citationGraph && citationGraph.library) || []
+  const externalMatches = (citationGraph && citationGraph.external) || []
+  const nodes = [
+    ...libraryMatches.map(m => ({ ...m, kind: 'library' })),
+    ...externalMatches.map(m => ({ ...m, kind: 'external' })),
+  ]
+  if (nodes.length === 0) {
+    section.classList.add('hidden')
+    container.innerHTML = ''
+    return
+  }
+  section.classList.remove('hidden')
+
+  const width = 460, height = 280, cx = width / 2, cy = height / 2
+  const nodeR = 40, centerR = 32
+  const radius = Math.min(width, height) / 2 - nodeR - 4
+  const angleStep = (2 * Math.PI) / nodes.length
+  const positioned = nodes.map((n, i) => {
+    const angle = -Math.PI / 2 + i * angleStep
+    return { ...n, x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) }
+  })
+
+  const truncate = (s, n) => (s && s.length > n) ? `${s.slice(0, n)}…` : (s || '')
+  let svg = `<svg viewBox="0 0 ${width} ${height}" class="primer-graph-svg">`
+  for (const n of positioned) {
+    svg += `<line x1="${cx}" y1="${cy}" x2="${n.x}" y2="${n.y}" class="primer-graph-edge" />`
+  }
+  svg += `<circle cx="${cx}" cy="${cy}" r="${centerR}" class="primer-graph-node primer-graph-node-center" />`
+  svg += `<text x="${cx}" y="${cy}" class="primer-graph-node-text primer-graph-node-text-center">이 논문</text>`
+  positioned.forEach((n, i) => {
+    const cls = n.kind === 'library' ? 'primer-graph-node-library' : 'primer-graph-node-external'
+    svg += `<g class="primer-graph-node-group" data-idx="${i}">`
+    svg += `<circle cx="${n.x}" cy="${n.y}" r="${nodeR}" class="primer-graph-node ${cls}" />`
+    svg += `<text x="${n.x}" y="${n.y}" class="primer-graph-node-text">${escapeHtml(truncate(n.title, 16))}</text>`
+    svg += `</g>`
+  })
+  svg += `</svg>`
+  container.innerHTML = svg
+
+  container.querySelectorAll('.primer-graph-node-group').forEach(g => {
+    g.addEventListener('click', async () => {
+      const n = positioned[parseInt(g.dataset.idx, 10)]
+      if (n.kind === 'library') {
+        const targetDoc = await fetchLibraryDoc(n.doc_id).catch(() => null)
+        if (!targetDoc) return
+        if (mode === 'gate') {
+          // gate 모드는 openFromLibrary가 이 모달의 프로미스를 await하며 대기
+          // 중이므로, 여기서 곧장 openFromLibrary를 호출하면 원래 문서 로딩과
+          // 동시에 실행되어 state가 뒤섞인다. 대신 redirect 시그널로 resolve해
+          // 호출부가 원래 문서 로딩을 건너뛰고 순서대로 이 논문을 열게 한다.
+          hidePrimerModal({ redirect: targetDoc })
+        } else {
+          hidePrimerModal()
+          openFromLibrary(targetDoc)
+        }
+      } else if (n.url) {
+        window.open(n.url, '_blank', 'noopener')
+      }
+    })
+  })
+}
+
+function renderPrimerContent(doc, data, mode) {
+  const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  primerTitle.textContent = displayTitle
+
+  if (data.hook) {
+    primerHookText.textContent = data.hook
+    primerHookSection.classList.remove('hidden')
+  } else {
+    primerHookSection.classList.add('hidden')
+  }
+
+  const questions = data.questions || []
+  primerQuestions.innerHTML = questions.map(q => `<li>${escapeHtml(q)}</li>`).join('')
+  primerQuestionsSection.classList.toggle('hidden', questions.length === 0)
+
+  const checklist = data.checklist || []
+  primerChecklist.innerHTML = checklist.map(c => `<li>${escapeHtml(c)}</li>`).join('')
+  primerChecklistSection.classList.toggle('hidden', checklist.length === 0)
+
+  if (data.figure) {
+    primerFigureImg.src = `/api/library/${doc.id}/primer-figure?ts=${Date.now()}`
+    primerFigureSection.classList.remove('hidden')
+  } else {
+    primerFigureSection.classList.add('hidden')
+  }
+
+  renderPrimerCitationGraph(primerGraph, data.citation_graph, mode)
+}
+
+async function showPrimerModal(doc, { mode = 'gate' } = {}) {
+  return new Promise((resolve) => {
+    primerResolve = resolve
+    primerModal.classList.remove('hidden')
+    primerLoading.classList.remove('hidden')
+    primerError.classList.add('hidden')
+    primerBody.classList.add('hidden')
+    primerSkipBtn.classList.toggle('hidden', mode !== 'gate')
+    primerContinueBtn.textContent = mode === 'gate' ? '읽으러 가기' : '닫기'
+
+    const targetLang = getTranslationOptions().targetLang
+    fetchPrimer(doc.id, targetLang)
+      .then(data => {
+        renderPrimerContent(doc, data, mode)
+        primerLoading.classList.add('hidden')
+        primerBody.classList.remove('hidden')
+      })
+      .catch(err => {
+        console.error('브리핑 로드 실패:', err)
+        primerLoading.classList.add('hidden')
+        primerError.classList.remove('hidden')
+      })
+  })
+}
+
+if (primerCloseBtn) primerCloseBtn.addEventListener('click', hidePrimerModal)
+if (primerSkipBtn) primerSkipBtn.addEventListener('click', hidePrimerModal)
+if (primerContinueBtn) primerContinueBtn.addEventListener('click', hidePrimerModal)
+if (primerModal) {
+  primerModal.addEventListener('click', (e) => {
+    if (e.target === primerModal) hidePrimerModal()
+  })
+}
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && primerModal && !primerModal.classList.contains('hidden')) {
+    hidePrimerModal()
+  }
+})
+if (viewerPrimerBtn) {
+  viewerPrimerBtn.addEventListener('click', () => {
+    if (!state.currentDocId) return
+    showPrimerModal(
+      { id: state.currentDocId, metadata: state.currentDocMetadata, filename: state.filename },
+      { mode: 'toolbar' }
+    )
+  })
+}
+
 async function loadDocumentImages(docId) {
   try {
     const imgRes = await fetchLibraryDocImages(docId)
@@ -4869,6 +5057,36 @@ async function openFromLibrary(doc, shouldPushState = true) {
     state.filename   = doc.filename
     state.currentDocId = doc.id
     state.currentDocMetadata = doc.metadata || {}
+
+    // 읽기 전 브리핑 게이팅: 설정에서 껐거나 이미 이 문서의 브리핑을 본 적
+    // 있으면 건너뛴다. primer_shown 필드 자체가 없는 구버전 문서(이 기능
+    // 배포 전 업로드분)는 "이미 열람한 적 있는지"(독서완료 표시 또는 마지막
+    // 읽던 페이지 존재)로 판단해, 이미 여러 번 읽은 논문에 갑자기 브리핑이
+    // 뜨지 않도록 그 자리에서 primer_shown을 백필한다.
+    if (viewerPrimerBtn) viewerPrimerBtn.classList.toggle('hidden', state.disablePrimer)
+    if (!state.disablePrimer) {
+      const meta = state.currentDocMetadata
+      const alreadyShown = meta.primer_shown === true
+      if (!alreadyShown) {
+        const alreadyOpenedBefore = meta.read === true || Number.isInteger(meta.last_page)
+        if (alreadyOpenedBefore) {
+          state.currentDocMetadata.primer_shown = true
+          updateLibraryDocMetadata(doc.id, { primer_shown: true }).catch(() => {})
+        } else {
+          const gateResult = await showPrimerModal(doc, { mode: 'gate' })
+          state.currentDocMetadata.primer_shown = true
+          updateLibraryDocMetadata(doc.id, { primer_shown: true }).catch(() => {})
+          // 브리핑의 인용 그래프에서 내 라이브러리의 다른 논문으로 바로 이동한
+          // 경우 - 지금 열던 이 문서(doc)는 아직 로딩을 시작하지도 않았으므로
+          // 이어서 로딩하지 않고, 대신 그 논문을 새로 연다 (finally에서
+          // docOpeningId가 정리된 뒤에 호출해야 재진입 가드에 걸리지 않는다).
+          if (gateResult && gateResult.redirect) {
+            docOpeningId = null
+            return openFromLibrary(gateResult.redirect)
+          }
+        }
+      }
+    }
 
     if (viewerReadToggleBtn) {
       const isRead = state.currentDocMetadata.read === true

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1580,6 +1580,163 @@ body.light-theme .toast.error { color: #dc2626; }
 .doc-preview-open-btn:hover { filter: brightness(1.1); }
 .doc-preview-open-btn:active { transform: scale(0.98); }
 
+/* ── 읽기 전 브리핑(Reading Primer) 모달 ── */
+.primer-content {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  width: 92%;
+  max-width: 620px;
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  transform: scale(0.95);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.modal-overlay:not(.hidden) .primer-content { transform: scale(1); }
+
+.primer-close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+}
+
+.primer-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 60px 20px;
+}
+.primer-loading .spinner { width: 26px; height: 26px; border-width: 3px; }
+.primer-loading p { font-size: 13.5px; color: var(--text-secondary); }
+
+.primer-error {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13.5px;
+}
+
+.primer-body {
+  overflow-y: auto;
+  padding: 32px 28px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.primer-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text-primary);
+  padding-right: 24px;
+}
+
+.primer-section h3 {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.primer-hook-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border-left: 3px solid var(--accent-mid);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+}
+
+.primer-list, .primer-checklist {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.primer-list li, .primer-checklist li {
+  padding-left: 18px;
+  position: relative;
+}
+.primer-list li::before {
+  content: "?";
+  position: absolute;
+  left: 0;
+  color: var(--accent-mid);
+  font-weight: 700;
+}
+.primer-checklist li::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid var(--accent-mid);
+  border-radius: 2px;
+}
+
+.primer-figure-img {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  display: block;
+}
+
+.primer-graph { display: flex; justify-content: center; }
+.primer-graph-svg { width: 100%; height: auto; max-width: 460px; }
+.primer-graph-edge {
+  stroke: var(--border-strong);
+  stroke-width: 1.5;
+}
+.primer-graph-node-group { cursor: pointer; }
+.primer-graph-node {
+  fill: var(--bg-elevated);
+  stroke: var(--border-strong);
+  stroke-width: 1.5;
+  transition: filter 0.15s ease;
+}
+.primer-graph-node-group:hover .primer-graph-node { filter: brightness(1.15); }
+.primer-graph-node-center {
+  fill: var(--control-accent);
+  stroke: none;
+}
+.primer-graph-node-library {
+  stroke: var(--accent-mid);
+  stroke-width: 2;
+}
+.primer-graph-node-external {
+  stroke-dasharray: 3 2;
+}
+.primer-graph-node-text {
+  font-size: 9px;
+  fill: var(--text-secondary);
+  text-anchor: middle;
+  dominant-baseline: middle;
+  pointer-events: none;
+}
+.primer-graph-node-text-center {
+  fill: #ffffff;
+  font-weight: 700;
+  font-size: 10px;
+}
+
+.primer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 28px;
+  border-top: 1px solid var(--border);
+}
+
 .doc-title-edit-btn:hover {
   opacity: 1 !important;
   color: var(--accent-mid) !important;


### PR DESCRIPTION
# Summary
## 1. 기능/버그 수정사항 1 — 백엔드: 브리핑 생성 파이프라인
- `services/llm_client.py`에 `generate_reading_primer()` 추가 — 논문 도입부(초록 등)로 훅 문장 1개, 예측 질문 3개, 체크리스트 3개를 생성. Ollama/OpenAI/Gemini/Claude API/CLI(antigravity, claude_code, codex) 전부 지원하며, CLI provider는 번역·채팅·인사이트와 동일한 문서당 공유 세션(session_id)을 그대로 재사용
- `services/pdf_parser.py`에 `render_image_crop()` 추가 — 기존 `render_cover_image`의 PyMuPDF 크롭 기법을 임의 페이지/영역에 쓸 수 있도록 일반화
- `services/library.py`에 `get_primer_figure_path()`/`save_primer_figure()` 추가
- `services/primer.py`(신규) — 생성 오케스트레이션:
  - LLM 훅/질문/체크리스트
  - `extract_pdf_images`로 찾은 대표 Figure(가장 번호가 낮은 Figure) 크롭
  - 참고문헌 목록을 내 라이브러리의 다른 논문 제목과 텍스트 매칭(외부 API 없이 무료로 항상 실행)
  - 라이브러리에 없는 참고문헌 중 최대 5건만 시도해 최대 3건까지 Semantic Scholar로 확장 조회 — 연도/제목 단어 겹침으로 매칭 검증 후 신뢰할 만한 것만 채택(레이트리밋 등으로 엉뚱한 논문이 매칭되는 걸 방지)
  - 결과는 `page_insights` 테이블(`page_num=0, kind="primer"`)에 캐싱
- `routers/primer.py`(신규) — `GET /library/{doc_id}/primer`(캐시 없으면 그 자리에서 생성), `GET /library/{doc_id}/primer-figure`
- `routers/upload.py` — primer 생성을 완전히 마친 뒤에만 번역 잡을 시작하도록 순차 실행. CLI provider는 문서당 세션이 하나뿐이라 동시에 점유하면 안 되기 때문
- `main.py`에 primer 라우터 등록

## 2. 기능/버그 수정사항 2 — 프론트엔드: 게이팅 모달 + 인용 그래프
- `openFromLibrary`에 게이팅 로직 추가 — 설정에서 껐거나 이미 브리핑을 본 문서는 건너뜀. `primer_shown` 필드가 없는 구버전 문서는 "이미 열람한 적 있는지"(`read`/`last_page`)로 판단해 자동 백필, 갑자기 브리핑이 뜨지 않도록 함
- 인용 그래프에서 내 라이브러리의 다른 논문 노드를 클릭하면 그 논문으로 바로 이동 — 게이팅 중(뷰어 진입 전)에 이동하면 원래 문서 로딩과 동시 실행될 수 있어, redirect 시그널로 `openFromLibrary`가 순서대로 처리하도록 함(레이스 컨디션 방지)
- 뷰어 툴바에 재열람 버튼 추가 — 설정에서 껐어도 언제든 다시 볼 수 있음
- 순수 SVG로 방사형 인용 그래프 렌더링(신규 의존성 없음) — 내 라이브러리 매칭/외부 확장 매칭을 다른 스타일로 표시
- 설정에 "읽기 전 브리핑 표시" 토글 추가

## Test plan
- [x] `pytest backend/tests/` — 기존 무관 실패 1건 제외 169개 통과
- [x] `npm run build` — 정상 빌드
- [x] 실제 PDF 업로드 + Ollama(gemma4:e4b)로 전체 파이프라인(훅/질문/체크리스트/Figure 크롭/캐싱) end-to-end 검증
- [x] 실제 claude_code/codex/antigravity CLI로 `generate_reading_primer` 개별 검증(정상 파싱 확인)
- [x] primer-then-translate 순차 실행 구조 코드 검토로 CLI 세션 동시 점유 불가 확인