### PR TITLE
feat: AI 어시스턴트 답변에 추천 후속 질문 3개 표시

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from typing import List
 
 from routers.upload import sessions, ensure_session, require_session_owner
-from services.llm_client import stream_chat
+from services.llm_client import stream_chat, generate_suggested_questions
 from services.db import (
     db_save_chat_message,
     db_get_chat_history,
@@ -130,6 +130,35 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
             "Connection": "keep-alive",
         }
     )
+
+
+@router.post("/chat/suggestions")
+async def chat_suggestions(data: ChatRequest, current_user: str = Depends(get_current_user)):
+    """직전 어시스턴트 답변과 논문 본문을 참고해 후속 질문 3개를 추천합니다. 채팅
+    기록(chats 테이블)에는 남기지 않는 보조 UI(추천 질문 칩) 전용 엔드포인트입니다."""
+    session_id = data.session_id
+    session = require_session_owner(session_id, current_user)
+
+    pages = session.get("pages", [])
+    paper_text = ""
+    for p in pages:
+        page_text = (p.get("text", "") or "").strip()
+        if page_text:
+            paper_text += f"\n\n{page_text}"
+            if len(paper_text) > 6000:
+                break
+
+    filename = session.get("filename", "알 수 없음")
+    history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
+
+    try:
+        questions = await generate_suggested_questions(
+            paper_text, history_messages, doc_title=filename, session_id=session_id
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"추천 질문 생성 실패: {str(e)}")
+
+    return {"questions": questions}
 
 
 # 아래 두 엔드포인트(/chat/compare/*)는 "/chat/{session_id}/history"보다

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1073,6 +1073,96 @@ async def generate_reading_primer(
     return result
 
 
+_SUGGESTED_QUESTION_LINE_RE = re.compile(r'^[\s\-\*>]*\**\s*(SQ1|SQ2|SQ3)\**\s*[:.\)]\s*(.+)$', re.IGNORECASE)
+
+
+async def generate_suggested_questions(
+    paper_text: str,
+    history_messages: list,
+    doc_title: str = "",
+    session_id: str = None,
+) -> list:
+    """
+    직전 어시스턴트 답변까지의 대화 흐름과 논문 본문 일부를 참고해, 사용자가 이어서
+    물어볼 만한 후속 질문 3개를 생성합니다. 채팅(Chat) 프로바이더/모델 설정을 그대로
+    재사용하며, generate_reading_primer와 동일하게 세션이 지속되는 CLI provider는
+    채팅과 동일한 문서당 공유 세션(session_id)을 사용합니다. 챗 답변 자체가 아니라
+    보조 UI(추천 질문 칩)용 생성이므로 채팅 기록(chats 테이블)에는 남기지 않습니다.
+    """
+    convo_lines = []
+    for msg in history_messages[-6:]:
+        role_label = "사용자" if msg.get("role") == "user" else "어시스턴트"
+        content = (msg.get("content") or "").strip()
+        if content:
+            convo_lines.append(f"{role_label}: {content[:800]}")
+    convo_text = "\n".join(convo_lines)
+
+    instruction = (
+        f"다음은 학술 논문 '{doc_title}'을 읽으며 사용자와 AI 어시스턴트가 나눈 대화입니다. "
+        f"이 대화의 마지막 어시스턴트 답변을 참고해, 사용자가 이어서 궁금해할 만한 자연스러운 "
+        f"후속 질문을 정확히 3개 제안하세요.\n\n"
+        f"- 각 질문은 아래 논문 본문 발췌 내용에 근거해 답할 수 있는 구체적인 질문이어야 합니다.\n"
+        f"- 방금 나온 답변을 단순 반복하지 말고, 더 깊이 파고들거나(근거, 한계, 비교 등) 다른 "
+        f"관점으로 확장하는 질문으로 구성하세요.\n"
+        f"- 각 질문은 물음표로 끝나는 한 문장의 자연스러운 한국어 질문으로, 서로 겹치지 않게 "
+        f"작성하세요.\n\n"
+        f"반드시 아래 형식으로만 출력하고 다른 설명이나 서론은 절대 추가하지 마세요.\n"
+        f"SQ1: <질문>\nSQ2: <질문>\nSQ3: <질문>"
+    )
+
+    prompt = f"{instruction}\n\n[논문 본문 발췌]\n{paper_text[:6000]}\n\n[대화 내역]\n{convo_text}"
+
+    provider = get_chat_provider()
+    model = get_chat_model()
+
+    async def _call_once() -> str:
+        tokens = []
+        if provider == "antigravity":
+            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="suggestions"):
+                tokens.append(token)
+        elif provider == "claude_code":
+            async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="suggestions"):
+                tokens.append(token)
+        elif provider == "codex":
+            async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="suggestions"):
+                tokens.append(token)
+        elif provider in ("openai", "gemini", "claude"):
+            messages = [{"role": "user", "content": prompt}]
+            if provider == "openai":
+                async for token in stream_openai(messages, model=model, temperature=0.6):
+                    tokens.append(token)
+            elif provider == "gemini":
+                async for token in stream_gemini(messages, model=model, temperature=0.6):
+                    tokens.append(token)
+            else:
+                async for token in stream_claude(messages, model=model, temperature=0.6):
+                    tokens.append(token)
+        else:
+            # Ollama 폴백
+            payload = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": False,
+                "options": {"temperature": 0.6, "num_ctx": 8192, "num_predict": 512},
+            }
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+                tokens.append(data.get("message", {}).get("content", ""))
+        return "".join(tokens)
+
+    raw = await _call_once()
+    questions = []
+    for line in raw.splitlines():
+        m = _SUGGESTED_QUESTION_LINE_RE.match(line.strip())
+        if m:
+            q = m.group(2).strip().rstrip('*').strip()
+            if q:
+                questions.append(q)
+    return questions[:3]
+
+
 async def check_ollama_health() -> dict:
     """Ollama 서버 상태를 확인합니다."""
     try:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -530,6 +530,24 @@ export function streamChatAPI(sessionId, messages, onToken, onDone, onError) {
 
 
 /**
+ * 직전 어시스턴트 답변과 논문 본문을 참고해 후속 질문 3개를 추천받습니다.
+ * @param {string} sessionId
+ * @param {Array} messages - [{role: 'user'|'assistant', content: '...'}, ...]
+ * @returns {Promise<string[]>} 추천 질문 목록 (최대 3개)
+ */
+export async function getSuggestedQuestionsAPI(sessionId, messages) {
+  const res = await fetch(`${API_BASE}/chat/suggestions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, messages })
+  })
+  if (!res.ok) throw new Error('추천 질문 생성 실패')
+  const data = await res.json()
+  return data.questions || []
+}
+
+
+/**
  * 세션의 번역 캐시를 삭제합니다.
  */
 export async function clearTranslationCacheAPI(sessionId) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer } from './library.js'
 import { icon } from './icons.js'
@@ -8760,7 +8760,8 @@ function regenerateResponse(assistantMsgEl) {
     showToast('대화 기록 싱크 오류', 'error');
     return;
   }
-  
+
+  clearSuggestedQuestions();
   appendTypingIndicator();
   
   chatInput.disabled = true;
@@ -8794,9 +8795,10 @@ function regenerateResponse(assistantMsgEl) {
         applyKatexToElement(replyBubble);
         if (replyBubble.parentElement) {
           appendActionButtons(replyBubble.parentElement, 'assistant', accumulatedText);
+          renderSuggestedQuestions(replyBubble.parentElement);
         }
       }
-      
+
       chatInput.disabled = false;
       updateChatSendBtnIcon(false);
       chatInput.focus();
@@ -8882,6 +8884,45 @@ function appendActionButtons(msgEl, role, content) {
   msgEl.appendChild(actionsEl)
 }
 
+// 대화가 이어지면 예전 답변에 달렸던 추천 질문은 더 이상 "다음에 물어볼 질문"이
+// 아니게 되므로, 새 질문을 보내거나 답변을 다시 받을 때마다 기존 칩을 모두 지운다.
+function clearSuggestedQuestions() {
+  chatMessages.querySelectorAll('.suggested-questions').forEach(el => el.remove())
+}
+
+// 어시스턴트 답변이 끝난 직후, 논문/대화 내용을 참고한 후속 질문 3개를 chat
+// bubble 아래에 클릭 가능한 칩으로 붙인다. 클릭하면 바로 그 질문으로 다음
+// 메시지를 보낸다.
+async function renderSuggestedQuestions(msgEl) {
+  if (!state.sessionId) return
+  try {
+    const questions = await getSuggestedQuestionsAPI(state.sessionId, state.chatHistory)
+    if (!questions.length) return
+    // 응답을 기다리는 사이 사용자가 이미 다음 질문을 보냈다면(이 메시지가 더
+    // 이상 마지막 어시스턴트 메시지가 아니라면) 뒤늦게 붙이지 않는다.
+    if (!msgEl.isConnected || msgEl !== chatMessages.lastElementChild) return
+
+    const wrap = document.createElement('div')
+    wrap.className = 'suggested-questions'
+    questions.forEach(q => {
+      const chip = document.createElement('button')
+      chip.type = 'button'
+      chip.className = 'suggested-question-chip'
+      chip.textContent = q
+      chip.addEventListener('click', () => {
+        if (state.chatActiveStream) return
+        chatInput.value = q
+        sendChatMessage()
+      })
+      wrap.appendChild(chip)
+    })
+    msgEl.appendChild(wrap)
+    chatMessages.scrollTop = chatMessages.scrollHeight
+  } catch (err) {
+    console.warn('추천 질문 생성 실패:', err)
+  }
+}
+
 function appendChatMessage(role, content, isHtml = false) {
   const msgEl = document.createElement('div')
   msgEl.className = `chat-message ${role}`
@@ -8945,7 +8986,8 @@ async function sendChatMessage() {
   
   chatInput.value = ''
   chatInput.style.height = 'auto'
-  
+  clearSuggestedQuestions()
+
   if (state.quotedText) {
     const fullPayload = `[인용된 본문 내용]:\n"${state.quotedText}"\n\n[질문]:\n${text}`
     
@@ -9020,9 +9062,10 @@ async function sendChatMessage() {
         replyBubble.innerHTML = formatChatHtml(accumulatedText)
         if (replyBubble.parentElement) {
           appendActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+          renderSuggestedQuestions(replyBubble.parentElement)
         }
       }
-      
+
       chatInput.disabled = false
       updateChatSendBtnIcon(false)
       chatInput.focus()

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3058,6 +3058,38 @@ body.light-theme .chat-loading-progress {
   transform: scale(0.92);
 }
 
+/* 추천 질문 칩 - 어시스턴트 답변 아래에 붙는 후속 질문 제안 */
+.suggested-questions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin-top: 8px;
+  max-width: 100%;
+}
+.suggested-question-chip {
+  display: block;
+  max-width: 100%;
+  padding: 7px 12px;
+  background: none;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.suggested-question-chip:hover {
+  background: var(--accent-soft, rgba(74, 135, 181, 0.12));
+  border-color: var(--accent-mid);
+  color: var(--text-primary);
+}
+.suggested-question-chip:active {
+  transform: scale(0.98);
+}
+
 /* ── 수식 렌더링 스타일 ───────────────────────────── */
 .katex-display-wrap {
   overflow-x: auto;


### PR DESCRIPTION
# Summary
## 1. 논문/대화 기반 추천 후속 질문 3개 생성 및 표시
- `backend/services/llm_client.py`에 `generate_suggested_questions()` 추가
  - `generate_reading_primer`와 동일한 provider 디스패치(`openai`/`gemini`/`claude`/`antigravity`/`claude_code`/`codex`/Ollama 폴백) 및 CLI 세션 재사용 패턴을 따름
  - 최근 대화 6턴 + 논문 본문 발췌(최대 6000자)를 프롬프트에 포함해 `SQ1`/`SQ2`/`SQ3` 형식으로 응답받고 정규식으로 파싱
- `backend/routers/chat.py`에 `POST /chat/suggestions` 엔드포인트 추가
  - 세션 소유권 검증 후 `session["pages"]`에서 논문 텍스트를 구성(기존 `/chat/stream`과 동일한 방식)
  - 채팅 기록(`chats` 테이블)에는 저장하지 않는 보조 UI 전용 엔드포인트
- `frontend/src/api.js`에 `getSuggestedQuestionsAPI(sessionId, messages)` 추가 (단순 fetch/json 패턴)
- `frontend/src/main.js`
  - `sendChatMessage`/`regenerateResponse`의 스트리밍 `onDone` 콜백에서 `renderSuggestedQuestions()` 호출 → 어시스턴트 답변의 `.chat-message` div에 `.suggested-questions` 칩 목록을 자식으로 append
  - 칩 클릭 시 `chatInput.value`에 질문을 채우고 바로 `sendChatMessage()` 호출
  - 새 질문 전송/답변 재생성 시 `clearSuggestedQuestions()`로 이전 칩 제거(오래된 답변에 붙은 칩이 계속 누적되는 것 방지)
- `frontend/src/style.css`에 `.suggested-questions`/`.suggested-question-chip` 스타일 추가 (라이트/다크 테마 변수 재사용)

## Test plan
- [x] 백엔드: 새 함수/엔드포인트 import 및 시그니처 확인, `SQ1:`/`SQ2:`/`SQ3:` 형식 파싱 정규식 유닛 테스트로 검증
- [x] 프론트엔드: `vite build` 성공 확인, Playwright로 `.chat-message.assistant` 구조 안에 칩이 렌더링된 모습을 라이트/다크 테마 각각 스크린샷으로 확인
- [ ] 실제 앱에서 PDF 업로드 후 질문 → 답변 완료 시 추천 질문 칩이 뜨는지, 클릭 시 실제로 질문이 전송되는지 수동 확인 (백엔드 LLM 프로바이더 설정 및 PDF 업로드가 필요해 이번 세션에서는 미실시)