### PR TITLE
fix: 툴바 버튼 마진 통일 및 아이콘 중앙 정렬 (모든 위치)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -201,17 +201,17 @@
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:4px"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg>EasyPaper</button>
         <!-- 독서 완료 토글 버튼 -->
-        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글" style="margin-left: 8px;">
+        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10"></circle>
             <path d="m9 12 2 2 4-4"></path>
           </svg>
           <span class="read-btn-text">독서 완료</span>
         </button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
-        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기" style="margin-left: 6px;">
+        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -355,7 +355,7 @@ body.toolbar-pos-right .topbar.toolbar-hidden {
 .topbar-center {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   flex-shrink: 0;
 }
 
@@ -4265,20 +4265,6 @@ body.toolbar-pos-right .topbar-right {
   flex: none;
   gap: 8px;
   width: 100%;
-}
-/* index.html에는 가로(행) 배치를 전제로 일부 버튼에 인라인
-   style="margin-left: 6~8px"가 박혀있다(독서완료/목차/브리핑 버튼). 세로
-   컬럼에서는 이 좌측 여백이 그대로 남아 가운데 정렬을 깨고 버튼이 오른쪽으로
-   치우쳐 보인다 - 인라인 스타일은 !important 없이는 이길 수 없으므로
-   !important로 모든 자식의 가로 마진을 0으로 되돌린다. */
-body.toolbar-pos-left .topbar-left > *,
-body.toolbar-pos-left .topbar-center > *,
-body.toolbar-pos-left .topbar-right > *,
-body.toolbar-pos-right .topbar-left > *,
-body.toolbar-pos-right .topbar-center > *,
-body.toolbar-pos-right .topbar-right > * {
-  margin-left: 0 !important;
-  margin-right: 0 !important;
 }
 
 /* 단독 아이콘 버튼: 테두리/배경 박스를 없애 순수 아이콘처럼 보이게 하고,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4250,6 +4250,11 @@ body.toolbar-pos-right .topbar {
   left: auto;
   border-left: 1px solid var(--border);
 }
+/* topbar-left/center/right는 가로 배치에서 왼쪽/가운데/오른쪽 정렬 그룹을
+   나누는 용도였을 뿐 세로 컬럼에서는 의미가 없어져, 버튼들이 사실상 하나로
+   이어진 목록처럼 보인다. 그런데 이 세 컨테이너 내부 간격(gap)과 컨테이너
+   사이 간격(.topbar 자체의 gap, 아래 4242행)이 각각 6px/8px로 달라 버튼마다
+   마진이 들쭉날쭉해 보였다 - .topbar의 gap과 동일한 8px로 맞춘다. */
 body.toolbar-pos-left .topbar-left,
 body.toolbar-pos-left .topbar-center,
 body.toolbar-pos-left .topbar-right,
@@ -4258,7 +4263,7 @@ body.toolbar-pos-right .topbar-center,
 body.toolbar-pos-right .topbar-right {
   flex-direction: column;
   flex: none;
-  gap: 6px;
+  gap: 8px;
   width: 100%;
 }
 /* index.html에는 가로(행) 배치를 전제로 일부 버튼에 인라인
@@ -4384,6 +4389,14 @@ body.toolbar-pos-right .logo-small-btn {
 body.toolbar-pos-left .logo-small-btn:hover,
 body.toolbar-pos-right .logo-small-btn:hover {
   background: var(--bg-hover);
+}
+/* 로고 svg에는 index.html에 인라인 style="margin-right:4px"가 박혀있다
+   ("EasyPaper" 글자와의 가로 간격용). 세로 컬럼에서는 글자를 font-size:0으로
+   숨길 뿐 텍스트 노드 자체는 남아있어, 오른쪽 여백만 계속 차지하며 아이콘을
+   버튼 중심에서 왼쪽으로 밀어낸다 - 세로 모드에서는 이 여백을 없앤다. */
+body.toolbar-pos-left .logo-small-btn svg,
+body.toolbar-pos-right .logo-small-btn svg {
+  margin-right: 0 !important;
 }
 /* 세로 컬럼에서는 폭이 넓게 필요한 문서 제목/페이지 표시를 숨겨 공간을
    확보한다 - 각 버튼의 title 툴팁으로 기능은 그대로 확인 가능하다.


### PR DESCRIPTION
## Summary
- 독서완료/목차/브리핑 버튼에 남아있던 가로 배치 전용 인라인 margin-left(6~8px)를 제거. 이 인라인 스타일이 top/bottom 배치에서도 topbar-left 내부 간격을 12/20/18/18/12/12px로 들쭉날쭉하게 만들던 근본 원인이었음 (세로 배치에서만 정렬 깨짐으로 눈에 띄었을 뿐 원인은 위치 무관)
- 인라인 스타일 제거로 flex gap만 간격을 결정하게 되어 top/bottom은 12px, left/right는 8px로 완전 균일해짐
- topbar-center의 gap도 12px로 통일 (다른 그룹과 일관성)
- 좌/우 전용으로 대증 처방했던 margin 리셋 !important 규칙은 원인이 사라져 삭제
- 로고 버튼 아이콘이 세로 모드에서 중심을 벗어나 보이던 문제 수정 (이전 커밋에서 완료, 가로 모드는 아이콘+텍스트 조합이라 해당 없음)

## Test plan
- [x] Playwright로 top/bottom/left/right 4개 위치 모두에서 topbar-left/topbar-right 내부 버튼 간 간격을 측정해 각각 12px/8px로 완전히 균일한지 확인
- [x] 순수 아이콘 버튼(.icon-btn)의 svg 중심과 버튼 중심 offset을 4개 위치 모두에서 측정해 0px인지 확인
- [x] 로고/독서완료 버튼(아이콘+텍스트 조합)은 텍스트가 보이는 top/bottom에서 offset이 있는 게 정상임을 확인(중앙 정렬 대상 아님)
- [x] 스크린샷으로 4개 위치 모두 시각적 회귀 없는지 확인