### PR TITLE
feat: 읽기 전 브리핑에 다시 생성하기 기능 추가

### DIFF
--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -6,7 +6,7 @@ from fastapi.responses import FileResponse
 from routers.upload import require_session_owner
 from routers.library import _require_owned_document
 from services.auth import get_current_user
-from services.primer import get_cached_primer, generate_primer
+from services.primer import get_cached_primer, generate_primer, invalidate_primer_cache
 from services.library import get_primer_figure_path
 
 router = APIRouter()
@@ -22,6 +22,31 @@ router = APIRouter()
 _pending_generations: dict[str, "asyncio.Task"] = {}
 
 
+def _ensure_generation_started(doc_id: str, target_lang: str, session: dict, current_user: str) -> None:
+    """이 문서/언어 조합의 브리핑 생성이 이미 진행 중이 아니면 백그라운드
+    태스크로 새로 시작한다. GET(캐시 미스)과 POST(재생성) 양쪽에서 공유한다."""
+    task_key = f"{doc_id}:{target_lang}"
+    task = _pending_generations.get(task_key)
+    if task is not None and not task.done():
+        return
+
+    async def _generate():
+        try:
+            await generate_primer(
+                doc_id,
+                session["pages"],
+                session["metadata"],
+                username=current_user,
+                pdf_path=session["pdf_path"],
+                target_lang=target_lang,
+                session_id=doc_id,
+            )
+        finally:
+            _pending_generations.pop(task_key, None)
+
+    _pending_generations[task_key] = asyncio.create_task(_generate())
+
+
 @router.get("/library/{doc_id}/primer")
 async def get_primer(doc_id: str, target_lang: str = "한국어", current_user: str = Depends(get_current_user)):
     """읽기 전 브리핑 콘텐츠를 반환합니다. 업로드 직후 백그라운드로 이미 생성되어
@@ -32,26 +57,18 @@ async def get_primer(doc_id: str, target_lang: str = "한국어", current_user: 
         return cached
 
     session = require_session_owner(doc_id, current_user)
+    _ensure_generation_started(doc_id, target_lang, session, current_user)
+    return {"status": "pending"}
 
-    task_key = f"{doc_id}:{target_lang}"
-    task = _pending_generations.get(task_key)
-    if task is None or task.done():
-        async def _generate():
-            try:
-                await generate_primer(
-                    doc_id,
-                    session["pages"],
-                    session["metadata"],
-                    username=current_user,
-                    pdf_path=session["pdf_path"],
-                    target_lang=target_lang,
-                    session_id=doc_id,
-                )
-            finally:
-                _pending_generations.pop(task_key, None)
 
-        _pending_generations[task_key] = asyncio.create_task(_generate())
-
+@router.post("/library/{doc_id}/primer/regenerate")
+async def regenerate_primer(doc_id: str, target_lang: str = "한국어", current_user: str = Depends(get_current_user)):
+    """캐시된 브리핑을 지우고 처음부터 다시 생성을 시작합니다. 사용자가 결과가
+    부실하다고 느낄 때 수동으로 재시도할 수 있게 하는 용도. GET과 마찬가지로
+    생성은 백그라운드로 돌리고 즉시 {"status": "pending"}을 반환한다."""
+    session = require_session_owner(doc_id, current_user)
+    invalidate_primer_cache(doc_id, target_lang)
+    _ensure_generation_started(doc_id, target_lang, session, current_user)
     return {"status": "pending"}
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -573,6 +573,18 @@ def db_clear_page_insights(doc_id: str) -> None:
         cursor.execute("DELETE FROM page_insights WHERE doc_id = ?", (doc_id,))
         conn.commit()
 
+def db_delete_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "") -> None:
+    """특정 kind/suffix 하나만 지운다. db_clear_page_insights는 문서의 모든
+    인사이트(키워드/요약/브리핑 등, 언어별로도 전부)를 지워버려 "이 브리핑
+    하나만 다시 생성" 같은 용도로 쓰기엔 범위가 너무 넓다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM page_insights WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?",
+            (doc_id, page_num, kind, suffix)
+        )
+        conn.commit()
+
 
 def db_clear_translations(doc_id: str) -> None:
     with get_db() as conn:

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -18,6 +18,7 @@ from services.db import (
     db_save_page_insight,
     db_get_page_insight,
     db_clear_page_insights,
+    db_delete_page_insight,
     db_update_document_metadata,
     db_bulk_translation_rows,
 )
@@ -281,6 +282,11 @@ def get_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "") ->
 def clear_page_insights(doc_id: str) -> None:
     """데이터베이스에서 모든 페이지 인사이트(키워드/요약) 데이터를 지웁니다."""
     db_clear_page_insights(doc_id)
+
+
+def delete_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "") -> None:
+    """특정 kind/suffix 하나의 페이지 인사이트만 지웁니다."""
+    db_delete_page_insight(doc_id, page_num, kind, suffix)
 
 
 def get_pdf_path(doc_id: str) -> Optional[str]:

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -36,6 +36,7 @@ from typing import Optional
 from services.library import (
     save_page_insight,
     get_page_insight,
+    delete_page_insight,
     get_pdf_path,
     save_primer_figure,
     list_documents,
@@ -250,3 +251,11 @@ def get_cached_primer(doc_id: str, target_lang: str = "한국어") -> Optional[d
         return json.loads(content)
     except (json.JSONDecodeError, TypeError):
         return None
+
+
+def invalidate_primer_cache(doc_id: str, target_lang: str = "한국어") -> None:
+    """캐시된 브리핑을 지운다("다시 생성하기" 용도). page_insights는
+    INSERT OR REPLACE로 저장되므로 재생성 자체는 캐시를 안 지워도 결국
+    덮어써지지만, 캐시를 먼저 지워둬야 재생성이 끝나기 전에 들어오는 GET
+    요청이 낡은 캐시를 즉시 반환해버리지 않고 올바르게 pending을 반환한다."""
+    delete_page_insight(doc_id, 0, _PRIMER_CACHE_KIND, suffix=target_lang)

--- a/backend/tests/test_primer_router.py
+++ b/backend/tests/test_primer_router.py
@@ -66,3 +66,29 @@ def test_does_not_start_duplicate_generation_while_one_is_in_flight(test_client,
     assert res1.json() == {"status": "pending"}
     assert res2.json() == {"status": "pending"}
     assert fake_generation["count"] == 1
+
+
+def test_regenerate_clears_cache_and_starts_new_generation(test_client, isolated_dirs, fake_generation):
+    _create_doc_owned_by(isolated_dirs, "doc-regen", "testuser")
+    isolated_dirs["library"].save_page_insight(
+        "doc-regen", 0, "primer_v2", '{"hook": "stale hook"}', suffix="한국어"
+    )
+
+    res = test_client.post("/api/library/doc-regen/primer/regenerate")
+    assert res.status_code == 200
+    assert res.json() == {"status": "pending"}
+    assert fake_generation["count"] == 1
+
+    # 재생성이 아직 안 끝난 시점에 GET을 호출하면 지워진 캐시 덕분에 낡은
+    # 내용을 바로 돌려주지 않고 pending을 반환해야 한다(중복 생성도 없어야 함).
+    res_get = test_client.get("/api/library/doc-regen/primer")
+    assert res_get.json() == {"status": "pending"}
+    assert fake_generation["count"] == 1
+
+
+def test_regenerate_does_not_duplicate_when_already_in_flight(test_client, isolated_dirs, fake_generation):
+    _create_doc_owned_by(isolated_dirs, "doc-regen-dup", "testuser")
+    test_client.get("/api/library/doc-regen-dup/primer")
+    res = test_client.post("/api/library/doc-regen-dup/primer/regenerate")
+    assert res.json() == {"status": "pending"}
+    assert fake_generation["count"] == 1

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1031,6 +1031,9 @@
   <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
   <div id="primer-modal" class="modal-overlay hidden">
     <div class="primer-content">
+      <button id="primer-regenerate-btn" class="close-btn primer-regenerate-btn" title="다시 생성하기">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M8 16H3v5"/></svg>
+      </button>
       <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
 
       <div id="primer-loading" class="primer-loading">

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -141,3 +141,15 @@ export async function fetchPrimer(docId, targetLang = '한국어') {
   }
   throw new Error('읽기 전 브리핑 생성이 너무 오래 걸립니다.')
 }
+
+// 캐시된 브리핑을 지우고 처음부터 다시 생성을 시작시킨다("다시 생성하기").
+// 이 호출 자체는 즉시 pending ack만 받고, 실제 완료 대기는 뒤이어 호출하는
+// fetchPrimer()의 폴링 루프가 맡는다.
+export async function regeneratePrimer(docId, targetLang = '한국어') {
+  const res = await fetch(
+    `${API_BASE}/library/${docId}/primer/regenerate?target_lang=${encodeURIComponent(targetLang)}`,
+    { method: 'POST' }
+  )
+  if (!res.ok) throw new Error('브리핑 재생성 요청 실패')
+  return res.json()
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -278,6 +278,7 @@ const viewerPrimerBtn    = $('viewer-primer-btn')
 // 읽기 전 브리핑(Reading Primer) 모달
 const primerModal          = $('primer-modal')
 const primerCloseBtn       = $('primer-close-btn')
+const primerRegenerateBtn  = $('primer-regenerate-btn')
 const primerLoading        = $('primer-loading')
 const primerError          = $('primer-error')
 const primerBody           = $('primer-body')
@@ -5075,31 +5076,67 @@ function renderPrimerContent(doc, data, mode) {
   switchPrimerTab('overview')
 }
 
+// 재생성 버튼 클릭 시 현재 보고 있던 문서/모드로 다시 로드할 수 있도록 기억해둔다.
+let primerCurrentDoc = null
+let primerCurrentMode = 'gate'
+
+function _loadPrimerInto(doc, mode, dataPromise) {
+  primerLoading.classList.remove('hidden')
+  primerError.classList.add('hidden')
+  primerBody.classList.add('hidden')
+  return dataPromise
+    .then(data => {
+      renderPrimerContent(doc, data, mode)
+      primerLoading.classList.add('hidden')
+      primerBody.classList.remove('hidden')
+    })
+    .catch(err => {
+      console.error('브리핑 로드 실패:', err)
+      primerLoading.classList.add('hidden')
+      primerError.classList.remove('hidden')
+    })
+}
+
 async function showPrimerModal(doc, { mode = 'gate' } = {}) {
+  primerCurrentDoc = doc
+  primerCurrentMode = mode
   return new Promise((resolve) => {
     primerResolve = resolve
     primerModal.classList.remove('hidden')
-    primerLoading.classList.remove('hidden')
-    primerError.classList.add('hidden')
-    primerBody.classList.add('hidden')
     primerSkipBtn.classList.toggle('hidden', mode !== 'gate')
     primerContinueBtn.textContent = mode === 'gate' ? '읽으러 가기' : '닫기'
 
     const targetLang = getTranslationOptions().targetLang
-    fetchPrimer(doc.id, targetLang)
-      .then(data => {
-        renderPrimerContent(doc, data, mode)
-        primerLoading.classList.add('hidden')
-        primerBody.classList.remove('hidden')
-      })
-      .catch(err => {
-        console.error('브리핑 로드 실패:', err)
-        primerLoading.classList.add('hidden')
-        primerError.classList.remove('hidden')
-      })
+    _loadPrimerInto(doc, mode, fetchPrimer(doc.id, targetLang))
   })
 }
 
+async function regenerateCurrentPrimer() {
+  if (!primerCurrentDoc || (primerRegenerateBtn && primerRegenerateBtn.disabled)) return
+  const doc = primerCurrentDoc
+  const mode = primerCurrentMode
+  const targetLang = getTranslationOptions().targetLang
+
+  if (primerRegenerateBtn) {
+    primerRegenerateBtn.disabled = true
+    primerRegenerateBtn.classList.add('is-loading')
+  }
+  try {
+    await regeneratePrimer(doc.id, targetLang)
+    await _loadPrimerInto(doc, mode, fetchPrimer(doc.id, targetLang))
+  } catch (err) {
+    console.error('브리핑 재생성 실패:', err)
+    primerLoading.classList.add('hidden')
+    primerError.classList.remove('hidden')
+  } finally {
+    if (primerRegenerateBtn) {
+      primerRegenerateBtn.disabled = false
+      primerRegenerateBtn.classList.remove('is-loading')
+    }
+  }
+}
+
+if (primerRegenerateBtn) primerRegenerateBtn.addEventListener('click', regenerateCurrentPrimer)
 if (primerCloseBtn) primerCloseBtn.addEventListener('click', hidePrimerModal)
 if (primerSkipBtn) primerSkipBtn.addEventListener('click', hidePrimerModal)
 if (primerContinueBtn) primerContinueBtn.addEventListener('click', hidePrimerModal)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1604,6 +1604,24 @@ body.light-theme .toast.error { color: #dc2626; }
   z-index: 1;
 }
 
+.primer-regenerate-btn {
+  position: absolute;
+  top: 16px;
+  right: 54px;
+  z-index: 1;
+}
+.primer-regenerate-btn.is-loading svg {
+  animation: primer-regenerate-spin 0.8s linear infinite;
+}
+.primer-regenerate-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+@keyframes primer-regenerate-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 .primer-loading {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# Summary
## 1. 캐시 무효화 계층 추가
- `backend/services/db.py`: `db_delete_page_insight(doc_id, page_num, kind, suffix)` 신규 추가 — 기존 `db_clear_page_insights`는 문서의 모든 인사이트(키워드/요약/언어별 브리핑 전부)를 지워버려 범위가 너무 넓어, 특정 kind/suffix 하나만 지우는 함수를 별도로 만듦
- `backend/services/library.py`: `delete_page_insight()` 래퍼 추가
- `backend/services/primer.py`: `invalidate_primer_cache(doc_id, target_lang)` 추가 — 캐시를 먼저 지워야 재생성 완료 전 들어오는 GET 요청이 낡은 캐시를 즉시 반환하지 않고 올바르게 pending을 반환함

## 2. 재생성 API 추가
- `backend/routers/primer.py`: `POST /library/{doc_id}/primer/regenerate` 신규 추가. 캐시 무효화 후 백그라운드 생성을 시작(#224에서 만든 `_pending_generations` 중복 방지 로직 재사용)하고 즉시 `{"status": "pending"}` 반환
- GET/POST가 공유하던 "생성 시작" 로직을 `_ensure_generation_started()`로 추출해 중복 제거

## 3. 프론트엔드
- `frontend/index.html` / `style.css`: 브리핑 모달 헤더에 새로고침 아이콘 버튼(`#primer-regenerate-btn`) 추가, 닫기 버튼 옆에 배치. 클릭 중에는 회전 애니메이션 + disabled 처리
- `frontend/src/library.js`: `regeneratePrimer(docId, targetLang)` API 클라이언트 추가
- `frontend/src/main.js`: 현재 보고 있는 문서/모드를 기억해뒀다가(`primerCurrentDoc`/`primerCurrentMode`) 재생성 버튼 클릭 시 캐시 무효화 요청 → 기존 폴링 로직(`fetchPrimer`) 재사용으로 재로드. 초기 로드/재생성이 로딩·에러 상태를 공유하도록 `_loadPrimerInto()`로 추출

## 4. 테스트
- `backend/tests/test_primer_router.py`에 재생성 관련 테스트 2개 추가: 캐시 무효화 후 낡은 내용을 바로 반환하지 않는지, 이미 생성 중일 때 중복 생성하지 않는지
- 전체 백엔드 테스트 스위트 통과 확인 (기존에도 실패하던 `test_project_root_falls_back_when_configured_path_missing` 1건은 본 변경과 무관)
- `library.js`의 `regeneratePrimer`/`fetchPrimer` 폴링 로직을 Node에서 fetch를 스텁해 단독 검증, 프론트엔드 `vite build` 성공, Playwright로 버튼 배치 시각 확인

## Test plan
- [x] `pytest backend/tests/test_primer_router.py` 통과 (5개, 재생성 2개 포함)
- [x] 전체 백엔드 테스트 스위트 통과 (기존 실패 1건 제외)
- [x] 프론트엔드 `vite build` 성공
- [x] Playwright로 재생성 버튼 배치 시각 확인, Node 스크립트로 폴링/재생성 네트워크 로직 검증