### PR TITLE
fix: 좌/우 세로 툴바에서 페이지 표시 박스가 줌 컨트롤과 겹치던 문제 수정

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4280,9 +4280,15 @@ body.toolbar-pos-left .logo-small-btn,
 body.toolbar-pos-right .logo-small-btn {
   font-size: 0;
 }
+/* 기본 .page-display는 가로 배치 기준 height:32px로 고정돼 있는데, 세로
+   컬럼(left/right)에서는 입력창과 "/N" 텍스트가 위아래로 쌓여 32px보다
+   더 필요하다 - height를 고정하지 않으면 내용이 박스 밖으로 흘러넘쳐
+   바로 아래 줌 컨트롤 그룹과 겹친다. */
 body.toolbar-pos-left .page-display,
 body.toolbar-pos-right .page-display {
   flex-direction: column;
+  height: auto;
+  padding: 8px 12px;
   gap: 4px;
 }
 body.toolbar-pos-left .page-display input[type=number],


### PR DESCRIPTION
## Summary
- `.page-display`(페이지 번호 입력창 + "/전체페이지" 텍스트)가 가로 배치 기준 `height: 32px`로 고정돼 있었음
- left/right 세로 컬럼 툴바에서는 이 요소가 `flex-direction: column`으로 바뀌어 입력창과 텍스트가 위아래로 쌓이는데, 높이는 여전히 32px로 고정돼 있어 내용이 박스 밖으로 흘러넘쳐 바로 아래 줌 컨트롤(−/100%/+) 캡슐과 겹쳐 보이던 버그 수정
- `height: auto` + 세로 배치에 맞는 패딩 적용

ask/image.png(사용자 제공 스크린샷)에서 "13" 페이지 입력창 pill과 "100%" 줌 컨트롤 pill이 겹쳐 보이는 문제를 재현·확인 후 수정했습니다.

## Test plan
- [x] Vite + Playwright로 left/right 위치에서 `.page-display`, `.toolbar-group.view-group`의 bounding box를 측정해 겹침이 없어졌는지 확인
- [x] 스크린샷으로 시각적으로도 겹침 없이 깔끔하게 분리되는지 확인
- [x] 툴바 내 전체 자식 요소를 대상으로 한 자동 겹침 검사(스크립트)에서 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)