### PR TITLE
fix: 읽기 전 브리핑 모달 첫 노출 시 탭 바가 안 보이던 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-C_G4vtnx.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DBOn9QUY.css">
+  <script type="module" crossorigin src="/assets/index-Cx7ih__z.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BIbdfDif.css">
 </head>
 <body>
 
@@ -195,7 +195,7 @@
   <div id="viewer-screen" class="screen">
 
     <!-- 상단 바 -->
-    <header class="topbar">
+    <header class="topbar" id="viewer-topbar">
       <div class="topbar-left">
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
@@ -227,21 +227,6 @@
         </span>
       </div>
       <div class="topbar-right">
-        <!-- 번역 작업 상태 정보 -->
-        <div id="translation-progress-mini" class="progress-mini hidden">
-          <div class="progress-mini-bar" id="progress-mini-bar"></div>
-          <span id="progress-mini-text">0%</span>
-        </div>
-        <div class="translation-status" id="translation-status">
-          <div class="spinner hidden" id="translate-spinner"></div>
-          <span id="translate-status-text"></span>
-        </div>
-
-        <!-- AI 번역 모델 선택 드롭다운 -->
-        <div id="viewer-trans-provider"></div>
-
-        <div class="toolbar-divider"></div>
-
         <!-- 뷰 확대/축소 조작 그룹 -->
         <div class="toolbar-group view-group">
           <button id="zoom-out-btn" class="icon-btn" title="축소">
@@ -274,33 +259,55 @@
 
         <div class="toolbar-divider"></div>
 
-        <!-- 번역 작업 관리 그룹 -->
-        <div class="toolbar-group action-group">
-          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+        <!-- 추가 메뉴(케밥): 번역 상태/모델, 번역 관리(다시 번역/중지/이어서/다운로드),
+             메모 숨기기, 테마 전환을 한데 모아 툴바를 간결하게 유지한다. -->
+        <div class="kebab-wrapper">
+          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>
           </button>
-          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-          </button>
-          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-          </button>
-          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
-          </button>
-          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
-          </button>
-        </div>
+          <div id="toolbar-kebab-menu" class="kebab-menu hidden">
+            <!-- 번역 작업 상태 정보 -->
+            <div id="translation-progress-mini" class="progress-mini hidden">
+              <div class="progress-mini-bar" id="progress-mini-bar"></div>
+              <span id="progress-mini-text">0%</span>
+            </div>
+            <!-- AI 번역 모델 선택 드롭다운 -->
+            <div class="kebab-menu-row">
+              <span class="kebab-menu-label">번역 모델</span>
+              <div id="viewer-trans-provider"></div>
+            </div>
 
-        <div class="toolbar-divider"></div>
+            <div class="kebab-menu-divider"></div>
 
-        <!-- 기타 환경 조작 그룹 -->
-        <div class="toolbar-group config-group">
-          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
-            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-          </button>
+            <button id="retranslate-btn" class="kebab-menu-item" title="처음부터 다시 번역하기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+              <span>처음부터 다시 번역하기</span>
+            </button>
+            <button id="cancel-trans-btn" class="kebab-menu-item hidden" title="번역 작업 중지" style="color: var(--error);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+              <span>번역 작업 중지</span>
+            </button>
+            <button id="resume-trans-btn" class="kebab-menu-item hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+              <span>이어서 번역하기</span>
+            </button>
+            <button id="export-btn" class="kebab-menu-item" title="번역본 내보내기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
+              <span>번역본 다운로드</span>
+            </button>
+
+            <div class="kebab-menu-divider"></div>
+
+            <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+              <span>메모 숨기기</span>
+            </button>
+            <button id="theme-toggle-btn" class="kebab-menu-item" title="화이트/다크 테마 토글">
+              <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+              <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+              <span>테마 전환</span>
+            </button>
+          </div>
         </div>
       </div>
     </header>
@@ -321,6 +328,22 @@
       <!-- 단일 뷰어 스크롤 컨테이너 -->
       <div class="viewer-scroll-container" id="viewer-scroll-container">
         <!-- page-pair 요소가 동적으로 생성됨 -->
+      </div>
+
+      <!-- 우측 하단 floating 스크롤 내비게이션 -->
+      <div class="floating-scroll-nav" id="floating-scroll-nav">
+        <button id="scroll-top-btn" class="floating-nav-btn" title="맨 위로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
+        </button>
+        <button id="scroll-page-up-btn" class="floating-nav-btn" title="이전 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+        </button>
+        <button id="scroll-page-down-btn" class="floating-nav-btn" title="다음 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <button id="scroll-bottom-btn" class="floating-nav-btn" title="맨 아래로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg>
+        </button>
       </div>
 
       <!-- AI Chat Sidebar Resizer -->
@@ -598,16 +621,31 @@
           </div>
           
           <div class="form-group">
-            <label>번역 제외 문서 요소</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-math" /> 수식 (LaTeX 수식 생략)
+            <label for="setting-translation-mode">번역 모드</label>
+            <select id="setting-translation-mode" class="form-select">
+              <option value="auto">업로드 시 자동 번역 (기본)</option>
+              <option value="pane">번역 창을 펼칠 때만 번역</option>
+              <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>번역에서 제외할 요소</label>
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-math" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">수식(LaTeX) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-table" checked /> 표 (Table 데이터 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-table" checked />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">표(Table) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-refs" /> 참고문헌 (References 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-refs" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">참고문헌 제외</span>
               </label>
             </div>
           </div>
@@ -619,6 +657,16 @@
               <option value="1.5">100% (기본)</option>
               <option value="2.0">130%</option>
               <option value="2.5">170%</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label for="setting-toolbar-position">툴바 위치</label>
+            <select id="setting-toolbar-position" class="form-select">
+              <option value="top">위 (기본)</option>
+              <option value="bottom">아래</option>
+              <option value="left">왼쪽</option>
+              <option value="right">오른쪽</option>
             </select>
           </div>
 
@@ -636,24 +684,41 @@
 
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>뷰어 편의 설정</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-hover-tooltip" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마우스를 올리면 자동으로 문장 선택<small>끄면 드래그로 직접 선택할 때만 툴팁이 뜸</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-bookmark" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마지막으로 읽던 위치 자동 이동<small>끄면 항상 1페이지부터 시작</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-insights" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">번역 패널의 키워드·요약 탭<small>탭을 열 때만 생성되지만 토큰을 추가로 사용함</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-citation-overlay" /> 본문 인용([1], (Smith, 2020) 등) 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-citation-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">본문 인용 표기 호버 미리보기<small>예: [1], (Smith, 2020)</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-figure-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기<small>예: Fig. 1, Table 2, Eq. (3)</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-primer" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
+              </label>
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-toolbar-autohide" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">스크롤 시 상단 툴바 자동 숨김<small>아래로 스크롤하면 숨겨지고, 위로 스크롤하면 다시 표시됨</small></span>
               </label>
             </div>
           </div>
@@ -1032,6 +1097,9 @@
   <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
   <div id="primer-modal" class="modal-overlay hidden">
     <div class="primer-content">
+      <button id="primer-regenerate-btn" class="close-btn primer-regenerate-btn" title="다시 생성하기">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M8 16H3v5"/></svg>
+      </button>
       <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
 
       <div id="primer-loading" class="primer-loading">
@@ -1054,41 +1122,96 @@
           </div>
         </div>
 
-        <div id="primer-hook-section" class="primer-hook-section hidden">
-          <span class="primer-hook-quote">&ldquo;</span>
-          <p id="primer-hook-text" class="primer-hook-text"></p>
+        <div id="primer-tabs" class="primer-tabs" role="tablist">
+          <button type="button" class="primer-tab-btn active" data-tab="overview">개요</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="lineage">계보</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="feynman">쉽게 이해하기</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="experiment">실험 흐름</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="glossary">용어집</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="graph">관련 논문</button>
         </div>
 
-        <div id="primer-questions-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
-            <span>읽기 전에 스스로 답해보기</span>
-          </div>
-          <ol id="primer-questions" class="primer-list"></ol>
-        </div>
+        <div class="primer-tab-panels">
+          <div class="primer-tab-panel active" data-panel="overview">
+            <div id="primer-hook-section" class="primer-hook-section hidden">
+              <span class="primer-hook-quote">&ldquo;</span>
+              <p id="primer-hook-text" class="primer-hook-text"></p>
+            </div>
 
-        <div id="primer-figure-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
-            <span>핵심 그림 먼저 보기</span>
-          </div>
-          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
-        </div>
+            <div id="primer-questions-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+                <span>읽기 전에 스스로 답해보기</span>
+              </div>
+              <ol id="primer-questions" class="primer-list"></ol>
+            </div>
 
-        <div id="primer-checklist-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
-            <span>읽으면서 확인할 것</span>
-          </div>
-          <ul id="primer-checklist" class="primer-checklist"></ul>
-        </div>
+            <div id="primer-figure-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+                <span>핵심 그림 먼저 보기</span>
+              </div>
+              <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+            </div>
 
-        <div id="primer-graph-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
-            <span>이 논문과 연결된 논문</span>
+            <div id="primer-checklist-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+                <span>읽으면서 확인할 것</span>
+              </div>
+              <ul id="primer-checklist" class="primer-checklist"></ul>
+            </div>
           </div>
-          <div id="primer-graph" class="primer-graph"></div>
+
+          <div class="primer-tab-panel" data-panel="lineage">
+            <div id="primer-lineage-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg></span>
+                <span>이 논문의 연구 계보</span>
+              </div>
+              <p id="primer-lineage-text" class="primer-lineage-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="feynman">
+            <div id="primer-feynman-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/></svg></span>
+                <span>파인만 기법으로 쉽게 이해하기</span>
+              </div>
+              <p id="primer-feynman-text" class="primer-feynman-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="experiment">
+            <div id="primer-experiment-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/></svg></span>
+                <span>가설 → 실험 → 결과 흐름</span>
+              </div>
+              <ol id="primer-experiment-flow" class="primer-experiment-flow"></ol>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="glossary">
+            <div id="primer-glossary-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span>
+                <span>이 논문이 새로 정의한 용어</span>
+              </div>
+              <div id="primer-glossary" class="primer-glossary"></div>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="graph">
+            <div id="primer-graph-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+                <span>이 논문과 연결된 논문</span>
+              </div>
+              <div id="primer-graph" class="primer-graph"></div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5236,6 +5236,12 @@ function _loadPrimerInto(doc, mode, dataPromise) {
       renderPrimerContent(doc, data, mode)
       primerLoading.classList.add('hidden')
       primerBody.classList.remove('hidden')
+      // 모달이 열리는 투명도/스케일 트랜지션과 동시에 개요 탭의 탭 바(overflow-x:
+      // auto)가 처음 노출되면, 브라우저가 이 스크롤 컨테이너를 제대로 페인트하지
+      // 않아 탭 버튼들이 안 보이는 경우가 실측됐다(다른 탭으로 전환하면 강제
+      // 리페인트되어 정상화됨). offsetHeight를 읽어 강제로 리플로우를 유도해
+      // 처음 노출 시에도 바로 정상 표시되게 한다.
+      if (primerTabsBar) void primerTabsBar.offsetHeight
     })
     .catch(err => {
       console.error('브리핑 로드 실패:', err)


### PR DESCRIPTION
## Summary
- primer 모달이 열릴 때 오버레이(opacity 트랜지션)와 `.primer-content`(transform: scale 바운스 트랜지션)가 동시에 진행되는 동안 `.primer-tabs`(`overflow-x: auto`) 탭 바가 처음 노출되면, 브라우저가 이 스크롤 컨테이너를 제대로 페인트하지 않아 탭 버튼이 전혀 안 보이는 문제가 있었음. 실사용 스크린샷으로 재현: 개요 탭에서는 탭 바가 안 보이다가 다른 탭으로 전환하면 강제 리페인트되어 정상적으로 나타남.
- `_loadPrimerInto`가 `primerBody`를 보이게 한 직후 `primerTabsBar.offsetHeight`를 읽어 강제로 리플로우를 유도해, 첫 노출 시에도 바로 정상 표시되도록 수정.

## Test plan
- [x] `npm run build` 성공
- [x] 격리된 정적 재현 HTML로 관련 CSS(transform 트랜지션 + overflow-x:auto) 조합 확인
- [ ] 배포 후 실제 브라우저에서 브리핑 첫 오픈 시 탭 바 정상 노출 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)