### PR TITLE
feat: 일반 설정 메뉴 checkbox를 toggle switch로 변경

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -597,16 +597,22 @@
           </div>
           
           <div class="form-group">
-            <label>번역 제외 문서 요소</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-math" /> 수식 (LaTeX 수식 생략)
+            <label>번역에서 제외할 요소</label>
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-math" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">수식(LaTeX) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-table" checked /> 표 (Table 데이터 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-table" checked />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">표(Table) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-refs" /> 참고문헌 (References 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-refs" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">참고문헌 제외</span>
               </label>
             </div>
           </div>
@@ -635,24 +641,36 @@
 
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>뷰어 편의 설정</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-hover-tooltip" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마우스를 올리면 자동으로 문장 선택<small>끄면 드래그로 직접 선택할 때만 툴팁이 뜸</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-bookmark" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마지막으로 읽던 위치 자동 이동<small>끄면 항상 1페이지부터 시작</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-insights" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">번역 패널의 키워드·요약 탭<small>탭을 열 때만 생성되지만 토큰을 추가로 사용함</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-citation-overlay" /> 본문 인용([1], (Smith, 2020) 등) 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-citation-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">본문 인용 표기 호버 미리보기<small>예: [1], (Smith, 2020)</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-figure-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-primer" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
               </label>
             </div>
           </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2338,12 +2338,15 @@ globalSettingsBtn.addEventListener('click', async () => {
   settingIgnoreTable.checked = localStorage.getItem('easypaper_ignore_table') !== 'false'
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
-  settingDisableHoverTooltip.checked = state.disableHoverTooltip
-  settingDisableBookmark.checked = state.disableBookmark
-  settingDisableInsights.checked = state.disableInsights
-  settingDisableCitationOverlay.checked = state.disableCitationOverlay
-  settingDisableFigureOverlay.checked = state.disableFigureOverlay
-  settingDisablePrimer.checked = state.disablePrimer
+  // 토글 스위치는 "기능이 켜져 있는지"를 직관적으로 보여줘야 하므로, 저장된
+  // disable* 플래그(true = 꺼짐)를 반전해서 보여준다 - 이 스위치들이 켜져
+  // 있으면 해당 기능이 켜진 것으로 보이도록.
+  settingDisableHoverTooltip.checked = !state.disableHoverTooltip
+  settingDisableBookmark.checked = !state.disableBookmark
+  settingDisableInsights.checked = !state.disableInsights
+  settingDisableCitationOverlay.checked = !state.disableCitationOverlay
+  settingDisableFigureOverlay.checked = !state.disableFigureOverlay
+  settingDisablePrimer.checked = !state.disablePrimer
   updateAccentSettingsUI(currentAccentColor)
 
   // 3. 시스템 설정값 로드 (백엔드 통신)
@@ -2566,17 +2569,17 @@ generalSettingsForm.addEventListener('submit', async (e) => {
 // 뷰어 편의 설정: 번역 관련 설정이 아니므로 폼 제출(및 재번역 제안)과 무관하게
 // 체크 즉시 저장하고 바로 적용한다.
 settingDisableHoverTooltip.addEventListener('change', () => {
-  state.disableHoverTooltip = settingDisableHoverTooltip.checked
+  state.disableHoverTooltip = !settingDisableHoverTooltip.checked
   localStorage.setItem('easypaper_disable_hover_tooltip', state.disableHoverTooltip)
 })
 
 settingDisableBookmark.addEventListener('change', () => {
-  state.disableBookmark = settingDisableBookmark.checked
+  state.disableBookmark = !settingDisableBookmark.checked
   localStorage.setItem('easypaper_disable_bookmark', state.disableBookmark)
 })
 
 settingDisableInsights.addEventListener('change', () => {
-  state.disableInsights = settingDisableInsights.checked
+  state.disableInsights = !settingDisableInsights.checked
   localStorage.setItem('easypaper_disable_insights', state.disableInsights)
   applyInsightsTabVisibility()
 })
@@ -2595,19 +2598,19 @@ function refreshAllPageOverlays() {
 }
 
 settingDisableCitationOverlay.addEventListener('change', () => {
-  state.disableCitationOverlay = settingDisableCitationOverlay.checked
+  state.disableCitationOverlay = !settingDisableCitationOverlay.checked
   localStorage.setItem('easypaper_disable_citation_overlay', state.disableCitationOverlay)
   refreshAllPageOverlays()
 })
 
 settingDisableFigureOverlay.addEventListener('change', () => {
-  state.disableFigureOverlay = settingDisableFigureOverlay.checked
+  state.disableFigureOverlay = !settingDisableFigureOverlay.checked
   localStorage.setItem('easypaper_disable_figure_overlay', state.disableFigureOverlay)
   refreshAllPageOverlays()
 })
 
 settingDisablePrimer.addEventListener('change', () => {
-  state.disablePrimer = settingDisablePrimer.checked
+  state.disablePrimer = !settingDisablePrimer.checked
   localStorage.setItem('easypaper_disable_primer', state.disablePrimer)
 })
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2460,6 +2460,72 @@ body.light-theme .pdf-annotation-underline {
   cursor: pointer;
 }
 
+/* ── 토글 스위치 (설정 메뉴의 켜기/끄기 항목) ── */
+.toggle-switch-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px 4px;
+}
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle-switch input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.toggle-switch-track {
+  display: inline-block;
+  position: relative;
+  flex-shrink: 0;
+  width: 38px;
+  height: 22px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+.toggle-switch-thumb {
+  display: block;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.2s ease;
+}
+.toggle-switch input:checked + .toggle-switch-track {
+  background: var(--accent-mid);
+  border-color: var(--accent-mid);
+}
+.toggle-switch input:checked + .toggle-switch-track .toggle-switch-thumb {
+  transform: translateX(16px);
+  background: #fff;
+}
+.toggle-switch input:focus-visible + .toggle-switch-track {
+  box-shadow: 0 0 0 2px var(--bg-elevated), 0 0 0 4px var(--accent-mid);
+}
+.toggle-switch-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+.toggle-switch-label small {
+  display: block;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-top: 2px;
+}
+
 /* ── 테마 색상(강조색) 커스터마이징 ── */
 .accent-swatch-group {
   display: flex;


### PR DESCRIPTION
# Summary
## 1. 일반 설정 탭 체크박스 9개를 토글 스위치로 교체
- 대상: 번역 제외 요소 3개(수식/표/참고문헌) + 뷰어 편의 설정 6개(마우스 오버 자동 선택/책갈피/키워드·요약 탭/인용 미리보기/Figure·Table 미리보기/읽기 전 브리핑)
- 계정/AI 모델 탭에 있는 다른 체크박스(로그인 생략, 채팅 모델 동일 사용 등)는 "일반 설정" 탭이 아니므로 이번 변경 범위에서 제외

## 2. 뷰어 편의 설정 6개의 이중부정 문제 해결
- 기존에는 전부 `disable*` 이중부정 체크박스였음(체크 = 기능이 꺼짐) - 토글 스위치에서는 "켜짐 = 기능 켜짐"이 직관적
- 내부 상태 변수(`state.disableHoverTooltip` 등)와 localStorage 키는 변경하지 않고(다른 코드 영향 없음), 화면에 보여주는 체크 상태만 반전(`checked = !state.disableX`)해서 스위치가 켜져 있으면 실제로 그 기능이 켜진 것처럼 보이게 함
- 번역 제외 3개(수식/표/참고문헌)는 원래도 "체크 = 제외"로 이중부정이 아니었으므로 반전 없이 스타일만 변경

## 3. 문구 정리
- 각 항목에 부연 설명이 길게 붙어 있던 문구를 `<small>` 보조 텍스트로 분리해 핵심 라벨을 짧고 읽기 쉽게 정리
- 예: "PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)" → "마우스를 올리면 자동으로 문장 선택" + 보조 설명 "끄면 드래그로 직접 선택할 때만 툴팁이 뜸"

## 구현 상세
- `frontend/index.html`: 두 `checkbox-group`을 `toggle-switch-group`으로 교체
- `frontend/src/main.js`: 6개 `disable*` 항목의 populate/change 핸들러에서 checked 값을 반전해서 읽고 씀
- `frontend/src/style.css`: `.toggle-switch-group`/`.toggle-switch`/`.toggle-switch-track`/`.toggle-switch-thumb` 등 새 스위치 컴포넌트 스타일 추가

## Test plan
- [x] `vite build` 성공 확인
- [x] Playwright로 실제 CSS를 그대로 적용한 독립 테스트 페이지에서 다크/라이트 테마 스크린샷 확인 - 켜짐/꺼짐 상태에 따른 트랙 색상/thumb 위치 정상 확인
- [x] 최초 구현에서 트랙이 라벨 텍스트와 겹치는 CSS 버그(`<span>`은 기본 inline이라 width/height가 무시됨) 발견 후 `display: inline-block`/`block` 추가로 수정, 재확인 완료
- [ ] 실제 앱에서 각 토글 클릭 시 실제 기능이 올바른 방향으로 켜지고 꺼지는지 수동 확인 (미실시)