### PR TITLE
fix: 툴바 위치(하단/왼쪽/오른쪽) 설정 시 케밥 메뉴·목차 사이드바 렌더링 버그 수정

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4208,7 +4208,6 @@ body.toolbar-pos-right .topbar {
   align-items: stretch;
   padding: 16px 10px;
   gap: 18px;
-  overflow-y: auto;
   border-bottom: none;
 }
 body.toolbar-pos-left .topbar {
@@ -4278,6 +4277,12 @@ body.toolbar-pos-left .outline-sidebar {
   top: 0;
   left: 72px;
 }
+/* left 위치에서는 사이드바의 평소 위치가 72px 밀려나 있으므로, 숨김 상태의
+   translateX(-100%)(자기 폭만큼만 이동)로는 왼쪽 툴바 영역(0~72px)을 완전히
+   벗어나지 못해 그 위에 그대로 겹쳐 클릭을 가로챈다 - 툴바 폭만큼 더 이동시킨다. */
+body.toolbar-pos-left .outline-sidebar.hidden {
+  transform: translateX(calc(-100% - 72px));
+}
 body.toolbar-pos-right .outline-sidebar {
   top: 0;
 }
@@ -4303,6 +4308,12 @@ body.toolbar-pos-right .kebab-menu {
   top: 0;
   right: calc(100% + 8px);
   left: auto;
+}
+/* bottom 위치에서는 버튼이 화면 맨 아래에 붙어있으므로 기본값(top:100%)대로
+   아래로 열면 뷰포트 밖으로 밀려나 보이지 않는다 - 위로 열리게 뒤집는다. */
+body.toolbar-pos-bottom .kebab-menu {
+  top: auto;
+  bottom: calc(100% + 8px);
 }
 
 /* ── 툴바 추가 메뉴(케밥) ─────────────────────────── */


### PR DESCRIPTION
## Summary
- 설정에서 툴바 위치를 하단/왼쪽/오른쪽으로 바꾸면 케밥(추가 메뉴) 및 목차 사이드바가 제대로 나타나지 않던 버그 수정
- `left`/`right`: `.topbar`의 `overflow-y: auto`가 CSS 스펙상 `overflow-x`까지 암묵적으로 클리핑시켜, 옆으로 열리도록 설계된 케밥 메뉴가 잘려서 안 보이던 문제 (left는 전체가 안 보였고, right는 가장자리만 살짝 보임)
- `bottom`: 케밥 메뉴가 기본값대로 버튼 "아래"로 열려 화면 밖으로 밀려나던 문제 → 위로 열리게 수정
- `left`: 숨김 상태의 목차 사이드바가 이동 거리 부족으로 좌측 툴바 컬럼(0~72px)과 그대로 겹쳐서 툴바 클릭 자체를 가로채던 문제 수정

## Test plan
- [x] Playwright로 top/bottom/left/right 4개 위치 모두 실제 클릭(force 없이) 시나리오 재현 및 검증
- [x] 각 위치에서 케밥 메뉴가 뷰포트 안에서 완전히 보이고 클릭 가능한지 확인
- [x] left 위치에서 목차 토글 등 툴바 버튼 클릭이 정상 동작하는지 확인
- [x] top(기본) 위치 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)