### PR TITLE
fix: 목차 아이콘에 빠진 stroke-linecap round로 중앙 정렬 어긋남 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -209,7 +209,7 @@
           <span class="read-btn-text">독서 완료</span>
         </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
         <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>


### PR DESCRIPTION
## Summary
- 논문 목차(outline-toggle-btn) svg만 다른 형제 아이콘들과 달리 `stroke-linecap="round"`가 빠져있었음
- 이 아이콘은 점(bullet) 3개를 길이 0.01인 선(`M3 5h.01` 등)으로 그리는데, 기본 선 끝(butt cap)은 길이 0인 선분을 그리지 않아 점이 렌더링되지 않고 있었음
- 결과적으로 실제 보이는 잉크는 오른쪽 긴 선 3개뿐이라 아이콘이 버튼 중심보다 오른쪽으로 치우쳐 보였음 (라스터화 실측 오프셋 +1.56px)
- `stroke-linecap="round" stroke-linejoin="round"` 추가로 점이 정상 렌더링되며 오프셋이 다른 아이콘과 동일 수준(-0.06px, 안티에일리어싱 오차)으로 정상화됨

## Test plan
- [x] SVG를 canvas에 8x 스케일로 래스터화해 실제 잉크(비배경 픽셀) bounding box를 측정, 아이콘 중심과의 오프셋이 다른 아이콘들과 동일 수준(약 0px)인지 확인
- [x] 버튼 스크린샷으로 점 3개가 정상적으로 보이는지 시각 확인