### PR TITLE
fix: 그림/표/수식 참조 미리보기 툴팁의 빈 여백 제거

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8462,10 +8462,13 @@ function getOrCreateFigurePreviewTooltip() {
   document.body.appendChild(el)
 
   try {
+    // 너비만 기억해둔다 - 높이까지 고정해서 복원하면, 이전에 열었던 그림/표와
+    // 비율이 다른 대상을 열었을 때 옛 높이가 그대로 남아 이미지+캡션 아래로
+    // 빈 여백이 생긴다. 높이는 항상 CSS(height: auto)에 맡겨 그 순간의
+    // 콘텐츠 크기에 맞게 정해지도록 둔다.
     const saved = JSON.parse(localStorage.getItem(_FIGURE_PREVIEW_SIZE_KEY) || 'null')
-    if (saved && saved.w >= _FIGURE_PREVIEW_MIN_WIDTH && saved.h >= _FIGURE_PREVIEW_MIN_HEIGHT) {
+    if (saved && saved.w >= _FIGURE_PREVIEW_MIN_WIDTH) {
       el.style.width = `${saved.w}px`
-      el.style.height = `${saved.h}px`
     }
   } catch {}
 
@@ -8522,7 +8525,12 @@ function getOrCreateFigurePreviewTooltip() {
       document.removeEventListener('mouseup', onUp)
       el.classList.remove('resizing')
       figurePreviewIsResizing = false
-      localStorage.setItem(_FIGURE_PREVIEW_SIZE_KEY, JSON.stringify({ w: el.offsetWidth, h: el.offsetHeight }))
+      // 드래그 중엔 실시간 피드백을 위해 높이를 직접 계산해 인라인으로 고정했지만,
+      // 드래그가 끝나면 그 고정값을 지워 다시 CSS의 height: auto로 돌려놓는다 -
+      // 그래야 이후 다른 비율의 그림/표로 내용이 바뀌어도 높이가 자동으로
+      // 맞춰지고, 지금 안 맞는 빈 여백이 남지 않는다. 너비만 기억해둔다.
+      el.style.height = ''
+      localStorage.setItem(_FIGURE_PREVIEW_SIZE_KEY, JSON.stringify({ w: el.offsetWidth }))
     }
     document.addEventListener('mousemove', onMove)
     document.addEventListener('mouseup', onUp)


### PR DESCRIPTION
# Summary
## 1. 참조 미리보기 툴팁(figure-preview-tooltip) 하단에 남던 빈 여백 수정
- `frontend/src/main.js`의 `getOrCreateFigurePreviewTooltip`에서 localStorage에 저장된 크기를 복원할 때 너비(`w`)만 적용하고, 높이(`h`)는 더 이상 인라인으로 고정하지 않도록 수정
- 원인: `.figure-preview-tooltip`의 CSS(`style.css:5448`)엔 원래 고정 `height` 규칙이 없어 콘텐츠에 맞춰 자동으로 크기가 정해지는데, JS가 이전 리사이즈 시점의 높이를 매번 인라인 `el.style.height`로 강제 고정해버려서, 이전과 다른 비율의 그림/표/수식을 열람하면 옛 높이가 그대로 남아 이미지+캡션 아래로 빈 공간이 생기고 있었음
- 리사이즈 핸들 드래그가 끝나는 시점(`onUp`)에 인라인 `el.style.height`를 제거(`''`)해 다시 CSS의 `height: auto`로 돌아가도록 하고, `localStorage`에는 너비만 저장

## 검증
- Playwright로 실제 앱을 구동해 다양한 비율의 Figure/Table 참조에 hover했을 때 툴팁이 콘텐츠 크기에 딱 맞게 나오는 것을 확인
- `localStorage`에 예전처럼 큰 높이 값({w:700, h:700})이 남아있는 상황을 재현해도, 실제 콘텐츠 크기(298px)에 맞춰 자동으로 줄어들고 빈 여백이 남지 않음을 확인