### PR TITLE
fix: 일반 설정의 마지막 체크박스를 토글 스위치로 통일

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -707,15 +707,17 @@
               <label class="toggle-switch">
                 <input type="checkbox" id="setting-disable-figure-overlay" />
                 <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기</span>
+                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기<small>예: Fig. 1, Table 2, Eq. (3)</small></span>
               </label>
               <label class="toggle-switch">
                 <input type="checkbox" id="setting-disable-primer" />
                 <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
                 <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-toolbar-autohide" /> 아래로 스크롤하면 상단 툴바 자동으로 숨기기 (위로 스크롤하면 다시 표시)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-toolbar-autohide" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">스크롤 시 상단 툴바 자동 숨김<small>아래로 스크롤하면 숨겨지고, 위로 스크롤하면 다시 표시됨</small></span>
               </label>
             </div>
           </div>


### PR DESCRIPTION
# Summary
## 1. 남은 체크박스를 토글 스위치로 전환
- `frontend/index.html`의 일반 설정 > 뷰어 편의 설정 그룹에서 유일하게 기존 `checkbox-label` 스타일로 남아있던 `setting-toolbar-autohide` 항목을 다른 항목들과 동일한 `.toggle-switch` 마크업으로 변경
## 2. 설정 항목 텍스트 직관적으로 수정
- "아래로 스크롤하면 상단 툴바 자동으로 숨기기 (위로 스크롤하면 다시 표시)" → "스크롤 시 상단 툴바 자동 숨김" (메인 라벨) + "아래로 스크롤하면 숨겨지고, 위로 스크롤하면 다시 표시됨" (보조 설명)으로 다른 토글 항목들과 동일한 라벨+보조설명 구조로 통일
- `setting-disable-figure-overlay` 항목에 다른 항목들과의 일관성을 위해 예시 보조 설명("예: Fig. 1, Table 2, Eq. (3)") 추가