### PR TITLE
fix: 브리핑 LLM 생성 실패 시 빈 결과가 캐시에 영구 저장되던 문제 수정

### DIFF
--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -41,6 +41,11 @@ def _ensure_generation_started(doc_id: str, target_lang: str, session: dict, cur
                 target_lang=target_lang,
                 session_id=doc_id,
             )
+        except Exception as e:
+            # generate_primer()가 실패하면 캐시에 아무것도 저장하지 않은 채 여기서
+            # 끝난다. 태스크가 pop되므로 다음 GET/재생성 요청이 처음부터 다시
+            # 시도한다(pending 폴링이 이미 그 재시도를 감당하도록 되어 있다).
+            print(f"[primer] 브리핑 생성 실패 ({doc_id}): {e}")
         finally:
             _pending_generations.pop(task_key, None)
 

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1005,16 +1005,22 @@ async def generate_reading_primer(
     provider = get_chat_provider()
     model = get_chat_model()
 
+    # 브리핑은 계보/파인만/실험 흐름/용어집까지 한 번에 뽑아내느라 항목이 많아,
+    # 사용자가 채팅용으로 설정해둔 effort를 그대로 쓰면 CLI가 오래 침묵하다 stall
+    # 타임아웃(120초)에 걸리는 경우가 실측됐다. 브리핑 생성만은 항상 낮은 effort로
+    # 강제해 완결된 응답을 더 빨리 받는 쪽을 택한다.
+    PRIMER_EFFORT = "low"
+
     async def _call_once() -> str:
         tokens = []
         if provider == "antigravity":
-            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer"):
+            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer", effort_override=PRIMER_EFFORT):
                 tokens.append(token)
         elif provider == "claude_code":
-            async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer"):
+            async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer", effort_override=PRIMER_EFFORT):
                 tokens.append(token)
         elif provider == "codex":
-            async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="primer"):
+            async for token in stream_codex(prompt, model=model, session_id=session_id, usage_label="primer", effort_override=PRIMER_EFFORT):
                 tokens.append(token)
         elif provider in ("openai", "gemini", "claude"):
             messages = [{"role": "user", "content": prompt}]
@@ -1237,7 +1243,7 @@ def _get_claude_code_session_lock(session_id: str):
     return _claude_code_session_locks[session_id]
 
 
-async def stream_claude_code(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False, usage_label: str = None) -> AsyncGenerator[str, None]:
+async def stream_claude_code(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False, usage_label: str = None, effort_override: str = None) -> AsyncGenerator[str, None]:
     import asyncio
     import os
     import codecs
@@ -1300,6 +1306,12 @@ async def stream_claude_code(prompt: str, model: str = None, session_id: str = N
             effort_level = parts[1].strip() or None
         else:
             model_name = raw
+
+    # 호출부가 명시적으로 요청한 effort는 모델 문자열에 파이프로 박아둔 값보다
+    # 우선한다(예: primer 생성은 사용자가 설정한 채팅 모델/effort와 무관하게
+    # 항상 낮은 effort로 빠르게 생성하고 싶을 때 사용).
+    if effort_override:
+        effort_level = effort_override
 
     if model_name:
         base_cmd.extend(["--model", model_name])
@@ -1424,7 +1436,7 @@ def _get_codex_session_lock(session_id: str) -> asyncio.Lock:
     return _codex_session_locks[session_id]
 
 
-async def stream_codex(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False, usage_label: str = None) -> AsyncGenerator[str, None]:
+async def stream_codex(prompt: str, model: str = None, session_id: str = None, is_chat: bool = False, usage_label: str = None, effort_override: str = None) -> AsyncGenerator[str, None]:
     """Codex CLI(`codex exec`)로 번역/채팅/인사이트를 생성합니다.
 
     codex exec --json은 claude/antigravity와 달리 토큰 단위 스트리밍을 제공하지
@@ -1452,6 +1464,10 @@ async def stream_codex(prompt: str, model: str = None, session_id: str = None, i
             effort_level = parts[1].strip() or None
         else:
             model_name = raw
+
+    # 호출부가 명시적으로 요청한 effort는 모델 문자열에 파이프로 박아둔 값보다 우선한다.
+    if effort_override:
+        effort_level = effort_override
 
     # 이 문서를 마지막으로 쓴 provider가 codex가 아니면(예: antigravity/claude_code로
     # 갔다가 다시 돌아온 경우) 그 세션은 이 provider에서 재사용할 수 없으므로 새로
@@ -1735,7 +1751,8 @@ async def stream_antigravity(
     model: str = None,
     session_id: str = None,
     is_chat: bool = False,
-    usage_label: str = None
+    usage_label: str = None,
+    effort_override: str = None
 ) -> AsyncGenerator[str, None]:
     import asyncio
     import os
@@ -1796,6 +1813,8 @@ async def stream_antigravity(
                 init_cmd = [agy_path, "--dangerously-skip-permissions", "--sandbox"]
                 if model and model.strip() and model.strip().lower() != "custom":
                     init_cmd.extend(["--model", model.strip()])
+                if effort_override:
+                    init_cmd.extend(["--effort", effort_override])
                 init_cmd.extend(["--log-file", temp_log_path])
                 init_prompt = (
                     "You are a direct-output assistant. Output ONLY 'OK'.\n\n"
@@ -1851,6 +1870,8 @@ async def stream_antigravity(
     cmd = [agy_path, "--dangerously-skip-permissions", "--sandbox"]
     if model and model.strip() and model.strip().lower() != "custom":
         cmd.extend(["--model", model.strip()])
+    if effort_override:
+        cmd.extend(["--effort", effort_override])
     if target_conv_id:
         cmd.extend(["--conversation", target_conv_id])
 

--- a/backend/services/primer.py
+++ b/backend/services/primer.py
@@ -163,25 +163,22 @@ async def generate_primer(
     session_id: str = None,
 ) -> dict:
     """primer 콘텐츠를 생성하고 캐시에 저장한 뒤 결과 dict를 반환한다.
-    실패해도 예외를 던지지 않고 부분 결과를 반환한다 - 업로드 직후 번역 착수를
-    막아서는 안 되는 백그라운드 부가 기능이기 때문이다.
+
+    LLM 생성이 실패(타임아웃 등)하면 예외를 그대로 전파한다 - 예전에는 여기서
+    빈 값(hook="", lineage="" 등)으로 대체해 반환했는데, 그 빈 결과가 "정상
+    완료된 브리핑"으로 캐시에 영구 저장되어 이후 재생성을 눌러도 계속 개요
+    탭만 있는 빈 브리핑이 반복되는 문제가 있었다. 호출부(routers/primer.py의
+    백그라운드 태스크)가 예외를 캐치해 캐시 저장을 건너뛰므로, 다음 조회/재생성
+    시 처음부터 다시 시도하게 된다.
     """
     title = metadata.get("title") or ""
     sections = detect_sections(pages)
     candidate_terms = extract_candidate_terms(pages)
 
     async def _run_llm() -> dict:
-        try:
-            return await generate_reading_primer(
-                title, sections, candidate_terms, target_lang=target_lang, session_id=session_id
-            )
-        except Exception as e:
-            print(f"[primer] LLM 생성 실패 ({doc_id}): {e}")
-            return {
-                "hook": "", "lineage": "", "feynman": "",
-                "questions": [], "checklist": [],
-                "experiment_flow": [], "glossary": [], "recommended_titles": [],
-            }
+        return await generate_reading_primer(
+            title, sections, candidate_terms, target_lang=target_lang, session_id=session_id
+        )
 
     async def _run_figure() -> Optional[dict]:
         try:

--- a/backend/tests/test_primer.py
+++ b/backend/tests/test_primer.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import services.primer as primer_module
 from services.primer import _is_plausible_match, _normalize_words, _resolve_recommended_titles
 
 
@@ -109,3 +110,31 @@ async def test_resolve_recommended_titles_respects_limit():
 
     assert call_count == 5
     assert len(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_generate_primer_propagates_llm_failure_without_caching():
+    """LLM 생성이 실패하면 예외가 그대로 전파되어야 하고, 빈 값으로 대체한
+    결과가 "정상 완료"인 것처럼 캐시에 저장되어서는 안 된다 - 예전에는 실패를
+    삼켜 빈 브리핑을 캐시에 영구 저장해버려, 재생성을 눌러도 계속 개요 탭만
+    남는 문제가 있었다."""
+
+    async def fake_generate_reading_primer(*args, **kwargs):
+        raise RuntimeError("Antigravity CLI 실행 실패 (code=1): timeout waiting for response")
+
+    with patch.object(primer_module, "detect_sections", return_value={}), \
+         patch.object(primer_module, "extract_candidate_terms", return_value=[]), \
+         patch.object(primer_module, "generate_reading_primer", fake_generate_reading_primer), \
+         patch.object(primer_module, "save_page_insight") as mock_save:
+        with pytest.raises(RuntimeError):
+            await primer_module.generate_primer(
+                doc_id="doc1",
+                pages=[],
+                metadata={"title": "Test Paper"},
+                username="tester",
+                pdf_path="/nonexistent.pdf",
+                target_lang="한국어",
+                session_id="doc1",
+            )
+
+    mock_save.assert_not_called()


### PR DESCRIPTION
## Summary
- Antigravity CLI 타임아웃 등으로 primer(읽기 전 브리핑) 생성이 실패하면, 그 실패를 삼켜 모든 필드가 빈 값인 결과를 "정상 완료"로 캐시에 영구 저장해버리던 버그를 수정. 이제 실패는 예외로 전파되어 캐시에 저장되지 않고, 다음 조회/재생성 시 처음부터 다시 시도한다.
- 브리핑 생성(계보/파인만/실험 흐름/용어집까지 뽑아내느라 항목이 많음)에 한해 `--effort low`를 강제해 CLI가 응답을 더 빨리, 더 안정적으로 완료하도록 함 (antigravity/claude_code/codex 공통).

## Test plan
- [x] `pytest` 전체 실행 - 219개 중 218개 통과 (나머지 1개는 이 변경과 무관한 기존 실패, stash 후에도 동일하게 재현됨을 확인)
- [x] 새 회귀 테스트 추가: `test_generate_primer_propagates_llm_failure_without_caching`

🤖 Generated with [Claude Code](https://claude.com/claude-code)