### PR TITLE
feat: 우측 하단 floating 스크롤 버튼 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -322,6 +322,22 @@
         <!-- page-pair 요소가 동적으로 생성됨 -->
       </div>
 
+      <!-- 우측 하단 floating 스크롤 내비게이션 -->
+      <div class="floating-scroll-nav" id="floating-scroll-nav">
+        <button id="scroll-top-btn" class="floating-nav-btn" title="맨 위로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
+        </button>
+        <button id="scroll-page-up-btn" class="floating-nav-btn" title="이전 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+        </button>
+        <button id="scroll-page-down-btn" class="floating-nav-btn" title="다음 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <button id="scroll-bottom-btn" class="floating-nav-btn" title="맨 아래로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg>
+        </button>
+      </div>
+
       <!-- AI Chat Sidebar Resizer -->
       <div id="chat-resizer" class="chat-resizer hidden"></div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1117,6 +1117,31 @@ pageInput.addEventListener('blur', (e) => {
   pageInput.value = num
 })
 
+// ── 우측 하단 floating 스크롤 내비게이션 (맨 위로/이전 페이지/다음 페이지/맨 아래로) ──
+const scrollTopBtn      = $('scroll-top-btn')
+const scrollPageUpBtn   = $('scroll-page-up-btn')
+const scrollPageDownBtn = $('scroll-page-down-btn')
+const scrollBottomBtn   = $('scroll-bottom-btn')
+
+if (scrollTopBtn) {
+  scrollTopBtn.addEventListener('click', () => scrollToPage(viewerScrollContainer, 1))
+}
+if (scrollBottomBtn) {
+  scrollBottomBtn.addEventListener('click', () => scrollToPage(viewerScrollContainer, state.totalPages))
+}
+if (scrollPageUpBtn) {
+  scrollPageUpBtn.addEventListener('click', () => {
+    const target = Math.max(1, (parseInt(pageInput.value, 10) || 1) - 1)
+    scrollToPage(viewerScrollContainer, target)
+  })
+}
+if (scrollPageDownBtn) {
+  scrollPageDownBtn.addEventListener('click', () => {
+    const target = Math.min(state.totalPages, (parseInt(pageInput.value, 10) || 1) + 1)
+    scrollToPage(viewerScrollContainer, target)
+  })
+}
+
 // ── 줌 ────────────────────────────────────────────
 // 클램핑 + 라벨 갱신만 즉시 수행하는 가벼운 버전. 핀치/휠 제스처처럼 짧은 시간에
 // 값이 계속 바뀌는 상황에서, 매번 무거운 캔버스 재렌더링(reRenderAll)을 부르지

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -600,6 +600,40 @@ html, body {
   height: 100%;
 }
 
+/* ── 우측 하단 floating 스크롤 내비게이션 ── */
+.floating-scroll-nav {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.floating-nav-btn {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  color: var(--text-secondary);
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(3px);
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+.floating-nav-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  transform: scale(1.06);
+}
+.floating-nav-btn:active {
+  transform: scale(0.94);
+}
+
 /* ── 개별 페이지 쌍 (원문 + 번역 한쌍의 카드) ── */
 .page-pair {
   display: flex;


### PR DESCRIPTION
# Summary
## 1. 우측 하단 floating 스크롤 내비게이션 버튼 4개 추가
- 맨 위로 / 이전 페이지 / 다음 페이지 / 맨 아래로
- 기존 `scrollToPage()` 유틸리티(pdfViewer.js)와 `pageInput.value` 기반 현재 페이지 추적을 그대로 재사용 - 페이지 입력창에서 Enter로 점프하는 기존 로직과 동일한 클램핑 방식

## 2. 구현 상세
- `frontend/index.html`: `.viewer-scroll-container` 옆에 `#floating-scroll-nav` 추가. 뷰어 화면(`#viewer-screen`) 안에만 위치해 라이브러리/비교 화면 등 다른 화면에서는 보이지 않음
- `frontend/src/main.js`: `scrollTopBtn`/`scrollPageUpBtn`/`scrollPageDownBtn`/`scrollBottomBtn` 클릭 핸들러 추가
- `frontend/src/style.css`: `.floating-scroll-nav`(`position:fixed`, 우측 하단, 세로 배치)와 `.floating-nav-btn`(원형 버튼, hover 시 확대 + 배경 강조, active 시 축소) 스타일 추가

## Test plan
- [x] `vite build` 성공 확인
- [x] Playwright로 실제 CSS를 그대로 적용한 독립 테스트 페이지에서 다크/라이트 테마 및 hover 상태 스크린샷 확인
- [ ] 실제 앱에서 4개 버튼 클릭 시 실제 스크롤 이동 동작 수동 확인 (미실시)