### PR TITLE
feat: 툴바 추가 메뉴(케밥)로 번역/메모/테마 관련 항목 재구성

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -226,21 +226,6 @@
         </span>
       </div>
       <div class="topbar-right">
-        <!-- 번역 작업 상태 정보 -->
-        <div id="translation-progress-mini" class="progress-mini hidden">
-          <div class="progress-mini-bar" id="progress-mini-bar"></div>
-          <span id="progress-mini-text">0%</span>
-        </div>
-        <div class="translation-status" id="translation-status">
-          <div class="spinner hidden" id="translate-spinner"></div>
-          <span id="translate-status-text"></span>
-        </div>
-
-        <!-- AI 번역 모델 선택 드롭다운 -->
-        <div id="viewer-trans-provider"></div>
-
-        <div class="toolbar-divider"></div>
-
         <!-- 뷰 확대/축소 조작 그룹 -->
         <div class="toolbar-group view-group">
           <button id="zoom-out-btn" class="icon-btn" title="축소">
@@ -273,33 +258,60 @@
 
         <div class="toolbar-divider"></div>
 
-        <!-- 번역 작업 관리 그룹 -->
-        <div class="toolbar-group action-group">
-          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+        <!-- 추가 메뉴(케밥): 번역 상태/모델, 번역 관리(다시 번역/중지/이어서/다운로드),
+             메모 숨기기, 테마 전환을 한데 모아 툴바를 간결하게 유지한다. -->
+        <div class="kebab-wrapper">
+          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>
           </button>
-          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-          </button>
-          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-          </button>
-          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
-          </button>
-          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
-          </button>
-        </div>
+          <div id="toolbar-kebab-menu" class="kebab-menu hidden">
+            <!-- 번역 작업 상태 정보 -->
+            <div id="translation-progress-mini" class="progress-mini hidden">
+              <div class="progress-mini-bar" id="progress-mini-bar"></div>
+              <span id="progress-mini-text">0%</span>
+            </div>
+            <div class="translation-status kebab-menu-status" id="translation-status">
+              <div class="spinner hidden" id="translate-spinner"></div>
+              <span id="translate-status-text">번역 대기 중</span>
+            </div>
 
-        <div class="toolbar-divider"></div>
+            <!-- AI 번역 모델 선택 드롭다운 -->
+            <div class="kebab-menu-row">
+              <span class="kebab-menu-label">번역 모델</span>
+              <div id="viewer-trans-provider"></div>
+            </div>
 
-        <!-- 기타 환경 조작 그룹 -->
-        <div class="toolbar-group config-group">
-          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
-            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-          </button>
+            <div class="kebab-menu-divider"></div>
+
+            <button id="retranslate-btn" class="kebab-menu-item" title="처음부터 다시 번역하기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+              <span>처음부터 다시 번역하기</span>
+            </button>
+            <button id="cancel-trans-btn" class="kebab-menu-item hidden" title="번역 작업 중지" style="color: var(--error);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+              <span>번역 작업 중지</span>
+            </button>
+            <button id="resume-trans-btn" class="kebab-menu-item hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+              <span>이어서 번역하기</span>
+            </button>
+            <button id="export-btn" class="kebab-menu-item" title="번역본 내보내기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
+              <span>번역본 다운로드</span>
+            </button>
+
+            <div class="kebab-menu-divider"></div>
+
+            <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+              <span>메모 숨기기</span>
+            </button>
+            <button id="theme-toggle-btn" class="kebab-menu-item" title="화이트/다크 테마 토글">
+              <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+              <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+              <span>테마 전환</span>
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -262,6 +262,8 @@ const progressMini          = $('translation-progress-mini')
 const progressMiniBar       = $('progress-mini-bar')
 const progressMiniText      = $('progress-mini-text')
 const toast                 = $('toast')
+const toolbarKebabBtn       = $('toolbar-kebab-btn')
+const toolbarKebabMenu      = $('toolbar-kebab-menu')
 
 // AI Chat Sidebar DOM references
 const chatToggleBtn      = $('chat-toggle-btn')
@@ -1354,6 +1356,27 @@ exportBtn.addEventListener('click', (e) => {
   menu.style.left = `${Math.max(8, Math.min(idealLeft, maxLeft))}px`
   menu.style.top = `${rect.bottom + 8 + window.scrollY}px`
 })
+
+// ── 추가 메뉴(케밥): 번역 상태/모델, 번역 관리, 메모 숨기기, 테마 전환을 모아둔
+// 드롭다운. 번역 모델 선택기(ProviderModelPicker)나 내보내기 형식 팝업처럼
+// 메뉴 안에서 열리는 하위 팝업은 각자 자기 컨테이너에 상대 위치로 붙거나
+// (모델 피커) document.body에 별도로 붙으므로(내보내기 팝업), 둘 다 케밥
+// 메뉴 바깥 클릭으로 오인되어 메뉴가 먼저 닫혀버리는 문제 없이 자연스럽게
+// 동작한다 - 모델 피커는 케밥 메뉴의 자손이라 outside-click 판정에서
+// "안쪽"으로 처리되고, 내보내기 팝업은 형식을 실제로 골라야 바깥 클릭으로
+// 잡혀 그때 케밥 메뉴도 함께 닫힌다.
+if (toolbarKebabBtn && toolbarKebabMenu) {
+  toolbarKebabBtn.addEventListener('click', (e) => {
+    e.stopPropagation()
+    toolbarKebabMenu.classList.toggle('hidden')
+  })
+
+  document.addEventListener('click', (e) => {
+    if (toolbarKebabMenu.classList.contains('hidden')) return
+    if (toolbarKebabMenu.contains(e.target) || toolbarKebabBtn.contains(e.target)) return
+    toolbarKebabMenu.classList.add('hidden')
+  })
+}
 
 // ── 다시 번역하기 ──────────────────────────────────
 retranslateBtn.addEventListener('click', async () => {
@@ -6078,6 +6101,8 @@ function updateMemosHideAllBtnUI() {
   memosHideAllBtn.title = allMemosHidden
     ? '숨긴 메모 모두 표시'
     : '작성된 모든 메모 숨기기 (하이라이트만 표시)'
+  const labelEl = memosHideAllBtn.querySelector('span')
+  if (labelEl) labelEl.textContent = allMemosHidden ? '숨긴 메모 모두 표시' : '메모 숨기기'
 }
 
 function redrawAllPageMemos() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4003,6 +4003,79 @@ body.resizing-trans .trans-resizer-handle::after {
   align-self: center;
 }
 
+/* ── 툴바 추가 메뉴(케밥) ─────────────────────────── */
+.kebab-wrapper {
+  position: relative;
+}
+.kebab-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 260px;
+  padding: 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(3px);
+  animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.kebab-menu .progress-mini,
+.kebab-menu .translation-status {
+  width: 100%;
+  box-sizing: border-box;
+  justify-content: center;
+}
+.kebab-menu-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 4px 8px;
+}
+.kebab-menu-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.kebab-menu-divider {
+  height: 1px;
+  background: var(--border-strong);
+  opacity: 0.5;
+  margin: 4px 2px;
+}
+.kebab-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.kebab-menu-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.kebab-menu-item.active {
+  background: rgba(126, 196, 232, 0.15);
+  color: var(--accent-mid);
+}
+.kebab-menu-item svg {
+  flex-shrink: 0;
+}
+
 /* ── 좌측 목차 사이드바 ── */
 .outline-sidebar {
   position: fixed;


### PR DESCRIPTION
# Summary
## 1. 툴바를 간결하게 하기 위해 6개 항목을 케밥(⋮) 드롭다운으로 이동
- 이동 대상: 번역 완료 표시(진행률/상태), 번역 모델 선택 dropdown, 번역 다시하기(중지/이어서 포함), 번역 다운로드, 메모 숨기기, 테마 전환
- 메인 툴바에는 확대/축소 그룹과 AI 어시스턴트 도구 그룹만 남음
- 기존 요소는 `id`를 그대로 유지한 채 위치만 옮겨서, 클릭 핸들러/상태 업데이트 로직(`main.js`)은 전혀 손대지 않고 그대로 재사용

## 2. 구현 상세
- `frontend/index.html`: `.topbar-right`에서 번역 상태/모델/액션 그룹, 테마 토글을 제거하고 새 `.kebab-wrapper > #toolbar-kebab-btn + #toolbar-kebab-menu` 드롭다운 안으로 재배치. 아이콘만 있던 버튼들에 `<span>` 텍스트 라벨 추가(드롭다운 메뉴 항목이므로 텍스트가 보여야 함)
- `frontend/src/main.js`: `toolbarKebabBtn`/`toolbarKebabMenu` 참조 추가, 클릭 시 토글 + 바깥 클릭 시 닫히는 로직 추가 - 내보내기 형식 팝업이나 번역 모델 피커(`ProviderModelPicker`)처럼 메뉴 안에서 열리는 하위 팝업과 자연스럽게 공존(모델 피커는 케밥 메뉴의 자손이라 outside-click 판정에서 "안쪽"으로 처리되고, 내보내기 팝업은 실제로 형식을 골라야 바깥 클릭으로 잡혀 케밥도 함께 닫힘). 메모 숨기기 버튼의 상태 텍스트(`<span>`)도 토글에 맞춰 갱신하도록 `updateMemosHideAllBtnUI()` 보강
- `frontend/src/style.css`: `.kebab-wrapper`/`.kebab-menu`/`.kebab-menu-item` 등 새 드롭다운 스타일 추가 - 기존 `.selection-menu`/`.provider-picker-panel`과 동일한 디자인 언어(배경/보더/그림자/팝업 애니메이션) 재사용

## Test plan
- [x] `vite build` 성공 확인
- [x] Playwright로 실제 HTML/CSS를 그대로 재현한 독립 테스트 페이지에서: 케밥 버튼 클릭 시 열림, 메뉴 안쪽 클릭 시 유지, 바깥 클릭 시 닫힘, 6개 항목 모두 정상 렌더링을 스크린샷과 함께 확인 (다크/라이트 테마 모두)
- [ ] 실제 앱에서 번역 다시하기/다운로드/메모 숨기기/테마 전환/모델 선택 각 기능이 실제로 동작하는지 수동 확인 (기존 핸들러를 그대로 재사용하므로 로직 자체는 변경 없음 - 위치 이동 후 실제 클릭 동작은 미실시)