### PR TITLE
hotfix: antigravity 브리핑 생성에서 --effort 강제 제거 + 실패 재시도 쿨다운

### DIFF
--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import FileResponse
@@ -21,6 +22,13 @@ router = APIRouter()
 # 간격으로 재조회한다.
 _pending_generations: dict[str, "asyncio.Task"] = {}
 
+# 실패 직후 폴링(3초 간격)이 곧바로 재시도를 몰아치는 걸 막기 위한 쿨다운.
+# CLI가 (설정 오류 등으로) 거의 즉시 실패하는 경우, 이 쿨다운이 없으면 매 폴링마다
+# 서브프로세스를 새로 띄우게 되어 백엔드 CPU를 독점하는 장애로 이어질 수 있다 -
+# 실제로 잘못된 CLI 인자 조합 때문에 이 문제가 재현된 적이 있다.
+_last_failure_at: dict[str, float] = {}
+_RETRY_COOLDOWN_SECONDS = 15
+
 
 def _ensure_generation_started(doc_id: str, target_lang: str, session: dict, current_user: str) -> None:
     """이 문서/언어 조합의 브리핑 생성이 이미 진행 중이 아니면 백그라운드
@@ -28,6 +36,10 @@ def _ensure_generation_started(doc_id: str, target_lang: str, session: dict, cur
     task_key = f"{doc_id}:{target_lang}"
     task = _pending_generations.get(task_key)
     if task is not None and not task.done():
+        return
+
+    last_failure = _last_failure_at.get(task_key)
+    if last_failure is not None and (time.monotonic() - last_failure) < _RETRY_COOLDOWN_SECONDS:
         return
 
     async def _generate():
@@ -41,11 +53,14 @@ def _ensure_generation_started(doc_id: str, target_lang: str, session: dict, cur
                 target_lang=target_lang,
                 session_id=doc_id,
             )
+            _last_failure_at.pop(task_key, None)
         except Exception as e:
             # generate_primer()가 실패하면 캐시에 아무것도 저장하지 않은 채 여기서
-            # 끝난다. 태스크가 pop되므로 다음 GET/재생성 요청이 처음부터 다시
-            # 시도한다(pending 폴링이 이미 그 재시도를 감당하도록 되어 있다).
+            # 끝난다. 태스크가 pop되므로 쿨다운이 지난 뒤 다음 GET/재생성 요청이
+            # 처음부터 다시 시도한다(pending 폴링이 이미 그 재시도를 감당하도록
+            # 되어 있다).
             print(f"[primer] 브리핑 생성 실패 ({doc_id}): {e}")
+            _last_failure_at[task_key] = time.monotonic()
         finally:
             _pending_generations.pop(task_key, None)
 

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1007,14 +1007,19 @@ async def generate_reading_primer(
 
     # 브리핑은 계보/파인만/실험 흐름/용어집까지 한 번에 뽑아내느라 항목이 많아,
     # 사용자가 채팅용으로 설정해둔 effort를 그대로 쓰면 CLI가 오래 침묵하다 stall
-    # 타임아웃(120초)에 걸리는 경우가 실측됐다. 브리핑 생성만은 항상 낮은 effort로
-    # 강제해 완결된 응답을 더 빨리 받는 쪽을 택한다.
+    # 타임아웃(120초)에 걸리는 경우가 실측됐다. claude_code/codex는 "모델|effort"
+    # 파이프 표기를 지원해 --effort를 별도로 얹어도 안전하지만, antigravity는
+    # (Gemini Flash 계열처럼) effort가 모델 이름 자체에 이미 포함된 경우가 있어
+    # --effort를 별도로 얹으면 "--effort is not supported for model ..."로 CLI가
+    # 즉시 거부한다 - 실제로 이 때문에 매 폴링(3초)마다 즉시 실패·재시도가
+    # 반복되어 백엔드 CPU를 독점하는 장애가 있었다. 그래서 antigravity에는
+    # effort를 강제하지 않고 사용자가 설정한 모델/effort를 그대로 쓴다.
     PRIMER_EFFORT = "low"
 
     async def _call_once() -> str:
         tokens = []
         if provider == "antigravity":
-            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer", effort_override=PRIMER_EFFORT):
+            async for token in stream_antigravity(prompt, model=model, session_id=session_id, usage_label="primer"):
                 tokens.append(token)
         elif provider == "claude_code":
             async for token in stream_claude_code(prompt, model=model, session_id=session_id, usage_label="primer", effort_override=PRIMER_EFFORT):

--- a/backend/tests/test_primer_router.py
+++ b/backend/tests/test_primer_router.py
@@ -9,6 +9,7 @@ test_primer.py에서 이미 다룬다).
 """
 
 import asyncio
+import time
 
 import pytest
 
@@ -37,6 +38,7 @@ def fake_generation(monkeypatch):
     monkeypatch.setattr(primer_router, "require_session_owner", fake_require_session_owner)
     monkeypatch.setattr(primer_router, "generate_primer", fake_generate_primer)
     primer_router._pending_generations.clear()
+    primer_router._last_failure_at.clear()
     return calls
 
 
@@ -92,3 +94,20 @@ def test_regenerate_does_not_duplicate_when_already_in_flight(test_client, isola
     res = test_client.post("/api/library/doc-regen-dup/primer/regenerate")
     assert res.json() == {"status": "pending"}
     assert fake_generation["count"] == 1
+
+
+def test_does_not_restart_generation_within_cooldown_after_a_recent_failure():
+    """generate_primer가 (설정 오류 등으로) 거의 즉시 실패하는 경우, 쿨다운 없이
+    다음 폴링(3초 간격)마다 곧바로 재시도하면 CLI 서브프로세스를 계속 새로
+    띄우게 되어 백엔드 CPU를 독점하는 장애로 이어졌다(실제로 재현됨). 최근 실패
+    기록이 쿨다운 이내면 새 생성을 시작하지 않아야 한다."""
+    task_key = "doc-cooldown:한국어"
+    primer_router._pending_generations.clear()
+    primer_router._last_failure_at.clear()
+    primer_router._last_failure_at[task_key] = time.monotonic()
+
+    primer_router._ensure_generation_started(
+        "doc-cooldown", "한국어", {"pages": [], "metadata": {}, "pdf_path": "/x"}, "testuser"
+    )
+
+    assert task_key not in primer_router._pending_generations


### PR DESCRIPTION
## Summary
- 직전 PR(#246)에서 브리핑 생성에 `--effort low`를 강제했는데, Gemini Flash 계열처럼 effort가 모델 이름 자체에 포함된 모델에는 agy가 `--effort`를 즉시 거부한다(`invalid model selection`). 이 즉시 실패가 3초 폴링마다 재시도되며 백엔드가 CPU를 독점해 웹 전체가 응답 불가 상태가 되는 장애가 실제로 발생함 (수동으로 `systemctl restart`로 긴급 조치).
- antigravity 경로는 effort 강제를 되돌려 사용자가 설정한 모델/effort를 그대로 사용하도록 함 (claude_code/codex는 파이프 표기로 안전하게 지원되므로 유지).
- 재발 방지: `generate_primer` 실패 직후 15초 쿨다운을 둬서, CLI가 어떤 이유로든 즉시 실패해도 폴링마다 서브프로세스를 새로 띄우지 않게 함.

## Test plan
- [x] `pytest` 전체 실행 - 219개 중 218개 통과(나머지 1개는 무관한 기존 실패)
- [x] 신규 회귀 테스트 `test_does_not_restart_generation_within_cooldown_after_a_recent_failure` 추가
- [x] 운영 서버에서 실제로 CPU 독점/무응답 확인 후 `systemctl restart`로 긴급 완화, 이 수정 배포 후 재확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)