### PR TITLE
fix: 좌/우 세로 툴바 버튼 모양/찌그러짐 수정 (진짜 원인 발견)

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4260,6 +4260,54 @@ body.toolbar-pos-right .toolbar-divider {
   height: 1px;
   margin: 2px 0;
 }
+/* .view-group(줌 컨트롤 캡슐)은 가로 배치 기준 height:32px, 내부 아이콘
+   버튼도 height:26px !important로 고정돼 있다. 세로 컬럼에서 이 캡슐이
+   flex-direction:column이 되면 −/100%/+ 세 요소를 32px 안에 다 넣으려고
+   flexbox가 버튼을 짓눌러(shrink) 아이콘 자체가 납작하게 찌그러진다 -
+   높이를 내용에 맞게 풀고, 버튼도 정사각형(24x24)으로 되돌린다. */
+body.toolbar-pos-left .view-group,
+body.toolbar-pos-right .view-group {
+  height: auto;
+  padding: 6px 2px;
+  gap: 2px;
+}
+body.toolbar-pos-left .view-group .icon-btn,
+body.toolbar-pos-right .view-group .icon-btn {
+  width: 24px !important;
+  height: 24px !important;
+  flex-shrink: 0;
+}
+/* "독서 완료" 버튼은 가로 배치 기준 좌우로 넓은 알약형(padding:0 12px)인데,
+   세로 컬럼에서는 텍스트가 숨겨져 아이콘만 남으면서도 폭이 그대로 남아
+   다른 정사각형 아이콘 버튼들과 크기/모양이 달라 보인다 - 동일한
+   32x32 정사각형 아이콘 버튼으로 맞춘다. */
+body.toolbar-pos-left .viewer-read-btn,
+body.toolbar-pos-right .viewer-read-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  gap: 0;
+}
+/* 로고 버튼은 가로 배치에서 아이콘+글자 조합의 텍스트 버튼이라 별도 배경/
+   테두리가 없는데, 세로 컬럼에서 글자가 사라지면 아이콘만 배경 없이 붕
+   떠서 옆의 정사각형 아이콘 버튼들과 톤이 어긋난다 - 동일한 아이콘 버튼
+   프레임을 씌운다. */
+body.toolbar-pos-left .logo-small-btn,
+body.toolbar-pos-right .logo-small-btn {
+  width: 32px;
+  height: 32px;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+}
+body.toolbar-pos-left .logo-small-btn:hover,
+body.toolbar-pos-right .logo-small-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
 /* 세로 컬럼에서는 폭이 넓게 필요한 문서 제목/페이지 표시를 숨겨 공간을
    확보한다 - 각 버튼의 title 툴팁으로 기능은 그대로 확인 가능하다.
    doc-title-edit-btn은 index.html에 인라인 style="display: inline-flex"가


### PR DESCRIPTION
## Summary
좌/우 세로 툴바에서 계속 신고되던 "버튼끼리 겹친다"는 문제의 진짜 원인을 찾았습니다: 세로 컬럼으로 바꿀 때 `flex-direction: column`만 적용했을 뿐, **가로 배치 기준으로 고정돼 있던 `height` 값들이 그대로 남아있어서** 실제로는 내용물이 그 고정 높이 안에 짓눌리거나 흘러넘치고 있었습니다.

- `.view-group`(줌 컨트롤 캡슐)이 `height: 32px`로 고정 + 내부 아이콘 버튼도 `height: 26px !important`로 고정 → 세로로 쌓인 −/100%/+ 세 요소를 flexbox가 32px 안에 다 넣으려다 아이콘 버튼이 **26px→15px로 짓눌려 찌그러짐** (스크린샷으로 확인된 실제 원인)
- "독서 완료" 토글 버튼이 가로 기준 좌우로 넓은 알약형(`padding:0 12px`)이라, 세로 모드에서 텍스트가 사라져도 폭이 그대로 남아 다른 정사각형 아이콘 버튼들과 크기/모양이 어긋남
- 로고 버튼이 텍스트 버튼 스타일(배경/테두리 없음)이라 세로 모드에서 아이콘만 남았을 때 배경 없이 떠 보임

세 가지 모두 세로 모드에 맞게 재설계했습니다(고정 height 제거, 정사각형 아이콘 버튼으로 통일).

## Test plan
- [x] Vite + Playwright로 getComputedStyle을 찍어 줌 버튼이 실제 24x24 정사각형으로 렌더링되는지 확인 (수정 전 28x15로 찌그러져 있던 것 확인)
- [x] left/right 위치 전체 스크린샷으로 아이콘 크기/정렬이 일관되게 보이는지 확인
- [x] 전체 툴바 자식 요소 자동 겹침 검사 0건
- [x] 케밥 메뉴, floating 스크롤 버튼, 자동 숨김 등 기존 수정 사항 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)