### PR TITLE
feat: 번역 시 vision 지원 provider에 페이지 이미지 첨부해 수식 정확도 개선

### DIFF
--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -3,12 +3,18 @@ import json
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 
+from config import get_trans_provider
 from routers.upload import require_session_owner
 from services.auth import get_current_user
 from services.chunker import split_into_chunks, align_sentences, tag_source_text, parse_tagged_translation
 from services.llm_client import stream_translation, check_ollama_health
 from services.cache import get_cached_translation, save_translation_cache, get_cached_translation_full
 from services.library import save_translation as lib_save_translation, get_translation as lib_get_translation, get_translation_full as lib_get_translation_full, clear_translations as lib_clear_translations
+from services.pdf_parser import render_page_image_base64
+
+# 수식(LaTeX) 번역 정확도를 위해 페이지 이미지를 함께 첨부할 수 있는 provider
+# (translation_job.py의 배치 번역 잡과 동일한 기준).
+_VISION_CAPABLE_PROVIDERS = ("openai", "gemini", "claude")
 
 router = APIRouter()
 
@@ -81,6 +87,15 @@ async def translate_page(
         doc_title = session.get("metadata", {}).get("title") or session.get("filename", "")
         sentences = []
 
+        # vision을 지원하는 provider면 페이지 원본 이미지를 함께 보내 수식(LaTeX)
+        # 재현 정확도를 높인다 (translation_job.py의 배치 번역 잡과 동일한 로직).
+        page_image_b64 = None
+        if get_trans_provider() in _VISION_CAPABLE_PROVIDERS and not ignore_math:
+            try:
+                page_image_b64 = render_page_image_base64(session["pdf_path"], page_num)
+            except Exception as e:
+                print(f"[Translate {session_id}] page {page_num} 이미지 렌더링 실패(텍스트만 사용): {e}")
+
         try:
             for chunk_idx, chunk in enumerate(chunks):
                 # 청크 구분자 (여러 청크일 때)
@@ -111,7 +126,8 @@ async def translate_page(
                     doc_title=doc_title,
                     prev_context=prev_context,
                     session_id=session_id,
-                    page_num=page_num
+                    page_num=page_num,
+                    page_image_b64=page_image_b64
                 ):
                     chunk_result.append(token)
                     data = json.dumps({"content": token, "done": False, "cached": False}, ensure_ascii=False)

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -121,7 +121,8 @@ async def stream_translation(
     doc_title: str = "",
     prev_context: str = "",
     session_id: str = None,
-    page_num: int = None
+    page_num: int = None,
+    page_image_b64: str = None
 ) -> AsyncGenerator[str, None]:
     """
     Ollama /api/chat 엔드포인트를 사용해 번역 결과를 스트리밍합니다.
@@ -262,7 +263,20 @@ async def stream_translation(
             "※ 중요 2: 원문에 식 번호(예: (1), (2), (3.4) 등 괄호 안에 숫자가 표기된 형태)가 붙어 있는 수식은 독립된 블록 수식으로 취급해야 합니다. 번역문에서도 이 수식은 본문 줄바꿈을 통해 반드시 별도의 단독 줄(Line break)로 분리하고, 블록 수식 기호인 $$...$$를 사용하여 식 번호와 함께 감싸서 출력하세요 (예: `\\n$$f(x) = y \\quad (1)$$\\n`). 이를 본문 한가운데에 인라인 형태로 이어 적지 마세요.\n"
             "※ 중요 3: 하나의 긴 수식이 원문 텍스트 레이어의 분리로 인해 여러 줄(Line)로 나뉘어 있거나, 시그마(\\sum) 등 수식의 일부 기호가 단독으로 쪼개져 보일 수 있습니다. 이 경우 번역문에서는 절대로 수식의 일부 기호(예: `\\sum^L` 등)를 중복되거나 잘못된 단독 수식으로 분리하여 출력하지 마세요. 여러 줄에 걸쳐 나뉜 수식 성분들을 누락이나 기호의 중복 생성 없이 온전히 하나로 병합하여 단 하나의 완성된 블록 수식 `$$수식 전체$$`로 결합하여 출력해야 합니다."
         )
-        
+        # PDF 텍스트 추출은 수식 폰트(그리스 문자, 첨자, 시그마/적분 등)의 글리프를
+        # 엉뚱한 유니코드로 옮기거나 순서를 뒤섞는 경우가 많아, 텍스트만으로는
+        # 원본 수식을 온전히 복원하기 어렵다 - vision을 지원하는 provider(openai/
+        # gemini/claude)에는 이 페이지의 실제 스캔 이미지를 함께 첨부해, 텍스트가
+        # 아니라 이미지를 근거로 수식을 재현하도록 지시한다.
+        if page_image_b64:
+            rules.append(
+                "이 페이지의 실제 스캔 이미지가 텍스트와 함께 첨부되어 있습니다. PDF에서 텍스트를 추출하는 "
+                "과정에서 수식 기호, 위/아래 첨자, 그리스 문자, 시그마·적분 등의 구조가 깨지거나 순서가 "
+                "뒤섞였을 수 있습니다. 수식의 정확한 표기(어떤 기호인지, 첨자가 위첨자인지 아래첨자인지, "
+                "항의 순서 등)는 텍스트가 아니라 반드시 첨부된 이미지를 직접 보고 확인하여 정확한 LaTeX로 "
+                "재현하세요. 추출된 텍스트와 이미지의 내용이 서로 다르게 보이면 이미지를 기준으로 삼으세요."
+            )
+
     if ignore_table:
         rules.append("Markdown 표(Table) 형식의 출력은 절대 하지 말고, 표 데이터는 번역에서 완전히 제외하세요.")
     else:
@@ -304,16 +318,35 @@ async def stream_translation(
             "content": prompt,
         }
     ]
+    # ignore_math일 때는 애초에 수식을 번역 결과에서 빼므로 이미지를 함께 보낼
+    # 이유가 없다 - 수식을 실제로 재현해야 하는 경우에만 첨부한다.
+    use_image = bool(page_image_b64) and not ignore_math
 
     if provider == "openai":
+        if use_image:
+            messages = [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{page_image_b64}"}}
+                ]
+            }]
         async for token in stream_openai(messages, model=model, temperature=0.3):
             yield token
         return
     elif provider == "gemini":
-        async for token in stream_gemini(messages, model=model, temperature=0.3):
+        async for token in stream_gemini(messages, model=model, temperature=0.3, image_b64=page_image_b64 if use_image else None):
             yield token
         return
     elif provider == "claude":
+        if use_image:
+            messages = [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": page_image_b64}}
+                ]
+            }]
         async for token in stream_claude(messages, model=model, temperature=0.3):
             yield token
         return
@@ -438,18 +471,18 @@ async def stream_openai(messages: list, model: str, temperature: float = 0.5) ->
         raise RuntimeError("OpenAI 요청 시간이 초과되었습니다.")
 
 
-async def stream_gemini(messages: list, model: str, temperature: float = 0.5) -> AsyncGenerator[str, None]:
+async def stream_gemini(messages: list, model: str, temperature: float = 0.5, image_b64: str = None) -> AsyncGenerator[str, None]:
     api_key = get_gemini_api_key()
     if not api_key:
         raise RuntimeError("Gemini API Key가 설정되지 않았습니다. 설정에서 입력해 주세요.")
-        
+
     headers = {
         "Content-Type": "application/json"
     }
-    
+
     gemini_contents = []
     system_instruction = None
-    
+
     for msg in messages:
         role = msg["role"]
         if role == "system":
@@ -460,7 +493,14 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5) ->
                 "role": gemini_role,
                 "parts": [{"text": msg["content"]}]
             })
-            
+
+    # 번역 시 수식(LaTeX) 재현 정확도를 높이기 위해 페이지 원본 이미지를 함께
+    # 보내는 경우, 마지막 user 메시지의 parts에 inline_data로 첨부한다.
+    if image_b64 and gemini_contents:
+        gemini_contents[-1]["parts"].append({
+            "inline_data": {"mime_type": "image/png", "data": image_b64}
+        })
+
     payload = {
         "contents": gemini_contents,
         "generationConfig": {

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,3 +1,4 @@
+import base64
 import fitz  # PyMuPDF
 import re
 from typing import List, Dict, Any, Optional
@@ -595,6 +596,27 @@ def render_image_crop(pdf_path: str, page_num: int, bbox_percent: Dict[str, floa
         pix = page.get_pixmap(matrix=matrix, clip=clip)
         pix.save(output_path)
         return True
+    finally:
+        doc.close()
+
+
+def render_page_image_base64(pdf_path: str, page_num: int, zoom: float = 1.5) -> Optional[str]:
+    """
+    지정한 페이지 전체를 PNG로 렌더링해 base64 문자열로 반환합니다. PDF 텍스트
+    추출은 수식(LaTeX) 기호·첨자·특수문자를 자주 깨뜨리는데, vision을 지원하는
+    LLM(openai/gemini/claude)에게는 추출된 텍스트와 함께 이 페이지의 실제
+    스캔 이미지를 첨부해 수식 표기의 근거로 삼게 함으로써 번역 시 수식이
+    원본과 어긋나는 문제를 줄인다. 디스크에 파일로 저장하지 않고 바로 LLM
+    호출에 실어 보낼 수 있도록 base64로 반환한다.
+    """
+    doc = fitz.open(pdf_path)
+    try:
+        if page_num < 1 or page_num > doc.page_count:
+            return None
+        page = doc[page_num - 1]
+        matrix = fitz.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=matrix)
+        return base64.b64encode(pix.tobytes("png")).decode("ascii")
     finally:
         doc.close()
 

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -11,11 +11,17 @@ import os
 from datetime import datetime, timezone
 from typing import Optional
 
-from config import LIBRARY_DIR
+from config import LIBRARY_DIR, get_trans_provider
 from services.atomic_io import atomic_write_text
 from services.chunker import split_into_chunks, align_sentences, tag_source_text, parse_tagged_translation
 from services.llm_client import stream_translation
-from services.library import save_translation, get_translation, get_document
+from services.library import save_translation, get_translation, get_document, get_pdf_path
+from services.pdf_parser import render_page_image_base64
+
+# 수식(LaTeX) 번역 정확도를 위해 페이지 이미지를 함께 첨부할 수 있는 provider.
+# CLI 기반 provider(antigravity/claude_code/codex)와 로컬 ollama는 이 코드베이스의
+# 추상화 계층에서 아직 이미지 첨부를 지원하지 않는다.
+_VISION_CAPABLE_PROVIDERS = ("openai", "gemini", "claude")
 
 # 메모리 내 활성 잡 ( session_id → asyncio.Task )
 _running_tasks: dict[str, asyncio.Task] = {}
@@ -159,6 +165,10 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
     except Exception as e:
         print(f"[Job {session_id}] Failed to get document title: {e}")
 
+    # vision을 지원하는 provider면 페이지별로 원본 이미지를 함께 보내 수식(LaTeX)
+    # 재현 정확도를 높인다 - ignore_math면 애초에 수식을 생략하므로 렌더링하지 않는다.
+    pdf_path = get_pdf_path(session_id) if (get_trans_provider() in _VISION_CAPABLE_PROVIDERS and not ignore_math) else None
+
     # 이미 완료된 페이지들을 루프 돌기 전 한 번에 스캔하여 저장
     scanned_any = False
     for page_data in pages:
@@ -193,6 +203,14 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
                 except Exception:
                     pass
 
+            # 페이지 원본 이미지 렌더링 (vision 지원 provider + 수식 번역 대상인 경우만)
+            page_image_b64 = None
+            if pdf_path:
+                try:
+                    page_image_b64 = render_page_image_base64(pdf_path, page_num)
+                except Exception as e:
+                    print(f"[Job {session_id}] page {page_num} 이미지 렌더링 실패(텍스트만 사용): {e}")
+
             try:
                 # 원문 태깅 처리
                 tagged_text, src_sentences = tag_source_text(text)
@@ -207,7 +225,8 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
                     doc_title=doc_title,
                     prev_context=prev_context,
                     session_id=session_id,
-                    page_num=page_num
+                    page_num=page_num,
+                    page_image_b64=page_image_b64
                 )
                 # 태그 분석 및 매핑 생성
                 cleaned_translation, sentences = parse_tagged_translation(translation, src_sentences)
@@ -285,7 +304,8 @@ async def _translate_page(
     doc_title: str = "",
     prev_context: str = "",
     session_id: str = None,
-    page_num: int = None
+    page_num: int = None,
+    page_image_b64: str = None
 ) -> str:
     """단일 페이지 텍스트를 번역합니다."""
     if not text:
@@ -306,6 +326,7 @@ async def _translate_page(
             ignore_refs=ignore_refs,
             doc_title=doc_title,
             prev_context=current_prev,
+            page_image_b64=page_image_b64,
             session_id=session_id,
             page_num=page_num
         ):


### PR DESCRIPTION
# Summary
## 1. 번역 시 LaTeX 수식이 원본과 어긋나는 문제 개선
- 원인: PDF 텍스트 추출(PyMuPDF)이 수식 폰트(그리스 문자/첨자/시그마·적분 기호 등)의 글리프를 엉뚱한 유니코드로 옮기거나 순서를 뒤섞는 경우가 많음. `ignore_math=False`일 때 LLM은 이 손상된 텍스트만 보고 LaTeX를 "재구성"해야 했는데,애초에 원문 LaTeX 자체가 PDF에 없어 텍스트 추출 손상이 그대로 번역 결과의 수식 오류로 이어졌음
- 해결: vision을 지원하는 provider(openai/gemini/claude)로 번역할 때 해당 페이지를 실제로 렌더링한 이미지를 텍스트와 함께 첨부하고, "수식 표기는 텍스트가 아니라 첨부된 이미지를 근거로 재현하라"고 명시적으로 지시
- CLI 기반 provider(antigravity/claude_code/codex)와 ollama는 이 코드베이스의 추상화 계층에 이미지 첨부 지원이 없어 그대로 텍스트 전용으로 동작 (회귀 없음, 유닛 테스트로 확인)
- `ignore_math=True`(수식 생략 옵션)일 때는 이미지를 첨부할 이유가 없으므로 렌더링/첨부 자체를 건너뜀

## 2. 구현 상세
- `backend/services/pdf_parser.py`: `render_page_image_base64()` 추가 - 기존 `render_cover_image`/`render_image_crop`과 동일한 PyMuPDF 래스터화 기법을 파일 저장 없이 base64로 반환하도록 일반화
- `backend/services/llm_client.py`: `stream_translation()`에 `page_image_b64` 파라미터 추가
  - OpenAI/Claude: `messages`의 `content`를 텍스트+이미지 배열로 구성(각 API가 이미 지원하는 멀티모달 포맷 그대로 통과 - `stream_openai`/`stream_claude` 자체는 수정 불필요)
  - Gemini: `stream_gemini()`에 `image_b64` 파라미터 추가해 마지막 user 파트에 `inline_data`로 첨부
  - 수식 재현 규칙에 "이미지를 근거로 삼으라"는 지시문 추가
- `backend/services/translation_job.py`: 배치 번역 잡(`_run_job`)에서 provider가 vision 지원 목록에 있고 `ignore_math`가 아닐 때만 페이지 이미지를 렌더링해 `_translate_page`로 전달
- `backend/routers/translate.py`: 단일 페이지 온디맨드 번역 엔드포인트(배치 잡과는 별도 코드 경로)에도 동일한 로직 적용

## Test plan
- [x] `render_page_image_base64()`를 실제로 생성한 테스트 PDF에 대해 실행 - 유효한 PNG(매직 바이트 확인) 생성 및 범위 밖 페이지 번호에 대한 `None` 반환 확인
- [x] `stream_openai`/`stream_claude`에 멀티모달 content 배열을 전달했을 때 HTTP 페이로드에 그대로(수정 없이) 전달되는지 mock으로 확인
- [x] `stream_gemini`의 `image_b64` 파라미터가 마지막 user part에 `inline_data`로 정확히 첨부되는지, 미제공 시 기존과 동일하게 텍스트만 전달되는지 확인
- [x] `stream_translation()` 통합 테스트: `ignore_math=False`+이미지 제공 시 첨부됨 / `ignore_math=True`+이미지 제공 시 첨부 안 됨 / 이미지 미제공 시 텍스트 전용 - 3가지 시나리오 모두 확인
- [x] ollama provider가 새 파라미터에 전혀 영향받지 않는지(회귀 없음) mock으로 확인
- [ ] 실제 수식이 포함된 논문 PDF로 openai/gemini/claude 각각 실제 번역 결과의 수식 정확도가 개선되는지 수동 확인 (API 키/실제 LLM 호출이 필요해 이번 세션에서는 미실시)