### PR TITLE
design: 읽기 전 브리핑 모달을 이모지 대신 아이콘 배지 기반으로 재디자인

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1043,30 +1043,50 @@
       </div>
 
       <div id="primer-body" class="primer-body hidden">
-        <h2 id="primer-title" class="primer-title"></h2>
+        <div class="primer-header">
+          <div class="primer-header-badge">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+          </div>
+          <div class="primer-header-text">
+            <span class="primer-eyebrow">읽기 전 브리핑</span>
+            <h2 id="primer-title" class="primer-title"></h2>
+          </div>
+        </div>
 
-        <div id="primer-hook-section" class="primer-section primer-hook-section hidden">
-          <h3>💡 이 논문이 다루는 문제</h3>
+        <div id="primer-hook-section" class="primer-hook-section hidden">
+          <span class="primer-hook-quote">&ldquo;</span>
           <p id="primer-hook-text" class="primer-hook-text"></p>
         </div>
 
-        <div id="primer-questions-section" class="primer-section hidden">
-          <h3>🤔 읽기 전에 스스로 답해보기</h3>
-          <ul id="primer-questions" class="primer-list"></ul>
+        <div id="primer-questions-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+            <span>읽기 전에 스스로 답해보기</span>
+          </div>
+          <ol id="primer-questions" class="primer-list"></ol>
         </div>
 
-        <div id="primer-figure-section" class="primer-section primer-figure-section hidden">
-          <h3>🖼️ 핵심 그림 먼저 보기</h3>
+        <div id="primer-figure-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+            <span>핵심 그림 먼저 보기</span>
+          </div>
           <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
         </div>
 
-        <div id="primer-checklist-section" class="primer-section hidden">
-          <h3>✅ 읽으면서 확인할 것</h3>
+        <div id="primer-checklist-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+            <span>읽으면서 확인할 것</span>
+          </div>
           <ul id="primer-checklist" class="primer-checklist"></ul>
         </div>
 
-        <div id="primer-graph-section" class="primer-section primer-graph-section hidden">
-          <h3>🔗 이 논문과 연결된 논문</h3>
+        <div id="primer-graph-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+            <span>이 논문과 연결된 논문</span>
+          </div>
           <div id="primer-graph" class="primer-graph"></div>
         </div>
       </div>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1584,13 +1584,13 @@ body.light-theme .toast.error { color: #dc2626; }
 .primer-content {
   background: var(--bg-surface);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius-lg);
+  border-radius: 24px;
   width: 92%;
-  max-width: 620px;
+  max-width: 600px;
   max-height: 86vh;
   display: flex;
   flex-direction: column;
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 30px 60px -12px rgba(0, 0, 0, 0.5);
   position: relative;
   transform: scale(0.95);
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -1599,8 +1599,8 @@ body.light-theme .toast.error { color: #dc2626; }
 
 .primer-close-btn {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 16px;
+  right: 16px;
   z-index: 1;
 }
 
@@ -1609,13 +1609,13 @@ body.light-theme .toast.error { color: #dc2626; }
   flex-direction: column;
   align-items: center;
   gap: 14px;
-  padding: 60px 20px;
+  padding: 64px 20px;
 }
 .primer-loading .spinner { width: 26px; height: 26px; border-width: 3px; }
 .primer-loading p { font-size: 13.5px; color: var(--text-secondary); }
 
 .primer-error {
-  padding: 60px 20px;
+  padding: 64px 20px;
   text-align: center;
   color: var(--text-secondary);
   font-size: 13.5px;
@@ -1623,70 +1623,166 @@ body.light-theme .toast.error { color: #dc2626; }
 
 .primer-body {
   overflow-y: auto;
-  padding: 32px 28px 8px;
+  padding: 30px 30px 10px;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 26px;
 }
 
-.primer-title {
-  font-size: 17px;
-  font-weight: 700;
-  color: var(--text-primary);
+/* 헤더: 아이콘 배지 + "읽기 전 브리핑" 킥커 + 논문 제목 */
+.primer-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
   padding-right: 24px;
 }
-
-.primer-section h3 {
-  font-size: 13.5px;
-  font-weight: 600;
+.primer-header-badge {
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
+  color: #fff;
+  box-shadow: 0 4px 14px var(--accent-glow);
+}
+.primer-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.primer-eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-to, var(--accent-mid));
+}
+.primer-title {
+  font-size: 18px;
+  font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 8px;
+  line-height: 1.35;
 }
 
+/* 훅: 이 브리핑의 헤드라인 역할 - 인용구처럼 크게 강조 */
+.primer-hook-section {
+  position: relative;
+  padding-left: 20px;
+}
+.primer-hook-quote {
+  position: absolute;
+  left: -4px;
+  top: -14px;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 52px;
+  font-weight: 700;
+  line-height: 1;
+  color: transparent;
+  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
+  -webkit-background-clip: text;
+  background-clip: text;
+  opacity: 0.4;
+  pointer-events: none;
+  user-select: none;
+}
 .primer-hook-text {
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.55;
   color: var(--text-primary);
-  background: var(--bg-elevated);
-  border-left: 3px solid var(--accent-mid);
-  border-radius: var(--radius-sm);
-  padding: 12px 14px;
+  letter-spacing: -0.01em;
+}
+
+/* 섹션 공용 라벨(아이콘 배지 + 텍스트) */
+.primer-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.primer-label-icon {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text, var(--accent-mid));
+}
+.primer-label span:last-child {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--text-primary);
 }
 
 .primer-list, .primer-checklist {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 9px;
   font-size: 13.5px;
   color: var(--text-secondary);
   line-height: 1.5;
 }
-.primer-list li, .primer-checklist li {
-  padding-left: 18px;
+.primer-list {
+  counter-reset: primer-question;
+}
+.primer-list li {
+  padding-left: 26px;
   position: relative;
 }
 .primer-list li::before {
-  content: "?";
+  counter-increment: primer-question;
+  content: counter(primer-question);
   position: absolute;
   left: 0;
-  color: var(--accent-mid);
+  top: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text, var(--accent-mid));
+  font-size: 10.5px;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.primer-checklist li {
+  padding-left: 24px;
+  position: relative;
 }
 .primer-checklist li::before {
   content: "";
   position: absolute;
-  left: 2px;
-  top: 6px;
-  width: 8px;
-  height: 8px;
-  border: 1.5px solid var(--accent-mid);
-  border-radius: 2px;
+  left: 1px;
+  top: 3px;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: 5px;
+}
+.primer-checklist li::after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 6.5px;
+  width: 7px;
+  height: 4px;
+  border-left: 1.5px solid var(--accent-mid);
+  border-bottom: 1.5px solid var(--accent-mid);
+  transform: rotate(-45deg);
 }
 
 .primer-figure-img {
   max-width: 100%;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   display: block;
 }
@@ -1733,7 +1829,7 @@ body.light-theme .toast.error { color: #dc2626; }
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  padding: 16px 28px;
+  padding: 18px 30px;
   border-top: 1px solid var(--border);
 }
 


### PR DESCRIPTION
# Summary
## 1. 헤더 재구성
- 그라데이션 아이콘 배지 + "읽기 전 브리핑" 킥커 라벨 + 논문 제목 구조로 정리

## 2. 훅 문장 강조
- 대형 인용부호(그라데이션 텍스트) + 굵은 헤드라인 스타일로 브리핑의 "메인 카피" 역할을 하도록 시각적 위계를 가장 높게 조정

## 3. 섹션 라벨에서 이모지 전면 제거
- 💡🤔🖼️✅🔗 이모지를 전부 SVG 아이콘(help-circle, image, list-checks, network)으로 교체하고, 톤온톤 배지 안에 넣는 형태로 통일

## 4. 리스트 스타일 개선
- 예측 질문: "?" 문자 대신 원형 번호 배지(1·2·3), `<ul>`을 의미적으로 맞는 `<ol>`로 변경
- 체크리스트: 테두리 사각형 흉내 대신 실제 체크 아이콘 스타일

## 5. 모달 컨테이너 톤 통일
- border-radius 14px → 24px, 그림자를 논문 미리보기 카드(doc-preview-card)와 동일한 톤으로 맞춤
- 더 이상 CSS에서 참조되지 않는 `.primer-section` 계열 클래스 정리

## Test plan
- [x] `npm run build` — 정상 빌드
- [x] Playwright(헤드리스 크로미움)로 빌드된 dist를 직접 렌더링해 다크/라이트 테마 스크린샷 확인
- [x] 모달 스크롤 동작(콘텐츠가 많을 때 본문만 스크롤, 헤더 닫기 버튼/푸터는 고정) 확인