### PR TITLE
fix: 어시스턴트 패널-floating 스크롤 버튼 겹침 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -278,6 +278,7 @@ const chatSidebar        = $('chat-sidebar')
 const chatResizer        = $('chat-resizer')
 const chatCloseBtn       = $('chat-close-btn')
 const chatMessages       = $('chat-messages')
+const floatingScrollNav  = $('floating-scroll-nav')
 const outlineToggleBtn   = $('outline-toggle-btn')
 const outlineSidebar     = $('outline-sidebar')
 const outlineCloseBtn    = $('outline-close-btn')
@@ -9260,6 +9261,17 @@ async function sendChatMessage() {
 }
 
 function initChatListeners() {
+  // 어시스턴트 패널의 실측 폭을 --chat-sidebar-offset으로 반영해, 우측 하단
+  // floating-scroll-nav가 패널과 겹치지 않고 뷰어 쪽으로 비켜서게 한다.
+  // 열림/닫힘(width: 0 ↔ 390px)과 리사이저 드래그 모두 이 하나의 관찰로 처리된다.
+  if (chatSidebar) {
+    const chatSidebarWidthObserver = new ResizeObserver((entries) => {
+      const width = entries[0].contentRect.width
+      document.documentElement.style.setProperty('--chat-sidebar-offset', `${width}px`)
+    })
+    chatSidebarWidthObserver.observe(chatSidebar)
+  }
+
   if (chatToggleBtn) {
     chatToggleBtn.addEventListener('click', toggleChatSidebar)
   }
@@ -9320,6 +9332,7 @@ function initChatListeners() {
       isDragging = true
       chatResizer.classList.add('dragging')
       chatSidebar.classList.add('resizing')
+      if (floatingScrollNav) floatingScrollNav.classList.add('resizing')
       document.body.style.cursor = 'col-resize'
       document.body.style.userSelect = 'none'
     })
@@ -9339,6 +9352,7 @@ function initChatListeners() {
       isDragging = false
       chatResizer.classList.remove('dragging')
       chatSidebar.classList.remove('resizing')
+      if (floatingScrollNav) floatingScrollNav.classList.remove('resizing')
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
       if (chatSidebar.style.width) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -609,14 +609,20 @@ html, body {
 }
 
 /* ── 우측 하단 floating 스크롤 내비게이션 ── */
+/* AI 어시스턴트 패널이 열리면 --chat-sidebar-offset(패널 실측 폭)만큼 왼쪽으로 밀어
+   패널과 겹치지 않도록 한다. main.js의 ResizeObserver가 이 변수를 갱신한다. */
 .floating-scroll-nav {
   position: fixed;
-  right: 24px;
+  right: calc(24px + var(--chat-sidebar-offset, 0px));
   bottom: 24px;
   z-index: 60;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  transition: right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.floating-scroll-nav.resizing {
+  transition: none !important;
 }
 .floating-nav-btn {
   width: 38px;


### PR DESCRIPTION
# Summary
## 1. AI 어시스턴트 탭 클릭 시 floating 버튼 겹침 문제 수정
- `.floating-scroll-nav`가 `position: fixed; right: 24px`로 뷰포트 기준 고정되어 있어, 어시스턴트 패널(`.chat-sidebar`, flex 레이아웃 width 390px)이 열려도 위치가 바뀌지 않고 패널 위에 그대로 겹치던 문제 수정
- `frontend/src/main.js`: `initChatListeners()`에 `chatSidebar`를 관찰하는 `ResizeObserver` 추가, 패널의 실측 폭을 `--chat-sidebar-offset` CSS 변수에 반영(패널 열림/닫힘, 리사이저 드래그 모두 하나의 로직으로 처리)
- `frontend/src/main.js`: 리사이저 드래그(mousedown/mouseup) 중 `floatingScrollNav`에도 `resizing` 클래스를 토글해 드래그 중 트랜지션 지연 방지
- `frontend/src/style.css`: `.floating-scroll-nav`의 `right` 값을 `calc(24px + var(--chat-sidebar-offset, 0px))`로 변경해 패널 폭만큼 왼쪽(뷰어 영역)으로 비켜서도록 수정, `right`에 트랜지션 추가로 패널 열림/닫힘 애니메이션과 자연스럽게 연동
- `frontend/src/style.css`: `.floating-scroll-nav.resizing { transition: none !important; }` 추가

## Test plan
- [x] Vite dev 서버 + Playwright(Chromium)로 어시스턴트 패널(`#chat-sidebar`)의 `hidden` 클래스를 제거해 강제로 연 뒤 `#floating-scroll-nav`의 `getBoundingClientRect()`를 측정, 패널이 열리기 전/후 겹침 여부(rect 교차)를 확인 → 열림 후 겹침 없음(`OVERLAP: false`), `--chat-sidebar-offset`이 패널 실측 폭(389px)과 일치함을 확인