### PR TITLE
feat: 툴바 위치 설정 기능 추가 (위/아래/왼쪽/오른쪽)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -621,6 +621,16 @@
             </select>
           </div>
 
+          <div class="form-group">
+            <label for="setting-toolbar-position">툴바 위치</label>
+            <select id="setting-toolbar-position" class="form-select">
+              <option value="top">위 (기본)</option>
+              <option value="bottom">아래</option>
+              <option value="left">왼쪽</option>
+              <option value="right">오른쪽</option>
+            </select>
+          </div>
+
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>테마 색상</label>
             <div id="setting-accent-swatches" class="accent-swatch-group"></div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -138,6 +138,7 @@ const settingIgnoreMath   = $('setting-ignore-math')
 const settingIgnoreTable  = $('setting-ignore-table')
 const settingIgnoreRefs   = $('setting-ignore-refs')
 const settingDefaultZoom  = $('setting-default-zoom')
+const settingToolbarPosition = $('setting-toolbar-position')
 const settingDisableHoverTooltip = $('setting-disable-hover-tooltip')
 const settingDisableBookmark = $('setting-disable-bookmark')
 const settingDisableInsights = $('setting-disable-insights')
@@ -318,6 +319,21 @@ function getTranslationOptions() {
     ignoreRefs: localStorage.getItem('easypaper_ignore_refs') === 'true'
   }
 }
+
+// 툴바 위치: 'top'(기본) / 'bottom' / 'left' / 'right'. body에 클래스로
+// 반영하고, 나머지는 전부 CSS(.toolbar-pos-*)가 처리한다 - 위치별로
+// .topbar/.panels/.outline-sidebar/.floating-scroll-nav 등의 레이아웃이
+// 바뀐다.
+const TOOLBAR_POSITIONS = ['top', 'bottom', 'left', 'right']
+function getToolbarPosition() {
+  const saved = localStorage.getItem('easypaper_toolbar_position')
+  return TOOLBAR_POSITIONS.includes(saved) ? saved : 'top'
+}
+function applyToolbarPosition(pos) {
+  TOOLBAR_POSITIONS.forEach(p => document.body.classList.remove(`toolbar-pos-${p}`))
+  if (pos !== 'top') document.body.classList.add(`toolbar-pos-${pos}`)
+}
+applyToolbarPosition(getToolbarPosition())
 
 // ── 토스트 ────────────────────────────────────────
 let toastTimer = null
@@ -2338,6 +2354,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingIgnoreTable.checked = localStorage.getItem('easypaper_ignore_table') !== 'false'
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
+  settingToolbarPosition.value = getToolbarPosition()
   settingDisableHoverTooltip.checked = state.disableHoverTooltip
   settingDisableBookmark.checked = state.disableBookmark
   settingDisableInsights.checked = state.disableInsights
@@ -2517,9 +2534,11 @@ generalSettingsForm.addEventListener('submit', async (e) => {
   localStorage.setItem('easypaper_ignore_table', settingIgnoreTable.checked)
   localStorage.setItem('easypaper_ignore_refs', settingIgnoreRefs.checked)
   localStorage.setItem('easypaper_default_zoom', settingDefaultZoom.value)
-  
+  localStorage.setItem('easypaper_toolbar_position', settingToolbarPosition.value)
+  applyToolbarPosition(settingToolbarPosition.value)
+
   showToast('일반 설정이 저장되었습니다.', 'success')
-  
+
   // 기본 줌 비율 즉시 업데이트 적용
   const newZoom = parseFloat(settingDefaultZoom.value) || 1.5
   if (state.sessionId) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4003,6 +4003,117 @@ body.resizing-trans .trans-resizer-handle::after {
   align-self: center;
 }
 
+/* ── 툴바 위치 설정 (top(기본)/bottom/left/right) ──────────
+   top 이외의 위치는 body.toolbar-pos-* 클래스로 전환된다. bottom은 상하만
+   뒤집으면 되지만, left/right는 가로로 넓게 설계된 툴바(문서 제목, 페이지
+   입력창, 줌%, 여러 아이콘 버튼 그룹)를 세로 컬럼에 욱여넣어야 하므로
+   문서 제목처럼 폭을 많이 차지하는 요소는 숨기고 각 그룹을 세로로 쌓는다. */
+
+/* 아래(bottom) */
+body.toolbar-pos-bottom .topbar {
+  top: auto;
+  bottom: 0;
+  border-bottom: none;
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -4px 30px rgba(0, 0, 0, 0.2);
+}
+body.toolbar-pos-bottom .panels {
+  padding-top: 0;
+  padding-bottom: var(--topbar-h);
+}
+body.toolbar-pos-bottom .outline-sidebar {
+  top: 0;
+  bottom: var(--topbar-h);
+}
+
+/* 왼쪽(left) / 오른쪽(right) 공통: 세로 컬럼 툴바 */
+body.toolbar-pos-left .topbar,
+body.toolbar-pos-right .topbar {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 72px;
+  height: auto;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 16px 10px;
+  gap: 18px;
+  overflow-y: auto;
+  border-bottom: none;
+}
+body.toolbar-pos-left .topbar {
+  right: auto;
+  border-right: 1px solid var(--border);
+}
+body.toolbar-pos-right .topbar {
+  left: auto;
+  border-left: 1px solid var(--border);
+}
+body.toolbar-pos-left .topbar-left,
+body.toolbar-pos-left .topbar-center,
+body.toolbar-pos-left .topbar-right,
+body.toolbar-pos-right .topbar-left,
+body.toolbar-pos-right .topbar-center,
+body.toolbar-pos-right .topbar-right {
+  flex-direction: column;
+  flex: none;
+  gap: 10px;
+  width: 100%;
+}
+body.toolbar-pos-left .toolbar-group,
+body.toolbar-pos-right .toolbar-group {
+  flex-direction: column;
+}
+body.toolbar-pos-left .toolbar-divider,
+body.toolbar-pos-right .toolbar-divider {
+  width: 100%;
+  height: 1px;
+  margin: 2px 0;
+}
+/* 세로 컬럼에서는 폭이 넓게 필요한 문서 제목/페이지 표시를 숨겨 공간을
+   확보한다 - 각 버튼의 title 툴팁으로 기능은 그대로 확인 가능하다. */
+body.toolbar-pos-left .doc-title,
+body.toolbar-pos-left .doc-title-edit-btn,
+body.toolbar-pos-left .read-btn-text,
+body.toolbar-pos-right .doc-title,
+body.toolbar-pos-right .doc-title-edit-btn,
+body.toolbar-pos-right .read-btn-text {
+  display: none;
+}
+/* "EasyPaper" 글자가 좁은 세로 컬럼 폭을 넘어 흘러나오는 것을 막는다 -
+   로고 아이콘(svg)은 폭/높이가 px로 고정돼 있어 font-size에 영향받지
+   않으므로 아이콘만 남기고 글자만 사라진다. */
+body.toolbar-pos-left .logo-small-btn,
+body.toolbar-pos-right .logo-small-btn {
+  font-size: 0;
+}
+body.toolbar-pos-left .page-display,
+body.toolbar-pos-right .page-display {
+  flex-direction: column;
+  gap: 4px;
+}
+body.toolbar-pos-left .page-display input[type=number],
+body.toolbar-pos-right .page-display input[type=number] {
+  width: 100%;
+}
+body.toolbar-pos-left .panels {
+  padding-top: 0;
+  padding-left: 72px;
+}
+body.toolbar-pos-right .panels {
+  padding-top: 0;
+  padding-right: 72px;
+}
+body.toolbar-pos-left .outline-sidebar {
+  top: 0;
+  left: 72px;
+}
+body.toolbar-pos-right .outline-sidebar {
+  top: 0;
+}
+
 /* ── 좌측 목차 사이드바 ── */
 .outline-sidebar {
   position: fixed;


### PR DESCRIPTION
# Summary
## 1. 툴바 위치 설정 추가
- 일반 설정에 "툴바 위치" 드롭다운 추가: 위(기본)/아래/왼쪽/오른쪽
- `body.toolbar-pos-{bottom|left|right}` 클래스로 반영, top은 클래스 없이 기존 동작 그대로 유지

## 2. 구현 상세
- **아래(bottom)**: `.topbar`를 `top→bottom`으로, `.panels`의 `padding-top→padding-bottom`으로 전환하는 상하 반전만으로 충분
- **왼쪽/오른쪽(left/right)**: 가로로 넓게 설계된 툴바(문서 제목, 페이지 입력창, 줌%, 여러 버튼 그룹)를 72px 폭의 세로 컬럼으로 전환
  - `.topbar-left`/`.topbar-center`/`.topbar-right`, `.toolbar-group`을 전부 `flex-direction: column`으로 전환
  - `.toolbar-divider`를 세로선 → 가로선으로 전환
  - 폭을 많이 차지하는 문서 제목/독서완료 텍스트 라벨은 숨김(각 버튼의 `title` 툴팁으로 기능은 그대로 확인 가능), 로고 버튼의 텍스트도 `font-size:0`으로 숨겨 좁은 컬럼 밖으로 흘러나오지 않게 함
  - `.outline-sidebar`/`.panels`도 각 위치에 맞춰 오프셋 조정해 툴바와 겹치지 않도록 함
- `frontend/index.html`: `#setting-toolbar-position` 셀렉트 추가
- `frontend/src/main.js`: `getToolbarPosition()`/`applyToolbarPosition()` 추가. 모듈 로드 시 저장된 위치를 즉시 적용, 설정 모달 로드/제출 핸들러에 연결
- `frontend/src/style.css`: `body.toolbar-pos-*` 스코프의 레이아웃 오버라이드 추가

## Test plan
- [x] `vite build` 성공 확인
- [x] Playwright로 실제 HTML/CSS를 그대로 재현한 독립 테스트 페이지에서 4가지 위치(top/bottom/left/right) 모두 스크린샷으로 레이아웃 확인 - 겹침/오버플로우 없음, 목차 사이드바 오프셋도 정상
- [ ] 실제 앱에서 설정 변경 후 즉시 반영되는지, 각 위치에서 모든 버튼이 정상 클릭되는지 수동 확인 (미실시)