### PR TITLE
fix: 설정 저장 버튼 삭제 및 자동 저장으로 변경

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -733,12 +733,9 @@
             <p style="font-size: 11px; color: var(--text-secondary); margin: 6px 0 0; line-height: 1.5;">서버(또는 앱) 재시작 후 문서를 처음 열 때 빠르게 뜨도록 저장해두는 캐시입니다. 비워도 데이터가 사라지지 않고, 다음에 열람할 때 자동으로 다시 채워집니다.</p>
           </div>
           
-          <div class="form-actions" style="margin-top: 15px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%;">일반 설정 저장</button>
-          </div>
         </form>
       </div>
-      
+
       <!-- 모델 설정 탭 -->
       <div id="tab-model" class="tab-pane">
         <!-- 시스템 설정 폼 (Ollama, OpenAI, Gemini, Claude 통합 및 번역/대화 분리) -->
@@ -803,9 +800,6 @@
             </div>
           </div>
 
-          <div class="form-actions" style="margin-top: 20px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%; justify-content: center;">시스템 설정 저장</button>
-          </div>
         </form>
 
         <!-- Ollama 미설치 안내 및 설치 섹션 -->
@@ -915,7 +909,7 @@
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>직관적인 번역 어투 및 스타일 수정 방법:</strong><br>
               아래 프롬프트 입력창 내부의 원하는 위치(예: <strong>번역 규칙</strong> 목록 밑에 직접 줄을 추가)에<br>
               <code style="background: rgba(255,255,255,0.08); padding: 2px 4px; border-radius: 3px; font-weight: bold; color: var(--accent-mid);">- 번역 시 어미는 무조건 경어체(~합니다, ~입니다)로 일관되게 끝맺으세요.</code><br>
-              또는 특정 전문 용어 번역 강제 등 <strong>원하는 번역 지시사항을 직접 입력한 후 하단의 저장 버튼</strong>을 누르시면 됩니다.<br>
+              또는 특정 전문 용어 번역 강제 등 <strong>원하는 번역 지시사항을 직접 입력</strong>하면 됩니다. 입력창에서 벗어나면(포커스 아웃) 자동으로 저장됩니다.<br>
               <span style="font-size: 11px; color: var(--text-secondary); display: block; margin-top: 6px;">※ <code>{{ ... }}</code> 형식의 중괄호 태그들은 시스템 치환용 매개변수이므로 형태를 그대로 유지해 주세요.</span>
             </div>
             <textarea id="setting-prompt-template" rows="12" style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-md); color: var(--text-primary); outline: none; font-size: 13px; font-family: var(--font-mono); resize: vertical; line-height: 1.6;">당신은 학술 논문 번역 전문가입니다. {{LANG_INSTRUCTION}}
@@ -938,9 +932,6 @@
 {{TARGET_LANG}} 번역:</textarea>
           </div>
           
-          <div class="form-actions" style="margin-top: 15px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%;">고급 설정 저장</button>
-          </div>
         </form>
       </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -134,7 +134,6 @@ const tabBtns           = document.querySelectorAll('.tab-btn')
 const tabPanes          = document.querySelectorAll('.tab-pane')
 
 // 설정 폼 및 엘리먼트
-const generalSettingsForm = $('general-settings-form')
 const settingTargetLang   = $('setting-target-lang')
 const settingTransStyle   = $('setting-trans-style')
 const settingTranslationMode = $('setting-translation-mode')
@@ -158,7 +157,6 @@ const settingAccentPicker   = $('setting-accent-picker')
 const settingAccentHex      = $('setting-accent-hex')
 const settingAccentResetBtn = $('setting-accent-reset-btn')
 
-const systemSettingsForm  = $('system-settings-form')
 const settingOllamaHost    = $('setting-ollama-host')
 const settingOpenAIKey     = $('setting-openai-key')
 const settingGeminiKey     = $('setting-gemini-key')
@@ -2226,12 +2224,12 @@ const chatSidebarPicker = new ProviderModelPicker($('chat-sidebar-provider'), {
 
 const settingTransPicker = new ProviderModelPicker($('setting-trans-provider'), {
   compact: false,
-  onChange: () => applyChatSameAsTransUI()
+  onChange: () => { applyChatSameAsTransUI(); autoSaveSystemSettings() }
 })
 
 const settingChatPicker = new ProviderModelPicker($('setting-chat-provider'), {
   compact: false,
-  onChange: () => updateSettingsUIVisibility()
+  onChange: () => { updateSettingsUIVisibility(); autoSaveSystemSettings() }
 })
 
 // "번역 모델과 동일한 모델 사용" 체크박스: 켜져 있으면 어시스턴트 선택기를
@@ -2643,10 +2641,10 @@ document.querySelectorAll('.recommend-model-btn').forEach(btn => {
   })
 })
 
-// 일반 설정 폼 제출
-generalSettingsForm.addEventListener('submit', async (e) => {
-  e.preventDefault()
-  
+// 일반 설정: 저장 버튼 없이 필드 변경 즉시 저장한다. 번역 결과에 영향을 주는
+// 필드(대상 언어/문체/모드/제외 요소)가 바뀌면 기존과 동일하게 재번역을 제안하고,
+// 줌/툴바 위치처럼 뷰어 표시에만 영향을 주는 필드는 저장 후 바로 적용만 한다.
+function persistGeneralSettingsToStorage() {
   localStorage.setItem('easypaper_target_lang', settingTargetLang.value)
   localStorage.setItem('easypaper_style', settingTransStyle.value)
   localStorage.setItem('easypaper_translation_mode', settingTranslationMode.value)
@@ -2655,18 +2653,12 @@ generalSettingsForm.addEventListener('submit', async (e) => {
   localStorage.setItem('easypaper_ignore_refs', settingIgnoreRefs.checked)
   localStorage.setItem('easypaper_default_zoom', settingDefaultZoom.value)
   localStorage.setItem('easypaper_toolbar_position', settingToolbarPosition.value)
-  applyToolbarPosition(settingToolbarPosition.value)
+}
 
+async function handleTranslationAffectingSettingChange() {
+  persistGeneralSettingsToStorage()
   showToast('일반 설정이 저장되었습니다.', 'success')
 
-  // 기본 줌 비율 즉시 업데이트 적용
-  const newZoom = parseFloat(settingDefaultZoom.value) || 1.5
-  if (state.sessionId) {
-    setZoom(newZoom)
-  }
-  
-  settingsModal.classList.add('hidden')
-  
   // 현재 논문을 작업 중인 경우 번역 잡 재시작 제안
   if (state.sessionId) {
     const ok = await showCustomConfirm('번역 설정을 즉시 변경하고 다시 번역하시겠습니까?\n(확인을 누르면 기존 번역이 초기화되고 새로 번역을 시작합니다.)', { title: '설정 변경 및 재번역', confirmText: '재번역', danger: true })
@@ -2676,7 +2668,7 @@ generalSettingsForm.addEventListener('submit', async (e) => {
       state.translationSentences = {}
       state.translatingPages.clear()
       state.translatedPages.clear()
-      
+
       // UI 상의 모든 번역창 초기화
       for (let i = 1; i <= state.totalPages; i++) {
         const contentEl = $(`trans-content-${i}`)
@@ -2689,7 +2681,7 @@ generalSettingsForm.addEventListener('submit', async (e) => {
           statusEl.classList.remove('done')
         }
       }
-      
+
       try {
         showToast('번역 작업을 재시작하는 중...', 'info')
         await restartJobAPI(state.sessionId, getTranslationOptions())
@@ -2700,6 +2692,25 @@ generalSettingsForm.addEventListener('submit', async (e) => {
       }
     }
   }
+}
+
+;[settingTargetLang, settingTransStyle, settingTranslationMode, settingIgnoreMath, settingIgnoreTable, settingIgnoreRefs].forEach(el => {
+  el.addEventListener('change', handleTranslationAffectingSettingChange)
+})
+
+settingDefaultZoom.addEventListener('change', () => {
+  persistGeneralSettingsToStorage()
+  showToast('일반 설정이 저장되었습니다.', 'success')
+  const newZoom = parseFloat(settingDefaultZoom.value) || 1.5
+  if (state.sessionId) {
+    setZoom(newZoom)
+  }
+})
+
+settingToolbarPosition.addEventListener('change', () => {
+  persistGeneralSettingsToStorage()
+  applyToolbarPosition(settingToolbarPosition.value)
+  showToast('일반 설정이 저장되었습니다.', 'success')
 })
 
 // 뷰어 편의 설정: 번역 관련 설정이 아니므로 폼 제출(및 재번역 제안)과 무관하게
@@ -2758,10 +2769,11 @@ settingToolbarAutoHide.addEventListener('change', () => {
   if (!state.toolbarAutoHide) setToolbarHidden(false)
 })
 
-// 시스템 설정 폼 제출
-systemSettingsForm.addEventListener('submit', async (e) => {
-  e.preventDefault()
-  
+// 모델 설정(시스템 설정) + 고급 설정(번역 프롬프트)은 백엔드에 하나의 설정
+// 객체로 저장되므로, 저장 버튼 없이 두 탭의 어느 필드든 값이 바뀌면 즉시 이
+// 통합 함수로 전체 설정을 다시 저장한다. 모델이 아직 선택되지 않은 초기
+// 로딩 상태에서는 조용히 건너뛴다(에러 토스트 없이).
+async function autoSaveSystemSettings({ silent = false } = {}) {
   const { provider: transProvider, model: transModel } = settingTransPicker.getValue()
   let { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
   if (settingChatSameAsTrans && settingChatSameAsTrans.checked) {
@@ -2769,15 +2781,8 @@ systemSettingsForm.addEventListener('submit', async (e) => {
     chatModel = transModel
   }
 
-  if (!transModel) {
-    showToast('번역 모델을 선택해주세요.', 'error')
-    return
-  }
-  if (!chatModel) {
-    showToast('어시스턴트 모델을 선택해주세요.', 'error')
-    return
-  }
-  
+  if (!transModel || !chatModel) return
+
   const settings = {
     ollama_host: settingOllamaHost.value.trim(),
     trans_provider: transProvider,
@@ -2790,67 +2795,30 @@ systemSettingsForm.addEventListener('submit', async (e) => {
     openalex_mailto: settingOpenAlexMailto.value.trim(),
     translation_prompt_template: $('setting-prompt-template').value
   }
-  
+
   try {
     await saveSystemSettingsAPI(settings)
     // sync compact pickers
     viewerTransPicker.setValue(transProvider, transModel)
     chatSidebarPicker.setValue(chatProvider, chatModel)
-    showToast('시스템 설정이 저장되었습니다.', 'success')
-    settingsModal.classList.add('hidden')
+    if (!silent) showToast('설정이 저장되었습니다.', 'success')
     checkAIStatus()
   } catch (err) {
     showToast(err.message, 'error')
   }
+}
+
+;[settingOllamaHost, settingOpenAIKey, settingGeminiKey, settingClaudeKey, settingOpenAlexMailto].forEach(el => {
+  el.addEventListener('change', () => autoSaveSystemSettings())
 })
 
-// 고급 설정 폼 제출
-const advancedSettingsForm = $('advanced-settings-form')
-if (advancedSettingsForm) {
-  advancedSettingsForm.addEventListener('submit', async (e) => {
-    e.preventDefault()
-    
-    const { provider: transProvider, model: transModel } = settingTransPicker.getValue()
-    let { provider: chatProvider, model: chatModel } = settingChatPicker.getValue()
-    if (settingChatSameAsTrans && settingChatSameAsTrans.checked) {
-      chatProvider = transProvider
-      chatModel = transModel
-    }
+if (settingChatSameAsTrans) {
+  settingChatSameAsTrans.addEventListener('change', () => autoSaveSystemSettings())
+}
 
-    if (!transModel) {
-      showToast('번역 모델을 선택해주세요.', 'error')
-      return
-    }
-    if (!chatModel) {
-      showToast('어시스턴트 모델을 선택해주세요.', 'error')
-      return
-    }
-    
-    const settings = {
-      ollama_host: settingOllamaHost.value.trim(),
-      trans_provider: transProvider,
-      trans_model: transModel,
-      chat_provider: chatProvider,
-      chat_model: chatModel,
-      openai_api_key: settingOpenAIKey.value.trim(),
-      gemini_api_key: settingGeminiKey.value.trim(),
-      claude_api_key: settingClaudeKey.value.trim(),
-      openalex_mailto: settingOpenAlexMailto.value.trim(),
-      translation_prompt_template: $('setting-prompt-template').value
-    }
-    
-    try {
-      await saveSystemSettingsAPI(settings)
-      // sync compact pickers
-      viewerTransPicker.setValue(transProvider, transModel)
-      chatSidebarPicker.setValue(chatProvider, chatModel)
-      showToast('고급 설정(번역 프롬프트)이 저장되었습니다.', 'success')
-      settingsModal.classList.add('hidden')
-      checkAIStatus()
-    } catch (err) {
-      showToast(err.message, 'error')
-    }
-  })
+const settingPromptTemplate = $('setting-prompt-template')
+if (settingPromptTemplate) {
+  settingPromptTemplate.addEventListener('change', () => autoSaveSystemSettings())
 }
 
 // 시스템 자동 업데이트: 확인(check)과 실행(run)을 분리한다 - 확인해서 새


### PR DESCRIPTION
## Summary
- 일반/모델/고급 설정 탭에 있던 "설정 저장" 버튼 3개를 모두 삭제
- select/checkbox/모델 선택기는 `change` 이벤트로 즉시 저장, 텍스트 입력(Ollama 주소, API 키, OpenAlex 이메일, 프롬프트 템플릿)은 포커스 아웃 시 저장되도록 변경
- 모델 설정 + 고급 설정은 백엔드에 하나의 설정 객체로 저장되는 구조라 `autoSaveSystemSettings()`로 통합
- 번역에 영향을 주는 일반 설정 필드는 기존과 동일하게 재번역 여부를 확인하는 다이얼로그를 유지

## Test plan
- [x] Playwright로 설정 모달의 저장 버튼이 사라졌는지, 일반/모델/고급 설정 필드 변경 시 자동 저장(토스트, localStorage, `/api/settings/system` 호출)이 되는지 확인 (임시 테스트, 통과 후 삭제)
- [x] `node --check src/main.js`, `npm run build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)