### PR TITLE
perf: 라이브러리 목록/문서 열기 성능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ CLAUDE.md
 # EasyPaper Local Databases & Storage
 backend/easypaper.db
 backend/easypaper.db-journal
+backend/easypaper.db-wal
+backend/easypaper.db-shm
 /cache/
 backend/uploads/
 backend/library/

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -287,13 +287,17 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
 
 @router.post("/settings/clear-pages-cache")
 async def clear_pages_cache(current_user: str = Depends(get_current_user)):
-    """모든 문서의 PDF 텍스트 추출 결과 디스크 캐시(extract_pages() 결과)를
-    삭제합니다. 이 캐시는 서버/앱 재시작 후 문서를 다시 열 때 PDF를 매번
-    재파싱하지 않도록 저장해두는 것으로, 지워도 다음 열람 시 자동으로
-    다시 채워지므로(ensure_session) 데이터 손실은 없습니다."""
-    from services.cache import clear_all_pages_cache
-    count, freed_bytes = clear_all_pages_cache()
-    return {"cleared_files": count, "freed_bytes": freed_bytes}
+    """모든 문서의 PDF 텍스트/이미지 추출 결과 디스크 캐시(extract_pages(),
+    extract_pdf_images() 결과)를 삭제합니다. 이 캐시는 서버/앱 재시작 후
+    문서를 다시 열 때 PDF를 매번 재파싱하지 않도록 저장해두는 것으로,
+    지워도 다음 열람 시 자동으로 다시 채워지므로 데이터 손실은 없습니다."""
+    from services.cache import clear_all_pages_cache, clear_all_images_cache
+    pages_count, pages_bytes = clear_all_pages_cache()
+    images_count, images_bytes = clear_all_images_cache()
+    return {
+        "cleared_files": pages_count + images_count,
+        "freed_bytes": pages_bytes + images_bytes,
+    }
 
 
 @router.get("/settings/ollama-status")

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -232,9 +232,14 @@ async def export_annotated_pdf(
 
 @router.get("/library/{doc_id}/cover")
 async def get_library_cover(doc_id: str, current_user: str = Depends(get_current_user)):
-    """라이브러리 카드 미리보기용 1페이지 상단(제목+abstract) 캡쳐 이미지를 서빙합니다."""
+    """라이브러리 카드 미리보기용 1페이지 상단(제목+abstract) 캡쳐 이미지를 서빙합니다.
+
+    최초 1회만 PyMuPDF로 렌더링하고 이후엔 파일만 서빙하지만(get_cover_path
+    내부에서 이미 캐싱), 그 최초 렌더링 자체가 동기 CPU 작업이라 이벤트
+    루프를 블로킹하지 않도록 스레드로 넘긴다."""
+    import asyncio
     _require_owned_document(doc_id, current_user)
-    cover_path = get_cover_path(doc_id)
+    cover_path = await asyncio.to_thread(get_cover_path, doc_id)
     if not cover_path:
         raise HTTPException(status_code=404, detail="미리보기 이미지를 생성할 수 없습니다.")
     return FileResponse(cover_path, media_type="image/jpeg", headers={"Cache-Control": "public, max-age=86400"})
@@ -267,15 +272,30 @@ async def delete_library_document_permanently(doc_id: str, current_user: str = D
 
 @router.get("/library/{doc_id}/images")
 async def get_library_document_images(doc_id: str, current_user: str = Depends(get_current_user)):
-    """특정 문서의 모든 페이지에서 이미지/Figure 좌표 정보(백분율) 목록을 반환합니다."""
+    """특정 문서의 모든 페이지에서 이미지/Figure 좌표 정보(백분율) 목록을 반환합니다.
+
+    find_tables()/get_drawings() 등을 페이지마다 두 차례 훑는 무거운 연산이라,
+    extract_pages()와 동일하게 디스크에 캐싱해 서버 재시작 이후에도 문서를
+    다시 열 때마다 재계산하지 않게 한다. 또한 이 연산은 완전히 동기
+    CPU-bound(PyMuPDF, GIL 점유)라 캐시 미스 시 asyncio 이벤트 루프를 그대로
+    블로킹하면 그동안 다른 요청(라이브러리 목록 등)이 전부 멈추므로,
+    별도 스레드로 넘긴다."""
+    import asyncio
+    from services.cache import get_cached_images, save_images_cache
+
     _require_owned_document(doc_id, current_user)
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
 
+    images = get_cached_images(doc_id, pdf_path)
+    if images is not None:
+        return {"images": images}
+
     try:
         from services.pdf_parser import extract_pdf_images
-        images = extract_pdf_images(pdf_path)
+        images = await asyncio.to_thread(extract_pdf_images, pdf_path)
+        save_images_cache(doc_id, pdf_path, images)
         return {"images": images}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"이미지 좌표 추출 실패: {str(e)}")
@@ -306,10 +326,18 @@ async def get_library_references(doc_id: str, current_user: str = Depends(get_cu
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
 
+    import asyncio
+    from services.cache import get_cached_pages, save_pages_cache
     from services.pdf_parser import extract_pages
     from services.reference_parser import extract_reference_list
     try:
-        pages = extract_pages(pdf_path)
+        # ensure_session()/get_cached_pages()와 같은 디스크 캐시를 공유한다 -
+        # 그렇지 않으면 세션이 아직 복원되지 않은 상태(서버 재시작 직후 첫
+        # 열람)에서 텍스트를 한 번 더 처음부터 추출하게 된다.
+        pages = get_cached_pages(doc_id, pdf_path)
+        if pages is None:
+            pages = await asyncio.to_thread(extract_pages, pdf_path)
+            save_pages_cache(doc_id, pdf_path, pages)
         references = extract_reference_list(pages)
     except Exception:
         references = {}

--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -133,3 +133,61 @@ def clear_all_pages_cache() -> "tuple[int, int]":
             except Exception:
                 pass
     return count, freed_bytes
+
+
+_IMAGES_CACHE_SUFFIX = "_images_extract.json"
+
+
+def _images_cache_path(doc_id: str) -> str:
+    return os.path.join(CACHE_DIR, f"{doc_id}{_IMAGES_CACHE_SUFFIX}")
+
+
+def get_cached_images(doc_id: str, pdf_path: str) -> Optional[list]:
+    """extract_pdf_images() 결과(그림/표 좌표)의 디스크 캐시를 반환합니다.
+    캐시가 없거나 원본 PDF의 mtime/크기가 저장 당시와 달라졌다면 None을
+    반환해 재추출을 유도합니다. get_cached_pages()와 동일한 방식이다 -
+    이 함수가 없으면 문서를 열 때마다 매번 PyMuPDF로 페이지별 표/그림
+    탐지(find_tables, get_drawings 등 비용이 큰 연산)를 처음부터 다시
+    수행하게 되어, 텍스트 추출 캐시가 있어도 열람이 계속 느리다."""
+    path = _images_cache_path(doc_id)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        stat = os.stat(pdf_path)
+        if data.get("mtime") != stat.st_mtime or data.get("size") != stat.st_size:
+            return None
+        return data.get("images")
+    except Exception:
+        return None
+
+
+def save_images_cache(doc_id: str, pdf_path: str, images: list) -> None:
+    """extract_pdf_images() 결과를 디스크에 캐싱합니다."""
+    try:
+        stat = os.stat(pdf_path)
+        atomic_write_text(_images_cache_path(doc_id), json.dumps({
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+            "images": images,
+        }, ensure_ascii=False))
+    except Exception:
+        pass
+
+
+def clear_all_images_cache() -> "tuple[int, int]":
+    """모든 문서의 이미지/표 좌표 추출 캐시 파일을 삭제합니다.
+    (삭제한 파일 개수, 확보한 바이트 수)를 반환합니다."""
+    count = 0
+    freed_bytes = 0
+    for fname in os.listdir(CACHE_DIR):
+        if fname.endswith(_IMAGES_CACHE_SUFFIX):
+            path = os.path.join(CACHE_DIR, fname)
+            try:
+                freed_bytes += os.path.getsize(path)
+                os.remove(path)
+                count += 1
+            except Exception:
+                pass
+    return count, freed_bytes

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -9,8 +9,13 @@ from typing import Optional, List, Dict, Any
 DB_PATH = os.getenv("DB_PATH") or os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "easypaper.db")
 
 def get_db():
-    conn = sqlite3.connect(DB_PATH)
+    # busy_timeout: 번역 잡이 쓰기 커넥션을 잡고 있는 동안(db_save_translation)
+    # 라이브러리 목록 등 읽기 커넥션이 "database is locked"로 즉시 실패하지
+    # 않고 잠깐 대기하도록 한다. journal_mode는 커넥션 단위가 아니라 DB
+    # 파일에 영속되는 설정이라 init_db()에서 한 번만 WAL로 전환해두면 된다.
+    conn = sqlite3.connect(DB_PATH, timeout=30)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 30000")
     return conn
 
 def init_db():
@@ -115,7 +120,22 @@ def init_db():
         )
         """)
 
+        # 라이브러리 목록/문서 조회가 doc_id(+suffix)로 translations를,
+        # doc_id로 documents/page_insights/chats를 매번 훑는데(문서 수 x
+        # 페이지 수만큼 뻥튀기됨) 인덱스가 없어 전부 풀스캔이었다. 목록
+        # 화면을 열 때마다, 그리고 4초 폴링마다 이 비용을 반복해서 냈다.
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_translations_doc_suffix ON translations(doc_id, suffix, page_num)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_translations_doc_saved ON translations(doc_id, saved_at)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_page_insights_doc ON page_insights(doc_id, kind, suffix)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_documents_username_deleted ON documents(username, is_deleted, created_at)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_chats_doc ON chats(doc_id, id)")
+
         conn.commit()
+
+        # WAL: 여러 읽기 커넥션이 번역 잡의 쓰기 커넥션과 부딪혀 잠기는
+        # 문제를 줄인다. 커넥션 단위 PRAGMA가 아니라 DB 파일에 영속되는
+        # 설정이라 여기서 한 번만 켜두면 이후 모든 커넥션에 적용된다.
+        conn.execute("PRAGMA journal_mode=WAL")
         
     # 기본 관리자 계정 초기 생성
     from config import get_app_username, get_app_password_hash
@@ -367,6 +387,36 @@ def db_list_translated_pages(doc_id: str, suffix: str = "") -> List[int]:
             (doc_id, suffix)
         )
         return [r["page_num"] for r in cursor.fetchall()]
+
+
+def db_bulk_translation_rows(doc_ids: List[str]) -> Dict[str, List[tuple]]:
+    """여러 문서의 (page_num, suffix, saved_at) 행을 한 번의 커넥션으로 모아
+    doc_id별로 묶어 반환합니다.
+
+    라이브러리 목록 화면은 문서마다 번역 완료 페이지 목록을 보여주는데,
+    예전에는 문서 개수(N)만큼 매번 새 sqlite3 커넥션을 열어 최대 3개의
+    쿼리를 던졌다(list_documents 참고). 문서가 늘어날수록, 그리고 4초
+    폴링이 반복될수록 이 비용이 그대로 누적돼 라이브러리 화면 자체가
+    느려지는 원인이었다. IN절 변수 개수 제한(SQLITE_MAX_VARIABLE_NUMBER,
+    보통 999)을 넘지 않도록 청크 단위로 나눠 조회한다.
+    """
+    result: Dict[str, list] = {doc_id: [] for doc_id in doc_ids}
+    if not doc_ids:
+        return result
+
+    CHUNK = 500
+    with get_db() as conn:
+        cursor = conn.cursor()
+        for i in range(0, len(doc_ids), CHUNK):
+            chunk = doc_ids[i:i + CHUNK]
+            placeholders = ",".join("?" for _ in chunk)
+            cursor.execute(
+                f"SELECT doc_id, page_num, suffix, saved_at FROM translations WHERE doc_id IN ({placeholders})",
+                chunk
+            )
+            for row in cursor.fetchall():
+                result[row["doc_id"]].append((row["page_num"], row["suffix"], row["saved_at"]))
+    return result
 
 
 # ── 채팅 (Chats) ──────────────────────────────────────────────────────────────

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -19,8 +19,25 @@ from services.db import (
     db_get_page_insight,
     db_clear_page_insights,
     db_update_document_metadata,
-    get_db
+    db_bulk_translation_rows,
 )
+
+
+def _resolve_translated_pages(rows: list, suffix: Optional[str]) -> list:
+    """(page_num, suffix, saved_at) 행 목록에서 문서 하나의 "번역 완료 페이지"
+    목록을 계산합니다. 요청한 suffix로 번역된 페이지가 있으면 그걸 쓰고,
+    없으면 가장 최근에 저장된 suffix의 페이지로 대체합니다(예전 설정으로
+    번역해둔 문서를 다른 target_lang/style로 열어도 목록이 비어 보이지
+    않도록). 원래 services/db.py의 db_get_translation()과 동일한 fallback
+    규칙이다."""
+    if not rows:
+        return []
+    if suffix:
+        pages = sorted({r[0] for r in rows if r[1] == suffix})
+        if pages:
+            return pages
+    fallback_suffix = max(rows, key=lambda r: r[2])[1]
+    return sorted({r[0] for r in rows if r[1] == fallback_suffix})
 
 def _pdf_path(doc_id: str) -> str:
     return os.path.join(LIBRARY_DIR, doc_id, "document.pdf")
@@ -60,39 +77,9 @@ def get_document(
         suffix = None
         if target_lang is not None and style is not None:
             suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
-            
-        with get_db() as conn:
-            cursor = conn.cursor()
-            pages = []
-            if suffix:
-                cursor.execute(
-                    "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? AND suffix = ? ORDER BY page_num ASC",
-                    (doc_id, suffix)
-                )
-                pages = [r["page_num"] for r in cursor.fetchall()]
-            
-            if not pages:
-                # Fallback to the most recent suffix's pages
-                cursor.execute(
-                    "SELECT suffix FROM translations WHERE doc_id = ? ORDER BY saved_at DESC LIMIT 1",
-                    (doc_id,)
-                )
-                row = cursor.fetchone()
-                if row:
-                    fallback_suffix = row["suffix"]
-                    cursor.execute(
-                        "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? AND suffix = ? ORDER BY page_num ASC",
-                        (doc_id, fallback_suffix)
-                    )
-                    pages = [r["page_num"] for r in cursor.fetchall()]
-                else:
-                    # If no suffix found, query any pages
-                    cursor.execute(
-                        "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? ORDER BY page_num ASC",
-                        (doc_id,)
-                    )
-                    pages = [r["page_num"] for r in cursor.fetchall()]
-        doc["translated_pages"] = pages
+
+        rows = db_bulk_translation_rows([doc_id]).get(doc_id, [])
+        doc["translated_pages"] = _resolve_translated_pages(rows, suffix)
         return doc
     return None
 
@@ -106,46 +93,23 @@ def list_documents(
     ignore_refs: Optional[bool] = None,
     only_trash: bool = False
 ) -> list:
-    """라이브러리의 문서를 최신순으로 반환합니다 (필터링 가능)."""
+    """라이브러리의 문서를 최신순으로 반환합니다 (필터링 가능).
+
+    예전에는 문서마다 새 SQLite 커넥션을 열어 최대 3개의 쿼리를 던졌다(N+1).
+    문서 수와 4초 주기 폴링이 곱해지며 라이브러리 화면 자체가 느려지는
+    주 원인이었던 부분 - 이제 전체 문서의 번역 행을 한 번의 커넥션으로 모아
+    메모리에서 매칭한다."""
     docs = db_list_documents(username, only_trash=only_trash)
-    
+    if not docs:
+        return docs
+
     suffix = None
     if target_lang is not None and style is not None:
         suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
 
+    rows_by_doc = db_bulk_translation_rows([doc["id"] for doc in docs])
     for doc in docs:
-        with get_db() as conn:
-            cursor = conn.cursor()
-            pages = []
-            if suffix:
-                cursor.execute(
-                    "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? AND suffix = ? ORDER BY page_num ASC",
-                    (doc["id"], suffix)
-                )
-                pages = [r["page_num"] for r in cursor.fetchall()]
-            
-            if not pages:
-                # Fallback to the most recent suffix's pages
-                cursor.execute(
-                    "SELECT suffix FROM translations WHERE doc_id = ? ORDER BY saved_at DESC LIMIT 1",
-                    (doc["id"],)
-                )
-                row = cursor.fetchone()
-                if row:
-                    fallback_suffix = row["suffix"]
-                    cursor.execute(
-                        "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? AND suffix = ? ORDER BY page_num ASC",
-                        (doc["id"], fallback_suffix)
-                    )
-                    pages = [r["page_num"] for r in cursor.fetchall()]
-                else:
-                    # If no suffix found, query any pages
-                    cursor.execute(
-                        "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? ORDER BY page_num ASC",
-                        (doc["id"],)
-                    )
-                    pages = [r["page_num"] for r in cursor.fetchall()]
-        doc["translated_pages"] = pages
+        doc["translated_pages"] = _resolve_translated_pages(rows_by_doc.get(doc["id"], []), suffix)
     return docs
 
 
@@ -156,14 +120,13 @@ def search_documents(username: str, query: str, only_trash: bool = False) -> lis
     if not query:
         return []
     docs = db_search_documents(username, query, only_trash=only_trash)
+    if not docs:
+        return docs
+
+    rows_by_doc = db_bulk_translation_rows([doc["id"] for doc in docs])
     for doc in docs:
-        with get_db() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT DISTINCT page_num FROM translations WHERE doc_id = ? ORDER BY page_num ASC",
-                (doc["id"],)
-            )
-            doc["translated_pages"] = [r["page_num"] for r in cursor.fetchall()]
+        pages = sorted({r[0] for r in rows_by_doc.get(doc["id"], [])})
+        doc["translated_pages"] = pages
     return docs
 
 

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -78,3 +78,32 @@ def test_app_meta_get_set_round_trip(isolated_dirs):
     # 같은 키를 다시 쓰면 덮어써야 한다 (INSERT가 아니라 upsert)
     db.db_set_meta("some_key", "value2")
     assert db.db_get_meta("some_key") == "value2"
+
+
+def test_bulk_translation_rows_groups_by_doc_id(isolated_dirs):
+    """list_documents()의 N+1 쿼리를 대체하는 벌크 조회 함수 - 문서마다 새
+    커넥션을 여는 대신 한 번의 커넥션으로 여러 문서의 번역 행을 모아온다."""
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_document("doc-2", "admin", "p2.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "a", suffix="ko_formal")
+    db.db_save_translation("doc-1", 2, "b", suffix="ko_formal")
+    db.db_save_translation("doc-2", 5, "c", suffix="en_casual")
+
+    rows = db.db_bulk_translation_rows(["doc-1", "doc-2"])
+    assert sorted(r[0] for r in rows["doc-1"]) == [1, 2]
+    assert {r[1] for r in rows["doc-1"]} == {"ko_formal"}
+    assert sorted(r[0] for r in rows["doc-2"]) == [5]
+
+
+def test_bulk_translation_rows_returns_empty_list_for_doc_without_translations(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+
+    rows = db.db_bulk_translation_rows(["doc-1"])
+    assert rows == {"doc-1": []}
+
+
+def test_bulk_translation_rows_empty_doc_ids_returns_empty_dict(isolated_dirs):
+    db = isolated_dirs["db"]
+    assert db.db_bulk_translation_rows([]) == {}

--- a/backend/tests/test_images_cache.py
+++ b/backend/tests/test_images_cache.py
@@ -1,0 +1,65 @@
+"""services/cache.py의 이미지/표 좌표 추출 결과 디스크 캐시(get_cached_images /
+save_images_cache / clear_all_images_cache) 테스트.
+
+extract_pdf_images()는 페이지마다 find_tables()/get_drawings() 등을 두
+차례씩 훑는 무거운 연산이라, extract_pages()와 동일하게 디스크에 캐싱해
+서버 재시작 이후에도 문서를 다시 열 때마다 재계산하지 않게 한다."""
+
+import os
+
+from services.cache import get_cached_images, save_images_cache, clear_all_images_cache
+
+
+def _make_pdf(path, size_bytes=200):
+    with open(path, "wb") as f:
+        f.write(b"%PDF-1.4 fake" + b"\0" * size_bytes)
+
+
+def test_cache_miss_when_never_saved(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    assert get_cached_images("doc-1", str(pdf_path)) is None
+
+
+def test_saved_images_are_returned_on_cache_hit(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    images = [{"page": 1, "bbox": [0.1, 0.1, 0.5, 0.5], "label": "Figure 1"}]
+
+    save_images_cache("doc-1", str(pdf_path), images)
+
+    assert get_cached_images("doc-1", str(pdf_path)) == images
+
+
+def test_cache_invalidated_when_pdf_content_changes(isolated_dirs, tmp_path):
+    """PDF가 (같은 경로에서) 다른 내용으로 교체되면(mtime/크기 변경),
+    오래된 캐시를 그대로 신뢰하지 않고 재추출을 유도해야 한다."""
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path, size_bytes=200)
+    save_images_cache("doc-1", str(pdf_path), [{"page": 1, "bbox": [0, 0, 1, 1]}])
+
+    import time
+    time.sleep(0.01)
+    _make_pdf(pdf_path, size_bytes=500)
+
+    assert get_cached_images("doc-1", str(pdf_path)) is None
+
+
+def test_clear_all_images_cache_removes_only_images_cache_files(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    _make_pdf(pdf_path)
+    save_images_cache("doc-1", str(pdf_path), [{"page": 1, "bbox": [0, 0, 1, 1]}])
+    save_images_cache("doc-2", str(pdf_path), [{"page": 1, "bbox": [0, 0, 1, 1]}])
+
+    # 다른 종류의 캐시 파일(페이지 텍스트 캐시)은 영향을 받으면 안 됨
+    from services.cache import save_pages_cache, get_cached_pages
+    save_pages_cache("doc-1", str(pdf_path), [{"page_num": 1, "text": "hello"}])
+
+    count, freed_bytes = clear_all_images_cache()
+
+    assert count == 2
+    assert freed_bytes > 0
+    assert get_cached_images("doc-1", str(pdf_path)) is None
+    assert get_cached_images("doc-2", str(pdf_path)) is None
+    assert get_cached_pages("doc-1", str(pdf_path)) == [{"page_num": 1, "text": "hello"}], \
+        "페이지 텍스트 캐시는 지워지면 안 됨"

--- a/backend/tests/test_library_images_api.py
+++ b/backend/tests/test_library_images_api.py
@@ -1,0 +1,44 @@
+"""GET /library/{doc_id}/images HTTP 레벨 테스트.
+
+extract_pdf_images()는 페이지마다 find_tables()/get_drawings() 등을 두
+차례씩 훑는 무거운 연산이다. 텍스트 추출(extract_pages)과 달리 예전에는
+디스크 캐시가 전혀 없어 문서를 열 때마다(같은 세션 안에서도) 매번
+처음부터 재계산했다 - 이 테스트는 그 디스크 캐시가 실제로 재계산을
+막아주는지 확인한다."""
+
+from unittest.mock import patch
+
+
+def _create_doc(isolated_dirs, doc_id="doc-1", username="testuser"):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "Test Paper"})
+
+
+def test_get_images_extracts_and_caches(test_client, isolated_dirs, tmp_path):
+    _create_doc(isolated_dirs)
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 200)
+
+    fake_images = [{"page": 1, "bbox": [0.1, 0.1, 0.5, 0.5], "label": "Figure 1"}]
+    with patch("services.pdf_parser.extract_pdf_images", return_value=fake_images) as mock_extract, \
+         patch("routers.library.get_pdf_path", return_value=str(pdf_path)):
+        res = test_client.get("/api/library/doc-1/images")
+
+    assert res.status_code == 200
+    assert res.json()["images"] == fake_images
+    mock_extract.assert_called_once()
+
+    # 두 번째 호출은 디스크 캐시를 써야 하므로 extract_pdf_images가 다시 호출되지 않아야 한다
+    with patch("services.pdf_parser.extract_pdf_images") as mock_extract2, \
+         patch("routers.library.get_pdf_path", return_value=str(pdf_path)):
+        res2 = test_client.get("/api/library/doc-1/images")
+
+    assert res2.status_code == 200
+    assert res2.json()["images"] == fake_images
+    mock_extract2.assert_not_called()
+
+
+def test_get_images_other_users_document_returns_404(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, doc_id="doc-other", username="otheruser")
+    res = test_client.get("/api/library/doc-other/images")
+    assert res.status_code == 404

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -46,3 +46,88 @@ def test_permanently_delete_document_cleans_up_all_locations(isolated_dirs):
 def test_permanently_delete_nonexistent_document_returns_false(isolated_dirs):
     library = isolated_dirs["library"]
     assert library.permanently_delete_document("no-such-doc") is False
+
+
+# list_documents()/get_document()의 translated_pages 계산은 예전에 문서마다
+# 새 SQLite 커넥션을 열어 최대 3개의 쿼리를 던지는 N+1 패턴이었다(성능
+# 문제). 여러 문서의 번역 행을 한 번에 모아 메모리에서 매칭하도록
+# 바꿨는데, 이 리팩터링이 기존 suffix-fallback 규칙과 문서별 격리를 그대로
+# 유지하는지가 핵심 리스크라 아래에서 확인한다.
+
+def test_list_documents_returns_pages_for_matching_suffix(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "번역1", suffix="ko_formal")
+    db.db_save_translation("doc-1", 2, "번역2", suffix="ko_formal")
+
+    docs = library.list_documents("admin", target_lang="ko", style="formal", ignore_math=False, ignore_table=False, ignore_refs=False)
+    assert docs[0]["translated_pages"] == [1, 2]
+
+
+def test_list_documents_falls_back_to_most_recent_suffix_when_no_match(isolated_dirs):
+    """요청한 suffix(예: 새 target_lang/style)로 번역된 페이지가 없으면,
+    가장 최근에 저장된 다른 suffix의 번역 페이지를 대신 보여줘야 한다."""
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "old", suffix="en_casual")
+
+    docs = library.list_documents("admin", target_lang="ko", style="formal", ignore_math=False, ignore_table=False, ignore_refs=False)
+    assert docs[0]["translated_pages"] == [1]
+
+
+def test_list_documents_isolates_translated_pages_per_document(isolated_dirs):
+    """여러 문서의 번역 행을 한 번의 쿼리로 모아오는 방식이라, 다른 문서의
+    페이지가 서로 뒤섞이지 않아야 한다."""
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_document("doc-2", "admin", "p2.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "d1p1")
+    db.db_save_translation("doc-1", 2, "d1p2")
+    db.db_save_translation("doc-2", 5, "d2p5")
+
+    docs = library.list_documents("admin")
+    by_id = {d["id"]: d["translated_pages"] for d in docs}
+    assert by_id["doc-1"] == [1, 2]
+    assert by_id["doc-2"] == [5]
+
+
+def test_list_documents_with_no_translations_returns_empty_pages(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+
+    docs = library.list_documents("admin")
+    assert docs[0]["translated_pages"] == []
+
+
+def test_get_document_returns_pages_for_matching_suffix(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "번역1", suffix="ko_formal")
+
+    doc = library.get_document("doc-1", target_lang="ko", style="formal", ignore_math=False, ignore_table=False, ignore_refs=False)
+    assert doc["translated_pages"] == [1]
+
+
+def test_get_document_falls_back_to_most_recent_suffix_when_no_match(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "old", suffix="en_casual")
+
+    doc = library.get_document("doc-1", target_lang="ko", style="formal", ignore_math=False, ignore_table=False, ignore_refs=False)
+    assert doc["translated_pages"] == [1]
+
+
+def test_get_document_without_suffix_uses_most_recent_translation(isolated_dirs):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-1", "admin", "p1.pdf", "/x", 3, {})
+    db.db_save_translation("doc-1", 1, "번역1")
+
+    doc = library.get_document("doc-1")
+    assert doc["translated_pages"] == [1]

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1551,11 +1551,18 @@ async function checkAuthentication() {
     globalLogoutBtn.classList.remove('hidden')
     globalSettingsBtn.classList.remove('hidden')
     if (location.hash && location.hash.startsWith('#viewer?id=')) {
+      // 뷰어로 바로 진입하는 경로라 라이브러리 화면이 렌더링되지 않으므로,
+      // 안읽음 배지/휴지통 탭 표시는 별도로 한 번 조회해서 채워야 한다.
       await handleRouting()
+      await loadLibraryCount()
     } else {
+      // showLibraryScreen() -> renderLibrary()가 이미 문서 목록을 받아와
+      // 배지/휴지통 탭까지 갱신하므로, 여기서 loadLibraryCount()를 또 불러
+      // GET /api/library(+trash)를 중복으로 쏠 필요가 없다. 앱 부팅 시마다
+      // 라이브러리 목록을 사실상 두 번 불러오던 게 체감 로딩을 늘리던
+      // 원인 중 하나였다.
       await showLibraryScreen()
     }
-    await loadLibraryCount()
     await refreshSystemSettings()
     maybeShowOnboarding()
     // 업데이트 직후(방금 재시작됨) 안내가 있으면 그것부터 먼저 보여주고, 없을
@@ -1619,7 +1626,6 @@ if (libEmptyTrashBtn) {
       await emptyLibraryTrash()
       showToast('휴지통이 비워졌습니다.', 'success')
       await renderLibrary()
-      await loadLibraryCount()
     } catch (err) {
       showToast('휴지통 비우기 실패: ' + err.message, 'error')
     }
@@ -3343,37 +3349,58 @@ checkAIStatus()
 setInterval(checkAIStatus, 30000)
 
 // ── 라이브러리 화면 ────────────────────────────────
-async function loadLibraryCount() {
-  try {
-    const data = await fetchLibrary(getTranslationOptions())
-    const docs = data.documents || []
-    const unreadCount = docs.filter(doc => doc.metadata?.read !== true).length
-    if (unreadCount > 0 && libraryCountBadge) {
-      libraryCountBadge.textContent = unreadCount
-      libraryCountBadge.classList.remove('hidden')
-    } else if (libraryCountBadge) {
-      libraryCountBadge.classList.add('hidden')
-    }
-  } catch {}
+// 이미 어딘가에서 fetchLibrary()로 받아온 문서 목록이 있을 때 그 결과로
+// 배지만 갱신한다(추가 네트워크 요청 없음). renderLibrary()와
+// loadLibraryCount() 양쪽에서 공유해서 쓰기 위해 분리했다 - 예전에는 이
+// 배지 갱신 로직이 양쪽에 중복 구현되어 있어서, "보관함 표시/삭제/복원"
+// 등 문서 하나를 조작할 때마다 renderLibrary()가 이미 새로 받아온 목록이
+// 있는데도 loadLibraryCount()가 GET /api/library를 한 번 더(+휴지통까지)
+// 쏴서 화면 갱신이 체감상 두 배로 느려졌었다.
+function updateUnreadBadge(docs) {
+  const unreadCount = docs.filter(doc => doc.metadata?.read !== true).length
+  if (unreadCount > 0 && libraryCountBadge && state.currentLibraryTab !== 'trash') {
+    libraryCountBadge.textContent = unreadCount
+    libraryCountBadge.classList.remove('hidden')
+  } else if (libraryCountBadge) {
+    libraryCountBadge.classList.add('hidden')
+  }
+}
 
-  // 동적 휴지통 탭 노출 여부 및 배지 카운트 표시 처리
+function updateTrashTabVisibility(trashDocs) {
+  if (!libTabTrash) return
+  const trashCount = trashDocs.length
+  if (trashCount > 0 || state.currentLibraryTab === 'trash') {
+    libTabTrash.classList.remove('hidden')
+    libTabTrash.title = `휴지통 (${trashCount}개 문서)`
+    libTabTrash.innerHTML = icon('trash2', 14)
+  } else {
+    libTabTrash.classList.add('hidden')
+  }
+}
+
+// 휴지통 탭 노출 여부/배지는 현재 보고 있는 탭이 무엇이든 항상 최신이어야
+// 하는데, 그러려면 archive/history 탭을 보고 있을 때도 휴지통 목록을 별도로
+// 조회해야 한다(현재 탭의 목록과는 다른 데이터라 재사용 불가). 화면
+// 갱신을 막지 않도록 호출부에서 await 없이 백그라운드로 실행한다.
+async function refreshTrashTabVisibility() {
   try {
     const trashData = await fetchLibraryTrash(getTranslationOptions())
-    const trashDocs = trashData.documents || []
-    const trashCount = trashDocs.length
-
-    if (libTabTrash) {
-      if (trashCount > 0 || state.currentLibraryTab === 'trash') {
-        libTabTrash.classList.remove('hidden')
-        libTabTrash.title = `휴지통 (${trashCount}개 문서)`
-        libTabTrash.innerHTML = icon('trash2', 14)
-      } else {
-        libTabTrash.classList.add('hidden')
-      }
-    }
+    updateTrashTabVisibility(trashData.documents || [])
   } catch (err) {
     console.error('휴지통 개수 조회 실패:', err)
   }
+}
+
+// 라이브러리 화면이 아직 렌더링되지 않은 상태(예: 뷰어 화면)에서 배지만
+// 갱신해야 할 때 쓰는, 처음부터 새로 fetch하는 버전. 라이브러리 화면이 이미
+// 최신 목록을 렌더링해둔 상태라면 이 함수 대신 updateUnreadBadge()+
+// refreshTrashTabVisibility()를 직접 쓰는 쪽이 중복 요청을 피할 수 있다.
+async function loadLibraryCount() {
+  try {
+    const data = await fetchLibrary(getTranslationOptions())
+    updateUnreadBadge(data.documents || [])
+  } catch {}
+  await refreshTrashTabVisibility()
 }
 
 // 탭 클릭 이벤트 리스너 등록
@@ -3849,12 +3876,17 @@ async function renderLibrary() {
     const allDocs = data.documents || []
 
     // 보관함 뱃지에는 안읽은 논문 개수 표시 (휴지통이 아닐 때만 적용하거나, archive 기준 개수 표시)
-    const unreadCount = allDocs.filter(doc => doc.metadata?.read !== true).length
-    if (unreadCount > 0 && libraryCountBadge && state.currentLibraryTab !== 'trash') {
-      libraryCountBadge.textContent = unreadCount
-      libraryCountBadge.classList.remove('hidden')
-    } else if (libraryCountBadge) {
-      libraryCountBadge.classList.add('hidden')
+    updateUnreadBadge(allDocs)
+
+    // 휴지통 탭 노출 여부/배지도 여기서 함께 최신화한다 - 문서 하나를
+    // 조작한 뒤(읽음 표시/삭제/복원 등) 호출부가 매번 loadLibraryCount()를
+    // 별도로 또 호출해 GET /api/library(+trash)를 중복으로 쏘지 않도록.
+    // 지금 보고 있는 탭이 마침 휴지통이면 이미 받아온 목록을 그대로 쓰고,
+    // 아니면 화면 갱신을 막지 않게 백그라운드로 별도 조회한다.
+    if (state.currentLibraryTab === 'trash') {
+      updateTrashTabVisibility(allDocs)
+    } else {
+      refreshTrashTabVisibility()
     }
 
     // 현재 선택된 탭에 따라 논문 목록 필터링
@@ -4510,7 +4542,6 @@ function wireDocItemEvents(container, doc, displayTitle) {
         await updateLibraryDocMetadata(doc.id, payload)
         showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
         await renderLibrary()
-        await loadLibraryCount()
       } catch (err) {
         showToast('상태 변경 실패: ' + err.message, 'error')
       }
@@ -4540,7 +4571,6 @@ function wireDocItemEvents(container, doc, displayTitle) {
         await deleteLibraryDoc(doc.id)
         showToast('휴지통으로 이동되었습니다.', 'success')
         await renderLibrary()
-        await loadLibraryCount()
       } catch {
         showToast('삭제 실패', 'error')
       }
@@ -4555,7 +4585,6 @@ function wireDocItemEvents(container, doc, displayTitle) {
         await restoreLibraryDoc(doc.id)
         showToast('논문이 복원되었습니다.', 'success')
         await renderLibrary()
-        await loadLibraryCount()
       } catch (err) {
         showToast('복원 실패: ' + err.message, 'error')
       }


### PR DESCRIPTION
# Summary
## 1. 이미지/표 좌표 추출 결과 디스크 캐싱 및 스레드 오프로딩
- `services/cache.py`: `get_cached_images`/`save_images_cache`/`clear_all_images_cache` 추가 - `get_cached_pages`(텍스트 추출 캐시)와 동일한 mtime/size 검증 방식
- `routers/library.py`의 `GET /library/{doc_id}/images`: 캐시 조회 후 미스일 때만 `extract_pdf_images`를 `asyncio.to_thread`로 실행하고 결과를 캐시에 저장 - 기존에는 캐시가 전혀 없어 문서를 열 때마다 매번 PyMuPDF로 페이지별 `find_tables()`/`get_drawings()`를 재계산했고, 이 연산이 `async def` 안에서 동기로 실행돼 이벤트 루프 전체(다른 요청 포함)를 블로킹했음
- `GET /library/{doc_id}/references`: 원문 텍스트 추출 시 `get_cached_pages`/`save_pages_cache`를 재사용하도록 변경(기존엔 `extract_pages`를 캐시 없이 직접 호출), 추출도 스레드로 오프로딩
- `GET /library/{doc_id}/cover`: 최초 렌더링(PyMuPDF)도 스레드로 오프로딩
- `routers/auth.py`의 `/settings/clear-pages-cache`: 이미지 캐시도 함께 정리하도록 확장

## 2. 라이브러리 목록/문서 조회 N+1 쿼리 제거
- `services/db.py`: `db_bulk_translation_rows()` 추가 - 여러 문서의 번역 행을 한 번의 커넥션으로 모아옴 (기존엔 문서마다 새 `sqlite3.connect()`를 열어 최대 3개 쿼리를 던지는 N+1 패턴)
- `services/library.py`: `list_documents()`/`get_document()`/`search_documents()`가 위 벌크 조회 + `_resolve_translated_pages()`(suffix 매칭/최근 suffix 폴백 규칙을 그대로 보존)로 동작하도록 재작성
- `services/db.py`: `translations`/`page_insights`/`documents`/`chats`에 인덱스 추가(기존엔 전무해서 위 쿼리들이 풀스캔이었음), WAL 저널 모드 + `busy_timeout` 적용(번역 잡의 쓰기 커넥션과 목록 조회용 읽기 커넥션이 부딪히는 문제 완화)

## 3. 프론트엔드 라이브러리 화면 중복 네트워크 요청 제거
- `main.js`: `renderLibrary()`가 이미 방금 받아온 문서 목록으로 안읽음 배지/휴지통 탭 노출 여부를 함께 갱신하도록 `updateUnreadBadge()`/`updateTrashTabVisibility()`/`refreshTrashTabVisibility()`로 분리
- 문서 읽음 표시·삭제·복원·휴지통 비우기 이벤트 핸들러에서 `renderLibrary()` 직후 중복으로 `GET /api/library`(+`/library/trash`)를 다시 쏘던 `loadLibraryCount()` 호출 제거
- 앱 부팅(로그인 직후) 시 라이브러리 화면으로 진입하는 경로에서도 동일한 중복 호출 제거 - `#viewer?id=`로 바로 진입하는 경로만 별도로 `loadLibraryCount()` 유지(라이브러리 화면이 렌더링되지 않아 배지 정보가 없으므로)

## 4. 검증
- 백엔드 유닛/API 테스트 신규 추가: `test_images_cache.py`, `test_library_images_api.py`, `test_db_service.py`/`test_library_service.py`에 N+1 리팩터링 회귀 테스트(suffix 폴백, 문서 간 격리 등) 추가
- 전체 테스트 스위트 185개 통과(기존에 있던 무관한 환경 이슈 1건 제외)
- 백엔드/프론트 개발 서버를 직접 띄우고 Playwright로 로그인→문서 열기→뒤로가기→삭제 흐름을 구동해 네트워크 로그 상 중복 요청이 사라졌고, 이미지 추출 캐시가 실제로 히트하는 것(137ms→3ms)을 확인