### PR TITLE
fix: AI 어시스턴트 캡처 이미지가 실제로 LLM에 전달되지 않던 문제 수정

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -2,7 +2,7 @@ import hashlib
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 from routers.upload import sessions, ensure_session, require_session_owner
 from services.llm_client import stream_chat, generate_suggested_questions
@@ -25,6 +25,10 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     session_id: str
     messages: List[ChatMessage]
+    # 캡처 모드로 첨부한 이미지의 raw base64(PNG, data URL 접두사 없음). 있으면
+    # 이번 질문(messages의 마지막 user 메시지)에 실제로 첨부해 vision 지원
+    # provider(openai/gemini/claude)가 캡처 영역을 직접 보고 답할 수 있게 한다.
+    image_base64: Optional[str] = None
 
 # ── 여러 논문 간 비교 채팅 ──────────────────────────────
 MIN_COMPARE_DOCS = 2
@@ -110,10 +114,13 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
         yield " "
         full_response = []
         try:
-            async for token in stream_chat(system_prompt, history_messages, session_id=session_id):
+            async for token in stream_chat(
+                system_prompt, history_messages, session_id=session_id,
+                page_image_b64=data.image_base64
+            ):
                 full_response.append(token)
                 yield token
-            
+
             # Save assistant response to database
             assistant_content = "".join(full_response).strip()
             if assistant_content:

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -652,28 +652,60 @@ async def stream_claude(messages: list, model: str, temperature: float = 0.5) ->
         raise RuntimeError("Claude 요청 시간이 초과되었습니다.")
 
 
+def _messages_with_trailing_image(messages: list, page_image_b64: str, image_block_builder) -> list:
+    """마지막 메시지(캡처 이미지를 첨부해 물어본 최신 질문)의 content를 텍스트+
+    이미지 멀티파트 블록으로 바꾼 사본을 반환한다. 원본 messages는 건드리지
+    않는다 - 이미지는 이번 호출 한 번에만 실어 보내면 되고, DB/히스토리에는
+    여전히 텍스트 placeholder만 남아야 하기 때문이다."""
+    if not page_image_b64 or not messages or messages[-1]["role"] != "user":
+        return messages
+    return messages[:-1] + [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": messages[-1]["content"]},
+            image_block_builder(),
+        ]
+    }]
+
+
 async def stream_chat(
     system_prompt: str,
     history_messages: list,
-    session_id: str = None
+    session_id: str = None,
+    page_image_b64: str = None
 ) -> AsyncGenerator[str, None]:
     """
     논문 관련 질문 답변 결과를 스트리밍합니다. (선택된 AI Provider에 따름)
+
+    page_image_b64가 있으면(사용자가 캡처 모드로 화면 영역을 잘라 질문에 첨부한
+    경우) vision을 지원하는 provider(openai/gemini/claude)에는 최신 질문 메시지에
+    실제 이미지를 함께 실어 보내, 캡처한 영역을 텍스트 placeholder가 아니라
+    이미지 자체로 보고 답하게 한다. CLI 기반 provider(antigravity/claude_code/
+    codex)는 텍스트 프롬프트만 받을 수 있어 이미지를 첨부할 수 없다 - 번역
+    기능의 페이지 이미지 첨부와 동일한 기존 제약이다.
     """
     messages = [{"role": "system", "content": system_prompt}] + history_messages
 
     provider = get_chat_provider()
     model = get_chat_model()
     if provider == "openai":
-        async for token in stream_openai(messages, model=model, temperature=0.5):
+        chat_messages = _messages_with_trailing_image(
+            messages, page_image_b64,
+            lambda: {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{page_image_b64}"}}
+        )
+        async for token in stream_openai(chat_messages, model=model, temperature=0.5):
             yield token
         return
     elif provider == "gemini":
-        async for token in stream_gemini(messages, model=model, temperature=0.5):
+        async for token in stream_gemini(messages, model=model, temperature=0.5, image_b64=page_image_b64):
             yield token
         return
     elif provider == "claude":
-        async for token in stream_claude(messages, model=model, temperature=0.5):
+        chat_messages = _messages_with_trailing_image(
+            messages, page_image_b64,
+            lambda: {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": page_image_b64}}
+        )
+        async for token in stream_claude(chat_messages, model=model, temperature=0.5):
             yield token
         return
     elif provider == "antigravity":

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -483,9 +483,12 @@ export function streamPullModelAPI(modelName, onStatus, onDone, onError) {
  * @param {function} onToken - 토큰 수신 시 콜백
  * @param {function} onDone - 완료 시 콜백
  * @param {function} onError - 에러 발생 시 콜백
+ * @param {string} [imageBase64] - 캡처 모드로 첨부한 이미지의 raw base64(PNG,
+ *   data URL 접두사 없음). 있으면 이번 질문에 실제로 첨부되어 vision을 지원하는
+ *   provider가 캡처 영역을 직접 보고 답한다.
  * @returns {function} abort - 중단 함수
  */
-export function streamChatAPI(sessionId, messages, onToken, onDone, onError) {
+export function streamChatAPI(sessionId, messages, onToken, onDone, onError, imageBase64) {
   const controller = new AbortController()
 
   fetch(`${API_BASE}/chat/stream`, {
@@ -493,7 +496,8 @@ export function streamChatAPI(sessionId, messages, onToken, onDone, onError) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       session_id: sessionId,
-      messages: messages
+      messages: messages,
+      image_base64: imageBase64 || undefined
     }),
     signal: controller.signal
   })

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9270,6 +9270,11 @@ async function sendChatMessage() {
   chatInput.style.height = 'auto'
   clearSuggestedQuestions()
 
+  // 캡처 이미지로 질문하는 경우, 이번 턴에 한해 실제 이미지를 AI에게 함께
+  // 전달하기 위한 raw base64(data URL 접두사 제거) - DB/히스토리에는 여전히
+  // 텍스트 placeholder만 저장되고, 이건 이번 요청에서만 사용된다.
+  let imageForThisTurn = null
+
   if (state.quotedText) {
     const fullPayload = `[인용된 본문 내용]:\n"${state.quotedText}"\n\n[질문]:\n${text}`
     
@@ -9288,6 +9293,7 @@ async function sendChatMessage() {
     const quoteId = `qimg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
     saveChatQuoteImage(state.sessionId, quoteId, state.quotedImage)
     const fullPayload = `[인용된 이미지 (Page ${state.quotedImagePage})|${quoteId}]\n\n질문:\n${text}`
+    imageForThisTurn = state.quotedImage.replace(/^data:image\/\w+;base64,/, '')
 
     // UI에 답장/인용구 레이아웃으로 표시
     const userMsgHtml = `<div class="message-quote"><span class="quote-symbol">❝</span><img class="message-quote-img" src="${state.quotedImage}" alt="Quoted Figure" /></div><div class="message-text">${escapeHtml(text)}</div>`
@@ -9366,7 +9372,8 @@ async function sendChatMessage() {
       chatInput.disabled = false
       updateChatSendBtnIcon(false)
       chatInput.focus()
-    }
+    },
+    imageForThisTurn
   )
 }
 


### PR DESCRIPTION
# Summary
## 1. 캡처 이미지가 텍스트 placeholder로만 전달되던 문제 수정
- `backend/routers/chat.py`: `ChatRequest`에 `image_base64` 필드 추가, `/chat/stream`에서 `stream_chat()` 호출 시 그대로 전달
- `backend/services/llm_client.py`: `stream_chat()`에 `page_image_b64` 파라미터 추가
  - openai/claude: 최신 질문 메시지를 텍스트+이미지 멀티파트로 변환하는 `_messages_with_trailing_image()` 헬퍼 추가
  - gemini: 기존 `stream_gemini()`의 `image_b64` 파라미터로 연결
  - CLI 기반 provider(antigravity/claude_code/codex)는 텍스트 프롬프트만 받을 수 있어 이번 범위에서 제외 (번역 기능의 페이지 이미지 첨부와 동일한 기존 제약)
## 2. 프론트엔드에서 raw base64 이미지를 요청에 포함하도록 수정
- `frontend/src/api.js`: `streamChatAPI()`에 `imageBase64` 인자 추가, 요청 body에 `image_base64`로 포함
- `frontend/src/main.js`: `sendChatMessage()`에서 캡처 이미지 첨부 질문 시 data URL 접두사를 제거한 raw base64를 추출해 `streamChatAPI`에 전달 (자유 영역 드래그 캡처·자동 감지 fig/table 캡처 둘 다 동일 경로)

## Test plan
- [x] 백엔드 `python3 -m py_compile` 통과
- [x] 프론트 `node --check` 통과
- [x] `_messages_with_trailing_image()` 단위 테스트: 원본 히스토리는 유지되고 최신 질문에만 이미지 블록이 붙는지 확인
- [ ] 실제 vision provider(openai/gemini/claude) 자격증명 환경에서 캡처→질문→응답 브라우저 e2e 테스트 (이 작업 환경에는 API 키가 없어 미실시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)