### PR TITLE
fix: 참조 미리보기 툴팁 리사이즈 시 이미지 비율 유지

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8268,16 +8268,30 @@ function getOrCreateFigurePreviewTooltip() {
     e.stopPropagation()
 
     const startX = e.clientX
-    const startY = e.clientY
     const startWidth = el.offsetWidth
     const startHeight = el.offsetHeight
+    // 이미지는 CSS에서 width:100%; height:auto로 표시되므로 컨테이너 너비가
+    // scale배 될 때 이미지의 실제 렌더링 높이도 같은 비율로 커진다. 반면
+    // 레이블/캡션 같은 텍스트 영역(chromeHeight)은 너비가 바뀌어도 높이가
+    // 거의 그대로다. 너비/높이를 마우스 이동량으로 각각 독립적으로 정하면
+    // 이미지 비율과 무관하게 박스 크기가 고정되어 이미지 아래로 빈 공간이
+    // 남거나 이미지가 잘려 스크롤이 생기는 문제가 있었다 - 높이를 "이미지
+    // 비율을 유지한 채 늘어난 이미지 높이 + 고정된 chromeHeight"로 다시
+    // 계산해 너비를 끌면 이미지 비율에 맞게 박스 전체가 adaptive하게
+    // 커지고 작아지도록 한다.
+    const loadedImgs = Array.from(el.querySelectorAll('.figure-preview-tooltip-img:not(.hidden)'))
+    const startImagesHeight = loadedImgs.reduce((sum, img) => sum + img.getBoundingClientRect().height, 0)
+    const chromeHeight = startHeight - startImagesHeight
+    const maxWidth = Math.min(window.innerWidth * 0.9, 900)
+    const maxHeight = Math.min(window.innerHeight * 0.9, 900)
     el.classList.add('resizing')
     figurePreviewIsResizing = true
     if (figurePreviewHideTimer) { clearTimeout(figurePreviewHideTimer); figurePreviewHideTimer = null }
 
     const onMove = (moveEvent) => {
-      const newWidth = Math.max(_FIGURE_PREVIEW_MIN_WIDTH, startWidth + (moveEvent.clientX - startX))
-      const newHeight = Math.max(_FIGURE_PREVIEW_MIN_HEIGHT, startHeight + (moveEvent.clientY - startY))
+      const newWidth = Math.max(_FIGURE_PREVIEW_MIN_WIDTH, Math.min(maxWidth, startWidth + (moveEvent.clientX - startX)))
+      const scale = startWidth > 0 ? newWidth / startWidth : 1
+      const newHeight = Math.max(_FIGURE_PREVIEW_MIN_HEIGHT, Math.min(maxHeight, chromeHeight + startImagesHeight * scale))
       el.style.width = `${newWidth}px`
       el.style.height = `${newHeight}px`
     }


### PR DESCRIPTION
# Summary
## 1. 오버레이 resize 시 비율 무시 문제 수정
- `frontend/src/main.js`의 `getOrCreateFigurePreviewTooltip()` 내 리사이즈 핸들 `mousedown` 핸들러 수정
- 기존에는 마우스 이동량으로 너비/높이를 각각 독립적으로 계산해, 이미지 실제 비율과 무관하게 박스 크기가 고정됨 (이미지 아래 빈 공간이 남거나, 박스가 작아지면 이미지가 잘려 스크롤 발생)
- 드래그 시작 시점에 로드된 이미지들의 렌더링 높이 합(`startImagesHeight`)과 레이블/캡션 등 고정 영역 높이(`chromeHeight`)를 분리해서 측정
- 이후 `onMove`에서 너비 변화 비율(`scale`)만큼 이미지 몫의 높이를 재계산하고 `chromeHeight`는 그대로 유지 → 박스 전체가 이미지 비율에 맞게 adaptive하게 커지고 작아짐
- CSS의 `max-width: min(90vw, 900px)` / `max-height: min(90vh, 900px)`와 동일한 상한을 JS 리사이즈 계산에도 적용해 클램프 불일치로 인한 크기 오차 방지

## Test plan
- [x] Playwright로 실제 리사이즈 로직을 재현한 독립 테스트 페이지에서 드래그 확대/축소 시뮬레이션 → 이미지 렌더링 비율이 원본 비율(2:1)과 거의 일치(≈1.99)하고, 리사이즈 전/후 스크린샷에서 이미지가 빈 공간/잘림 없이 박스를 정확히 채우는 것을 확인
- [ ] 실제 앱에서 PDF 업로드 후 Figure/Table 참조에 마우스 호버 → 미리보기 툴팁 리사이즈 핸들 드래그로 수동 확인 (백엔드 PDF 처리 필요해 이번 세션에서는 미실시)