### PR TITLE
fix: 개요 탭 콘텐츠가 길어지면 브리핑 탭 바가 짓눌려 안 보이던 문제 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DtT68_IM.js"></script>
+  <script type="module" crossorigin src="/assets/index-Cx7ih__z.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BIbdfDif.css">
 </head>
 <body>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Cx7ih__z.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BIbdfDif.css">
+  <script type="module" crossorigin src="/assets/index-C_G4vtnx.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DBOn9QUY.css">
 </head>
 <body>
 
@@ -195,7 +195,7 @@
   <div id="viewer-screen" class="screen">
 
     <!-- 상단 바 -->
-    <header class="topbar" id="viewer-topbar">
+    <header class="topbar">
       <div class="topbar-left">
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
@@ -227,6 +227,21 @@
         </span>
       </div>
       <div class="topbar-right">
+        <!-- 번역 작업 상태 정보 -->
+        <div id="translation-progress-mini" class="progress-mini hidden">
+          <div class="progress-mini-bar" id="progress-mini-bar"></div>
+          <span id="progress-mini-text">0%</span>
+        </div>
+        <div class="translation-status" id="translation-status">
+          <div class="spinner hidden" id="translate-spinner"></div>
+          <span id="translate-status-text"></span>
+        </div>
+
+        <!-- AI 번역 모델 선택 드롭다운 -->
+        <div id="viewer-trans-provider"></div>
+
+        <div class="toolbar-divider"></div>
+
         <!-- 뷰 확대/축소 조작 그룹 -->
         <div class="toolbar-group view-group">
           <button id="zoom-out-btn" class="icon-btn" title="축소">
@@ -259,55 +274,33 @@
 
         <div class="toolbar-divider"></div>
 
-        <!-- 추가 메뉴(케밥): 번역 상태/모델, 번역 관리(다시 번역/중지/이어서/다운로드),
-             메모 숨기기, 테마 전환을 한데 모아 툴바를 간결하게 유지한다. -->
-        <div class="kebab-wrapper">
-          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>
+        <!-- 번역 작업 관리 그룹 -->
+        <div class="toolbar-group action-group">
+          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
           </button>
-          <div id="toolbar-kebab-menu" class="kebab-menu hidden">
-            <!-- 번역 작업 상태 정보 -->
-            <div id="translation-progress-mini" class="progress-mini hidden">
-              <div class="progress-mini-bar" id="progress-mini-bar"></div>
-              <span id="progress-mini-text">0%</span>
-            </div>
-            <!-- AI 번역 모델 선택 드롭다운 -->
-            <div class="kebab-menu-row">
-              <span class="kebab-menu-label">번역 모델</span>
-              <div id="viewer-trans-provider"></div>
-            </div>
+          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+          </button>
+          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+          </button>
+          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
+          </button>
+          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          </button>
+        </div>
 
-            <div class="kebab-menu-divider"></div>
+        <div class="toolbar-divider"></div>
 
-            <button id="retranslate-btn" class="kebab-menu-item" title="처음부터 다시 번역하기">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-              <span>처음부터 다시 번역하기</span>
-            </button>
-            <button id="cancel-trans-btn" class="kebab-menu-item hidden" title="번역 작업 중지" style="color: var(--error);">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-              <span>번역 작업 중지</span>
-            </button>
-            <button id="resume-trans-btn" class="kebab-menu-item hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-              <span>이어서 번역하기</span>
-            </button>
-            <button id="export-btn" class="kebab-menu-item" title="번역본 내보내기">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
-              <span>번역본 다운로드</span>
-            </button>
-
-            <div class="kebab-menu-divider"></div>
-
-            <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
-              <span>메모 숨기기</span>
-            </button>
-            <button id="theme-toggle-btn" class="kebab-menu-item" title="화이트/다크 테마 토글">
-              <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-              <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-              <span>테마 전환</span>
-            </button>
-          </div>
+        <!-- 기타 환경 조작 그룹 -->
+        <div class="toolbar-group config-group">
+          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
+            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
         </div>
       </div>
     </header>
@@ -328,22 +321,6 @@
       <!-- 단일 뷰어 스크롤 컨테이너 -->
       <div class="viewer-scroll-container" id="viewer-scroll-container">
         <!-- page-pair 요소가 동적으로 생성됨 -->
-      </div>
-
-      <!-- 우측 하단 floating 스크롤 내비게이션 -->
-      <div class="floating-scroll-nav" id="floating-scroll-nav">
-        <button id="scroll-top-btn" class="floating-nav-btn" title="맨 위로">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
-        </button>
-        <button id="scroll-page-up-btn" class="floating-nav-btn" title="이전 페이지">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
-        </button>
-        <button id="scroll-page-down-btn" class="floating-nav-btn" title="다음 페이지">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
-        </button>
-        <button id="scroll-bottom-btn" class="floating-nav-btn" title="맨 아래로">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg>
-        </button>
       </div>
 
       <!-- AI Chat Sidebar Resizer -->
@@ -621,31 +598,16 @@
           </div>
           
           <div class="form-group">
-            <label for="setting-translation-mode">번역 모드</label>
-            <select id="setting-translation-mode" class="form-select">
-              <option value="auto">업로드 시 자동 번역 (기본)</option>
-              <option value="pane">번역 창을 펼칠 때만 번역</option>
-              <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
-            </select>
-          </div>
-
-          <div class="form-group">
-            <label>번역에서 제외할 요소</label>
-            <div class="toggle-switch-group">
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-ignore-math" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">수식(LaTeX) 제외</span>
+            <label>번역 제외 문서 요소</label>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-ignore-math" /> 수식 (LaTeX 수식 생략)
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-ignore-table" checked />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">표(Table) 제외</span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-ignore-table" checked /> 표 (Table 데이터 생략)
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-ignore-refs" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">참고문헌 제외</span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-ignore-refs" /> 참고문헌 (References 생략)
               </label>
             </div>
           </div>
@@ -657,16 +619,6 @@
               <option value="1.5">100% (기본)</option>
               <option value="2.0">130%</option>
               <option value="2.5">170%</option>
-            </select>
-          </div>
-
-          <div class="form-group">
-            <label for="setting-toolbar-position">툴바 위치</label>
-            <select id="setting-toolbar-position" class="form-select">
-              <option value="top">위 (기본)</option>
-              <option value="bottom">아래</option>
-              <option value="left">왼쪽</option>
-              <option value="right">오른쪽</option>
             </select>
           </div>
 
@@ -684,41 +636,24 @@
 
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>뷰어 편의 설정</label>
-            <div class="toggle-switch-group">
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-hover-tooltip" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">마우스를 올리면 자동으로 문장 선택<small>끄면 드래그로 직접 선택할 때만 툴팁이 뜸</small></span>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-bookmark" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">마지막으로 읽던 위치 자동 이동<small>끄면 항상 1페이지부터 시작</small></span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-insights" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">번역 패널의 키워드·요약 탭<small>탭을 열 때만 생성되지만 토큰을 추가로 사용함</small></span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-citation-overlay" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">본문 인용 표기 호버 미리보기<small>예: [1], (Smith, 2020)</small></span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-citation-overlay" /> 본문 인용([1], (Smith, 2020) 등) 표기 호버 미리보기 끄기
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-figure-overlay" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기<small>예: Fig. 1, Table 2, Eq. (3)</small></span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
               </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-disable-primer" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
-              </label>
-              <label class="toggle-switch">
-                <input type="checkbox" id="setting-toolbar-autohide" />
-                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
-                <span class="toggle-switch-label">스크롤 시 상단 툴바 자동 숨김<small>아래로 스크롤하면 숨겨지고, 위로 스크롤하면 다시 표시됨</small></span>
+              <label class="checkbox-label">
+                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
               </label>
             </div>
           </div>
@@ -1097,9 +1032,6 @@
   <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
   <div id="primer-modal" class="modal-overlay hidden">
     <div class="primer-content">
-      <button id="primer-regenerate-btn" class="close-btn primer-regenerate-btn" title="다시 생성하기">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M8 16H3v5"/></svg>
-      </button>
       <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
 
       <div id="primer-loading" class="primer-loading">
@@ -1122,96 +1054,41 @@
           </div>
         </div>
 
-        <div id="primer-tabs" class="primer-tabs" role="tablist">
-          <button type="button" class="primer-tab-btn active" data-tab="overview">개요</button>
-          <button type="button" class="primer-tab-btn hidden" data-tab="lineage">계보</button>
-          <button type="button" class="primer-tab-btn hidden" data-tab="feynman">쉽게 이해하기</button>
-          <button type="button" class="primer-tab-btn hidden" data-tab="experiment">실험 흐름</button>
-          <button type="button" class="primer-tab-btn hidden" data-tab="glossary">용어집</button>
-          <button type="button" class="primer-tab-btn hidden" data-tab="graph">관련 논문</button>
+        <div id="primer-hook-section" class="primer-hook-section hidden">
+          <span class="primer-hook-quote">&ldquo;</span>
+          <p id="primer-hook-text" class="primer-hook-text"></p>
         </div>
 
-        <div class="primer-tab-panels">
-          <div class="primer-tab-panel active" data-panel="overview">
-            <div id="primer-hook-section" class="primer-hook-section hidden">
-              <span class="primer-hook-quote">&ldquo;</span>
-              <p id="primer-hook-text" class="primer-hook-text"></p>
-            </div>
-
-            <div id="primer-questions-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
-                <span>읽기 전에 스스로 답해보기</span>
-              </div>
-              <ol id="primer-questions" class="primer-list"></ol>
-            </div>
-
-            <div id="primer-figure-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
-                <span>핵심 그림 먼저 보기</span>
-              </div>
-              <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
-            </div>
-
-            <div id="primer-checklist-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
-                <span>읽으면서 확인할 것</span>
-              </div>
-              <ul id="primer-checklist" class="primer-checklist"></ul>
-            </div>
+        <div id="primer-questions-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+            <span>읽기 전에 스스로 답해보기</span>
           </div>
+          <ol id="primer-questions" class="primer-list"></ol>
+        </div>
 
-          <div class="primer-tab-panel" data-panel="lineage">
-            <div id="primer-lineage-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg></span>
-                <span>이 논문의 연구 계보</span>
-              </div>
-              <p id="primer-lineage-text" class="primer-lineage-text"></p>
-            </div>
+        <div id="primer-figure-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+            <span>핵심 그림 먼저 보기</span>
           </div>
+          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+        </div>
 
-          <div class="primer-tab-panel" data-panel="feynman">
-            <div id="primer-feynman-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/></svg></span>
-                <span>파인만 기법으로 쉽게 이해하기</span>
-              </div>
-              <p id="primer-feynman-text" class="primer-feynman-text"></p>
-            </div>
+        <div id="primer-checklist-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+            <span>읽으면서 확인할 것</span>
           </div>
+          <ul id="primer-checklist" class="primer-checklist"></ul>
+        </div>
 
-          <div class="primer-tab-panel" data-panel="experiment">
-            <div id="primer-experiment-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/></svg></span>
-                <span>가설 → 실험 → 결과 흐름</span>
-              </div>
-              <ol id="primer-experiment-flow" class="primer-experiment-flow"></ol>
-            </div>
+        <div id="primer-graph-section" class="hidden">
+          <div class="primer-label">
+            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+            <span>이 논문과 연결된 논문</span>
           </div>
-
-          <div class="primer-tab-panel" data-panel="glossary">
-            <div id="primer-glossary-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span>
-                <span>이 논문이 새로 정의한 용어</span>
-              </div>
-              <div id="primer-glossary" class="primer-glossary"></div>
-            </div>
-          </div>
-
-          <div class="primer-tab-panel" data-panel="graph">
-            <div id="primer-graph-section" class="hidden">
-              <div class="primer-label">
-                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
-                <span>이 논문과 연결된 논문</span>
-              </div>
-              <div id="primer-graph" class="primer-graph"></div>
-            </div>
-          </div>
+          <div id="primer-graph" class="primer-graph"></div>
         </div>
       </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5236,12 +5236,6 @@ function _loadPrimerInto(doc, mode, dataPromise) {
       renderPrimerContent(doc, data, mode)
       primerLoading.classList.add('hidden')
       primerBody.classList.remove('hidden')
-      // 모달이 열리는 투명도/스케일 트랜지션과 동시에 개요 탭의 탭 바(overflow-x:
-      // auto)가 처음 노출되면, 브라우저가 이 스크롤 컨테이너를 제대로 페인트하지
-      // 않아 탭 버튼들이 안 보이는 경우가 실측됐다(다른 탭으로 전환하면 강제
-      // 리페인트되어 정상화됨). offsetHeight를 읽어 강제로 리플로우를 유도해
-      // 처음 노출 시에도 바로 정상 표시되게 한다.
-      if (primerTabsBar) void primerTabsBar.offsetHeight
     })
     .catch(err => {
       console.error('브리핑 로드 실패:', err)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5047,13 +5047,6 @@ function switchPrimerTab(tabName) {
   document.querySelectorAll('.primer-tab-panel').forEach(panel => {
     panel.classList.toggle('active', panel.dataset.panel === tabName)
   })
-  // primer-body(overflow-y: auto)는 모달을 닫아도 DOM이 유지되며 스크롤 위치가
-  // 그대로 남는다. 이전에 개요 탭에서 아래로 스크롤해둔 채 모달을 닫았다가 다시
-  // 열면(항상 개요 탭으로 시작하는데도) 탭 바가 스크롤 밖으로 밀려나 안 보이거나,
-  // 짧은 다른 탭으로 전환했을 때만 우연히 스크롤이 맞아 보이는 것처럼 착시가
-  // 생겼다 - 실제로는 페인트 문제가 아니라 단순 스크롤 위치 문제였다. 탭을
-  // 전환할 때마다 맨 위로 스크롤을 리셋한다.
-  if (primerBody) primerBody.scrollTop = 0
 }
 
 function togglePrimerTabButton(tabName, visible) {
@@ -5243,6 +5236,12 @@ function _loadPrimerInto(doc, mode, dataPromise) {
       renderPrimerContent(doc, data, mode)
       primerLoading.classList.add('hidden')
       primerBody.classList.remove('hidden')
+      // 모달이 열리는 투명도/스케일 트랜지션과 동시에 개요 탭의 탭 바(overflow-x:
+      // auto)가 처음 노출되면, 브라우저가 이 스크롤 컨테이너를 제대로 페인트하지
+      // 않아 탭 버튼들이 안 보이는 경우가 실측됐다(다른 탭으로 전환하면 강제
+      // 리페인트되어 정상화됨). offsetHeight를 읽어 강제로 리플로우를 유도해
+      // 처음 노출 시에도 바로 정상 표시되게 한다.
+      if (primerTabsBar) void primerTabsBar.offsetHeight
     })
     .catch(err => {
       console.error('브리핑 로드 실패:', err)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1707,6 +1707,7 @@ body.light-theme .toast.error { color: #dc2626; }
    숨긴다(main.js togglePrimerTabButton). */
 .primer-tabs {
   display: flex;
+  flex-shrink: 0;
   gap: 4px;
   overflow-x: auto;
   padding-bottom: 2px;


### PR DESCRIPTION
# Summary
## 1. PR #248, #249 되돌림
- `git revert`로 `3524944`(#248), `e1808e8`(#249)의 변경을 모두 되돌림
- `frontend/src/main.js`의 강제 리페인트(`primerTabsBar.offsetHeight` 읽기), 탭 전환 시 `primerBody.scrollTop = 0` 리셋 코드 제거 — 두 커밋 모두 진단이 틀려 실제 증상을 해결하지 못했음
- `frontend/dist/index.html`도 되돌림 커밋에 포함되어 자동으로 원복됨

## 2. 진짜 원인 파악 및 수정
- Playwright로 실제 브리핑 모달 마크업 + `style.css`를 그대로 로드한 재현 페이지를 만들어, 개요 탭 콘텐츠를 길게 채운 뒤 각 요소의 실제 렌더링 높이를 측정해 원인 재현
- `#primer-body`(`overflow-y: auto`)는 `.primer-header` / `.primer-tabs` / `.primer-tab-panels`를 자식으로 둔 flex column인데, `.primer-tabs`는 `overflow-x: auto`만 지정하고 `overflow-y`는 지정하지 않았음. CSS 스펙상 `overflow-x`/`overflow-y` 중 하나라도 `visible`이 아니면 나머지도 `auto`로 강제 계산되어 `.primer-tabs`의 `overflow-y`도 `auto`가 되고, flexbox의 "자동 최소 크기"가 콘텐츠 기준이 아닌 0이 되어버림
- 반면 header/tab-panels는 `overflow: visible`이라 콘텐츠 크기 이하로 줄어들지 않아서, 개요 탭 콘텐츠가 길어져 `#primer-body`의 가용 높이가 부족해질수록 유일하게 0까지 줄어들 수 있는 `.primer-tabs`가 압축분을 전부 떠안아 실측 높이가 2~3px까지 짓눌려 사실상 안 보이게 됨(콘텐츠 높이에 비례해 재현되는 이유)
- `frontend/src/style.css`의 `.primer-tabs`에 `flex-shrink: 0;` 추가해 탭 바를 압축 대상에서 제외 — 탭 바는 항상 원래 높이로 렌더링되고, 넘치는 콘텐츠는 기존처럼 `#primer-body`의 스크롤로 접근 가능

## Test plan
- [x] Playwright로 개요 탭에 긴 콘텐츠(hook/질문/체크리스트)를 채운 재현 페이지에서 수정 전(탭 바 2~3px로 짓눌려 안 보임) / 수정 후(탭 바 정상 표시) 스크린샷 비교로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)