### PR TITLE
fix: 케밥 메뉴 번역 모델 라벨 세로 배치 버그 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -270,11 +270,6 @@
               <div class="progress-mini-bar" id="progress-mini-bar"></div>
               <span id="progress-mini-text">0%</span>
             </div>
-            <div class="translation-status kebab-menu-status" id="translation-status">
-              <div class="spinner hidden" id="translate-spinner"></div>
-              <span id="translate-status-text">번역 대기 중</span>
-            </div>
-
             <!-- AI 번역 모델 선택 드롭다운 -->
             <div class="kebab-menu-row">
               <span class="kebab-menu-label">번역 모델</span>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -263,8 +263,6 @@ const backBtn           = $('back-btn')
 const logoBtn           = $('logo-btn')
 const viewerReadToggleBtn = $('viewer-read-toggle-btn')
 const viewerScrollContainer = $('viewer-scroll-container')
-const translateSpinner      = $('translate-spinner')
-const translateStatusText   = $('translate-status-text')
 const progressMini          = $('translation-progress-mini')
 const progressMiniBar       = $('progress-mini-bar')
 const progressMiniText      = $('progress-mini-text')
@@ -1161,14 +1159,9 @@ function startJobPolling(sessionId) {
       updateProgressMiniRaw(done, total, isRunning)
 
       if (job.status === 'running') {
-        translateSpinner.classList.remove('hidden')
-        translateStatusText.textContent = `백그라운드 번역 중 (${done}/${total}p)`
         cancelTransBtn.classList.remove('hidden')
         resumeTransBtn.classList.add('hidden')
       } else {
-        translateSpinner.classList.add('hidden')
-        translateStatusText.textContent =
-          job.status === 'completed' ? `번역 완료 ✓ (${done}/${total}p)` : `상태: ${job.status}`
         cancelTransBtn.classList.add('hidden')
         if (job.status !== 'completed') {
           resumeTransBtn.classList.remove('hidden')
@@ -1548,8 +1541,6 @@ cancelTransBtn.addEventListener('click', async () => {
         clearInterval(state.pollingTimer)
         state.pollingTimer = null
       }
-      translateSpinner.classList.add('hidden')
-      translateStatusText.textContent = '번역 중지됨'
       cancelTransBtn.classList.add('hidden')
       
       for (let i = 1; i <= state.totalPages; i++) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4294,8 +4294,7 @@ body.toolbar-pos-right .kebab-menu {
   backdrop-filter: blur(3px);
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.kebab-menu .progress-mini,
-.kebab-menu .translation-status {
+.kebab-menu .progress-mini {
   width: 100%;
   box-sizing: border-box;
   justify-content: center;
@@ -4308,9 +4307,17 @@ body.toolbar-pos-right .kebab-menu {
   padding: 4px 8px;
 }
 .kebab-menu-label {
+  flex-shrink: 0;
   font-size: 12px;
   color: var(--text-muted);
   font-weight: 500;
+  white-space: nowrap;
+}
+.kebab-menu-row .provider-picker {
+  min-width: 0;
+}
+.kebab-menu-row .provider-picker-btn {
+  min-width: 0;
 }
 .kebab-menu-divider {
   height: 1px;


### PR DESCRIPTION
## Summary
- 케밥 메뉴에서 번역 모델 선택 버튼이 긴 모델명으로 넓어지면서 "번역 모델" 라벨이 극도로 좁은 폭으로 밀려나 한 글자씩 세로로 줄바꿈되던 버그 수정
- 중복 정보였던 번역 상태 텍스트("번역 대기 중" / "번역 완료 ✓ ..." 등) 표시를 제거하고, 그 자리를 번역 모델 선택 드롭다운이 차지하도록 정리

## Test plan
- [x] `npm run dev`로 프론트엔드 실행 후 Playwright로 케밥 메뉴를 강제 노출시켜 스크린샷으로 레이아웃 확인 (수정 전: "번역 모델" 4글자가 세로로 각각 줄바꿈됨 / 수정 후: 한 줄로 정상 표시)
- [x] 콘솔에 새로 발생하는 JS 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)