### PR TITLE
fix: 브리핑 생성이 리버스 프록시 타임아웃에 걸려 실패하는 문제 수정

### DIFF
--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import FileResponse
 
@@ -9,25 +11,48 @@ from services.library import get_primer_figure_path
 
 router = APIRouter()
 
+# 캐시가 없는 문서(구버전 등)는 이 자리에서 생성해야 하는데, 계보/실험 흐름/
+# 용어집까지 생성하는 지금의 프롬프트는 로컬 LLM 기준 수 분씩 걸릴 수 있다.
+# 이 시간 동안 HTTP 요청을 열어둔 채 기다리면 리버스 프록시(nginx 등)의 기본
+# read timeout(보통 60초)에 걸려 요청이 끊겨버린다 - 실제로 이 문제로 "브리핑을
+# 불러오지 못했다"는 문제가 재현됐다. 그래서 생성은 백그라운드 태스크로 돌리고
+# 매 GET 요청은 "완료됐으면 결과, 아니면 즉시 pending"만 응답해 요청 자체는
+# 항상 짧게 끝나도록 한다 - 프런트(library.js fetchPrimer)가 pending이면 짧은
+# 간격으로 재조회한다.
+_pending_generations: dict[str, "asyncio.Task"] = {}
+
 
 @router.get("/library/{doc_id}/primer")
 async def get_primer(doc_id: str, target_lang: str = "한국어", current_user: str = Depends(get_current_user)):
     """읽기 전 브리핑 콘텐츠를 반환합니다. 업로드 직후 백그라운드로 이미 생성되어
-    있으면 캐시에서 즉시 반환하고, 아직 없으면(구버전 문서 등) 그 자리에서 생성합니다."""
+    있으면 캐시에서 즉시 반환하고, 아직 없으면(구버전 문서 등) 백그라운드 생성을
+    시작(또는 이미 진행 중이면 그대로 두고)하고 {"status": "pending"}을 반환합니다."""
     cached = get_cached_primer(doc_id, target_lang=target_lang)
     if cached:
         return cached
 
     session = require_session_owner(doc_id, current_user)
-    return await generate_primer(
-        doc_id,
-        session["pages"],
-        session["metadata"],
-        username=current_user,
-        pdf_path=session["pdf_path"],
-        target_lang=target_lang,
-        session_id=doc_id,
-    )
+
+    task_key = f"{doc_id}:{target_lang}"
+    task = _pending_generations.get(task_key)
+    if task is None or task.done():
+        async def _generate():
+            try:
+                await generate_primer(
+                    doc_id,
+                    session["pages"],
+                    session["metadata"],
+                    username=current_user,
+                    pdf_path=session["pdf_path"],
+                    target_lang=target_lang,
+                    session_id=doc_id,
+                )
+            finally:
+                _pending_generations.pop(task_key, None)
+
+        _pending_generations[task_key] = asyncio.create_task(_generate())
+
+    return {"status": "pending"}
 
 
 @router.get("/library/{doc_id}/primer-figure")

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -993,13 +993,17 @@ async def generate_reading_primer(
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
-                "options": {"temperature": 0.5, "num_ctx": 16384},
+                # num_predict을 지정하지 않으면 모델이 지시를 벗어나 장황하게
+                # 늘어지는 경우 생성이 끝없이 길어져 아래 타임아웃까지 그대로
+                # 소모할 수 있다(실측: 로컬 8~9B 모델에서 360초 타임아웃을 실제로
+                # 초과하는 경우를 확인). 항목이 최대 28줄인 이 응답 형식은 2048
+                # 토큰이면 충분히 넉넉하므로 상한을 걸어 최악의 경우를 방지한다.
+                "options": {"temperature": 0.5, "num_ctx": 16384, "num_predict": 2048},
             }
-            # 스트리밍 없이 응답을 한 번에 기다리는 호출이라, 로컬 CPU 추론처럼 느린
-            # 환경에서도 끊기지 않도록 다른 ollama 스트리밍 호출들과 동일하게 360초를 준다
-            # (stream_page_insight의 120초는 페이지 단위라 상대적으로 짧아도 되지만, 이
-            # 함수는 문서 전체 도입부를 한 번에 처리해 응답이 더 오래 걸릴 수 있다).
-            async with httpx.AsyncClient(timeout=360.0) as client:
+            # LINEAGE/FEYNMAN/실험 흐름/용어집이 추가되며 응답 항목이 늘어나
+            # 로컬 CPU/GPU 환경에서 1~3분씩 걸리는 경우를 실측했다 - 기존
+            # 360초보다 여유를 더 둔다(위 num_predict 상한과 함께 이중 안전장치).
+            async with httpx.AsyncClient(timeout=480.0) as client:
                 resp = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
                 resp.raise_for_status()
                 data = resp.json()

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -28,6 +28,7 @@ LLM이 primer 생성 시점에 자기 지식으로 직접 관련 논문을 추�
 OpenAlex로 재검색해 실제로 존재하고 제목이 충분히 일치하는 것만 채택하는 방식으로
 바꿔 개수와 관련성을 모두 개선했다.
 """
+import asyncio
 import json
 import re
 from typing import Optional
@@ -168,17 +169,33 @@ async def generate_primer(
     sections = detect_sections(pages)
     candidate_terms = extract_candidate_terms(pages)
 
-    try:
-        llm_part = await generate_reading_primer(
-            title, sections, candidate_terms, target_lang=target_lang, session_id=session_id
-        )
-    except Exception as e:
-        print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
-        llm_part = {
-            "hook": "", "lineage": "", "feynman": "",
-            "questions": [], "checklist": [],
-            "experiment_flow": [], "glossary": [], "recommended_titles": [],
-        }
+    async def _run_llm() -> dict:
+        try:
+            return await generate_reading_primer(
+                title, sections, candidate_terms, target_lang=target_lang, session_id=session_id
+            )
+        except Exception as e:
+            print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
+            return {
+                "hook": "", "lineage": "", "feynman": "",
+                "questions": [], "checklist": [],
+                "experiment_flow": [], "glossary": [], "recommended_titles": [],
+            }
+
+    async def _run_figure() -> Optional[dict]:
+        try:
+            picked = await asyncio.to_thread(_pick_primary_figure, pdf_path)
+            if picked and save_primer_figure(doc_id, pdf_path, picked["page"], picked):
+                return {"page": picked["page"], "label": picked.get("label")}
+        except Exception as e:
+            print(f"[primer] Figure 크롭 실패 ({doc_id}): {e}")
+        return None
+
+    # LLM 생성(계보/실험 흐름/용어집 등 필드가 늘면서 로컬 모델 기준 1~3분까지
+    # 걸릴 수 있다)과 Figure 크롭(이미지가 많은 논문은 PDF 이미지 추출/렌더링에
+    # 수십 초가 걸릴 수 있다)은 서로 의존하지 않는데도 예전에는 순차 실행돼
+    # 대기 시간이 그대로 합산됐다. 병렬로 돌려 전체 응답 시간을 단축한다.
+    llm_part, figure = await asyncio.gather(_run_llm(), _run_figure())
 
     try:
         reference_map = extract_reference_list(pages)
@@ -201,14 +218,6 @@ async def generate_primer(
             external_matches = await _resolve_recommended_titles(recommended_titles, library_title_words)
         except Exception as e:
             print(f"[primer] 관련 논문 추천 검증 실패 ({doc_id}): {e}")
-
-    figure = None
-    try:
-        picked = _pick_primary_figure(pdf_path)
-        if picked and save_primer_figure(doc_id, pdf_path, picked["page"], picked):
-            figure = {"page": picked["page"], "label": picked.get("label")}
-    except Exception as e:
-        print(f"[primer] Figure 크롭 실패 ({doc_id}): {e}")
 
     result = {
         "hook": llm_part.get("hook", ""),

--- a/backend/tests/test_primer_router.py
+++ b/backend/tests/test_primer_router.py
@@ -1,0 +1,68 @@
+"""GET /library/{doc_id}/primer 라우터의 pending 응답/중복 생성 방지 테스트.
+
+계보/실험 흐름/용어집까지 만드는 지금의 프롬프트는 로컬 LLM 기준 수 분씩 걸릴
+수 있어, 이 엔드포인트가 생성이 끝날 때까지 요청을 블로킹하면 리버스 프록시의
+기본 read timeout(보통 60초)에 걸려 끊긴다(실측으로 재현). 그래서 캐시가 없으면
+즉시 {"status": "pending"}을 반환하고 실제 생성은 백그라운드 태스크로 돌리도록
+바꿨다 - 이 동작만 검증한다(실제 생성 내용 파싱은 test_generate_reading_primer.py,
+test_primer.py에서 이미 다룬다).
+"""
+
+import asyncio
+
+import pytest
+
+import routers.primer as primer_router
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id, username):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "My Paper"})
+
+
+@pytest.fixture()
+def fake_generation(monkeypatch):
+    """require_session_owner/generate_primer를 대체해 실제 PDF/LLM 없이
+    라우터의 pending·중복 방지 로직만 검증한다."""
+    calls = {"count": 0}
+
+    def fake_require_session_owner(doc_id, current_user):
+        return {"pages": [], "metadata": {"title": "My Paper"}, "pdf_path": "/x/paper.pdf"}
+
+    async def fake_generate_primer(doc_id, pages, metadata, username, pdf_path, target_lang, session_id):
+        calls["count"] += 1
+        await asyncio.sleep(2)  # 두 번째 요청이 들어올 때까지 완료되지 않게 함
+        return {"hook": "done"}
+
+    monkeypatch.setattr(primer_router, "require_session_owner", fake_require_session_owner)
+    monkeypatch.setattr(primer_router, "generate_primer", fake_generate_primer)
+    primer_router._pending_generations.clear()
+    return calls
+
+
+def test_returns_cached_content_immediately_without_pending(test_client, isolated_dirs, fake_generation):
+    _create_doc_owned_by(isolated_dirs, "doc-cached", "testuser")
+    isolated_dirs["library"].save_page_insight(
+        "doc-cached", 0, "primer_v2", '{"hook": "cached hook"}', suffix="한국어"
+    )
+    res = test_client.get("/api/library/doc-cached/primer")
+    assert res.status_code == 200
+    assert res.json() == {"hook": "cached hook"}
+    assert fake_generation["count"] == 0
+
+
+def test_returns_pending_immediately_when_not_cached(test_client, isolated_dirs, fake_generation):
+    _create_doc_owned_by(isolated_dirs, "doc-pending", "testuser")
+    res = test_client.get("/api/library/doc-pending/primer")
+    assert res.status_code == 200
+    assert res.json() == {"status": "pending"}
+    assert fake_generation["count"] == 1
+
+
+def test_does_not_start_duplicate_generation_while_one_is_in_flight(test_client, isolated_dirs, fake_generation):
+    _create_doc_owned_by(isolated_dirs, "doc-dup", "testuser")
+    res1 = test_client.get("/api/library/doc-dup/primer")
+    res2 = test_client.get("/api/library/doc-dup/primer")
+    assert res1.json() == {"status": "pending"}
+    assert res2.json() == {"status": "pending"}
+    assert fake_generation["count"] == 1

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -123,8 +123,21 @@ export async function deleteLibraryDocPermanently(docId) {
   return res.json()
 }
 
+// 캐시가 없는 문서는 백엔드가 생성을 백그라운드로 돌리고 매 요청마다
+// {status: 'pending'}만 즉시 반환한다(계보/실험 흐름/용어집까지 만드는 지금의
+// 프롬프트는 로컬 LLM 기준 수 분씩 걸릴 수 있어, 하나의 요청을 그만큼 열어두면
+// 리버스 프록시의 기본 read timeout에 걸려 끊기기 때문). 완료될 때까지 짧은
+// 간격으로 재조회한다.
+const PRIMER_POLL_INTERVAL_MS = 3000
+const PRIMER_POLL_MAX_ATTEMPTS = 150 // 최대 약 7.5분 대기
+
 export async function fetchPrimer(docId, targetLang = '한국어') {
-  const res = await fetch(`${API_BASE}/library/${docId}/primer?target_lang=${encodeURIComponent(targetLang)}`)
-  if (!res.ok) throw new Error('읽기 전 브리핑 조회 실패')
-  return res.json()
+  for (let attempt = 0; attempt < PRIMER_POLL_MAX_ATTEMPTS; attempt++) {
+    const res = await fetch(`${API_BASE}/library/${docId}/primer?target_lang=${encodeURIComponent(targetLang)}`)
+    if (!res.ok) throw new Error('읽기 전 브리핑 조회 실패')
+    const data = await res.json()
+    if (data.status !== 'pending') return data
+    await new Promise(resolve => setTimeout(resolve, PRIMER_POLL_INTERVAL_MS))
+  }
+  throw new Error('읽기 전 브리핑 생성이 너무 오래 걸립니다.')
 }


### PR DESCRIPTION
# Summary
## 1. 근본 원인: 무거워진 프롬프트가 리버스 프록시 read timeout을 초과
- #223에서 브리핑에 계보/파인만 설명/실험 흐름/용어집을 추가하며 LLM이 생성해야 할 출력량이 크게 늘어, 로컬 LLM 기준 첫 생성이 실측 1~7분까지 걸리는 것을 확인
- `GET /library/{doc_id}/primer`는 캐시가 없으면 이 생성을 요청 안에서 그대로 기다렸는데, 실서비스의 리버스 프록시(nginx-proxy-manager, `proxy_read_timeout` 미설정 → 기본값 60초)가 그보다 훨씬 먼저 연결을 끊어 "브리핑을 불러오지 못했습니다" 에러로 나타남을 실제 배포 환경에서 확인

## 2. 생성을 백그라운드 태스크 + 폴링 구조로 변경
- `backend/routers/primer.py`: 캐시가 없으면 `asyncio.create_task`로 `generate_primer()`를 백그라운드로 실행하고, 요청 자체는 즉시 `{"status": "pending"}`을 반환하도록 변경. 같은 문서에 대해 생성이 이미 진행 중이면 중복 실행하지 않도록 `_pending_generations` 딕셔너리로 추적
- `frontend/src/library.js`: `fetchPrimer()`가 응답이 `pending`이면 3초 간격으로 최대 150회(~7.5분) 재조회하도록 폴링 루프 추가. 호출부(`main.js`)는 여전히 하나의 Promise로 결과를 받으므로 변경 불필요

## 3. 부가적인 안전장치
- `backend/services/llm_client.py`: Ollama 폴백 호출에 `num_predict: 2048` 상한 추가(지시를 벗어나 응답이 무한정 길어지는 것 방지), httpx 타임아웃을 360초 → 480초로 상향
- `backend/services/primer.py`: LLM 생성과 Figure 크롭(이미지 많은 논문은 수십 초 소요 가능)이 서로 독립적인데 순차 실행되고 있던 것을 `asyncio.gather`로 병렬화해 전체 대기 시간 단축

## 4. 테스트
- `backend/tests/test_primer_router.py` 신규 추가: 캐시 있으면 즉시 반환/캐시 없으면 즉시 pending 반환/동시 요청 시 중복 생성 방지 검증
- 전체 백엔드 테스트 스위트 통과 확인 (기존에도 실패하던 `test_project_root_falls_back_when_configured_path_missing` 1건은 본 변경과 무관)

## Test plan
- [x] `pytest backend/tests/test_primer_router.py` 통과
- [x] 전체 백엔드 테스트 스위트 통과 (기존 실패 1건 제외)
- [x] 프론트엔드 `vite build` 성공
- [x] 로컬 Ollama로 `generate_reading_primer` 직접 호출해 정상 완료 확인(수 분 소요되지만 예외 없이 완료)