### PR TITLE
chore: 데스크톱 앱 버전을 0.1.12로 올림

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.11"
+version = "0.1.12"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
# Summary
## 1. 데스크톱 앱 버전 범프 (0.1.11 → 0.1.12)
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`의 version 필드를 0.1.12로 동기화
- #240(툴바 자동 숨김 시 뷰어/AI 어시스턴트 패널 상단 여백 남는 문제 수정) 배포용

🤖 Generated with [Claude Code](https://claude.com/claude-code)