### PR TITLE
fix: 메모 색상 하이라이트 미동기화 및 접기 UI 빈 공간 버그 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6493,18 +6493,15 @@ function renderPageMemos(pageNum) {
       dot.addEventListener('click', (e) => {
         e.stopPropagation()
         const selectedColor = dot.getAttribute('data-color')
-        
-        colorDots.forEach(d => d.classList.remove('selected'))
-        dot.classList.add('selected')
-        
-        memoEl.className = `floating-memo color-${selectedColor}${memo.collapsed ? ' collapsed' : ''}`
 
         memo.color = selectedColor
         const allMemosObj = loadMemos(state.sessionId)
         allMemosObj[`page_${pageNum}`] = pageMemos
         saveMemos(state.sessionId, allMemosObj)
-        
-        updateMemoConnectorLine(pageWrapper, memo)
+
+        // 카드뿐 아니라 원문 하이라이트(색상 클래스)도 함께 갱신되어야 하므로
+        // 전체 재렌더링을 통해 두 경로(카드 UI + VTM/폴백 하이라이트)를 동기화한다
+        renderPageMemos(pageNum)
       })
     })
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4487,7 +4487,12 @@ body.light-theme .custom-confirm-modal {
   margin-right: 4px;
 }
 
-/* 접기 상태: 헤더(제목 탭)만 남기고 본문은 숨긴다 */
+/* 접기 상태: 헤더(제목 탭)만 남기고 본문은 숨긴다.
+   min-height를 함께 풀어주지 않으면 body가 사라져도 카드 높이가
+   그대로 유지되어 헤더 아래에 빈 공간만 남는다. */
+.floating-memo.collapsed {
+  min-height: 0;
+}
 .floating-memo.collapsed .floating-memo-body {
   display: none;
 }


### PR DESCRIPTION
## Summary
- 메모 색상 변경 시 원문 하이라이트(VTM 오버레이/폴백 스팬)가 즉시 반영되지 않던 버그 수정 — 색상 선택 시 `renderPageMemos`를 재호출해 카드와 원문 하이라이트를 함께 동기화
- 메모 접기 시 `.floating-memo`의 `min-height: 160px` 때문에 헤더 아래 빈 공간이 남던 버그 수정 — 접힘 상태에서 `min-height: 0`을 적용해 헤더만 남도록 함

## Test plan
- [ ] 메모 생성 후 색상 dot 클릭 → 원문 하이라이트 색이 즉시 바뀌는지 확인
- [ ] 메모 접기 버튼 클릭 → 카드가 헤더 높이로 줄어드는지 확인, 펼치기 시 정상 복원되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)