### PR TITLE
feat: 읽기 전 브리핑에 연구 계보/파인만 설명/실험 흐름/용어집 추가

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -868,18 +868,38 @@ async def stream_page_insight(
 
 
 _PRIMER_LINE_RE = re.compile(
-    r'^[\s\-\*>]*\**\s*(HOOK|Q1|Q2|Q3|CHECK1|CHECK2|CHECK3|REC1|REC2|REC3|REC4|REC5)\**\s*[:.\)]\s*(.+)$',
+    r'^[\s\-\*>]*\**\s*(HOOK|LINEAGE|FEYNMAN|Q1|Q2|Q3|CHECK1|CHECK2|CHECK3|'
+    r'HYPOTHESIS1|HYPOTHESIS2|HYPOTHESIS3|METHOD1|METHOD2|METHOD3|'
+    r'RESULT1|RESULT2|RESULT3|GLOSSARY1|GLOSSARY2|GLOSSARY3|GLOSSARY4|GLOSSARY5|'
+    r'REC1|REC2|REC3|REC4|REC5)\**\s*[:.\)]\s*(.+)$',
     re.IGNORECASE,
 )
 
 
-async def generate_reading_primer(title: str, text: str, target_lang: str = "한국어", session_id: str = None) -> dict:
+async def generate_reading_primer(
+    title: str,
+    sections: dict,
+    candidate_terms: list,
+    target_lang: str = "한국어",
+    session_id: str = None,
+) -> dict:
     """
-    논문 제목과 도입부(초록 등) 원문으로 "읽기 전 브리핑" 콘텐츠(훅 문장, 예측 질문 3개,
-    읽으면서 확인할 체크리스트 3개, 관련 논문 추천 최대 5개)를 생성합니다. 채팅(Chat)
-    프로바이더/모델 설정을 재사용하며, stream_page_insight와 마찬가지로 세션이 지속되는
-    CLI provider는 번역/채팅/인사이트와 동일한 문서당 공유 세션(session_id)을 그대로
-    사용합니다.
+    논문 제목과 섹션별 발췌(services.section_parser.detect_sections 결과)로 "읽기 전
+    브리핑" 콘텐츠를 생성합니다: 훅 문장, 연구 계보(LINEAGE), 파인만 기법 설명(FEYNMAN),
+    예측 질문 3개, 체크리스트 3개, 가설/실험/결과 흐름 최대 3세트, 논문 고유 용어집 최대
+    5개, 관련 논문 추천 최대 5개. 채팅(Chat) 프로바이더/모델 설정을 재사용하며,
+    stream_page_insight와 마찬가지로 세션이 지속되는 CLI provider는 번역/채팅/인사이트와
+    동일한 문서당 공유 세션(session_id)을 그대로 사용합니다.
+
+    이전에는 인트로 2페이지(3000자)만 봤지만, 계보(기존 한계→해결)와 실험 흐름을 뽑아
+    내려면 서론만으로는 근거가 부족하다. section_parser가 논문 전체를 스캔해 서론/관련
+    연구, 방법론/실험 결과, 결론 세 버킷으로 미리 압축해 넘겨주므로, 여기서는 원문
+    전체를 그대로 프롬프트에 넣지 않고도 전체 문서 맥락을 반영할 수 있다.
+
+    용어집(GLOSSARY)은 term_extractor가 정규식으로 뽑은 "논문 고유 용어 후보"를 참고
+    자료로 제공하고, 이 논문이 실제로 새로 정의한 용어인지 최종 판단은 LLM에 맡긴다 -
+    후보 추출은 재현율을 우선하므로 흔한 배경지식 용어(CNN 등)가 섞여 들어올 수 있어,
+    프롬프트에서 배경지식 용어는 제외하라고 명시한다.
 
     관련 논문은 이 논문의 참고문헌 목록을 텍스트로 기계적으로 매칭하지 않고, LLM이 자기
     지식으로 직접 추천하게 한다 - 참고문헌 목록 매칭 방식은 인용 형식이 지저분하거나
@@ -889,24 +909,58 @@ async def generate_reading_primer(title: str, text: str, target_lang: str = "한
     다시 검증한 뒤에만 채택한다.
     """
     instruction = (
-        f"다음은 학술 논문 '{title}'의 도입부(초록 등) 원문입니다. 이 논문을 읽기 전 독자가 "
-        f"호기심을 갖고 몰입할 수 있도록 아래 형식에 맞춰 {target_lang}로 작성해주세요.\n\n"
+        f"다음은 학술 논문 '{title}'에서 발췌한 원문입니다. 이 논문을 읽기 전 독자가 "
+        f"호기심을 갖고 몰입하며 스스로 학습하고 인사이트를 얻을 수 있도록 아래 형식에 "
+        f"맞춰 {target_lang}로 작성해주세요.\n\n"
         f"- HOOK: 이 논문이 다루는 문제를 흥미로운 질문 형태로 재구성한 한두 문장. 초록을 "
         f"그대로 요약하지 말고 \"왜 이 문제가 어려운가/왜 흥미로운가\"를 짚어 궁금증을 유발하세요.\n"
+        f"- LINEAGE: 기존 접근법이 어떤 한계를 가지고 있었고, 이 논문이 그 한계를 어떻게 "
+        f"해결해서 어떤 성능/결과 개선을 이뤘는지를 \"기존에는 ~해서 ~한계가 있었는데, 이 "
+        f"논문은 ~함으로써 ~했다\" 형태의 발전 계보로 2~3문장에 담으세요. 줄바꿈 없이 한 "
+        f"줄로 쓰세요.\n"
+        f"- FEYNMAN: 전문용어를 최대한 배제하고 일상적인 비유를 사용해 이 논문의 핵심 "
+        f"아이디어를 비전문가에게 설명하듯 2~4문장으로 쉽게 풀어 쓰세요(파인만 기법). "
+        f"줄바꿈 없이 한 줄로 쓰세요.\n"
         f"- Q1/Q2/Q3: 독자가 본문을 읽기 전 스스로 답을 예측해볼 만한 질문 3개. 각각 한 문장.\n"
         f"- CHECK1/CHECK2/CHECK3: 본문을 읽는 동안 확인하면 좋을 구체적인 포인트(예: 비교 대상, "
         f"핵심 수치, 한계점 등) 3개. 각각 한 문장.\n"
+        f"- HYPOTHESIS1~3/METHOD1~3/RESULT1~3: 저자가 세운 가설, 그것을 검증하기 위해 "
+        f"설계한 실험/방법, 실제로 나온 결과를 최대 3개 세트로 정리하세요. 한 세트는 "
+        f"HYPOTHESIS/METHOD/RESULT를 모두 채워야 하고, 각각 한 문장입니다. 근거가 2세트뿐 "
+        f"이면 2세트만 쓰고 3번째 세트는 통째로 생략하세요.\n"
+        f"- GLOSSARY1~5: 아래 '용어 후보' 목록을 참고해, 이 논문이 새로 만들었거나 이 "
+        f"논문의 맥락에서만 특별한 의미로 쓰이는 용어만 골라 쉬운 말로 정의하세요. "
+        f"Convolutional Neural Network, GPU처럼 이미 널리 알려진 일반 배경지식 용어는 "
+        f"절대 포함하지 마세요. 새로 만든 용어가 없다고 판단되면 GLOSSARY 항목을 하나도 "
+        f"쓰지 마세요. 형식: \"GLOSSARY1: 용어 :: 정의(한 문장)\"\n"
         f"- REC1~REC5: 이 논문을 이해하는 데 도움이 되는, 실제로 존재하는 유명하거나 핵심적인 "
         f"관련/선행 연구 논문 제목을 최대 5개까지 추천하세요. 반드시 실존하는 논문의 정확한 "
         f"원제(영어 원문 그대로, 번역하지 말 것)만 쓰고, 확신이 없거나 제목이 정확히 기억나지 "
         f"않으면 억지로 채우지 말고 그 줄은 생략하세요. 각 줄에는 논문 제목만 쓰고 저자·연도· "
         f"설명은 붙이지 마세요.\n\n"
-        f"반드시 아래 형식으로만 출력하세요(REC 항목은 확신하는 만큼만, 0~5줄). 다른 설명이나 "
-        f"서론은 절대 추가하지 마세요.\n"
-        f"HOOK: <내용>\nQ1: <내용>\nQ2: <내용>\nQ3: <내용>\nCHECK1: <내용>\nCHECK2: <내용>\n"
-        f"CHECK3: <내용>\nREC1: <논문 원제>\nREC2: <논문 원제>\n..."
+        f"반드시 아래 형식으로만 출력하세요(HYPOTHESIS/METHOD/RESULT, GLOSSARY, REC 항목은 "
+        f"확신하는 만큼만 채우고 나머지는 통째로 생략). 다른 설명이나 서론은 절대 추가하지 "
+        f"마세요.\n"
+        f"HOOK: <내용>\nLINEAGE: <내용>\nFEYNMAN: <내용>\nQ1: <내용>\nQ2: <내용>\nQ3: <내용>\n"
+        f"CHECK1: <내용>\nCHECK2: <내용>\nCHECK3: <내용>\nHYPOTHESIS1: <내용>\nMETHOD1: <내용>\n"
+        f"RESULT1: <내용>\n...\nGLOSSARY1: <용어> :: <정의>\n...\nREC1: <논문 원제>\n..."
     )
-    prompt = f"{instruction}\n\n원문:\n{text[:3000]}"
+
+    context_parts = []
+    if sections.get("intro_related"):
+        context_parts.append(f"[서론/관련 연구 발췌]\n{sections['intro_related']}")
+    if sections.get("method_results"):
+        context_parts.append(f"[방법론/실험 결과 발췌]\n{sections['method_results']}")
+    if sections.get("conclusion"):
+        context_parts.append(f"[결론 발췌]\n{sections['conclusion']}")
+    context_text = "\n\n".join(context_parts)
+
+    terms_text = ""
+    if candidate_terms:
+        term_lines = [f"- {t['term']}: \"...{t['context_sentence']}...\"" for t in candidate_terms]
+        terms_text = "\n\n[용어 후보]\n" + "\n".join(term_lines)
+
+    prompt = f"{instruction}\n\n원문 발췌:\n{context_text}{terms_text}"
 
     provider = get_chat_provider()
     model = get_chat_model()
@@ -939,7 +993,7 @@ async def generate_reading_primer(title: str, text: str, target_lang: str = "한
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
-                "options": {"temperature": 0.5},
+                "options": {"temperature": 0.5, "num_ctx": 16384},
             }
             # 스트리밍 없이 응답을 한 번에 기다리는 호출이라, 로컬 CPU 추론처럼 느린
             # 환경에서도 끊기지 않도록 다른 ollama 스트리밍 호출들과 동일하게 360초를 준다
@@ -953,7 +1007,17 @@ async def generate_reading_primer(title: str, text: str, target_lang: str = "한
         return "".join(tokens)
 
     def _parse(raw: str) -> dict:
-        result = {"hook": "", "questions": [], "checklist": [], "recommended_titles": []}
+        result = {
+            "hook": "",
+            "lineage": "",
+            "feynman": "",
+            "questions": [],
+            "checklist": [],
+            "experiment_flow": [],
+            "glossary": [],
+            "recommended_titles": [],
+        }
+        hypotheses, methods, results = {}, {}, {}
         for line in raw.splitlines():
             m = _PRIMER_LINE_RE.match(line.strip())
             if not m:
@@ -961,12 +1025,36 @@ async def generate_reading_primer(title: str, text: str, target_lang: str = "한
             key, value = m.group(1).upper(), m.group(2).strip().rstrip('*').strip()
             if key == "HOOK":
                 result["hook"] = value
+            elif key == "LINEAGE":
+                result["lineage"] = value
+            elif key == "FEYNMAN":
+                result["feynman"] = value
             elif key in ("Q1", "Q2", "Q3"):
                 result["questions"].append(value)
             elif key.startswith("CHECK"):
                 result["checklist"].append(value)
+            elif key.startswith("HYPOTHESIS"):
+                hypotheses[key[-1]] = value
+            elif key.startswith("METHOD"):
+                methods[key[-1]] = value
+            elif key.startswith("RESULT"):
+                results[key[-1]] = value
+            elif key.startswith("GLOSSARY"):
+                if "::" in value:
+                    term, _, definition = value.partition("::")
+                    term, definition = term.strip(), definition.strip()
+                    if term and definition:
+                        result["glossary"].append({"term": term, "definition": definition})
             elif key.startswith("REC"):
                 result["recommended_titles"].append(value)
+
+        for idx in ("1", "2", "3"):
+            if idx in hypotheses and idx in methods and idx in results:
+                result["experiment_flow"].append({
+                    "hypothesis": hypotheses[idx],
+                    "method": methods[idx],
+                    "result": results[idx],
+                })
         return result
 
     # CLI 기반 provider(특히 claude_code)가 드물게 지시를 완전히 무시하고 입력

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -1,12 +1,25 @@
 """
 "읽기 전 브리핑(Reading Primer)" 생성 오케스트레이션.
 
-업로드 직후 백그라운드로 실행되어 아래 네 가지를 조합한 결과를 page_insights
-테이블(doc_id, page_num=0, kind="primer")에 캐싱한다:
-  1. 훅 문장 / 예측 질문 3개 / 체크리스트 3개 (LLM, llm_client.generate_reading_primer)
+업로드 직후 백그라운드로 실행되어 아래를 조합한 결과를 page_insights 테이블
+(doc_id, page_num=0, kind="primer_v2")에 캐싱한다:
+  1. 훅 문장 / 연구 계보(LINEAGE) / 파인만 설명(FEYNMAN) / 예측 질문 3개 /
+     체크리스트 3개 / 가설-실험-결과 흐름 최대 3세트 / 논문 고유 용어집 최대 5개
+     (LLM, llm_client.generate_reading_primer)
   2. 대표 Figure 크롭 이미지 (pdf_parser.extract_pdf_images + render_image_crop)
   3. 내 라이브러리 안에서 이 논문의 참고문헌과 겹치는 논문 매칭 (외부 API 없이 텍스트 매칭)
   4. LLM이 직접 추천한 관련 논문(최대 5개)을 OpenAlex로 실존 여부 검증 후 채택
+
+1번은 예전에는 인트로 2페이지(3000자)만 LLM에 넘겼으나, 계보/실험 흐름 서사를
+뽑아내려면 서론만으로는 근거가 부족하다. section_parser.detect_sections로 논문
+전체를 스캔해 서론/관련 연구·방법론/실험 결과·결론 세 버킷으로 압축하고,
+term_extractor.extract_candidate_terms로 논문 고유 용어 후보를 정규식으로 뽑아
+LLM 합성 프롬프트에 근거로 제공한다(원문 전체를 그대로 프롬프트에 욱여넣지 않음 -
+Ollama 컨텍스트/타임아웃 제약 때문).
+
+캐시 kind를 기존 "primer"에서 "primer_v2"로 바꾼 것은 프롬프트/응답 스키마가
+바뀌어 기존 캐시에 새 필드가 없기 때문이다 - 기존 로우는 별도 마이그레이션 없이
+그냥 고아로 남는다.
 
 4번은 원래 이 논문의 참고문헌 목록을 그대로 외부 검색해 매칭하는 방식이었으나,
 인용 형식이 지저분하거나 따옴표로 감싼 제목이 없는 스타일이면 매칭 개수가 너무
@@ -27,8 +40,11 @@ from services.library import (
     list_documents,
 )
 from services.reference_parser import extract_reference_list
+from services.section_parser import detect_sections
+from services.term_extractor import extract_candidate_terms
 from services.llm_client import generate_reading_primer
 
+_PRIMER_CACHE_KIND = "primer_v2"
 _RECOMMENDATION_LIMIT = 5
 _LIBRARY_MATCH_THRESHOLD = 0.7
 _DUPLICATE_TITLE_THRESHOLD = 0.6
@@ -149,13 +165,20 @@ async def generate_primer(
     막아서는 안 되는 백그라운드 부가 기능이기 때문이다.
     """
     title = metadata.get("title") or ""
-    combined_text = "\n".join(p.get("text", "") for p in pages[:2])
+    sections = detect_sections(pages)
+    candidate_terms = extract_candidate_terms(pages)
 
     try:
-        llm_part = await generate_reading_primer(title, combined_text, target_lang=target_lang, session_id=session_id)
+        llm_part = await generate_reading_primer(
+            title, sections, candidate_terms, target_lang=target_lang, session_id=session_id
+        )
     except Exception as e:
         print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
-        llm_part = {"hook": "", "questions": [], "checklist": [], "recommended_titles": []}
+        llm_part = {
+            "hook": "", "lineage": "", "feynman": "",
+            "questions": [], "checklist": [],
+            "experiment_flow": [], "glossary": [], "recommended_titles": [],
+        }
 
     try:
         reference_map = extract_reference_list(pages)
@@ -189,8 +212,12 @@ async def generate_primer(
 
     result = {
         "hook": llm_part.get("hook", ""),
+        "lineage": llm_part.get("lineage", ""),
+        "feynman": llm_part.get("feynman", ""),
         "questions": llm_part.get("questions", []),
         "checklist": llm_part.get("checklist", []),
+        "experiment_flow": llm_part.get("experiment_flow", []),
+        "glossary": llm_part.get("glossary", []),
         "figure": figure,
         "citation_graph": {
             "library": library_matches,
@@ -199,7 +226,7 @@ async def generate_primer(
     }
 
     try:
-        save_page_insight(doc_id, 0, "primer", json.dumps(result, ensure_ascii=False), suffix=target_lang)
+        save_page_insight(doc_id, 0, _PRIMER_CACHE_KIND, json.dumps(result, ensure_ascii=False), suffix=target_lang)
     except Exception as e:
         print(f"[primer] 캐시 저장 실패 ({doc_id}): {e}")
 
@@ -207,7 +234,7 @@ async def generate_primer(
 
 
 def get_cached_primer(doc_id: str, target_lang: str = "한국어") -> Optional[dict]:
-    content = get_page_insight(doc_id, 0, "primer", suffix=target_lang)
+    content = get_page_insight(doc_id, 0, _PRIMER_CACHE_KIND, suffix=target_lang)
     if not content:
         return None
     try:

--- a/backend/services/section_parser.py
+++ b/backend/services/section_parser.py
@@ -1,0 +1,146 @@
+"""
+논문 원문 텍스트를 "서론/관련 연구", "방법론/실험 결과", "결론" 세 버킷으로
+나누는 순수 텍스트 처리 로직 (네트워크 호출 없음).
+
+읽기 전 브리핑(primer)이 "연구 계보"(기존 한계 → 해결 → 성능 향상)와
+"실험 흐름"(가설 → 방법 → 결과) 서사를 뽑아내려면 인트로 2페이지만으로는
+근거가 부족하다. 이 모듈은 논문 전체 페이지를 훑어 관련 섹션 헤더를 찾고,
+헤더 탐지가 실패하는 논문(포맷이 특이한 경우)에는 페이지 위치 기반
+휴리스틱으로 폴백한다.
+
+헤더 매칭은 reference_parser.py의 _HEADER_PREFIX_RE와 동일한 원칙(드롭캡
+대응을 위해 글자 사이 공백 허용)을 따르고, References 섹션 시작 위치도
+reference_parser의 헤더 매처를 그대로 재사용해 "결론 발췌에 참고문헌이
+섞여 들어가는 것"을 막는다.
+"""
+
+import re
+from typing import Dict, List, Optional
+
+from services.reference_parser import _match_section_header_prefix as _match_reference_header
+
+_INTRO_RELATED_MAX_CHARS = 4000
+_METHOD_RESULTS_MAX_CHARS = 4000
+_CONCLUSION_MAX_CHARS = 1500
+
+_NUM_PREFIX = r"(?:\d{1,2}[.)]?\s*|[ivx]{1,4}[.)]\s*)?"
+
+_INTRO_HEADER_RE = re.compile(
+    _NUM_PREFIX + r"(?:i\s*n\s*t\s*r\s*o\s*d\s*u\s*c\s*t\s*i\s*o\s*n|서\s*론|들\s*어\s*가\s*며)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RELATED_WORK_HEADER_RE = re.compile(
+    _NUM_PREFIX + r"(?:r\s*e\s*l\s*a\s*t\s*e\s*d\s*w\s*o\s*r\s*k|b\s*a\s*c\s*k\s*g\s*r\s*o\s*u\s*n\s*d|관\s*련\s*연\s*구)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_METHOD_HEADER_RE = re.compile(
+    _NUM_PREFIX + r"(?:m\s*e\s*t\s*h\s*o\s*d\s*(?:o\s*l\s*o\s*g\s*y)?|a\s*p\s*p\s*r\s*o\s*a\s*c\s*h|방\s*법\s*론?)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RESULTS_HEADER_RE = re.compile(
+    _NUM_PREFIX + r"(?:r\s*e\s*s\s*u\s*l\s*t\s*s?|e\s*x\s*p\s*e\s*r\s*i\s*m\s*e\s*n\s*t\s*s?|실\s*험|결\s*과)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_CONCLUSION_HEADER_RE = re.compile(
+    _NUM_PREFIX + r"(?:c\s*o\s*n\s*c\s*l\s*u\s*s\s*i\s*o\s*n\s*s?|d\s*i\s*s\s*c\s*u\s*s\s*s\s*i\s*o\s*n|결\s*론|맺\s*음\s*말)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _first_match_pos(pattern: "re.Pattern", text: str) -> Optional[int]:
+    m = pattern.search(text)
+    return m.start() if m else None
+
+
+def _min_found(*positions: Optional[int]) -> Optional[int]:
+    found = [p for p in positions if p is not None]
+    return min(found) if found else None
+
+
+def _find_reference_start_offset(page_texts: List[str]) -> Optional[int]:
+    """References/참고문헌 섹션이 시작하는 페이지를 찾아 전체 텍스트 기준
+    글자 오프셋으로 변환한다. 결론 발췌 끝을 여기서 잘라 참고문헌 목록이
+    섞여 들어가지 않게 하는 데 쓴다."""
+    ref_start_page_idx = None
+    for i in range(len(page_texts) - 1, -1, -1):
+        if any(_match_reference_header(line) is not None for line in page_texts[i].split("\n")):
+            ref_start_page_idx = i
+            break
+    if ref_start_page_idx is None:
+        return None
+    return sum(len(page_texts[i]) + 1 for i in range(ref_start_page_idx))
+
+
+def _positional_fallback(full_text: str, doc_end: int) -> Dict[str, str]:
+    """헤더 탐지가 실패했을 때 페이지(글자) 위치 비율로 대체 분할한다:
+    앞 30% → 서론/관련 연구, 중간 55% → 방법론/실험, 마지막 15% → 결론."""
+    intro_end = int(doc_end * 0.3)
+    conclusion_start = int(doc_end * 0.85)
+    return {
+        "intro_related": full_text[:intro_end].strip(),
+        "method_results": full_text[intro_end:conclusion_start].strip(),
+        "conclusion": full_text[conclusion_start:doc_end].strip(),
+    }
+
+
+def detect_sections(pages: List[dict]) -> Dict[str, str]:
+    """페이지 목록(각 {"text": ...} 포함)에서 서론/관련 연구, 방법론/실험 결과,
+    결론 발췌를 뽑아낸다. 실패해도 예외를 던지지 않고 빈 문자열들을 반환한다
+    (호출부가 이 실패를 전체 기능 중단으로 이어가지 않도록)."""
+    try:
+        return _detect_sections_impl(pages)
+    except Exception:
+        return {"intro_related": "", "method_results": "", "conclusion": ""}
+
+
+def _detect_sections_impl(pages: List[dict]) -> Dict[str, str]:
+    page_texts = [p.get("text", "") or "" for p in pages]
+    full_text = "\n".join(page_texts)
+    if not full_text.strip():
+        return {"intro_related": "", "method_results": "", "conclusion": ""}
+
+    ref_start_offset = _find_reference_start_offset(page_texts)
+    doc_end = ref_start_offset if ref_start_offset is not None else len(full_text)
+
+    intro_pos = _first_match_pos(_INTRO_HEADER_RE, full_text)
+    related_pos = _first_match_pos(_RELATED_WORK_HEADER_RE, full_text)
+    method_pos = _first_match_pos(_METHOD_HEADER_RE, full_text)
+    results_pos = _first_match_pos(_RESULTS_HEADER_RE, full_text)
+    conclusion_pos = _first_match_pos(_CONCLUSION_HEADER_RE, full_text)
+
+    intro_related_start = _min_found(intro_pos, related_pos)
+    method_start = _min_found(method_pos, results_pos)
+
+    # 방법론/결론 헤더가 서론보다 앞에서(오탐으로) 잡히면 순서가 뒤집히므로 무시한다.
+    if method_start is not None and intro_related_start is not None and method_start <= intro_related_start:
+        method_start = None
+    if conclusion_pos is not None:
+        earliest = method_start if method_start is not None else intro_related_start
+        if earliest is not None and conclusion_pos <= earliest:
+            conclusion_pos = None
+
+    intro_related_end = method_start if method_start is not None else (
+        conclusion_pos if conclusion_pos is not None else doc_end
+    )
+    method_end = conclusion_pos if conclusion_pos is not None else doc_end
+
+    sections = {"intro_related": "", "method_results": "", "conclusion": ""}
+    if intro_related_start is not None:
+        sections["intro_related"] = full_text[intro_related_start:intro_related_end].strip()
+    if method_start is not None:
+        sections["method_results"] = full_text[method_start:method_end].strip()
+    if conclusion_pos is not None:
+        sections["conclusion"] = full_text[conclusion_pos:doc_end].strip()
+
+    if not sections["intro_related"] and not sections["method_results"] and not sections["conclusion"]:
+        sections = _positional_fallback(full_text, doc_end)
+    elif not sections["intro_related"]:
+        # 계보/파인만 설명의 최소 근거는 항상 확보한다 - 방법론/결론 헤더만
+        # 잡히고 서론 헤더 탐지에만 실패하는 경우를 대비.
+        sections["intro_related"] = full_text[: int(doc_end * 0.3)].strip()
+
+    return {
+        "intro_related": sections["intro_related"][:_INTRO_RELATED_MAX_CHARS],
+        "method_results": sections["method_results"][:_METHOD_RESULTS_MAX_CHARS],
+        "conclusion": sections["conclusion"][:_CONCLUSION_MAX_CHARS],
+    }

--- a/backend/services/term_extractor.py
+++ b/backend/services/term_extractor.py
@@ -1,0 +1,90 @@
+"""
+논문 원문에서 저자가 새로 만든(coined) 용어/약어 후보를 뽑아내는 순수 텍스트
+처리 로직 (네트워크 호출/LLM 호출 없음).
+
+읽기 전 브리핑의 "용어집" 섹션은 독자가 해당 분야는 알아도 이 논문이 새로
+붙인 이름(예: "HNEN")은 모를 수 있다는 문제를 다룬다. 이 모듈은 정규식으로
+전체 문서를 스캔해 후보를 값싸게 넓게 모으고, 실제로 이 논문 고유의 용어인지
+최종 판단은 LLM 합성 단계(llm_client.generate_reading_primer)에 맡긴다 -
+여기서는 재현율(누락 방지)을 우선하고 정밀도는 프롬프트 지시로 보완한다.
+"""
+
+import re
+from typing import Dict, List, Optional
+
+_MAX_CANDIDATES = 10
+_CONTEXT_WINDOW = 100
+
+# "Full Term (ACRONYM)" 형태의 최초 정의. 2~7개의 대문자로 시작하는 단어가
+# 이어지고 뒤에 대문자 약어(2~8자)가 괄호로 붙는 경우만 인정한다.
+_ACRONYM_DEF_RE = re.compile(
+    r"\b((?:[A-Z][a-zA-Z]*\s+){1,6}[A-Z][a-zA-Z]*)\s*\(([A-Z]{2,8})\)"
+)
+# "we call/term/refer to/denote/define ... as X" 패턴.
+_COINED_TERM_RE = re.compile(
+    r"\bwe\s+(?:call|term|refer to|denote|define)\b[^.]{0,80}?\bas\s+"
+    r"[\"“]?([A-Z][A-Za-z0-9\-]{1,40})[\"”]?",
+    re.IGNORECASE,
+)
+# "we introduce/propose X" 패턴.
+_INTRODUCE_TERM_RE = re.compile(
+    r"\bwe\s+(?:introduce|propose)\s+(?:a\s+|an\s+|the\s+|new\s+|novel\s+)*"
+    r"[\"“]?([A-Z][A-Za-z0-9\-]{1,40})[\"”]?",
+)
+# "... a novel method called X" 처럼 "introduce/propose"와 용어 사이에 수식어가
+# 낀 경우까지 잡기 위한 보조 패턴.
+_CALLED_TERM_RE = re.compile(
+    r"\bcalled\s+[\"“]?([A-Z][A-Za-z0-9\-]{1,40})[\"”]?"
+)
+
+# 이미 널리 알려진 일반 배경지식 약어는 후보에서 미리 제외한다(정밀도 보완).
+# 그 외 애매한 경우의 최종 판단은 LLM 합성 프롬프트가 맡는다.
+_COMMON_ACRONYM_STOPLIST = {
+    "CNN", "RNN", "LSTM", "GAN", "GPU", "CPU", "API", "PDF", "NLP", "SVM",
+    "MLP", "VAE", "ROC", "AUC", "IID", "SGD", "RELU", "BERT", "GPT", "AI",
+    "ML", "DL", "USA", "UK", "EU",
+}
+
+
+def extract_candidate_terms(pages: List[dict]) -> List[Dict[str, Optional[str]]]:
+    """페이지 목록(각 {"text": ..., "page_num": ...} 포함)에서 논문 고유
+    용어 후보를 뽑는다. 실패해도 예외를 던지지 않고 빈 리스트를 반환한다."""
+    try:
+        return _extract_candidate_terms_impl(pages)
+    except Exception:
+        return []
+
+
+def _extract_candidate_terms_impl(pages: List[dict]) -> List[Dict[str, Optional[str]]]:
+    candidates = []
+    seen = set()
+
+    for page in pages:
+        text = page.get("text", "") or ""
+        page_num = page.get("page_num")
+
+        for pattern, is_acronym_def in (
+            (_ACRONYM_DEF_RE, True),
+            (_COINED_TERM_RE, False),
+            (_INTRODUCE_TERM_RE, False),
+            (_CALLED_TERM_RE, False),
+        ):
+            for m in pattern.finditer(text):
+                term = (m.group(2) if is_acronym_def else m.group(1)).strip("\"“”").strip()
+                if not term:
+                    continue
+                if is_acronym_def and term.upper() in _COMMON_ACRONYM_STOPLIST:
+                    continue
+                key = term.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                start = max(0, m.start() - _CONTEXT_WINDOW)
+                end = min(len(text), m.end() + _CONTEXT_WINDOW)
+                context = re.sub(r"\s+", " ", text[start:end]).strip()
+                candidates.append({"term": term, "context_sentence": context, "page_num": page_num})
+
+                if len(candidates) >= _MAX_CANDIDATES:
+                    return candidates
+    return candidates

--- a/backend/tests/test_generate_reading_primer.py
+++ b/backend/tests/test_generate_reading_primer.py
@@ -1,0 +1,94 @@
+"""services/llm_client.py의 generate_reading_primer() 응답 파싱 테스트.
+
+실제 LLM 호출은 하지 않고 stream_antigravity를 대체해 고정된 응답 텍스트를
+돌려주게 한 뒤, 신규 필드(LINEAGE/FEYNMAN/HYPOTHESIS-METHOD-RESULT/GLOSSARY)를
+포함한 응답이 올바르게 파싱되는지 검증한다.
+"""
+
+import pytest
+
+import services.llm_client as llm_client
+
+
+@pytest.fixture()
+def fake_provider(monkeypatch):
+    """stream_antigravity가 실제 CLI를 호출하지 않도록 대체하고, 미리 정해둔
+    응답을 돌려주게 한다."""
+    state = {"response": ""}
+
+    async def fake_stream_antigravity(prompt, model=None, session_id=None, **kwargs):
+        yield state["response"]
+
+    monkeypatch.setattr(llm_client, "stream_antigravity", fake_stream_antigravity)
+    monkeypatch.setattr(llm_client, "get_chat_provider", lambda: "antigravity")
+    monkeypatch.setattr(llm_client, "get_chat_model", lambda: "test-model")
+    return state
+
+
+_FULL_RESPONSE = (
+    "HOOK: 기존 접근이 왜 실패하는가?\n"
+    "LINEAGE: 기존 방법은 한계가 있었는데, 이 논문은 이를 해결해 성능을 높였다.\n"
+    "FEYNMAN: 마치 지도를 그리듯 핵심 아이디어를 비유로 설명한다.\n"
+    "Q1: 질문1\nQ2: 질문2\nQ3: 질문3\n"
+    "CHECK1: 체크1\nCHECK2: 체크2\nCHECK3: 체크3\n"
+    "HYPOTHESIS1: 가설1\nMETHOD1: 방법1\nRESULT1: 결과1\n"
+    "HYPOTHESIS2: 가설2\nMETHOD2: 방법2\nRESULT2: 결과2\n"
+    "GLOSSARY1: HNEN :: 계층적 신경 인코딩 누락 현상을 뜻하는 용어\n"
+    "GLOSSARY2: ViEEG :: 시각-EEG 교차 인코딩 프레임워크\n"
+    "REC1: Attention Is All You Need\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_parses_all_new_fields(fake_provider):
+    fake_provider["response"] = _FULL_RESPONSE
+    result = await llm_client.generate_reading_primer(
+        "Test Paper",
+        {"intro_related": "intro text", "method_results": "method text", "conclusion": "concl text"},
+        [{"term": "HNEN", "context_sentence": "...HNEN framework...", "page_num": 1}],
+    )
+
+    assert result["hook"] == "기존 접근이 왜 실패하는가?"
+    assert "해결해 성능을 높였다" in result["lineage"]
+    assert "비유로 설명한다" in result["feynman"]
+    assert result["questions"] == ["질문1", "질문2", "질문3"]
+    assert result["checklist"] == ["체크1", "체크2", "체크3"]
+    assert result["recommended_titles"] == ["Attention Is All You Need"]
+
+    assert result["experiment_flow"] == [
+        {"hypothesis": "가설1", "method": "방법1", "result": "결과1"},
+        {"hypothesis": "가설2", "method": "방법2", "result": "결과2"},
+    ]
+
+    assert result["glossary"] == [
+        {"term": "HNEN", "definition": "계층적 신경 인코딩 누락 현상을 뜻하는 용어"},
+        {"term": "ViEEG", "definition": "시각-EEG 교차 인코딩 프레임워크"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_incomplete_experiment_flow_set_is_dropped(fake_provider):
+    """HYPOTHESIS만 있고 METHOD/RESULT가 없는 불완전한 세트는 결과에 포함하지 않는다."""
+    fake_provider["response"] = "HOOK: h\nHYPOTHESIS1: 가설만 있음\n"
+    result = await llm_client.generate_reading_primer(
+        "Test Paper", {"intro_related": "x", "method_results": "", "conclusion": ""}, []
+    )
+    assert result["experiment_flow"] == []
+
+
+@pytest.mark.asyncio
+async def test_glossary_line_without_delimiter_is_ignored(fake_provider):
+    fake_provider["response"] = "HOOK: h\nGLOSSARY1: 구분자가 없는 잘못된 형식\n"
+    result = await llm_client.generate_reading_primer(
+        "Test Paper", {"intro_related": "x", "method_results": "", "conclusion": ""}, []
+    )
+    assert result["glossary"] == []
+
+
+@pytest.mark.asyncio
+async def test_empty_sections_and_terms_do_not_crash_prompt_building(fake_provider):
+    fake_provider["response"] = "HOOK: h\n"
+    result = await llm_client.generate_reading_primer(
+        "Test Paper", {"intro_related": "", "method_results": "", "conclusion": ""}, []
+    )
+    assert result["hook"] == "h"

--- a/backend/tests/test_section_parser.py
+++ b/backend/tests/test_section_parser.py
@@ -1,0 +1,47 @@
+"""services/section_parser.py의 순수 텍스트 처리 로직 테스트."""
+
+from services.section_parser import detect_sections
+
+
+def _page(page_num, text):
+    return {"page_num": page_num, "text": text}
+
+
+def test_detect_sections_splits_by_headers():
+    pages = [
+        _page(1, "Abstract\nThis paper studies X.\n\n1. Introduction\nExisting methods suffer from Y."),
+        _page(2, "2. Related Work\nPrior work Z has limitations."),
+        _page(3, "3. Method\nWe hypothesize A. Our approach uses B."),
+        _page(4, "4. Results\nOur method improves accuracy by 10%."),
+        _page(5, "5. Conclusion\nWe showed that A holds."),
+        _page(6, "References\n[1] Someone. Some Paper. 2020."),
+    ]
+    sections = detect_sections(pages)
+    assert "Existing methods suffer from Y" in sections["intro_related"]
+    assert "Prior work Z has limitations" in sections["intro_related"]
+    assert "We hypothesize A" in sections["method_results"]
+    assert "improves accuracy by 10%" in sections["method_results"]
+    assert "We showed that A holds" in sections["conclusion"]
+    # References 섹션은 어느 버킷에도 섞여 들어가지 않는다
+    assert "Someone" not in sections["conclusion"]
+    assert "Someone" not in sections["method_results"]
+
+
+def test_detect_sections_falls_back_to_positional_split_when_no_headers_found():
+    pages = [_page(i, f"Page {i} body text without any recognizable section headers. " * 5) for i in range(1, 11)]
+    sections = detect_sections(pages)
+    assert sections["intro_related"]
+    assert sections["method_results"]
+    assert sections["conclusion"]
+
+
+def test_detect_sections_handles_empty_pages():
+    assert detect_sections([]) == {"intro_related": "", "method_results": "", "conclusion": ""}
+    assert detect_sections([_page(1, "")]) == {"intro_related": "", "method_results": "", "conclusion": ""}
+
+
+def test_detect_sections_truncates_to_char_limits():
+    long_intro = "1. Introduction\n" + ("word " * 2000)
+    pages = [_page(1, long_intro)]
+    sections = detect_sections(pages)
+    assert len(sections["intro_related"]) <= 4000

--- a/backend/tests/test_term_extractor.py
+++ b/backend/tests/test_term_extractor.py
@@ -1,0 +1,45 @@
+"""services/term_extractor.py의 순수 텍스트 처리 로직 테스트."""
+
+from services.term_extractor import extract_candidate_terms
+
+
+def _page(page_num, text):
+    return {"page_num": page_num, "text": text}
+
+
+def test_extracts_acronym_definition():
+    pages = [_page(1, "We propose the Hierarchical Neural Encoding Neglect (HNEN) framework.")]
+    terms = [t["term"] for t in extract_candidate_terms(pages)]
+    assert "HNEN" in terms
+
+
+def test_extracts_coined_term_phrase():
+    pages = [_page(1, "We call this phenomenon as EncodingDrift throughout the paper.")]
+    terms = [t["term"] for t in extract_candidate_terms(pages)]
+    assert "EncodingDrift" in terms
+
+
+def test_extracts_introduced_term_phrase():
+    pages = [_page(1, "We introduce a novel method called ViEEG for cross-modal encoding.")]
+    terms = [t["term"] for t in extract_candidate_terms(pages)]
+    assert "ViEEG" in terms
+
+
+def test_filters_common_acronyms():
+    pages = [_page(1, "We use a Convolutional Neural Network (CNN) as a baseline encoder.")]
+    terms = [t["term"] for t in extract_candidate_terms(pages)]
+    assert "CNN" not in terms
+
+
+def test_deduplicates_repeated_terms_across_pages():
+    pages = [
+        _page(1, "We propose the Hierarchical Neural Encoding Neglect (HNEN) framework."),
+        _page(2, "As discussed, the Hierarchical Neural Encoding Neglect (HNEN) framework generalizes well."),
+    ]
+    terms = [t["term"] for t in extract_candidate_terms(pages)]
+    assert terms.count("HNEN") == 1
+
+
+def test_returns_empty_list_when_no_candidates():
+    pages = [_page(1, "This is a plain sentence with no defined terms at all.")]
+    assert extract_candidate_terms(pages) == []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1053,41 +1053,96 @@
           </div>
         </div>
 
-        <div id="primer-hook-section" class="primer-hook-section hidden">
-          <span class="primer-hook-quote">&ldquo;</span>
-          <p id="primer-hook-text" class="primer-hook-text"></p>
+        <div id="primer-tabs" class="primer-tabs" role="tablist">
+          <button type="button" class="primer-tab-btn active" data-tab="overview">개요</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="lineage">계보</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="feynman">쉽게 이해하기</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="experiment">실험 흐름</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="glossary">용어집</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="graph">관련 논문</button>
         </div>
 
-        <div id="primer-questions-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
-            <span>읽기 전에 스스로 답해보기</span>
-          </div>
-          <ol id="primer-questions" class="primer-list"></ol>
-        </div>
+        <div class="primer-tab-panels">
+          <div class="primer-tab-panel active" data-panel="overview">
+            <div id="primer-hook-section" class="primer-hook-section hidden">
+              <span class="primer-hook-quote">&ldquo;</span>
+              <p id="primer-hook-text" class="primer-hook-text"></p>
+            </div>
 
-        <div id="primer-figure-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
-            <span>핵심 그림 먼저 보기</span>
-          </div>
-          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
-        </div>
+            <div id="primer-questions-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+                <span>읽기 전에 스스로 답해보기</span>
+              </div>
+              <ol id="primer-questions" class="primer-list"></ol>
+            </div>
 
-        <div id="primer-checklist-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
-            <span>읽으면서 확인할 것</span>
-          </div>
-          <ul id="primer-checklist" class="primer-checklist"></ul>
-        </div>
+            <div id="primer-figure-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+                <span>핵심 그림 먼저 보기</span>
+              </div>
+              <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+            </div>
 
-        <div id="primer-graph-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
-            <span>이 논문과 연결된 논문</span>
+            <div id="primer-checklist-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+                <span>읽으면서 확인할 것</span>
+              </div>
+              <ul id="primer-checklist" class="primer-checklist"></ul>
+            </div>
           </div>
-          <div id="primer-graph" class="primer-graph"></div>
+
+          <div class="primer-tab-panel" data-panel="lineage">
+            <div id="primer-lineage-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg></span>
+                <span>이 논문의 연구 계보</span>
+              </div>
+              <p id="primer-lineage-text" class="primer-lineage-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="feynman">
+            <div id="primer-feynman-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/></svg></span>
+                <span>파인만 기법으로 쉽게 이해하기</span>
+              </div>
+              <p id="primer-feynman-text" class="primer-feynman-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="experiment">
+            <div id="primer-experiment-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/></svg></span>
+                <span>가설 → 실험 → 결과 흐름</span>
+              </div>
+              <ol id="primer-experiment-flow" class="primer-experiment-flow"></ol>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="glossary">
+            <div id="primer-glossary-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span>
+                <span>이 논문이 새로 정의한 용어</span>
+              </div>
+              <div id="primer-glossary" class="primer-glossary"></div>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="graph">
+            <div id="primer-graph-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+                <span>이 논문과 연결된 논문</span>
+              </div>
+              <div id="primer-graph" class="primer-graph"></div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -290,6 +290,15 @@ const primerFigureSection  = $('primer-figure-section')
 const primerFigureImg      = $('primer-figure-img')
 const primerChecklistSection = $('primer-checklist-section')
 const primerChecklist      = $('primer-checklist')
+const primerTabsBar        = $('primer-tabs')
+const primerLineageSection = $('primer-lineage-section')
+const primerLineageText    = $('primer-lineage-text')
+const primerFeynmanSection = $('primer-feynman-section')
+const primerFeynmanText    = $('primer-feynman-text')
+const primerExperimentSection = $('primer-experiment-section')
+const primerExperimentFlow = $('primer-experiment-flow')
+const primerGlossarySection = $('primer-glossary-section')
+const primerGlossary       = $('primer-glossary')
 const primerGraphSection   = $('primer-graph-section')
 const primerGraph          = $('primer-graph')
 const primerSkipBtn        = $('primer-skip-btn')
@@ -4879,6 +4888,92 @@ function hidePrimerModal(result) {
   }
 }
 
+// 섹션이 계보/파인만 설명/실험 흐름/용어집/관련 논문까지 늘어나 세로로 나열하면
+// 모달이 너무 길어지므로 탭 구조로 나눈다. 개요 탭은 항상 노출하고, 나머지
+// 탭은 해당 데이터가 없으면(예: 논문이 새 용어를 안 만든 경우 용어집) 탭
+// 버튼 자체를 숨겨 탭바가 지저분해지지 않게 한다.
+function switchPrimerTab(tabName) {
+  document.querySelectorAll('.primer-tab-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tabName)
+  })
+  document.querySelectorAll('.primer-tab-panel').forEach(panel => {
+    panel.classList.toggle('active', panel.dataset.panel === tabName)
+  })
+}
+
+function togglePrimerTabButton(tabName, visible) {
+  const btn = primerTabsBar && primerTabsBar.querySelector(`.primer-tab-btn[data-tab="${tabName}"]`)
+  if (btn) btn.classList.toggle('hidden', !visible)
+}
+
+if (primerTabsBar) {
+  primerTabsBar.addEventListener('click', (e) => {
+    const btn = e.target.closest('.primer-tab-btn')
+    if (!btn || btn.classList.contains('hidden')) return
+    switchPrimerTab(btn.dataset.tab)
+  })
+}
+
+function renderPrimerLineage(data) {
+  if (data.lineage) {
+    primerLineageText.textContent = data.lineage
+    primerLineageSection.classList.remove('hidden')
+  } else {
+    primerLineageSection.classList.add('hidden')
+  }
+  togglePrimerTabButton('lineage', !!data.lineage)
+}
+
+function renderPrimerFeynman(data) {
+  if (data.feynman) {
+    primerFeynmanText.textContent = data.feynman
+    primerFeynmanSection.classList.remove('hidden')
+  } else {
+    primerFeynmanSection.classList.add('hidden')
+  }
+  togglePrimerTabButton('feynman', !!data.feynman)
+}
+
+function renderPrimerExperimentFlow(data) {
+  const flow = data.experiment_flow || []
+  if (flow.length === 0) {
+    primerExperimentSection.classList.add('hidden')
+    primerExperimentFlow.innerHTML = ''
+    togglePrimerTabButton('experiment', false)
+    return
+  }
+  primerExperimentFlow.innerHTML = flow.map((step, i) => `
+    <li class="primer-experiment-step">
+      <div class="primer-experiment-step-num">${i + 1}</div>
+      <div class="primer-experiment-step-body">
+        <div class="primer-experiment-row"><span class="primer-experiment-tag">가설</span><span>${escapeHtml(step.hypothesis)}</span></div>
+        <div class="primer-experiment-row"><span class="primer-experiment-tag">방법</span><span>${escapeHtml(step.method)}</span></div>
+        <div class="primer-experiment-row"><span class="primer-experiment-tag">결과</span><span>${escapeHtml(step.result)}</span></div>
+      </div>
+    </li>
+  `).join('')
+  primerExperimentSection.classList.remove('hidden')
+  togglePrimerTabButton('experiment', true)
+}
+
+function renderPrimerGlossary(data) {
+  const glossary = data.glossary || []
+  if (glossary.length === 0) {
+    primerGlossarySection.classList.add('hidden')
+    primerGlossary.innerHTML = ''
+    togglePrimerTabButton('glossary', false)
+    return
+  }
+  primerGlossary.innerHTML = glossary.map(g => `
+    <details class="primer-glossary-item">
+      <summary class="primer-glossary-term">${escapeHtml(g.term)}</summary>
+      <p class="primer-glossary-def">${escapeHtml(g.definition)}</p>
+    </details>
+  `).join('')
+  primerGlossarySection.classList.remove('hidden')
+  togglePrimerTabButton('glossary', true)
+}
+
 function renderPrimerCitationGraph(container, citationGraph, mode) {
   const section = primerGraphSection
   const libraryMatches = (citationGraph && citationGraph.library) || []
@@ -4890,9 +4985,11 @@ function renderPrimerCitationGraph(container, citationGraph, mode) {
   if (nodes.length === 0) {
     section.classList.add('hidden')
     container.innerHTML = ''
+    togglePrimerTabButton('graph', false)
     return
   }
   section.classList.remove('hidden')
+  togglePrimerTabButton('graph', true)
 
   const width = 460, height = 280, cx = width / 2, cy = height / 2
   const nodeR = 40, centerR = 32
@@ -4969,7 +5066,13 @@ function renderPrimerContent(doc, data, mode) {
     primerFigureSection.classList.add('hidden')
   }
 
+  renderPrimerLineage(data)
+  renderPrimerFeynman(data)
+  renderPrimerExperimentFlow(data)
+  renderPrimerGlossary(data)
   renderPrimerCitationGraph(primerGraph, data.citation_graph, mode)
+
+  switchPrimerTab('overview')
 }
 
 async function showPrimerModal(doc, { mode = 'gate' } = {}) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1626,8 +1626,53 @@ body.light-theme .toast.error { color: #dc2626; }
   padding: 30px 30px 10px;
   display: flex;
   flex-direction: column;
-  gap: 26px;
+  gap: 22px;
 }
+
+/* 섹션이 늘어나(계보/파인만 설명/실험 흐름/용어집/관련 논문) 세로 나열로는
+   모달이 너무 길어져 탭 구조로 나눈다. 데이터가 없는 탭은 버튼 자체를
+   숨긴다(main.js togglePrimerTabButton). */
+.primer-tabs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  border-bottom: 1px solid var(--border);
+}
+.primer-tab-btn {
+  flex-shrink: 0;
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  position: relative;
+  transition: color 0.15s ease;
+}
+.primer-tab-btn:hover { color: var(--text-primary); }
+.primer-tab-btn.active { color: var(--accent-mid); }
+.primer-tab-btn.active::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
+}
+
+.primer-tab-panels { display: flex; flex-direction: column; }
+.primer-tab-panel {
+  display: none;
+  flex-direction: column;
+  gap: 22px;
+}
+.primer-tab-panel.active { display: flex; }
 
 /* 헤더: 아이콘 배지 + "읽기 전 브리핑" 킥커 + 논문 제목 */
 .primer-header {
@@ -1778,6 +1823,101 @@ body.light-theme .toast.error { color: #dc2626; }
   border-left: 1.5px solid var(--accent-mid);
   border-bottom: 1.5px solid var(--accent-mid);
   transform: rotate(-45deg);
+}
+
+/* 계보 / 파인만 설명: 서사형 문단이라 인용구 대신 일반 본문 스타일로 보여준다 */
+.primer-lineage-text,
+.primer-feynman-text {
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+/* 실험 흐름: 가설 → 방법 → 결과를 세로 스텝퍼로 표시 */
+.primer-experiment-flow {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.primer-experiment-step {
+  display: flex;
+  gap: 12px;
+}
+.primer-experiment-step-num {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text, var(--accent-mid));
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.primer-experiment-step-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.primer-experiment-step:last-child .primer-experiment-step-body {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.primer-experiment-row {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.primer-experiment-tag {
+  flex-shrink: 0;
+  width: 34px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-to, var(--accent-mid));
+}
+
+/* 용어집: 논문 고유 용어를 접었다 펼치는 카드 형태 */
+.primer-glossary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.primer-glossary-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+}
+.primer-glossary-term {
+  cursor: pointer;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  list-style: none;
+}
+.primer-glossary-term::-webkit-details-marker { display: none; }
+.primer-glossary-term::before {
+  content: "+";
+  display: inline-block;
+  width: 14px;
+  color: var(--accent-mid);
+  font-weight: 700;
+}
+.primer-glossary-item[open] .primer-glossary-term::before { content: "−"; }
+.primer-glossary-def {
+  margin-top: 6px;
+  padding-left: 14px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
 }
 
 .primer-figure-img {


### PR DESCRIPTION
# Summary
## 1. 브리핑 LLM 컨텍스트 확장 (인트로 2페이지 → 논문 전체 스캔)
- `backend/services/section_parser.py` 신규 추가: `detect_sections()`로 논문 전체를 서론/관련연구, 방법론/실험결과, 결론 세 버킷으로 분리
  - 섹션 헤더 정규식 탐지(번호/로마숫자 접두어, 드롭캡 대응 글자 사이 공백 허용)
  - 헤더 탐지 실패 시 페이지 위치 비율(30%/55%/15%) 기반 폴백
  - References 섹션 시작 위치를 `reference_parser._match_section_header_prefix` 재사용으로 계산해 결론 발췌에 참고문헌이 섞이지 않도록 처리
  - 각 버킷 글자 수 상한(4000/4000/1500자) 적용
- `backend/services/term_extractor.py` 신규 추가: `extract_candidate_terms()`로 논문 고유 용어 후보를 정규식으로 추출
  - "Full Term (ACRONYM)" 정의, "we call/term/refer to/denote/define ... as X", "we introduce/propose X", "... called X" 패턴 지원
  - CNN/GPU 등 흔한 배경지식 약어는 스톱리스트로 사전 제외
  - LLM 호출 없이 전체 문서를 커버(비용 0), 최종 채택 여부는 LLM 합성 단계가 판단

## 2. LLM 프롬프트/파싱 확장 (backend/services/llm_client.py)
- `generate_reading_primer()` 시그니처를 `(title, sections, candidate_terms, target_lang, session_id)`로 변경
- 신규 필드 추가: `LINEAGE`(기존 한계 → 해결 → 성능 향상 계보), `FEYNMAN`(비유 기반 쉬운 설명), `HYPOTHESIS/METHOD/RESULT 1~3`(가설-실험-결과 흐름), `GLOSSARY 1~5`(논문 고유 용어 정의, `용어 :: 정의` 포맷)
- `_PRIMER_LINE_RE` 정규식 alternation 확장 및 `_parse()`에 신규 필드 파싱/조합 로직 추가 (실험 흐름은 HYPOTHESIS/METHOD/RESULT 세트가 모두 있을 때만 채택)
- Ollama 폴백 호출에 `num_ctx: 16384` 추가 (입력 컨텍스트 증가 대응)

## 3. primer.py 오케스트레이션 반영
- `combined_text = pages[:2]` 방식을 `detect_sections()` + `extract_candidate_terms()` 호출로 교체
- 결과 JSON에 `lineage`, `feynman`, `experiment_flow`, `glossary` 필드 추가
- 캐시 kind를 `"primer"` → `"primer_v2"`로 변경(프롬프트/스키마 변경에 따른 캐시 무효화, 기존 캐시는 자연 소멸)

## 4. 프론트엔드 탭 구조 재설계
- `frontend/index.html`: 브리핑 모달을 개요/계보/쉽게 이해하기/실험 흐름/용어집/관련 논문 6개 탭으로 재구성 (체크리스트는 개요 탭에 유지)
- `frontend/src/main.js`: 탭 전환 로직(`switchPrimerTab`, `togglePrimerTabButton`), 신규 렌더 함수(`renderPrimerLineage`, `renderPrimerFeynman`, `renderPrimerExperimentFlow`, `renderPrimerGlossary`) 추가, 데이터 없는 탭은 버튼 자동 숨김
- `frontend/src/style.css`: 탭바/탭패널, 계보·파인만 문단 스타일, 실험 흐름 스텝퍼, 용어집 아코디언(`<details>`) 스타일 추가

## 5. 테스트
- `backend/tests/test_section_parser.py`, `test_term_extractor.py`, `test_generate_reading_primer.py` 신규 작성 (23개 테스트)
- 전체 백엔드 테스트 스위트 통과 확인 (기존에도 실패하던 `test_project_root_falls_back_when_configured_path_missing` 1건은 본 변경과 무관)
- Playwright로 dev 서버에서 탭 전환/용어집 아코디언/실험 흐름 스텝퍼 렌더링 시각 확인

## Test plan
- [x] 신규 백엔드 유닛 테스트 통과 (`pytest backend/tests/test_section_parser.py backend/tests/test_term_extractor.py backend/tests/test_generate_reading_primer.py`)
- [x] 전체 백엔드 테스트 스위트 통과 (기존 실패 1건 제외)
- [x] 프론트엔드 `vite build` 성공
- [x] Playwright로 탭 전환/아코디언/스텝퍼 UI 시각 검증
- [ ] 실제 논문 업로드 후 로컬 LLM으로 브리핑 생성 결과 육안 확인 (환경 제약으로 이번 PR에서는 미실시)