### PR TITLE
feat: 인용(Citation) 오버레이 감지 로직을 다양한 스타일로 확장

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Ir7J-XCg.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Ca9Rsbe5.css">
+  <script type="module" crossorigin src="/assets/index-C_G4vtnx.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DBOn9QUY.css">
 </head>
 <body>
 
@@ -91,13 +91,15 @@
       <div class="library-tabs-container">
         <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>보관함</button>
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
+        <button id="lib-tab-chat" class="library-tab-btn" data-tab="chat"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>채팅</button>
+        <button id="lib-tab-annotations" class="library-tab-btn" data-tab="annotations"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>주석</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
       <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
 
       <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
-      <div style="position: relative; margin-bottom: 14px;">
+      <div id="library-search-box" style="position: relative; margin-bottom: 14px;">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
         <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
         <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
@@ -121,6 +123,25 @@
           <p>저장된 논문이 없습니다</p>
           <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>
         </div>
+      </div>
+
+      <!-- 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 채팅 세션 목록) -->
+      <div id="library-chat-section" class="hidden">
+        <div class="chat-session-subtabs">
+          <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트</button>
+          <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교</button>
+        </div>
+        <div id="chat-session-list" class="chat-session-list"></div>
+      </div>
+
+      <!-- 주석 조회 (메모 / 하이라이트 / 언더라인 목록) -->
+      <div id="library-annotations-section" class="hidden">
+        <div class="chat-session-subtabs">
+          <button id="annotation-subtab-memo" class="chat-session-subtab-btn active" data-subtab="memo">메모</button>
+          <button id="annotation-subtab-highlight" class="chat-session-subtab-btn" data-subtab="highlight">하이라이트</button>
+          <button id="annotation-subtab-underline" class="chat-session-subtab-btn" data-subtab="underline">언더라인</button>
+        </div>
+        <div id="annotation-list" class="chat-session-list"></div>
       </div>
     </div>
     <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
@@ -190,6 +211,9 @@
         </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
+        </button>
+        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기" style="margin-left: 6px;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
@@ -263,6 +287,9 @@
           </button>
           <button id="export-btn" class="icon-btn" title="번역본 내보내기">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
+          </button>
+          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
           </button>
         </div>
 
@@ -625,6 +652,9 @@
               <label class="checkbox-label">
                 <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
               </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              </label>
             </div>
           </div>
 
@@ -633,6 +663,10 @@
             <button type="button" id="clear-cache-btn" class="btn btn-secondary" style="width: 100%; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>브라우저 번역 캐시 비우기
             </button>
+            <button type="button" id="clear-pages-cache-btn" class="btn btn-secondary" style="width: 100%; margin-top: 8px; color: var(--error); border-color: rgba(239, 68, 68, 0.2); background: rgba(239, 68, 68, 0.05); font-weight: 600;">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>서버 PDF 추출 캐시 비우기
+            </button>
+            <p style="font-size: 11px; color: var(--text-secondary); margin: 6px 0 0; line-height: 1.5;">서버(또는 앱) 재시작 후 문서를 처음 열 때 빠르게 뜨도록 저장해두는 캐시입니다. 비워도 데이터가 사라지지 않고, 다음에 열람할 때 자동으로 다시 채워집니다.</p>
           </div>
           
           <div class="form-actions" style="margin-top: 15px;">
@@ -667,6 +701,18 @@
             <div class="form-group" id="setting-claude-key-group" style="display: none;">
               <label for="setting-claude-key">Claude API Key</label>
               <input type="password" id="setting-claude-key" placeholder="sk-ant-..." style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
+            </div>
+          </div>
+
+          <!-- 참고문헌 링크 조회(OpenAlex) 설정 -->
+          <div style="border-top: 1px solid var(--border); padding-top: 15px; margin-top: 15px;">
+            <h4 style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; display: flex; align-items: center; gap: 4px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r="1.5"/></svg>참고문헌 링크 조회 설정</h4>
+            <div class="form-group">
+              <label for="setting-openalex-mailto">연락 가능한 이메일 (선택 사항)</label>
+              <input type="email" id="setting-openalex-mailto" placeholder="you@example.com" style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
+              <p style="font-size: 12px; color: var(--text-secondary); margin-top: 6px; line-height: 1.5;">
+                본문 인용 오버레이와 읽기 전 브리핑의 참고문헌 링크 조회는 <a href="https://openalex.org" target="_blank" rel="noopener" style="color: var(--accent-mid);">OpenAlex</a>를 사용합니다. 별도 가입이나 API 키 발급 없이 이메일만 입력해도 더 넉넉한 요청 한도("polite pool")가 적용됩니다 — 자세한 내용은 <a href="https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication" target="_blank" rel="noopener" style="color: var(--accent-mid);">공식 문서</a>를 참고하세요.
+              </p>
             </div>
           </div>
 
@@ -900,7 +946,15 @@
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>데스크탑 앱 업데이트:</strong><br>
               아래 버튼을 누르면 새 버전이 있는지 확인합니다. 새 버전이 있으면 다운로드 후 설치하고 앱을 자동으로 재시작합니다.
             </div>
-            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 10px; margin-bottom: 12px;">
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="font-size: 12.5px; color: var(--text-secondary); white-space: nowrap;">자동 업데이트 확인</span>
+                <select id="setting-tauri-update-check-interval" class="form-select" style="width: auto; min-width: 110px;">
+                  <option value="daily">매일</option>
+                  <option value="weekly">매주</option>
+                  <option value="never">사용 안 함</option>
+                </select>
+              </div>
               <span id="tauri-current-version-label" style="font-size: 11.5px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
             <div id="tauri-update-notes-box" class="update-changelog-box hidden" style="margin-bottom: 12px;">
@@ -972,6 +1026,76 @@
         </div>
       </div>
       <button id="doc-preview-open-btn" class="doc-preview-open-btn">열기</button>
+    </div>
+  </div>
+
+  <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
+  <div id="primer-modal" class="modal-overlay hidden">
+    <div class="primer-content">
+      <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
+
+      <div id="primer-loading" class="primer-loading">
+        <div class="spinner"></div>
+        <p>읽기 전 브리핑을 준비하고 있어요...</p>
+      </div>
+
+      <div id="primer-error" class="primer-error hidden">
+        <p>브리핑을 불러오지 못했습니다.</p>
+      </div>
+
+      <div id="primer-body" class="primer-body hidden">
+        <div class="primer-header">
+          <div class="primer-header-badge">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+          </div>
+          <div class="primer-header-text">
+            <span class="primer-eyebrow">읽기 전 브리핑</span>
+            <h2 id="primer-title" class="primer-title"></h2>
+          </div>
+        </div>
+
+        <div id="primer-hook-section" class="primer-hook-section hidden">
+          <span class="primer-hook-quote">&ldquo;</span>
+          <p id="primer-hook-text" class="primer-hook-text"></p>
+        </div>
+
+        <div id="primer-questions-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+            <span>읽기 전에 스스로 답해보기</span>
+          </div>
+          <ol id="primer-questions" class="primer-list"></ol>
+        </div>
+
+        <div id="primer-figure-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+            <span>핵심 그림 먼저 보기</span>
+          </div>
+          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+        </div>
+
+        <div id="primer-checklist-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+            <span>읽으면서 확인할 것</span>
+          </div>
+          <ul id="primer-checklist" class="primer-checklist"></ul>
+        </div>
+
+        <div id="primer-graph-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+            <span>이 논문과 연결된 논문</span>
+          </div>
+          <div id="primer-graph" class="primer-graph"></div>
+        </div>
+      </div>
+
+      <div class="primer-footer">
+        <button id="primer-skip-btn" class="btn btn-secondary">건너뛰기</button>
+        <button id="primer-continue-btn" class="btn btn-primary">읽으러 가기</button>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -48,6 +48,7 @@ const state = {
   quotedText: null,            // AI 질문 시 인용구 보관용
   documentImages: [],          // 문서 내 이미지 좌표 목록
   referenceMap: {},            // 참고문헌 번호 -> 원문 텍스트 맵
+  citationStyle: null,         // 'number' | 'author-year' | 'mixed' | null(미감지) - detectCitationStyle 결과
   referencesHeaderPageNum: null, // References/참고문헌 섹션이 시작되는 페이지 번호(감지 전엔 null)
   quotedImage: null,           // AI 질문 시 인용 이미지 보관용 (Base64)
   quotedImagePage: null,       // AI 질문 시 인용 이미지의 페이지 번호
@@ -371,7 +372,7 @@ function resetState() {
     zoom: 1.5, translationCache: {}, translationSentences: {}, translatingPages: new Set(), translatedPages: new Set(), pollingTimer: null,
     chatHistory: [], chatActiveStream: null, quotedText: null, quotedImage: null, quotedImagePage: null,
     activeHighlightColor: '#eab308', activeUnderlineColor: '#ef4444', isCropMode: false, documentImages: [], referenceMap: {},
-    referencesHeaderPageNum: null
+    citationStyle: null, referencesHeaderPageNum: null
   })
   if (typeof toggleCropMode === 'function') toggleCropMode(false)
   viewerScrollContainer.innerHTML = ''
@@ -5045,6 +5046,7 @@ async function loadDocumentReferences(docId) {
   try {
     const refRes = await fetchLibraryReferences(docId)
     state.referenceMap = refRes.references || {}
+    state.citationStyle = detectCitationStyle(state.referenceMap)
 
     // 이미 렌더링되어 있는 페이지들의 인용 오버레이 갱신
     document.querySelectorAll('.textLayer').forEach(textLayerDiv => {
@@ -5057,6 +5059,7 @@ async function loadDocumentReferences(docId) {
   } catch (e) {
     console.warn("참고문헌 목록 로드 실패:", e)
     state.referenceMap = {}
+    state.citationStyle = null
   }
 }
 
@@ -7597,15 +7600,18 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
   inner.appendChild(layer)
 }
 
-// 본문 인용 표기 세 스타일을 지원한다:
-// 1) 번호 인용: [12], [12, 13], [12-14]
+// 본문 인용 표기 네 스타일을 지원한다:
+// 1) 번호 인용: [12], [12, 13], [12-14], [1,3,5-8](단일 번호와 범위 혼합)
 // 2) 키워드 인용(alpha 스타일 BibTeX): [BCV13], [BCV13, Dev86] - 저자 이니셜+
 //    연도 형태의 키(예: VAE 논문의 [BCV13], [Dev86])도 순수 숫자와 동일하게
 //    대괄호 토큰으로 취급한다. 백엔드 reference_parser.py의 _BRACKET_ENTRY_RE도
 //    동일한 키 형식을 파싱한다.
-// 3) 저자-연도 인용: (Smith, 2020), (Smith et al., 2020), (Smith & Jones, 2020),
-//    (Smith, 2020; Jones, 2019) 등 - 백엔드 reference_parser.py의
-//    _parse_author_year_entries와 동일하게 "저자 성(소문자)+연도"를 키로 매칭한다.
+// 3) 괄호형 저자-연도 인용: (Smith, 2020), (Smith et al., 2020),
+//    (Smith & Jones, 2020), (Smith, 2020; Jones, 2019) 등 - 백엔드
+//    reference_parser.py의 _parse_author_year_entries와 동일하게 "저자
+//    성(소문자)+연도"를 키로 매칭한다.
+// 4) 서술형 저자-연도 인용: 저자가 괄호 밖에 오고 연도만 괄호 안에 있는
+//    "Smith (2020)", "Li and Wang (2023)", "Smith et al. (2020)" 등.
 //
 // 대괄호 안 토큰 하나 - 순수 숫자(1~3자리) 또는 "BCV13"류 키워드 키(영문
 // 1~6자 + 선택적 "+" + 숫자 2~4자리 + 선택적 소문자 접미사)만 인정한다.
@@ -7618,7 +7624,7 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
 const CITATION_TOKEN_SRC = '(?:\\d{1,3}|[A-Za-z]{1,6}\\+?\\d{2,4}[a-z]?)'
 // 대괄호 목록의 항목 하나는 위 단일 키이거나, 숫자 범위("12-14")일 수 있다 -
 // 범위는 CITATION_TOKEN_SRC 모양에 안 맞으므로(하이픈 포함) 마커 탐지
-// 단계에서 별도 대안으로 허용해두고, 실제 펼치기는 parseCitationNumbers가 한다.
+// 단계에서 별도 대안으로 허용해두고, 실제 펼치기는 extractBracketCitationItems가 한다.
 const CITATION_LIST_ITEM_SRC = `(?:\\d{1,3}\\s*[-–]\\s*\\d{1,3}|${CITATION_TOKEN_SRC})`
 const CITATION_MARKER_RE = new RegExp(
   `\\[\\s*${CITATION_LIST_ITEM_SRC}(?:\\s*,\\s*${CITATION_LIST_ITEM_SRC})*\\s*\\]`, 'g'
@@ -7627,29 +7633,45 @@ const CITATION_MARKER_RE = new RegExp(
 // 있어야 인용으로 인정한다(오탐 방지 - 그냥 "(그림 2020년 기준)" 같은 일반
 // 괄호 문구가 걸리지 않도록 대문자 시작 + 연도 둘 다 요구).
 const CITATION_AUTHOR_YEAR_MARKER_RE = /\([A-ZÀ-Ö][^()]{2,160}?\d{4}[a-z]?[^()]{0,20}\)/g
+// 서술형 저자-연도: 저자명(과 "and"/"&"로 이어지는 공저자, 또는 "et al.")
+// 뒤에 곧바로 "(2020)"류 연도만 담긴 괄호가 온다. 콤마나 이니셜이 중간에
+// 끼면 REF_ENTRY_AUTHOR_YEAR_RE(참고문헌 목록 항목)이 담당할 형태이므로
+// 여기서는 매칭하지 않는다 - 두 정규식이 References 섹션 안에서 같은
+// 텍스트에 중복으로 걸리는 것을 방지.
+const CITATION_NARRATIVE_AUTHOR_YEAR_RE =
+  /\b([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+)(?:\s+(?:and|&)\s+[A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+)?(?:\s+et\s+al\.?)?\s+\((\d{4})[a-z]?\)/g
 
-// "[12, 14-16]", "[BCV13, Dev86]" 형태의 대괄호 안 내용을 개별 참고문헌
-// 키 목록으로 펼친다. 숫자 범위("14-16")만 확장 대상이고, 키워드 키는
-// 범위 개념이 없으므로 토큰 그대로 유지한다.
-function parseCitationNumbers(bracketText) {
-  const inner = bracketText.slice(1, -1)
-  const nums = []
-  inner.split(',').forEach(part => {
-    const trimmed = part.trim()
-    const range = trimmed.match(/^(\d{1,3})\s*[-–]\s*(\d{1,3})$/)
+// "[12, 14-16]", "[BCV13, Dev86]", "[1,3,5-8]" 형태의 대괄호 안 내용을
+// 항목별 위치 정보와 함께 뽑아낸다. 쉼표로 나열된 각 항목은 독립적인
+// 오버레이를 갖는다("[1, 2, 3]" -> 각 번호마다 별도 오버레이). 단, "5-8"
+// 같은 범위 표기는 문서 상에서 하나로 붙어 있는 토큰이라 쪼갤 수 없으므로
+// 범위 전체가 하나의 오버레이를 갖되, 그 안에 펼쳐진 모든 번호를 함께
+// 담아 툴팁에서 전부 보여준다.
+const CITATION_ITEM_RE = new RegExp(CITATION_LIST_ITEM_SRC, 'g')
+function extractBracketCitationItems(fullText, match) {
+  const innerStart = match.index + 1
+  const innerEnd = match.index + match[0].length - 1
+  const inner = fullText.slice(innerStart, innerEnd)
+  const items = []
+  CITATION_ITEM_RE.lastIndex = 0
+  let m
+  while ((m = CITATION_ITEM_RE.exec(inner)) !== null) {
+    const start = innerStart + m.index
+    const end = start + m[0].length
+    const range = m[0].match(/^(\d{1,3})\s*[-–]\s*(\d{1,3})$/)
     if (range) {
-      const start = parseInt(range[1], 10)
-      const end = parseInt(range[2], 10)
+      const rangeStart = parseInt(range[1], 10)
+      const rangeEnd = parseInt(range[2], 10)
       // 비정상적으로 넓은 범위(오탐 - 예: 페이지/연도 범위 오인)는 무시
-      if (end >= start && end - start <= 50) {
-        for (let n = start; n <= end; n++) nums.push(String(n))
-      }
-      return
+      const keys = (rangeEnd >= rangeStart && rangeEnd - rangeStart <= 50)
+        ? Array.from({ length: rangeEnd - rangeStart + 1 }, (_, i) => String(rangeStart + i))
+        : []
+      items.push({ start, end, keys })
+    } else {
+      items.push({ start, end, keys: [m[0]] })
     }
-    const token = trimmed.match(new RegExp(`^${CITATION_TOKEN_SRC}$`))
-    if (token) nums.push(token[0])
-  })
-  return nums
+  }
+  return items
 }
 
 // 참고문헌 목록 항목 자체의 "시작 표기"를 찾기 위한 정규식들(대괄호가 없는
@@ -7667,21 +7689,50 @@ const REF_ENTRY_PLAIN_NUMBER_RE = /\b(\d{1,3})[.)]\s+(?=[A-Z가-힣])/g
 // 있는 문헌 목록 서식(APA류)을 겨냥한다.
 const REF_ENTRY_AUTHOR_YEAR_RE = /\b([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+),\s[^()]{0,160}?\((\d{4})[a-z]?\)/g
 
-// "(Smith, 2020; Jones et al., 2019)" 형태를 세미콜론 기준으로 나눠 각각에서
-// 앞쪽 저자 성과 끝쪽 연도만 앵커로 뽑는다(공저자 나열/"et al." 등 그 사이
-// 내용은 굳이 파싱하지 않아도 이 두 앵커만으로 백엔드 키와 매칭 가능).
-function parseAuthorYearKeys(parenText) {
-  const inner = parenText.slice(1, -1)
-  const keys = []
-  inner.split(';').forEach(part => {
-    const trimmed = part.trim()
-    const surnameMatch = trimmed.match(/^([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+)/)
-    const yearMatch = trimmed.match(/(\d{4})[a-z]?/)
-    if (surnameMatch && yearMatch) {
-      keys.push(`${surnameMatch[1].toLowerCase()}${yearMatch[1]}`)
-    }
+// "(Smith, 2020; Jones et al., 2019)" 형태를 세미콜론 기준으로 나눠, 각
+// 항목의 위치 정보와 함께 반환한다 - 항목마다 독립적인 오버레이를 걸기
+// 위함이다("(Morrill et al., 2021; Kidger et al., 2020)" -> 각 인용마다
+// 별도 오버레이). 공저자 나열/"et al." 등 세부 내용은 굳이 파싱하지 않고
+// 앞쪽 저자 성과 끝쪽 연도만 앵커로 뽑는다.
+function extractAuthorYearClauses(fullText, match) {
+  const innerStart = match.index + 1
+  const innerEnd = match.index + match[0].length - 1
+  const inner = fullText.slice(innerStart, innerEnd)
+  const clauses = []
+  let cursor = 0
+  inner.split(';').forEach(rawPart => {
+    const partStart = cursor
+    cursor += rawPart.length + 1 // ';' 구분자 1글자만큼 다음 조각 시작 위치를 밀어줌
+    const leading = rawPart.match(/^\s*/)[0].length
+    const trailing = rawPart.match(/\s*$/)[0].length
+    const text = rawPart.slice(leading, rawPart.length - trailing)
+    if (!text) return
+    const surnameMatch = text.match(/^([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+)/)
+    const yearMatch = text.match(/(\d{4})[a-z]?/)
+    if (!surnameMatch || !yearMatch) return
+    clauses.push({
+      start: innerStart + partStart + leading,
+      end: innerStart + partStart + rawPart.length - trailing,
+      key: `${surnameMatch[1].toLowerCase()}${yearMatch[1]}`,
+    })
   })
-  return keys
+  return clauses
+}
+
+// 참고문헌 맵의 키 형식(순수 숫자 vs "저자성+연도")으로 이 논문이 Number
+// Citation 스타일인지 Author-Year 스타일인지 판단한다. 스타일을 미리
+// 알면 반대 스타일 정규식은 아예 돌리지 않아, "Dimension = [64, 128, 256]"
+// 같은 숫자 배열이 Author-Year 논문에서 대괄호 인용으로 오인되는 등의
+// 오탐을 원천적으로 줄일 수 있다. 두 스타일이 섞여 있거나 아직 참고문헌이
+// 없으면(null) 두 스타일을 모두 검사하는 기존 동작으로 안전하게 폴백한다.
+function detectCitationStyle(refMap) {
+  const keys = Object.keys(refMap)
+  if (keys.length === 0) return null
+  let numeric = 0, authorYear = 0
+  keys.forEach(k => { /^\d+$/.test(k) ? numeric++ : authorYear++ })
+  if (numeric > 0 && authorYear === 0) return 'number'
+  if (authorYear > 0 && numeric === 0) return 'author-year'
+  return 'mixed'
 }
 
 // References/Bibliography/참고문헌 섹션 헤더 판별 - 백엔드 reference_parser.py의
@@ -7728,7 +7779,22 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
 
   const referencesSectionStart = detectReferencesSectionStart(vtm, pageNum)
 
-  const addCitationBox = (charStart, charEnd, refKey) => {
+  // 이 문서가 Number 스타일인지 Author-Year 스타일인지 미리 알면, 반대
+  // 스타일 정규식은 아예 돌리지 않는다 - 예를 들어 문서가 Author-Year
+  // 스타일이면 "[64, 128, 256]" 같은 순수 숫자 배열은 애초에 대괄호 인용
+  // 후보로 검사조차 하지 않으므로 오탐 여지가 없다. 스타일이 섞여 있거나
+  // (mixed) 아직 판별하지 못했으면(null) 기존처럼 두 스타일 모두 검사한다.
+  const citationStyle = state.citationStyle
+  const checkNumberStyle = citationStyle !== 'author-year'
+  const checkAuthorYearStyle = citationStyle !== 'number'
+
+  // refKeys(여러 개일 수 있음)를 받아 하나의 오버레이 박스를 그린다. 툴팁에는
+  // refMap에 실제로 존재하는 키의 원문을 전부 이어붙여 보여준다("[66-69]"
+  // 같은 범위 인용이 여러 참고문헌을 한 번에 가리키는 경우를 위함). "원문
+  // 링크 찾기"/Google Scholar 검색은 첫 번째 키를 기준으로 동작한다.
+  const addCitationBox = (charStart, charEnd, refKeys) => {
+    const validKeys = refKeys.filter(k => refMap[k])
+    if (validKeys.length === 0) return
     const rects = getSentenceRects({ charStart, charEnd }, vtm, textLayerDiv)
     rects.forEach(r => {
       const box = document.createElement('div')
@@ -7737,8 +7803,8 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.style.top    = `${r.top}px`
       box.style.width  = `${r.width}px`
       box.style.height = `${r.height}px`
-      box.dataset.refNum = refKey
-      box.addEventListener('mouseenter', () => showCitationTooltip(docId, refKey, refMap[refKey] || '', box))
+      box.dataset.refNum = validKeys.join(',')
+      box.addEventListener('mouseenter', () => showCitationTooltip(docId, validKeys, refMap, box))
       box.addEventListener('mouseleave', scheduleCitationTooltipHide)
       // 클릭도 항상 툴팁을 띄운다(호버가 없는 터치 기기 대응). 실제 마우스
       // 클릭은 브라우저가 클릭 직전에 mouseenter를 먼저 쏘므로, 여기서 굳이
@@ -7748,53 +7814,69 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
-        showCitationTooltip(docId, refKey, refMap[refKey] || '', box)
+        showCitationTooltip(docId, validKeys, refMap, box)
       })
       overlay.appendChild(box)
     })
   }
 
-  // 대괄호 안에 여러 번호가 있어도([12, 13]) 툴팁은 첫 번째 매칭 번호 기준으로만
-  // 보여준다 - 대부분 단일 인용이고, 여러 개를 한 번에 보여주면 오히려 복잡해진다.
-  CITATION_MARKER_RE.lastIndex = 0
   let match
-  while ((match = CITATION_MARKER_RE.exec(vtm.fullText)) !== null) {
-    const nums = parseCitationNumbers(match[0]).filter(n => refMap[n])
-    if (nums.length === 0) continue
-    addCitationBox(match.index, match.index + match[0].length, nums[0])
+
+  if (checkNumberStyle) {
+    // "[1, 2, 3]"은 번호마다, "[66-69]"는 범위 전체가 하나로(내부에 66~69
+    // 전부 담아) 독립적인 오버레이를 갖는다. "[1,3,5-8]" 같은 혼합 표현도
+    // 항목 단위로 처리되므로 자연스럽게 지원된다.
+    CITATION_MARKER_RE.lastIndex = 0
+    while ((match = CITATION_MARKER_RE.exec(vtm.fullText)) !== null) {
+      extractBracketCitationItems(vtm.fullText, match).forEach(item => {
+        addCitationBox(item.start, item.end, item.keys)
+      })
+    }
   }
 
-  CITATION_AUTHOR_YEAR_MARKER_RE.lastIndex = 0
-  while ((match = CITATION_AUTHOR_YEAR_MARKER_RE.exec(vtm.fullText)) !== null) {
-    const keys = parseAuthorYearKeys(match[0]).filter(k => refMap[k])
-    if (keys.length === 0) continue
-    addCitationBox(match.index, match.index + match[0].length, keys[0])
+  if (checkAuthorYearStyle) {
+    // "(Morrill et al., 2021; Kidger et al., 2020; Walker et al., 2024)"처럼
+    // 세미콜론으로 묶인 여러 인용도 각각 독립적인 오버레이를 갖는다.
+    CITATION_AUTHOR_YEAR_MARKER_RE.lastIndex = 0
+    while ((match = CITATION_AUTHOR_YEAR_MARKER_RE.exec(vtm.fullText)) !== null) {
+      extractAuthorYearClauses(vtm.fullText, match).forEach(clause => {
+        addCitationBox(clause.start, clause.end, [clause.key])
+      })
+    }
+
+    // "Smith (2020)", "Li and Wang (2023)" 같은 서술형 인용
+    CITATION_NARRATIVE_AUTHOR_YEAR_RE.lastIndex = 0
+    while ((match = CITATION_NARRATIVE_AUTHOR_YEAR_RE.exec(vtm.fullText)) !== null) {
+      const key = `${match[1].toLowerCase()}${match[2]}`
+      addCitationBox(match.index, match.index + match[0].length, [key])
+    }
   }
 
-  // 참고문헌 목록 자체(대괄호가 없는 스타일)에도 오버레이를 건다 - 위 두
-  // 정규식은 대괄호 인용([12]) 또는 괄호로 묶인 저자-연도 인용((Smith, 2020))만
-  // 잡아내는데, 참고문헌 목록의 각 항목 시작 표기는 스타일에 따라 그 어느
-  // 쪽에도 안 걸리는 경우가 있다("12. Author..." 같은 번호형, "Author, A.
-  // (2020). Title..." 같은 저자-연도형). 참고문헌 목록을 훑어보다가 바로 그
-  // 자리에서 원문 링크/Scholar 검색을 쓸 수 있도록, References 헤더 이후
+  // 참고문헌 목록 자체(대괄호가 없는 스타일)에도 오버레이를 건다 - 위 정규식들은
+  // 대괄호 인용([12]) 또는 괄호/서술형 저자-연도 인용((Smith, 2020), Smith
+  // (2020))만 잡아내는데, 참고문헌 목록의 각 항목 시작 표기는 스타일에 따라
+  // 그 어느 쪽에도 안 걸리는 경우가 있다("12. Author..." 같은 번호형, "Author,
+  // A. (2020). Title..." 같은 저자-연도형). 참고문헌 목록을 훑어보다가 바로
+  // 그 자리에서 원문 링크/Scholar 검색을 쓸 수 있도록, References 헤더 이후
   // 영역에서만 이 두 표기도 추가로 인용 표기로 인정한다(섹션 밖에서 걸면
   // "2. Introduction" 같은 절 번호나 "Smith (2020)는..." 같은 서술형 문장까지
   // 오탐될 위험이 크다).
   if (referencesSectionStart >= 0) {
-    REF_ENTRY_PLAIN_NUMBER_RE.lastIndex = 0
-    while ((match = REF_ENTRY_PLAIN_NUMBER_RE.exec(vtm.fullText)) !== null) {
-      if (match.index < referencesSectionStart) continue
-      const num = match[1]
-      if (!refMap[num]) continue
-      addCitationBox(match.index, match.index + match[0].length, num)
+    if (checkNumberStyle) {
+      REF_ENTRY_PLAIN_NUMBER_RE.lastIndex = 0
+      while ((match = REF_ENTRY_PLAIN_NUMBER_RE.exec(vtm.fullText)) !== null) {
+        if (match.index < referencesSectionStart) continue
+        addCitationBox(match.index, match.index + match[0].length, [match[1]])
+      }
     }
 
-    REF_ENTRY_AUTHOR_YEAR_RE.lastIndex = 0
-    while ((match = REF_ENTRY_AUTHOR_YEAR_RE.exec(vtm.fullText)) !== null) {
-      if (match.index < referencesSectionStart) continue
-      const key = `${match[1].toLowerCase()}${match[2]}`
-      if (!refMap[key]) continue
-      addCitationBox(match.index, match.index + match[0].length, key)
+    if (checkAuthorYearStyle) {
+      REF_ENTRY_AUTHOR_YEAR_RE.lastIndex = 0
+      while ((match = REF_ENTRY_AUTHOR_YEAR_RE.exec(vtm.fullText)) !== null) {
+        if (match.index < referencesSectionStart) continue
+        const key = `${match[1].toLowerCase()}${match[2]}`
+        addCitationBox(match.index, match.index + match[0].length, [key])
+      }
     }
   }
 }
@@ -7830,7 +7912,7 @@ function normalizeFigureTableKind(keyword) {
 }
 
 // "1", "1, 2", "3-5", "1 and 2", "1, 2 and 3", "I", "I and II" 같은 숫자(아라비아
-// 또는 로마) 나열을 개별 번호 목록으로 펼친다 (본문 인용 파싱의 parseCitationNumbers와
+// 또는 로마) 나열을 개별 번호 목록으로 펼친다 (본문 인용 파싱의 extractBracketCitationItems와
 // 동일한 원칙). 로마 숫자는 범위("I-III") 표기는 흔치 않아 지원하지 않고, backend가
 // 라벨을 항상 대문자로 저장하므로(_find_page_captions) 매칭을 위해 대문자로 맞춘다.
 function parseFigureTableNumberList(text) {
@@ -8158,17 +8240,29 @@ function positionCitationTooltip() {
   citationTooltipEl.style.top = `${top}px`
 }
 
-function showCitationTooltip(docId, refNum, refText, boxEl) {
+// refKeys가 여러 개면(예: "[66-69]" 범위 인용, "(A, 2020; B, 2019)" 나열)
+// 각 항목을 "[키] 원문" 형태로 구분해 전부 보여준다. "원문 링크 찾기"/
+// Google Scholar 검색용 textContent에서도 항목 사이가 구분되도록 줄바꿈으로
+// 이어붙인다.
+function buildCitationTooltipHtml(refKeys, refMap) {
+  if (refKeys.length === 1) return renderBoldText(refMap[refKeys[0]] || '')
+  return refKeys
+    .map(k => `<div class="citation-tooltip-multi-item"><span class="citation-tooltip-multi-key">[${escapeHtml(k)}]</span> ${renderBoldText(refMap[k] || '')}</div>`)
+    .join('\n')
+}
+
+function showCitationTooltip(docId, refKeys, refMap, boxEl) {
   // 텍스트 드래그 선택 중에 마우스가 마커 박스 위를 스쳐 지나가도(mouseenter)
   // 미리보기가 뜨지 않도록 막는다 - 다른 호버 오버레이들과 동일한 가드.
   if (state.isSelectionDragging) return
   if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
   citationTooltipDocId = docId
-  citationTooltipRefNum = refNum
+  // "원문 링크 찾기"/Google Scholar 검색은 여러 키 중 첫 번째를 기준으로 동작한다.
+  citationTooltipRefNum = refKeys[0]
   citationTooltipBoxEl = boxEl
 
   const tooltip = getOrCreateCitationTooltip()
-  tooltip.querySelector('.citation-tooltip-text').innerHTML = renderBoldText(refText)
+  tooltip.querySelector('.citation-tooltip-text').innerHTML = buildCitationTooltipHtml(refKeys, refMap)
   const resultEl = tooltip.querySelector('.citation-tooltip-result')
   resultEl.className = 'citation-tooltip-result hidden'
   resultEl.innerHTML = ''

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4829,6 +4829,14 @@ body.light-theme .citation-tooltip {
   overflow-y: auto;
   margin-bottom: 10px;
 }
+.citation-tooltip-multi-item + .citation-tooltip-multi-item {
+  margin-top: 6px;
+}
+.citation-tooltip-multi-key {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-right: 2px;
+}
 .citation-tooltip-result {
   font-size: 12.5px;
   line-height: 1.5;


### PR DESCRIPTION
# Summary
## 1. 서술형 저자-연도 인용 감지 추가
- `CITATION_NARRATIVE_AUTHOR_YEAR_RE` 정규식을 추가해 `Smith (2020)`, `Li and Wang (2023)`, `Smith et al. (2020)`처럼 저자명이 괄호 밖에 있고 연도만 괄호 안에 있는 서술형 인용을 감지
- 참고문헌 목록 항목 시작 표기(`REF_ENTRY_AUTHOR_YEAR_RE`)와 겹치지 않도록 콤마/이니셜이 낀 형태는 매칭 대상에서 제외

## 2. 대괄호/저자-연도 다중 인용을 항목별 개별 오버레이로 분리
- `extractBracketCitationItems`를 추가해 `[1, 2, 3]`처럼 나열된 번호 인용을 번호마다 독립적인 오버레이로 분리(`renderCitationOverlayLayer`)
- `extractAuthorYearClauses`를 추가해 `(Morrill et al., 2021; Kidger et al., 2020; Walker et al., 2024)`처럼 세미콜론으로 묶인 인용도 항목마다 개별 오버레이 제공
- 기존 `parseCitationNumbers`/`parseAuthorYearKeys`(첫 번째 항목만 사용) 로직 제거

## 3. Citation Range 및 혼합 표현 처리
- `[66-69]`, `[5–8]` 같은 범위 표기는 하나의 오버레이로 유지하되, 오버레이 내부(툴팁)에 범위 안의 모든 참고문헌 원문을 함께 표시
- `[1,3,5-8]`처럼 단일 번호와 범위가 섞인 혼합 표현도 항목 단위 처리로 자연스럽게 지원
- 여러 참고문헌을 함께 보여주기 위해 `addCitationBox`/`showCitationTooltip`이 단일 키 대신 키 배열(`refKeys`)을 받도록 변경, `buildCitationTooltipHtml`로 다중 항목 툴팁 렌더링 추가
- `style.css`에 `.citation-tooltip-multi-item`, `.citation-tooltip-multi-key` 스타일 추가

## 4. 논문의 Citation 스타일(Number/Author-Year) 사전 판별로 오탐 감소
- `detectCitationStyle`을 추가해 참고문헌 맵의 키 형식(순수 숫자 vs "저자성+연도")으로 이 논문이 Number 스타일인지 Author-Year 스타일인지 판별
- 판별된 스타일과 반대되는 정규식은 아예 실행하지 않도록 해 `Dimension = [64, 128, 256]` 같은 숫자 배열이 Author-Year 논문에서 대괄호 인용으로 오인되는 등의 오탐을 줄임
- `state.citationStyle`을 `loadDocumentReferences` 호출 시점에 계산해 저장

## Test plan
- 독립 실행 스크립트로 위 모든 케이스(범위/혼합/서술형/스타일 감지, 및 `[H, W]`/`x ∈ R^[d]` 같은 비인용 대괄호 오탐 방지)를 검증 - 전부 통과
- `node --check`로 문법 검증, `npm run build` 정상 빌드 확인
- 기존 e2e 테스트(`citation-links.spec.js`)는 로컬 샌드박스에 PDF.js CDN 네트워크 접근이 없어 원본 코드에서도 동일하게 실패함을 교차 확인(이번 변경과 무관) - 실제 네트워크 접근 가능한 환경에서 재확인 권장