### PR TITLE
fix: 참고문헌 목록의 저자-연도 스타일이 2단 레이아웃에서 통째로 뭉쳐 파싱되던 문제 수정

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -55,11 +55,21 @@ _BRACKET_MARKER_RE = re.compile(r"\[(" + _BRACKET_KEY_RE.pattern + r")\]")
 # 우연히 일치하는 페이지/연도 숫자를 걸러낸다.
 _PLAIN_NUMBERED_MARKER_RE = re.compile(r"(?:^|\s)(\d{1,3})[.)]\s+(?=[A-Z가-힣])")
 
-# (Author, Year) 스타일 항목의 시작 줄 판별용 - "Surname, Initial..." 형태로
-# 시작하는 줄을 새 항목의 시작으로 본다. 실제로 참고문헌 항목인지는 flush 시점에
-# 텍스트 전체에서 연도((\d{4}))가 발견되는지로 한 번 더 검증한다(오탐 방지).
+# (Author, Year) 스타일 항목의 시작 판별용 - "Surname, Initial..." 형태로
+# 시작하는 구간을 새 항목의 시작으로 본다. 실제로 참고문헌 항목인지는 flush
+# 시점에 텍스트 전체에서 연도가 발견되는지로 한 번 더 검증한다(오탐 방지).
 _AUTHOR_YEAR_ENTRY_START_RE = re.compile(r"^\s*([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+),\s")
-_YEAR_RE = re.compile(r"\((\d{4})[a-z]?\)")
+# 항목 경계 자체를 텍스트 전체에서 찾을 때 쓴다(_parse_author_year_entries 참고) -
+# 문장 경계(마침표/느낌표/물음표 + 공백) 또는 텍스트 시작 바로 뒤에 "Surname,"
+# 패턴이 오는 지점을 새 항목의 시작으로 본다. 항목 안의 공저자 나열은 보통
+# 세미콜론이나 "&"로 구분되고 성 뒤에 곧바로 마침표+공백이 오는 경우가 거의
+# 없어(이니셜 뒤에는 대개 쉼표나 세미콜론이 옴) 오탐 위험이 낮다.
+_AUTHOR_YEAR_ENTRY_BOUNDARY_RE = re.compile(
+    r"(?:^|[.!?]\s+)(?=[A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+,\s)"
+)
+# 연도는 APA류처럼 괄호로 싸인 경우("(2020)")뿐 아니라, AAAI/IJCAI류처럼
+# 저자 목록 바로 뒤에 괄호 없이 오는 경우("... 2020. Title...")도 지원한다.
+_YEAR_RE = re.compile(r"\((\d{4})[a-z]?\)|(?<!\d)(\d{4})[a-z]?\.(?=\s|$)")
 
 _MAX_ENTRY_LENGTH = 500
 
@@ -140,7 +150,7 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
     if not entries:
         entries = _extract_marker_entries(body_text, _PLAIN_NUMBERED_MARKER_RE, sequential=True)
     if not entries:
-        entries = _parse_author_year_entries(body_lines)
+        entries = _parse_author_year_entries(body_text)
 
     return entries
 
@@ -175,45 +185,44 @@ def _extract_marker_entries(text: str, marker_re: "re.Pattern", sequential: bool
     return entries
 
 
-def _parse_author_year_entries(body_lines: List[str]) -> Dict[str, str]:
+def _parse_author_year_entries(body_text: str) -> Dict[str, str]:
     """번호가 없는 (Author, Year) 스타일 참고문헌 목록을 파싱합니다.
 
-    "Surname, Initial. ..." 형태로 시작하는 줄을 새 항목의 시작으로 보고,
-    그 항목(여러 줄에 걸칠 수 있음)을 전부 모은 뒤 연도가 실제로 포함돼
-    있는지 확인해서만 채택한다 - 그냥 대문자로 시작하는 일반 문장이 새
-    항목으로 오인되는 것을 막기 위함이다. 키는 "성(소문자)+연도"
-    (예: "vaswani2017")이며, 같은 저자가 같은 해에 여러 편을 낸 경우
-    (2020a/2020b 등) 먼저 나온 항목만 유지한다.
-    """
-    entries: Dict[str, str] = {}
-    current_first_line = None
-    current_parts: List[str] = []
+    예전에는 물리적 줄(\\n) 시작에서만 새 항목을 판별했는데, 2단 레이아웃
+    논문에서 실제로 관찰된 문제: PyMuPDF가 참고문헌 항목 사이의 여백을
+    인식하지 못하고 여러(때로는 대부분의) 항목을 줄바꿈이 전혀 없는 하나의
+    블록으로 통째로 추출하는 경우가 흔하다. 그러면 줄 기반 판별로는 첫
+    항목만 인식되고 나머지 전부가 그 항목 하나에 흡수돼버린다.
 
-    def flush():
-        if current_first_line is None:
-            return
-        text = re.sub(r"\s+", " ", " ".join(current_parts)).strip()
+    이를 피하기 위해 번호형(_extract_marker_entries)과 동일한 원칙으로,
+    항목 경계를 줄바꿈이 아니라 "문장 경계(마침표 등) 뒤에 오는 Surname,
+    패턴" 자체를 텍스트 전체에서 찾아 판정한다. 실제로 참고문헌 항목인지는
+    잘라낸 구간 안에 연도가 포함돼 있는지로 한 번 더 검증한다(오탐 방지).
+    키는 "성(소문자)+연도"(예: "vaswani2017")이며, 같은 저자가 같은 해에
+    여러 편을 낸 경우(2020a/2020b 등) 먼저 나온 항목만 유지한다.
+    """
+    normalized = re.sub(r"\s+", " ", body_text).strip()
+    if not normalized:
+        return {}
+
+    starts = [m.end() for m in _AUTHOR_YEAR_ENTRY_BOUNDARY_RE.finditer(normalized)]
+    if not starts or starts[0] != 0:
+        starts.insert(0, 0)
+
+    entries: Dict[str, str] = {}
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(normalized)
+        text = normalized[start:end].strip()
         if not text:
-            return
+            continue
+        surname_match = _AUTHOR_YEAR_ENTRY_START_RE.match(text)
+        if not surname_match:
+            continue
         year_match = _YEAR_RE.search(text)
-        surname_match = _AUTHOR_YEAR_ENTRY_START_RE.match(current_first_line)
-        if not (year_match and surname_match):
-            return
-        key = f"{surname_match.group(1).lower()}{year_match.group(1)}"
+        if not year_match:
+            continue
+        year = year_match.group(1) or year_match.group(2)
+        key = f"{surname_match.group(1).lower()}{year}"
         if key not in entries:
             entries[key] = text[:_MAX_ENTRY_LENGTH]
-
-    for raw_line in body_lines:
-        line = raw_line.strip()
-        if not line:
-            continue
-
-        if _AUTHOR_YEAR_ENTRY_START_RE.match(line):
-            flush()
-            current_first_line = line
-            current_parts = [line]
-        elif current_first_line is not None:
-            current_parts.append(line)
-
-    flush()
     return entries

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -222,3 +222,40 @@ def test_author_year_keeps_first_entry_on_duplicate_key():
     refs = extract_reference_list(pages)
     assert set(refs.keys()) == {"kim2020"}
     assert "First paper title" in refs["kim2020"]
+
+
+def test_author_year_entries_merged_into_single_block_without_line_breaks():
+    """2단 레이아웃 논문에서 실제로 관찰된 문제: pdf_parser.py가 여러(때로는
+    거의 대부분의) 참고문헌 항목 사이에 줄바꿈을 전혀 남기지 않고 하나의
+    블록으로 통째로 추출하는 경우가 있다(실제 논문에서 재현됨). 줄 기반
+    판별이었다면 첫 항목만 인식되고 나머지 전부가 거기 흡수됐을 것이다.
+    또한 이 케이스는 AAAI/IJCAI류 서식(연도가 괄호 없이 "... 2022. Title"
+    형태로 저자 목록 바로 뒤에 옴)도 함께 검증한다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Gifford, A. T.; Dwivedi, K.; Roig, G.; and Cichy, R. M. 2022. A large "
+        "and rich EEG dataset for modeling human visual object recognition. "
+        "NeuroImage, 264: 119754. Grill-Spector, K.; and Malach, R. 2004. The "
+        "human visual cortex. Annu. Rev. Neurosci., 27(1): 649-677. Hansen, "
+        "K. A.; Kay, K. N.; and Gallant, J. L. 2007. Topographic organization "
+        "in and near human visual area V4. Journal of Neuroscience, 27(44): "
+        "11896-11911."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"gifford2022", "grill-spector2004", "hansen2007"}
+    assert "EEG dataset" in refs["gifford2022"]
+    assert "human visual cortex" in refs["grill-spector2004"]
+    assert "Topographic organization" in refs["hansen2007"]
+
+
+def test_author_year_supports_plain_year_without_parentheses():
+    """APA류("(2020)")뿐 아니라 AAAI/IJCAI류처럼 연도가 괄호 없이 오는
+    서식("... 2020. Title")도 지원해야 한다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Smith, J.; and Lee, K. 2020. A paper without parenthesized year. "
+        "Some Venue, 1: 1-10."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"smith2020"}
+    assert "without parenthesized year" in refs["smith2020"]


### PR DESCRIPTION
# Summary
## 1. 저자-연도 참고문헌 파싱을 줄바꿈 독립적인 방식으로 재작성
- `_parse_author_year_entries`가 물리적 줄(`\n`) 시작에서만 새 항목을 판별하던 방식을, 번호형(`_extract_marker_entries`)과 동일하게 텍스트 전체에서 항목 경계를 찾는 방식으로 재작성
- 항목 경계는 `_AUTHOR_YEAR_ENTRY_BOUNDARY_RE`(문장 경계 뒤에 오는 "Surname," 패턴)로 판정, 실제 참고문헌인지는 연도 포함 여부로 재검증(오탐 방지)
- 원인: 2단 레이아웃 논문에서 PyMuPDF가 References 섹션의 여러(때로는 대부분의) 항목 사이에 줄바꿈을 전혀 남기지 않고 하나의 블록으로 통째로 추출하는 경우가 실제로 관찰됨 - 줄 기반 판별이었을 땐 첫 항목만 인식되고 나머지 전부가 거기 흡수돼, 참고문헌이 40여 개인 논문에서 뭉쳐진 항목 1개만 만들어지는 문제가 있었음

## 2. 괄호 없는 연도 서식(AAAI/IJCAI류) 지원 추가
- `_YEAR_RE`가 APA류(`(2020)`)만 인식하던 것을, AAAI/IJCAI류처럼 저자 목록 바로 뒤에 괄호 없이 오는 연도(`... 2020. Title`)도 인식하도록 확장

## 3. 테스트
- `backend/tests/test_reference_parser.py`에 회귀 방지 테스트 2건 추가: 줄바꿈 없이 하나의 블록으로 뭉쳐 추출된 경우, 괄호 없는 연도 서식
- 기존 테스트 20건 전부 통과 확인
- 실제로 문제가 됐던 논문(2단 레이아웃, AAAI 포맷)으로 직접 검증: 참고문헌 45개가 뭉쳐진 항목 1개(`{"hebart6582": "<45개 항목이 뒤섞인 500자 블록>"}`) 대신 올바르게 개별 파싱됨(`allen2022`, `gifford2022`, `hansen2007` 등)

## Test plan
- `pytest backend/tests/test_reference_parser.py` - 20/20 통과
- `pytest backend/tests/` 전체 실행 - 기존에 있던 무관한 테스트 1건(`test_config_cross_platform.py::test_project_root_falls_back_when_configured_path_missing`, subprocess stdout에 admin 기본 계정 경고 배너가 섞이는 테스트 환경 이슈)을 제외하고 전부 통과
- 실제 프로덕션에서 문제가 보고된 문서(`ViEEG.pdf`)의 PDF로 직접 재현 및 수정 확인