### PR TITLE
fix: 좌/우/하단 툴바 위치에서 floating 스크롤 버튼·케밥 메뉴 겹침 수정

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4203,6 +4203,17 @@ body.toolbar-hidden.toolbar-pos-bottom .panels {
 body.toolbar-hidden.toolbar-pos-bottom .outline-sidebar {
   bottom: 0;
 }
+/* 우측 하단 floating 스크롤 버튼은 기본적으로 --chat-sidebar-offset(어시스턴트
+   패널 폭)만 고려해 위치가 계산되는데, bottom 위치에서는 화면 맨 아래에
+   툴바(--topbar-h)가 추가로 깔려있어 그만큼 띄우지 않으면 버튼 일부가
+   툴바 뒤에 가려진다. */
+body.toolbar-pos-bottom .floating-scroll-nav {
+  bottom: calc(24px + var(--topbar-h));
+}
+/* 툴바 자동 숨김 시에는 툴바가 화면 밖으로 사라지므로 띄워둔 여백도 되돌린다. */
+body.toolbar-hidden.toolbar-pos-bottom .floating-scroll-nav {
+  bottom: 24px;
+}
 
 /* 왼쪽(left) / 오른쪽(right) 공통: 세로 컬럼 툴바 */
 body.toolbar-pos-left .topbar,
@@ -4286,6 +4297,17 @@ body.toolbar-pos-right .panels {
   padding-top: 0;
   padding-right: 72px;
 }
+/* 우측 하단 floating 스크롤 버튼도 기본적으로 --chat-sidebar-offset만 고려해
+   위치가 계산되는데, right 위치에서는 세로 툴바(72px)가 화면 우측에 추가로
+   깔려있어 그만큼 왼쪽으로 더 밀지 않으면 버튼이 툴바 컬럼 밑에 깔려 거의
+   보이지 않는다. */
+body.toolbar-pos-right .floating-scroll-nav {
+  right: calc(24px + var(--chat-sidebar-offset, 0px) + 72px);
+}
+/* 툴바 자동 숨김 시에는 툴바가 화면 밖으로 사라지므로 띄워둔 여백도 되돌린다. */
+body.toolbar-hidden.toolbar-pos-right .floating-scroll-nav {
+  right: calc(24px + var(--chat-sidebar-offset, 0px));
+}
 body.toolbar-pos-left .outline-sidebar {
   top: 0;
   left: 72px;
@@ -4311,14 +4333,18 @@ body.toolbar-hidden.toolbar-pos-left .outline-sidebar {
 }
 /* 케밥 메뉴는 평소 버튼 아래(top:100%)/오른쪽 정렬로 뜨는데, 세로 컬럼
    툴바(left/right)에서는 버튼 옆으로 열려야 좁은 컬럼 안에 눌려 보이거나
-   화면 밖으로 잘리지 않는다. */
+   화면 밖으로 잘리지 않는다. 케밥 버튼은 툴바 맨 아래쪽에 있으므로 top:0
+   (버튼 위치에서 아래로 펼침)으로 두면 우측 하단 floating 스크롤 버튼과
+   겹친다 - bottom:0(버튼 위치에서 위로 펼침)으로 띄운다. */
 body.toolbar-pos-left .kebab-menu {
-  top: 0;
+  top: auto;
+  bottom: 0;
   left: calc(100% + 8px);
   right: auto;
 }
 body.toolbar-pos-right .kebab-menu {
-  top: 0;
+  top: auto;
+  bottom: 0;
   right: calc(100% + 8px);
   left: auto;
 }


### PR DESCRIPTION
## Summary
- 우측 하단 floating 스크롤 버튼(맨 위로/이전/다음/맨 아래로)이 `--chat-sidebar-offset`만 고려하고 툴바 자체가 차지하는 공간은 고려하지 않아:
  - `right` 위치: 세로 컬럼 툴바(72px) 밑에 깔려 거의 보이지 않음
  - `bottom` 위치: 하단 바(`--topbar-h`)에 가려짐
  둘 다 수정하고, 툴바 자동 숨김 시엔 여백을 원래대로 되돌리도록 처리
- left/right 세로 컬럼 툴바의 케밥 메뉴가 버튼 위치 기준 아래로 펼쳐져(`top:0`), 케밥 버튼이 툴바 맨 아래에 있는 특성상 floating 스크롤 버튼과 겹치던 문제 수정 (`bottom:0`으로 위로 펼치게 변경)

이전 PR(#259, #257)에서 다루지 못했던, 좌/우 툴바 배치 시 남아있던 겹침 버그를 마저 수정했습니다.

## Test plan
- [x] Vite + Playwright로 뷰어 화면을 강제 활성화해 bounding box로 겹침 여부 수치 확인 (수정 전/후 비교)
- [x] left/right/bottom 각 위치에서 채팅 패널, 목차 사이드바, 케밥 메뉴를 동시에 열어도 floating 버튼과 겹치지 않는지 스크린샷 확인
- [x] 툴바 자동 숨김 상태에서 floating 버튼이 원래 위치(24px)로 복귀하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)