### PR TITLE
feat: 스크롤 방향에 따른 상단 툴바 자동 숨김/표시

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -194,7 +194,7 @@
   <div id="viewer-screen" class="screen">
 
     <!-- 상단 바 -->
-    <header class="topbar">
+    <header class="topbar" id="viewer-topbar">
       <div class="topbar-left">
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
@@ -653,6 +653,9 @@
               </label>
               <label class="checkbox-label">
                 <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-toolbar-autohide" /> 아래로 스크롤하면 상단 툴바 자동으로 숨기기 (위로 스크롤하면 다시 표시)
               </label>
             </div>
           </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -75,6 +75,9 @@ const state = {
   // 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 게이팅 모달을 끌지 여부. 꺼도
   // 뷰어 툴바 버튼으로는 언제든 다시 열어볼 수 있다.
   disablePrimer: localStorage.getItem('easypaper_disable_primer') === 'true',
+  // 아래로 스크롤하면 상단 툴바를 자동으로 숨기고 위로 스크롤하면 다시 보여줄지
+  // 여부. 다른 편의 설정과 달리 새로 추가하는 화면 동작이라 기본값은 꺼짐(false).
+  toolbarAutoHide: localStorage.getItem('easypaper_toolbar_autohide') === 'true',
   // pageNum_kind(예: "3_keywords") → 생성된 텍스트. 탭 재방문 시 재요청 방지용 캐시.
   pageInsightCache: {}
 }
@@ -144,6 +147,8 @@ const settingDisableInsights = $('setting-disable-insights')
 const settingDisableCitationOverlay = $('setting-disable-citation-overlay')
 const settingDisableFigureOverlay = $('setting-disable-figure-overlay')
 const settingDisablePrimer = $('setting-disable-primer')
+const settingToolbarAutoHide = $('setting-toolbar-autohide')
+const viewerTopbar = $('viewer-topbar')
 const clearCacheBtn       = $('clear-cache-btn')
 const clearPagesCacheBtn  = $('clear-pages-cache-btn')
 const settingAccentSwatches = $('setting-accent-swatches')
@@ -2344,6 +2349,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingDisableCitationOverlay.checked = state.disableCitationOverlay
   settingDisableFigureOverlay.checked = state.disableFigureOverlay
   settingDisablePrimer.checked = state.disablePrimer
+  settingToolbarAutoHide.checked = state.toolbarAutoHide
   updateAccentSettingsUI(currentAccentColor)
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
@@ -2609,6 +2615,14 @@ settingDisableFigureOverlay.addEventListener('change', () => {
 settingDisablePrimer.addEventListener('change', () => {
   state.disablePrimer = settingDisablePrimer.checked
   localStorage.setItem('easypaper_disable_primer', state.disablePrimer)
+})
+
+settingToolbarAutoHide.addEventListener('change', () => {
+  state.toolbarAutoHide = settingToolbarAutoHide.checked
+  localStorage.setItem('easypaper_toolbar_autohide', state.toolbarAutoHide)
+  // 기능을 끄면 스크롤 위치와 무관하게 즉시 툴바를 다시 보여준다 - 꺼둔 채로
+  // 숨겨진 상태가 남아있으면 툴바가 영영 안 보이는 것처럼 느껴질 수 있다.
+  if (!state.toolbarAutoHide) setToolbarHidden(false)
 })
 
 // 시스템 설정 폼 제출
@@ -9223,6 +9237,38 @@ if (viewerScrollContainer) {
 }
 
 window.addEventListener('resize', hideSelectionMenu);
+
+// ── 스크롤 방향에 따른 상단 툴바 자동 숨김/표시 ─────────
+// 설정에서 켜져 있을 때만: 아래로 스크롤하면 툴바를 위로 슬라이드시켜 숨기고,
+// 위로 스크롤하면 다시 보여준다. 맨 위 근처(툴바 높이 이내)에서는 방향과
+// 무관하게 항상 보이게 해, 페이지 맨 위로 돌아왔는데 툴바가 없는 어색한
+// 상태를 방지한다.
+function setToolbarHidden(hidden) {
+  if (viewerTopbar) viewerTopbar.classList.toggle('toolbar-hidden', hidden)
+}
+
+if (viewerScrollContainer && viewerTopbar) {
+  let lastToolbarScrollTop = viewerScrollContainer.scrollTop
+  const TOOLBAR_HIDE_THRESHOLD = 8   // 이보다 작은 이동은 잔떨림으로 보고 무시
+  const TOOLBAR_TOP_ZONE = 64        // 이 안쪽이면 방향과 무관하게 항상 표시
+
+  viewerScrollContainer.addEventListener('scroll', () => {
+    if (!state.toolbarAutoHide) return
+
+    const currentScrollTop = viewerScrollContainer.scrollTop
+    const delta = currentScrollTop - lastToolbarScrollTop
+
+    if (currentScrollTop <= TOOLBAR_TOP_ZONE) {
+      setToolbarHidden(false)
+    } else if (delta > TOOLBAR_HIDE_THRESHOLD) {
+      setToolbarHidden(true)
+    } else if (delta < -TOOLBAR_HIDE_THRESHOLD) {
+      setToolbarHidden(false)
+    }
+
+    lastToolbarScrollTop = currentScrollTop
+  })
+}
 
 // 문장 중간에 섞여 있는 짧은 인라인 수식 조각인지 휴리스틱으로 판단.
 // findDisplayEquationsFromVTM은 줄 전체가 수식인 "독립 수식 줄"만 찾아내므로,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -321,6 +321,14 @@ html, body {
   z-index: 100;
   gap: 16px;
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
+  transform: translateY(0);
+  transition: transform 0.25s ease;
+}
+/* 스크롤 방향에 따른 툴바 자동 숨김(설정에서 켠 경우) - 위로 슬라이드시켜
+   숨긴다. 컨텐츠 영역(.panels)은 fixed 툴바 높이만큼 이미 padding-top이
+   있으므로, 숨겨져도 본문이 다시 배치되지 않고 툴바가 있던 자리만 비어 보인다. */
+.topbar.toolbar-hidden {
+  transform: translateY(-100%);
 }
 
 .topbar-left, .topbar-right {


### PR DESCRIPTION
# Summary
## 1. 스크롤 방향 기반 툴바 자동 숨김/표시 기능 추가 (on/off 가능)
- 일반 설정에 `#setting-toolbar-autohide` 체크박스 추가 - 기본값 꺼짐(기존 사용자 화면 동작 유지)
- 켜면: 아래로 스크롤 시 상단 툴바를 위로 슬라이드해 숨기고, 위로 스크롤 시 다시 표시
- 최상단 근처(툴바 높이 이내)에서는 스크롤 방향과 무관하게 항상 표시해 "페이지 맨 위인데 툴바가 없는" 어색함 방지
- 설정을 끄는 즉시 숨겨진 상태였다면 강제로 다시 표시

## 2. 구현 상세
- `frontend/index.html`: `<header class="topbar">`에 `id="viewer-topbar"` 부여, "뷰어 편의 설정" 그룹에 체크박스 추가
- `frontend/src/main.js`
  - `state.toolbarAutoHide` 추가 - 기존 `disable*` 설정들과 동일한 localStorage 저장 패턴 (`easypaper_toolbar_autohide`)
  - 설정 모달 열기/제출 핸들러에 로드·저장 로직 연결
  - 기존 `viewerScrollContainer`의 `scroll` 리스너(`hideSelectionMenu`) 옆에 스크롤 델타 기반 방향 감지 로직 추가 (`TOOLBAR_HIDE_THRESHOLD=8px`로 잔떨림 무시, `TOOLBAR_TOP_ZONE=64px` 이내는 항상 표시)
  - `setToolbarHidden(hidden)` 헬퍼로 `.toolbar-hidden` 클래스 토글
- `frontend/src/style.css`: `.topbar`에 `transform`/`transition` 추가, `.topbar.toolbar-hidden { transform: translateY(-100%) }` 추가. `.panels`가 이미 툴바 높이만큼 `padding-top`을 갖고 있어 툴바가 숨겨져도 본문이 재배치되지 않고 자리만 비게 됨

## Test plan
- [x] `vite build` 성공 확인
- [x] Playwright로 실제 스크롤 로직을 재현한 독립 테스트 페이지에서: 아래로 스크롤 시 숨김, 위로 스크롤 시 다시 표시, 최상단 근처에서 항상 표시, 설정 끄면 숨겨지지 않음 - 4가지 시나리오 모두 스크린샷과 함께 확인
- [ ] 실제 앱에서 PDF를 열고 설정에서 기능을 켠 뒤 실제 스크롤로 확인 (수동 확인은 미실시)