### PR TITLE
feat: 연관 논문 그래프를 참고문헌 매칭 대신 LLM 추천 + 실존 검증 방식으로 개선

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -868,7 +868,7 @@ async def stream_page_insight(
 
 
 _PRIMER_LINE_RE = re.compile(
-    r'^[\s\-\*>]*\**\s*(HOOK|Q1|Q2|Q3|CHECK1|CHECK2|CHECK3)\**\s*[:.\)]\s*(.+)$',
+    r'^[\s\-\*>]*\**\s*(HOOK|Q1|Q2|Q3|CHECK1|CHECK2|CHECK3|REC1|REC2|REC3|REC4|REC5)\**\s*[:.\)]\s*(.+)$',
     re.IGNORECASE,
 )
 
@@ -876,9 +876,17 @@ _PRIMER_LINE_RE = re.compile(
 async def generate_reading_primer(title: str, text: str, target_lang: str = "한국어", session_id: str = None) -> dict:
     """
     논문 제목과 도입부(초록 등) 원문으로 "읽기 전 브리핑" 콘텐츠(훅 문장, 예측 질문 3개,
-    읽으면서 확인할 체크리스트 3개)를 생성합니다. 채팅(Chat) 프로바이더/모델 설정을
-    재사용하며, stream_page_insight와 마찬가지로 세션이 지속되는 CLI provider는
-    번역/채팅/인사이트와 동일한 문서당 공유 세션(session_id)을 그대로 사용합니다.
+    읽으면서 확인할 체크리스트 3개, 관련 논문 추천 최대 5개)를 생성합니다. 채팅(Chat)
+    프로바이더/모델 설정을 재사용하며, stream_page_insight와 마찬가지로 세션이 지속되는
+    CLI provider는 번역/채팅/인사이트와 동일한 문서당 공유 세션(session_id)을 그대로
+    사용합니다.
+
+    관련 논문은 이 논문의 참고문헌 목록을 텍스트로 기계적으로 매칭하지 않고, LLM이 자기
+    지식으로 직접 추천하게 한다 - 참고문헌 목록 매칭 방식은 인용 형식이 지저분하거나
+    따옴표로 감싼 제목이 없는 스타일이면 매칭 개수가 너무 적고, 매칭되더라도 이 논문의
+    참고문헌으로 한정돼 "관련성"이 아니라 "우연히 잘 파싱된 것"에 가까웠다. LLM 추천은
+    환각 위험이 있으므로, 호출부(primer.py)에서 실제로 존재하는 논문인지 OpenAlex로
+    다시 검증한 뒤에만 채택한다.
     """
     instruction = (
         f"다음은 학술 논문 '{title}'의 도입부(초록 등) 원문입니다. 이 논문을 읽기 전 독자가 "
@@ -887,67 +895,89 @@ async def generate_reading_primer(title: str, text: str, target_lang: str = "한
         f"그대로 요약하지 말고 \"왜 이 문제가 어려운가/왜 흥미로운가\"를 짚어 궁금증을 유발하세요.\n"
         f"- Q1/Q2/Q3: 독자가 본문을 읽기 전 스스로 답을 예측해볼 만한 질문 3개. 각각 한 문장.\n"
         f"- CHECK1/CHECK2/CHECK3: 본문을 읽는 동안 확인하면 좋을 구체적인 포인트(예: 비교 대상, "
-        f"핵심 수치, 한계점 등) 3개. 각각 한 문장.\n\n"
-        f"반드시 아래 형식으로 정확히 7줄만 출력하세요. 다른 설명이나 서론은 절대 추가하지 마세요.\n"
-        f"HOOK: <내용>\nQ1: <내용>\nQ2: <내용>\nQ3: <내용>\nCHECK1: <내용>\nCHECK2: <내용>\nCHECK3: <내용>"
+        f"핵심 수치, 한계점 등) 3개. 각각 한 문장.\n"
+        f"- REC1~REC5: 이 논문을 이해하는 데 도움이 되는, 실제로 존재하는 유명하거나 핵심적인 "
+        f"관련/선행 연구 논문 제목을 최대 5개까지 추천하세요. 반드시 실존하는 논문의 정확한 "
+        f"원제(영어 원문 그대로, 번역하지 말 것)만 쓰고, 확신이 없거나 제목이 정확히 기억나지 "
+        f"않으면 억지로 채우지 말고 그 줄은 생략하세요. 각 줄에는 논문 제목만 쓰고 저자·연도· "
+        f"설명은 붙이지 마세요.\n\n"
+        f"반드시 아래 형식으로만 출력하세요(REC 항목은 확신하는 만큼만, 0~5줄). 다른 설명이나 "
+        f"서론은 절대 추가하지 마세요.\n"
+        f"HOOK: <내용>\nQ1: <내용>\nQ2: <내용>\nQ3: <내용>\nCHECK1: <내용>\nCHECK2: <내용>\n"
+        f"CHECK3: <내용>\nREC1: <논문 원제>\nREC2: <논문 원제>\n..."
     )
     prompt = f"{instruction}\n\n원문:\n{text[:3000]}"
 
     provider = get_chat_provider()
     model = get_chat_model()
 
-    tokens = []
-    if provider == "antigravity":
-        async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer"):
-            tokens.append(token)
-    elif provider == "claude_code":
-        async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer"):
-            tokens.append(token)
-    elif provider == "codex":
-        async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="primer"):
-            tokens.append(token)
-    elif provider in ("openai", "gemini", "claude"):
-        messages = [{"role": "user", "content": prompt}]
-        if provider == "openai":
-            async for token in stream_openai(messages, model=model, temperature=0.5):
+    async def _call_once() -> str:
+        tokens = []
+        if provider == "antigravity":
+            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer"):
                 tokens.append(token)
-        elif provider == "gemini":
-            async for token in stream_gemini(messages, model=model, temperature=0.5):
+        elif provider == "claude_code":
+            async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer"):
                 tokens.append(token)
+        elif provider == "codex":
+            async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="primer"):
+                tokens.append(token)
+        elif provider in ("openai", "gemini", "claude"):
+            messages = [{"role": "user", "content": prompt}]
+            if provider == "openai":
+                async for token in stream_openai(messages, model=model, temperature=0.5):
+                    tokens.append(token)
+            elif provider == "gemini":
+                async for token in stream_gemini(messages, model=model, temperature=0.5):
+                    tokens.append(token)
+            else:
+                async for token in stream_claude(messages, model=model, temperature=0.5):
+                    tokens.append(token)
         else:
-            async for token in stream_claude(messages, model=model, temperature=0.5):
-                tokens.append(token)
-    else:
-        # Ollama 폴백
-        payload = {
-            "model": model,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": False,
-            "options": {"temperature": 0.5},
-        }
-        # 스트리밍 없이 응답을 한 번에 기다리는 호출이라, 로컬 CPU 추론처럼 느린
-        # 환경에서도 끊기지 않도록 다른 ollama 스트리밍 호출들과 동일하게 360초를 준다
-        # (stream_page_insight의 120초는 페이지 단위라 상대적으로 짧아도 되지만, 이
-        # 함수는 문서 전체 도입부를 한 번에 처리해 응답이 더 오래 걸릴 수 있다).
-        async with httpx.AsyncClient(timeout=360.0) as client:
-            resp = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
-            resp.raise_for_status()
-            data = resp.json()
-            tokens.append(data.get("message", {}).get("content", ""))
+            # Ollama 폴백
+            payload = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": False,
+                "options": {"temperature": 0.5},
+            }
+            # 스트리밍 없이 응답을 한 번에 기다리는 호출이라, 로컬 CPU 추론처럼 느린
+            # 환경에서도 끊기지 않도록 다른 ollama 스트리밍 호출들과 동일하게 360초를 준다
+            # (stream_page_insight의 120초는 페이지 단위라 상대적으로 짧아도 되지만, 이
+            # 함수는 문서 전체 도입부를 한 번에 처리해 응답이 더 오래 걸릴 수 있다).
+            async with httpx.AsyncClient(timeout=360.0) as client:
+                resp = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+                tokens.append(data.get("message", {}).get("content", ""))
+        return "".join(tokens)
 
-    raw = "".join(tokens)
-    result = {"hook": "", "questions": [], "checklist": []}
-    for line in raw.splitlines():
-        m = _PRIMER_LINE_RE.match(line.strip())
-        if not m:
-            continue
-        key, value = m.group(1).upper(), m.group(2).strip().rstrip('*').strip()
-        if key == "HOOK":
-            result["hook"] = value
-        elif key in ("Q1", "Q2", "Q3"):
-            result["questions"].append(value)
-        else:
-            result["checklist"].append(value)
+    def _parse(raw: str) -> dict:
+        result = {"hook": "", "questions": [], "checklist": [], "recommended_titles": []}
+        for line in raw.splitlines():
+            m = _PRIMER_LINE_RE.match(line.strip())
+            if not m:
+                continue
+            key, value = m.group(1).upper(), m.group(2).strip().rstrip('*').strip()
+            if key == "HOOK":
+                result["hook"] = value
+            elif key in ("Q1", "Q2", "Q3"):
+                result["questions"].append(value)
+            elif key.startswith("CHECK"):
+                result["checklist"].append(value)
+            elif key.startswith("REC"):
+                result["recommended_titles"].append(value)
+        return result
+
+    # CLI 기반 provider(특히 claude_code)가 드물게 지시를 완전히 무시하고 입력
+    # 원문 일부를 그대로 돌려주는 현상을 실측으로 확인했다(같은 프롬프트를 5번
+    # 중 3번꼴로 실패, 재시도하면 정상 응답). 파싱 결과가 통째로 비어있으면(형식이
+    # 하나도 안 맞았다는 뜻) 한 번만 더 시도한다 - 매번 재시도하면 정상적으로
+    # "REC 항목 없음"처럼 일부만 비는 경우까지 불필요하게 다시 호출하게 되므로,
+    # 완전 실패로 보이는 경우로만 좁힌다.
+    result = _parse(await _call_once())
+    if not any((result["hook"], result["questions"], result["checklist"], result["recommended_titles"])):
+        result = _parse(await _call_once())
     return result
 
 

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -6,7 +6,14 @@
   1. 훅 문장 / 예측 질문 3개 / 체크리스트 3개 (LLM, llm_client.generate_reading_primer)
   2. 대표 Figure 크롭 이미지 (pdf_parser.extract_pdf_images + render_image_crop)
   3. 내 라이브러리 안에서 이 논문의 참고문헌과 겹치는 논문 매칭 (외부 API 없이 텍스트 매칭)
-  4. 내 라이브러리에 없는 참고문헌 중 최대 3건만 OpenAlex로 확장 조회
+  4. LLM이 직접 추천한 관련 논문(최대 5개)을 OpenAlex로 실존 여부 검증 후 채택
+
+4번은 원래 이 논문의 참고문헌 목록을 그대로 외부 검색해 매칭하는 방식이었으나,
+인용 형식이 지저분하거나 따옴표로 감싼 제목이 없는 스타일이면 매칭 개수가 너무
+적고("참고문헌으로 한정" - 진짜 "관련성"과는 다름), 결과 품질도 들쭉날쭉했다.
+LLM이 primer 생성 시점에 자기 지식으로 직접 관련 논문을 추천하게 하고, 그 제목을
+OpenAlex로 재검색해 실제로 존재하고 제목이 충분히 일치하는 것만 채택하는 방식으로
+바꿔 개수와 관련성을 모두 개선했다.
 """
 import json
 import re
@@ -22,9 +29,9 @@ from services.library import (
 from services.reference_parser import extract_reference_list
 from services.llm_client import generate_reading_primer
 
-_EXTERNAL_MATCH_LIMIT = 3
-_EXTERNAL_ATTEMPT_LIMIT = 5
+_RECOMMENDATION_LIMIT = 5
 _LIBRARY_MATCH_THRESHOLD = 0.7
+_DUPLICATE_TITLE_THRESHOLD = 0.6
 _STOPWORDS = {
     "the", "a", "an", "of", "for", "and", "or", "on", "in", "to", "with",
     "using", "via", "based", "towards", "toward", "from", "into", "at", "by",
@@ -36,7 +43,7 @@ def _normalize_words(text: str) -> set:
     return {w for w in words if len(w) > 2 and w not in _STOPWORDS}
 
 
-def _match_library_references(reference_map: dict, doc_id: str, username: str) -> tuple[list, set]:
+def _match_library_references(reference_map: dict, doc_id: str, username: str) -> list:
     """참고문헌 원문 목록을 내 라이브러리의 다른 논문 제목과 텍스트 매칭한다.
     외부 API를 쓰지 않아 업로드마다 항상 실행해도 부담이 없다."""
     candidates = []
@@ -51,7 +58,6 @@ def _match_library_references(reference_map: dict, doc_id: str, username: str) -
 
     matches = []
     matched_doc_ids = set()
-    matched_ref_nums = set()
     for ref_num, ref_text in reference_map.items():
         ref_words = _normalize_words(ref_text)
         if not ref_words:
@@ -62,39 +68,48 @@ def _match_library_references(reference_map: dict, doc_id: str, username: str) -
             if len(words & ref_words) / len(words) >= _LIBRARY_MATCH_THRESHOLD:
                 matches.append({"ref_num": ref_num, "doc_id": cand_doc_id, "title": title})
                 matched_doc_ids.add(cand_doc_id)
-                matched_ref_nums.add(ref_num)
                 break
-    return matches, matched_ref_nums
+    return matches
 
 
-def _is_plausible_match(ref_text: str, resolved: dict) -> bool:
-    """참고문헌 검색(reference_linker.resolve_reference)이 지저분한 인용 문자열
-    때문에 엉뚱한 논문을 최상위로 반환하는 경우가 있어(실제로 EEG 논문 테스트에서
-    무관한 논문이 매칭된 사례를 확인함), 연도가 인용 원문에 그대로 등장하거나
-    제목 단어가 인용 원문과 충분히 겹칠 때만 신뢰할 만한 매칭으로 받아들인다."""
+def _is_plausible_match(query_text: str, resolved: dict) -> bool:
+    """resolve_reference() 검색 결과가 실제로 찾으려던 논문이 맞는지 검증한다.
+    참고문헌 검색은 지저분한 인용 문자열 때문에, LLM 추천 검증은 환각(존재하지 않는
+    논문 제목을 지어내거나 부정확하게 기억)때문에 엉뚱한 논문이 최상위로 반환될 수
+    있어(실제로 EEG 논문 테스트에서 무관한 논문이 매칭된 사례를 확인함), 연도가 원문에
+    그대로 등장하거나 제목 단어가 원문과 충분히 겹칠 때만 신뢰할 만한 매칭으로 받아들인다."""
     year = resolved.get("year")
-    if year and str(year) in (ref_text or ""):
+    if year and str(year) in (query_text or ""):
         return True
     title_words = _normalize_words(resolved.get("title", ""))
     if not title_words:
         return False
-    ref_words = _normalize_words(ref_text)
-    return len(title_words & ref_words) / len(title_words) >= 0.5
+    query_words = _normalize_words(query_text)
+    return len(title_words & query_words) / len(title_words) >= 0.5
 
 
-async def _resolve_external_references(reference_map: dict, matched_ref_nums: set) -> list:
+async def _resolve_recommended_titles(titles: list, exclude_title_words: list) -> list:
+    """LLM이 추천한 논문 제목들을 OpenAlex로 검증해 실제로 존재하는 논문만 채택한다.
+    LLM은 환각으로 없는 논문을 만들어내거나 제목을 부정확하게 기억할 수 있으므로,
+    검색 결과 제목이 추천받은 제목과 충분히 일치할 때만(_is_plausible_match) 신뢰한다.
+    이미 내 라이브러리 매칭으로 뜬 논문과 같은 논문을 추천했다면 중복 표시하지 않는다."""
     from services.reference_linker import resolve_reference
     results = []
-    attempts = 0
-    for ref_num, ref_text in reference_map.items():
-        if len(results) >= _EXTERNAL_MATCH_LIMIT or attempts >= _EXTERNAL_ATTEMPT_LIMIT:
-            break
-        if ref_num in matched_ref_nums:
+    seen_word_sets = list(exclude_title_words)
+    for title in titles[:_RECOMMENDATION_LIMIT]:
+        title = (title or "").strip()
+        if not title:
             continue
-        attempts += 1
-        resolved = await resolve_reference(ref_text)
-        if resolved and _is_plausible_match(ref_text, resolved):
-            results.append({"ref_num": ref_num, **resolved})
+        resolved = await resolve_reference(title)
+        if not resolved or not _is_plausible_match(title, resolved):
+            continue
+        result_words = _normalize_words(resolved.get("title", ""))
+        if not result_words:
+            continue
+        if any(len(result_words & seen) / len(result_words) >= _DUPLICATE_TITLE_THRESHOLD for seen in seen_word_sets):
+            continue
+        seen_word_sets.append(result_words)
+        results.append(resolved)
     return results
 
 
@@ -140,7 +155,7 @@ async def generate_primer(
         llm_part = await generate_reading_primer(title, combined_text, target_lang=target_lang, session_id=session_id)
     except Exception as e:
         print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
-        llm_part = {"hook": "", "questions": [], "checklist": []}
+        llm_part = {"hook": "", "questions": [], "checklist": [], "recommended_titles": []}
 
     try:
         reference_map = extract_reference_list(pages)
@@ -148,19 +163,21 @@ async def generate_primer(
         print(f"[primer] 참고문헌 파싱 실패 ({doc_id}): {e}")
         reference_map = {}
 
-    library_matches, matched_ref_nums = [], set()
+    library_matches = []
     if reference_map:
         try:
-            library_matches, matched_ref_nums = _match_library_references(reference_map, doc_id, username)
+            library_matches = _match_library_references(reference_map, doc_id, username)
         except Exception as e:
             print(f"[primer] 라이브러리 매칭 실패 ({doc_id}): {e}")
 
     external_matches = []
-    if reference_map:
+    recommended_titles = llm_part.get("recommended_titles", [])
+    if recommended_titles:
         try:
-            external_matches = await _resolve_external_references(reference_map, matched_ref_nums)
+            library_title_words = [_normalize_words(m["title"]) for m in library_matches]
+            external_matches = await _resolve_recommended_titles(recommended_titles, library_title_words)
         except Exception as e:
-            print(f"[primer] 외부 참고문헌 조회 실패 ({doc_id}): {e}")
+            print(f"[primer] 관련 논문 추천 검증 실패 ({doc_id}): {e}")
 
     figure = None
     try:

--- a/backend/tests/test_primer.py
+++ b/backend/tests/test_primer.py
@@ -1,0 +1,111 @@
+"""services/primer.py의 순수 로직(참고문헌 매칭 검증, 관련 논문 추천 검증)에 대한
+테스트. 외부 API(resolve_reference) 호출은 모킹해 로직만 검증한다.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.primer import _is_plausible_match, _normalize_words, _resolve_recommended_titles
+
+
+def test_normalize_words_strips_stopwords_and_short_tokens():
+    words = _normalize_words("A Study of the Attention Mechanism for NLP")
+    assert "study" in words
+    assert "attention" in words
+    assert "mechanism" in words
+    # 불용어와 2글자 이하 토큰은 제외
+    assert "a" not in words
+    assert "of" not in words
+    assert "the" not in words
+    assert "for" not in words
+
+
+def test_is_plausible_match_accepts_year_match():
+    resolved = {"title": "Completely Unrelated Words Here", "year": 2019}
+    assert _is_plausible_match("... published in 2019 ...", resolved) is True
+
+
+def test_is_plausible_match_accepts_title_overlap():
+    resolved = {"title": "Attention Is All You Need", "year": 2017}
+    assert _is_plausible_match("Vaswani et al. Attention Is All You Need. 2020", resolved) is True
+
+
+def test_is_plausible_match_rejects_unrelated_result():
+    resolved = {"title": "Postoperative Endophthalmitis Analysis", "year": 2020}
+    assert _is_plausible_match("Zheng et al. Identifying stable EEG patterns. 2019", resolved) is False
+
+
+def test_is_plausible_match_rejects_when_no_title():
+    assert _is_plausible_match("some query", {"title": "", "year": None}) is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_recommended_titles_keeps_plausible_results():
+    async def fake_resolve(title):
+        return {"title": title, "url": f"https://example.com/{title}", "year": 2021}
+
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(side_effect=fake_resolve)):
+        results = await _resolve_recommended_titles(["Attention Is All You Need"], [])
+
+    assert len(results) == 1
+    assert results[0]["title"] == "Attention Is All You Need"
+
+
+@pytest.mark.asyncio
+async def test_resolve_recommended_titles_drops_unresolved_and_implausible():
+    async def fake_resolve(title):
+        if title == "Real Paper":
+            return {"title": "Real Paper", "url": "https://example.com/real", "year": 2020}
+        if title == "Hallucinated Paper":
+            # 검색은 되지만 완전히 무관한 논문이 반환된 경우
+            return {"title": "Totally Different Topic", "url": "https://example.com/x", "year": 1999}
+        return None  # 검색 결과 없음
+
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(side_effect=fake_resolve)):
+        results = await _resolve_recommended_titles(
+            ["Real Paper", "Hallucinated Paper", "Nonexistent Paper", ""], []
+        )
+
+    assert len(results) == 1
+    assert results[0]["title"] == "Real Paper"
+
+
+@pytest.mark.asyncio
+async def test_resolve_recommended_titles_deduplicates_against_library_matches():
+    async def fake_resolve(title):
+        return {"title": "Attention Is All You Need", "url": "https://example.com/a", "year": 2017}
+
+    already_in_library = [_normalize_words("Attention Is All You Need")]
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(side_effect=fake_resolve)):
+        results = await _resolve_recommended_titles(["Attention Is All You Need"], already_in_library)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_recommended_titles_respects_limit():
+    call_count = 0
+
+    async def fake_resolve(title):
+        nonlocal call_count
+        call_count += 1
+        return {"title": title, "url": f"https://example.com/{call_count}", "year": 2020}
+
+    titles = [
+        "Convolutional Neural Networks for Image Classification",
+        "Recurrent Sequence Models for Machine Translation",
+        "Graph Attention Networks for Node Embeddings",
+        "Variational Autoencoders for Generative Modeling",
+        "Reinforcement Learning for Robotic Control",
+        "Transformer Architectures for Language Understanding",
+        "Contrastive Learning for Visual Representations",
+        "Diffusion Models for Image Synthesis",
+        "Federated Learning for Privacy Preservation",
+        "Meta Learning for Few Shot Classification",
+    ]
+    with patch("services.reference_linker.resolve_reference", new=AsyncMock(side_effect=fake_resolve)):
+        results = await _resolve_recommended_titles(titles, [])
+
+    assert call_count == 5
+    assert len(results) == 5


### PR DESCRIPTION
# Summary
## 1. LLM이 직접 관련 논문 추천 (llm_client.py)
- `generate_reading_primer()`의 프롬프트에 `REC1~REC5` 항목 추가 - 논문 이해에 도움이 되는 실존 관련/선행 연구 논문 제목을 최대 5개까지 추천하되, 확신 없으면 생략하도록 지시
- `_PRIMER_LINE_RE`에 REC1~5 키 추가, 파싱 로직에 `recommended_titles` 필드 추가

## 2. OpenAlex로 실존 여부 재검증 (primer.py)
- `_resolve_external_references()`를 `_resolve_recommended_titles()`로 교체 - 참고문헌 목록이 아니라 LLM이 추천한 "깨끗한 제목"을 검색어로 사용(이전 PR에서 확인한 "깨끗한 제목으로 검색하면 매칭 품질이 훨씬 좋다"는 특성을 그대로 활용)
- LLM 환각(존재하지 않는 논문을 지어내거나 제목을 부정확하게 기억) 방지를 위해 검색 결과가 실제로 추천받은 제목과 충분히 일치할 때만(`_is_plausible_match`) 채택
- 이미 내 라이브러리 매칭으로 뜬 논문과 같은 논문을 추천했으면 중복 표시하지 않도록 제목 유사도 기반 dedup 추가

## 3. claude_code CLI 안정성 버그 수정 (llm_client.py)
- 검증 중 발견: claude_code CLI에 실제 논문 원문(길고 지저분한 텍스트)을 넣으면 5번 중 2~3번꼴로 지시를 완전히 무시하고 입력 원문 일부를 그대로 반환하는 현상 확인
- `generate_reading_primer()`의 파싱 결과가 통째로 비어있으면(hook/questions/checklist/recommended_titles 전부 빈 경우) 한 번 더 자동 재시도하도록 안전장치 추가

## 4. 테스트
- `tests/test_primer.py`(신규) - `_normalize_words`, `_is_plausible_match`, `_resolve_recommended_titles`(검증 통과/실패/중복 제거/개수 제한)에 대한 단위 테스트 9개 추가

## Test plan
- [x] `pytest backend/tests/` — 196 passed (기존 무관 실패 1건 그대로)
- [x] 실제 EEG 논문으로 전체 파이프라인 end-to-end 테스트(실제 claude_code CLI 사용): LLM이 추천한 5개 전부 OpenAlex 검증 통과(Attention Is All You Need, ViT, EEGNet, Deep Learning CNN for EEG Decoding, FBCSP) - 전부 실제로 관련성 높은 논문. 기존 방식(0~1개) 대비 확연한 개선