### PR TITLE
feat: 번역 모드 설정 추가 (자동/번역창 펼칠 때/스크롤 시)

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -106,6 +106,7 @@ async def upload_pdf(
     ignore_math: bool = False,
     ignore_table: bool = True,
     ignore_refs: bool = False,
+    translation_mode: str = "auto",
     current_user: str = Depends(get_current_user)
 ):
     """PDF 파일을 업로드하고 텍스트를 추출합니다."""
@@ -173,6 +174,12 @@ async def upload_pdf(
     # 세션을 동시에 쓸 수 없다 - primer를 완료한 뒤에만 번역이 세션을 점유하도록
     # 순차 실행한다 (API 기반 provider는 세션 개념이 없어 이 순서가 지연을 조금
     # 더할 뿐 문제가 되지 않는다).
+    #
+    # translation_mode가 "auto"(기본값)가 아니면 - 번역 창을 펼칠 때(pane) 또는
+    # 스크롤로 페이지를 볼 때(scroll)만 번역하길 원하는 사용자이므로 - 업로드
+    # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다. 이후
+    # 번역은 프런트엔드가 상황에 맞춰 /jobs/{id}/restart(pane) 또는
+    # /translate/{id}/{page}(scroll) 를 호출해 트리거한다.
     async def _run_primer_then_translate():
         try:
             await generate_primer(
@@ -186,15 +193,16 @@ async def upload_pdf(
             )
         except Exception as e:
             print(f"[Upload {session_id}] Primer 생성 실패: {e}")
-        start_job(
-            session_id,
-            pages,
-            target_lang=target_lang,
-            style=style,
-            ignore_math=ignore_math,
-            ignore_table=ignore_table,
-            ignore_refs=ignore_refs
-        )
+        if translation_mode == "auto":
+            start_job(
+                session_id,
+                pages,
+                target_lang=target_lang,
+                style=style,
+                ignore_math=ignore_math,
+                ignore_table=ignore_table,
+                ignore_refs=ignore_refs
+            )
 
     asyncio.create_task(_run_primer_then_translate())
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -597,6 +597,15 @@
           </div>
           
           <div class="form-group">
+            <label for="setting-translation-mode">번역 모드</label>
+            <select id="setting-translation-mode" class="form-select">
+              <option value="auto">업로드 시 자동 번역 (기본)</option>
+              <option value="pane">번역 창을 펼칠 때만 번역</option>
+              <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
+            </select>
+          </div>
+
+          <div class="form-group">
             <label>번역 제외 문서 요소</label>
             <div class="checkbox-group">
               <label class="checkbox-label">

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,8 +4,8 @@ export async function uploadPDF(file, options, onProgress) {
   const formData = new FormData()
   formData.append('file', file)
 
-  const { targetLang, style, ignoreMath, ignoreTable, ignoreRefs } = options
-  const query = `?target_lang=${encodeURIComponent(targetLang)}&style=${style}&ignore_math=${ignoreMath}&ignore_table=${ignoreTable}&ignore_refs=${ignoreRefs}`
+  const { targetLang, style, ignoreMath, ignoreTable, ignoreRefs, translationMode } = options
+  const query = `?target_lang=${encodeURIComponent(targetLang)}&style=${style}&ignore_math=${ignoreMath}&ignore_table=${ignoreTable}&ignore_refs=${ignoreRefs}&translation_mode=${encodeURIComponent(translationMode || 'auto')}`
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
@@ -62,15 +62,18 @@ export async function getTranslationStatus(sessionId) {
  * SSE 스트리밍으로 페이지 번역을 수신합니다.
  * @param {string} sessionId
  * @param {number} pageNum
+ * @param {object} options - {targetLang, style, ignoreMath, ignoreTable, ignoreRefs}
  * @param {function} onToken - 토큰이 수신될 때마다 호출
- * @param {function} onDone - 완료 시 호출
+ * @param {function} onDone - 완료 시 호출 (cached, sentences)
  * @param {function} onError - 오류 시 호출
  * @returns {function} abort - 번역 중단 함수
  */
-export function streamTranslation(sessionId, pageNum, onToken, onDone, onError) {
+export function streamTranslation(sessionId, pageNum, options, onToken, onDone, onError) {
   const controller = new AbortController()
+  const { targetLang, style, ignoreMath, ignoreTable, ignoreRefs } = options
+  const query = `?target_lang=${encodeURIComponent(targetLang)}&style=${style}&ignore_math=${ignoreMath}&ignore_table=${ignoreTable}&ignore_refs=${ignoreRefs}`
 
-  fetch(`${API_BASE}/translate/${sessionId}/${pageNum}`, {
+  fetch(`${API_BASE}/translate/${sessionId}/${pageNum}${query}`, {
     signal: controller.signal,
   })
     .then(async (res) => {
@@ -107,7 +110,7 @@ export function streamTranslation(sessionId, pageNum, onToken, onDone, onError) 
               onToken(data.content, data.cached || false)
             }
             if (data.done) {
-              onDone(data.cached || false)
+              onDone(data.cached || false, data.sentences || [])
               return
             }
           } catch (e) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -134,6 +134,7 @@ const tabPanes          = document.querySelectorAll('.tab-pane')
 const generalSettingsForm = $('general-settings-form')
 const settingTargetLang   = $('setting-target-lang')
 const settingTransStyle   = $('setting-trans-style')
+const settingTranslationMode = $('setting-translation-mode')
 const settingIgnoreMath   = $('setting-ignore-math')
 const settingIgnoreTable  = $('setting-ignore-table')
 const settingIgnoreRefs   = $('setting-ignore-refs')
@@ -319,6 +320,14 @@ function getTranslationOptions() {
   }
 }
 
+// 번역 모드: 'auto'(업로드 시 전체 자동 번역, 기본값) / 'pane'(번역 창을 펼칠 때만
+// 시작) / 'scroll'(스크롤로 페이지가 보일 때마다 그 페이지만 번역). 대상 언어/문체와
+// 달리 캐시 접미사에 영향을 주지 않는 "언제 번역할지"만 다루는 옵션이라
+// getTranslationOptions()와는 별도로 관리한다.
+function getTranslationMode() {
+  return localStorage.getItem('easypaper_translation_mode') || 'auto'
+}
+
 // ── 토스트 ────────────────────────────────────────
 let toastTimer = null
 function showToast(msg, type = '') {
@@ -446,7 +455,7 @@ async function handleFiles(files) {
     uploadItemSuccessIcon.classList.add('hidden')
 
     try {
-      const result = await uploadPDF(file, getTranslationOptions(), (pct) => {
+      const result = await uploadPDF(file, { ...getTranslationOptions(), translationMode: getTranslationMode() }, (pct) => {
         uploadItemProgressBar.style.width = `${pct}%`
         uploadItemStatus.textContent = `업로드 중... ${pct}%`
       })
@@ -540,6 +549,23 @@ function createPagePair(pageNum) {
   return pair
 }
 
+// 번역 모드가 'pane'일 때, 번역 창이 펼쳐진 시점에 전체 문서 백그라운드 번역
+// 잡을 시작한다. 이미 잡이 있으면(과거에 시작되었거나 완료됨) 아무 것도 하지
+// 않는다 - start_job은 동일 옵션으로 이미 완료된 잡이면 재시작하지 않고,
+// 실행 중인 잡을 다시 시작해도 캐시된 페이지는 건너뛰므로 여러 번 호출돼도
+// 안전하지만, 불필요한 네트워크 호출을 줄이기 위해 잡 존재 여부를 먼저 확인한다.
+async function ensureTranslationJobStarted() {
+  if (!state.sessionId) return
+  try {
+    const job = await getJobStatus(state.sessionId)
+    if (!job) {
+      await restartJobAPI(state.sessionId, getTranslationOptions())
+    }
+  } catch (err) {
+    console.warn('번역 잡 시작 확인 실패:', err)
+  }
+}
+
 // ── 스크롤 뷰어 초기화 ────────────────────────────
 async function initScrollViewer() {
   viewerScrollContainer.innerHTML = ''
@@ -576,29 +602,46 @@ async function initScrollViewer() {
           // 않도록, 이미 그려진 문장 분할 기준으로 메모를 다시 그려준다.
           renderPageMemos(pageNum)
         }
+      } else if (getTranslationMode() === 'scroll') {
+        // 번역 모드가 'scroll'이면 전체 문서 백그라운드 잡이 아예 시작되지
+        // 않으므로, 스크롤로 보이게 된 페이지를 그때그때 개별 번역한다.
+        translatePage(pageNum)
       }
 
       // 비동기 다음 페이지 번역 프리페칭 및 미리 렌더링
       const nextPage = pageNum + 1
-      if (nextPage <= state.totalPages && !state.translationCache[nextPage] && state.translatedPages.has(nextPage)) {
-        state.translationCache[nextPage] = '__fetching__'
-        const currentSessionId = state.sessionId
-        const opts = getTranslationOptions()
-        fetchLibraryTranslation(currentSessionId, nextPage, opts).then(res => {
-          if (state.sessionId === currentSessionId) {
-            state.translationCache[nextPage] = res.translation
-            state.translationSentences[nextPage] = res.sentences || []
-            renderTransContent(nextPage, res.translation, true)
-          }
-        }).catch(err => {
-          if (state.sessionId === currentSessionId) {
-            delete state.translationCache[nextPage]
-            renderPageMemos(nextPage)
-          }
-        })
+      if (nextPage <= state.totalPages && !state.translationCache[nextPage]) {
+        if (state.translatedPages.has(nextPage)) {
+          state.translationCache[nextPage] = '__fetching__'
+          const currentSessionId = state.sessionId
+          const opts = getTranslationOptions()
+          fetchLibraryTranslation(currentSessionId, nextPage, opts).then(res => {
+            if (state.sessionId === currentSessionId) {
+              state.translationCache[nextPage] = res.translation
+              state.translationSentences[nextPage] = res.sentences || []
+              renderTransContent(nextPage, res.translation, true)
+            }
+          }).catch(err => {
+            if (state.sessionId === currentSessionId) {
+              delete state.translationCache[nextPage]
+              renderPageMemos(nextPage)
+            }
+          })
+        } else if (getTranslationMode() === 'scroll') {
+          // 다음 페이지도 미리 번역해둬 스크롤이 도착했을 때 바로 보이게 한다.
+          translatePage(nextPage)
+        }
       }
     }
   })
+
+  // 번역 모드가 'pane'이고 번역 창이 이미 펼쳐진 상태로 문서를 열었다면,
+  // (예: 이전에 펼친 채로 남겨둔 경우) 폴링을 시작하기 전에 전체 문서 번역
+  // 잡을 지금 시작해둔다. 접힌 채로 열었다면 아래 trans-collapse-btn
+  // 클릭 핸들러가 나중에 펼칠 때 시작한다.
+  if (getTranslationMode() === 'pane' && !isTransPaneCollapsed) {
+    ensureTranslationJobStarted()
+  }
 
   // 백그라운드 잡 폴링 시작
   startJobPolling(state.sessionId)
@@ -785,9 +828,14 @@ function renderInsightContent(contentEl, kind, text) {
 }
 
 // ── 페이지 번역 ───────────────────────────────────
-// 폰링 중인 페이지를 플레이스홀더로 표시
+// 번역 모드가 'scroll'일 때 - 전체 문서 백그라운드 잡이 돌고 있지 않으므로 -
+// 스크롤로 보이게 된 페이지 하나만 그 자리에서 즉시 번역한다(/translate/{id}/{page}
+// SSE 엔드포인트, 캐시가 있으면 즉시 반환). 완료되면 job-polling 경로와 동일하게
+// state.translatedPages/translationCache/translationSentences를 채워 이후
+// 다시 방문했을 때는 재번역 없이 캐시를 바로 쓴다.
 function translatePage(pageNum) {
   if (state.translatingPages.has(pageNum) || state.translatedPages.has(pageNum)) return
+  if (!state.sessionId) return
   state.translatingPages.add(pageNum)
 
   const statusEl  = $(`trans-status-${pageNum}`)
@@ -798,9 +846,30 @@ function translatePage(pageNum) {
   contentEl.innerHTML = `
     <div class="trans-waiting">
       <div class="trans-wait-spinner"></div>
-      <span>백그라운드에서 번역 중...</span>
+      <span>번역 중...</span>
     </div>`
   if (statusEl) statusEl.textContent = '번역 중...'
+
+  const currentSessionId = state.sessionId
+  let buffer = ''
+  streamTranslation(
+    currentSessionId, pageNum, getTranslationOptions(),
+    (token) => { buffer += token },
+    (cached, sentences) => {
+      state.translatingPages.delete(pageNum)
+      if (state.sessionId !== currentSessionId) return
+      state.translatedPages.add(pageNum)
+      state.translationCache[pageNum] = buffer
+      state.translationSentences[pageNum] = sentences || []
+      renderTransContent(pageNum, buffer, false)
+    },
+    (err) => {
+      state.translatingPages.delete(pageNum)
+      if (state.sessionId !== currentSessionId) return
+      if (statusEl) statusEl.textContent = '번역 실패'
+      contentEl.innerHTML = `<div class="trans-error">번역 실패: ${escapeHtml(err.message)}</div>`
+    }
+  )
 }
 
 // ── 코드 블록 외부의 볼드체를 <strong> 태그로 미리 변환 ──
@@ -2334,6 +2403,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   // 2. 일반 설정값 로드
   settingTargetLang.value = localStorage.getItem('easypaper_target_lang') || '한국어'
   settingTransStyle.value = localStorage.getItem('easypaper_style') || 'academic'
+  settingTranslationMode.value = getTranslationMode()
   settingIgnoreMath.checked = localStorage.getItem('easypaper_ignore_math') === 'true'
   settingIgnoreTable.checked = localStorage.getItem('easypaper_ignore_table') !== 'false'
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
@@ -2513,6 +2583,7 @@ generalSettingsForm.addEventListener('submit', async (e) => {
   
   localStorage.setItem('easypaper_target_lang', settingTargetLang.value)
   localStorage.setItem('easypaper_style', settingTransStyle.value)
+  localStorage.setItem('easypaper_translation_mode', settingTranslationMode.value)
   localStorage.setItem('easypaper_ignore_math', settingIgnoreMath.checked)
   localStorage.setItem('easypaper_ignore_table', settingIgnoreTable.checked)
   localStorage.setItem('easypaper_ignore_refs', settingIgnoreRefs.checked)
@@ -11234,6 +11305,12 @@ viewerScrollContainer.addEventListener('click', (e) => {
   })
   
   showToast(isTransPaneCollapsed ? '번역 창이 접혔습니다.' : '번역 창이 펼쳐졌습니다.', 'info')
+
+  // 번역 모드가 'pane'이면 번역 창을 펼치는 순간이 곧 "번역을 시작해도 좋다"는
+  // 신호다 - 접혀 있는 동안은 백그라운드 잡을 시작하지 않고 아껴뒀다가 여기서 시작한다.
+  if (!isTransPaneCollapsed && getTranslationMode() === 'pane') {
+    ensureTranslationJobStarted()
+  }
 });
 
 // 초기 로드 시 localStorage 상태 복원 및 초기화 실행


### PR DESCRIPTION
# Summary
## 1. 번역 모드 3종 추가 (업로드 시 자동 / 번역 창을 펼칠 때 / 스크롤 시)
- 기존에는 업로드 즉시 전체 문서를 백그라운드로 자동 번역하는 방식(`auto`)만 존재
- 일반 설정에 `#setting-translation-mode` 드롭다운 추가 (`frontend/index.html`)
  - `auto` (기본): 업로드 시 전체 문서 자동 번역 - 기존 동작 그대로
  - `pane`: 번역 창을 펼칠 때에만 전체 문서 번역 잡 시작
  - `scroll`: 스크롤로 페이지가 보일 때 그 페이지만 즉시 번역

## 2. 백엔드: 업로드 시 자동 번역 시작 여부 제어
- `backend/routers/upload.py`의 `POST /upload`에 `translation_mode` 쿼리 파라미터 추가
- `translation_mode != "auto"`일 때는 업로드 직후 `start_job(...)`(전체 문서 백그라운드 번역)을 실행하지 않음 (읽기 전 브리핑 생성은 모드와 무관하게 그대로 진행)
- 새 엔드포인트는 추가하지 않고 기존 `POST /jobs/{id}/restart`(전체 문서 잡 시작/재시작)와 `GET /translate/{id}/{page}`(단일 페이지 SSE, 기존에 구현은 되어 있었지만 프런트엔드에서 호출되지 않던 코드)를 재사용

## 3. 프런트엔드: 모드별 번역 트리거
- `frontend/src/main.js`
  - `getTranslationMode()` 추가 (localStorage 기반)
  - `ensureTranslationJobStarted()` 추가: 잡이 아직 없으면 `restartJobAPI`로 전체 문서 번역 잡 시작. `pane` 모드에서 번역 창이 펼쳐지는 시점(뷰어 진입 시 이미 펼쳐져 있는 경우 + 접기/펴기 버튼으로 펼치는 시점)에 호출
  - `translatePage(pageNum)`: 기존에는 스피너만 보여주고 실제로는 아무 것도 하지 않던 미사용 함수였는데, `streamTranslation`을 호출해 해당 페이지를 실제로 번역하고 완료 시 `state.translatedPages`/`translationCache`/`translationSentences`를 채우도록 구현
  - `initScrollViewer`의 `onPageVisible`에서 `scroll` 모드일 때 현재 페이지 + 다음 페이지(prefetch)에 대해 `translatePage()` 호출
- `frontend/src/api.js`
  - `uploadPDF`: `translation_mode` 쿼리 파라미터 전달
  - `streamTranslation`: 번역 옵션(대상 언어/문체/제외 옵션)을 쿼리로 전달하도록 시그니처 변경 (기존에는 옵션 없이 호출되어 백엔드 기본값과 사용자 설정 언어/문체가 어긋날 수 있는 잠재적 버그가 있었음), 완료 콜백에 `sentences` 데이터 전달 추가

## Test plan
- [x] `vite build` 성공 확인, 백엔드 모듈 import 및 `upload_pdf` 시그니처 확인
- [x] `streamTranslation` 유닛 테스트: fetch를 모킹한 가짜 SSE 스트림으로 쿼리 파라미터 구성과 `onDone(cached, sentences)` 콜백 전달을 검증
- [ ] 실제 앱에서 세 모드 각각 업로드/스크롤/번역창 펼치기 동작 수동 확인 (백엔드 LLM 프로바이더 설정 및 실제 PDF 업로드가 필요해 이번 세션에서는 미실시)