### PR TITLE
fix: 논문 제목 추출 시 저자명/섹션 헤더가 섞이는 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -346,7 +346,7 @@ def _extract_paper_title(doc: fitz.Document) -> str:
             
         # 1. y좌표 기준으로 1차 정렬한 뒤, 동적으로 같은 행(Line)에 있는 스팬들을 묶어서 그룹화합니다.
         #    이렇게 하면 PDF 렌더링 시 y좌표가 소수점 단위로 미세하게 다른 스팬들이 엉뚱하게 정렬되는 문제를 방지합니다.
-        def sort_spans_by_reading_order(spans_list):
+        def group_spans_into_lines(spans_list):
             if not spans_list:
                 return []
             sorted_by_y = sorted(spans_list, key=lambda s: s["bbox"][1])
@@ -372,13 +372,47 @@ def _extract_paper_title(doc: fitz.Document) -> str:
             if current_line:
                 current_line.sort(key=lambda x: x["bbox"][0])
                 lines_list.append(current_line)
-            
-            flat = []
-            for line_item in lines_list:
-                flat.extend(line_item)
-            return flat
+            return lines_list
 
-        sorted_spans = sort_spans_by_reading_order(title_spans)
+        line_groups = group_spans_into_lines(title_spans)
+
+        # 1-1. 제목 폰트 크기가 우연히 저자명/소속 또는 "1. Introduction" 같은 번호 매겨진
+        #      섹션 헤더와 비슷한 경우, 이런 줄들이 제목 후보에 섞여 들어올 수 있습니다.
+        #      제목은 항상 페이지 최상단의 "하나의 연속된 블록"이므로, 아래 패턴에 걸리는 줄이나
+        #      비정상적으로 큰 줄 간격(제목-저자 블록 사이의 여백)이 나타나면 그 지점에서 수집을 중단합니다.
+        SECTION_HEADER_RE = re.compile(
+            r'^\(?[ivxlc\d]{1,4}\)?[\.\:\)]?\s+(introduction|abstract|related\s+work|background|'
+            r'method(ology)?|conclusion|references|experiments?|results?|discussion|acknowledg|'
+            r'appendix|approach|overview|preliminaries|evaluation|analysis|motivation)\b',
+            re.IGNORECASE,
+        )
+        AUTHOR_HINT_RE = re.compile(
+            r'(@|university|institute|department|school of|college of|laborator|corporation|\bltd\.?\b|\binc\.?\b)',
+            re.IGNORECASE,
+        )
+
+        kept_lines = []
+        prev_line_bottom = None
+        prev_line_height = None
+        for line_spans in line_groups:
+            line_text_norm = re.sub(r'\s+', ' ', "".join(s["text"] for s in line_spans)).strip()
+
+            if SECTION_HEADER_RE.match(line_text_norm) or AUTHOR_HINT_RE.search(line_text_norm):
+                break
+
+            line_top = min(s["bbox"][1] for s in line_spans)
+            line_bottom = max(s["bbox"][3] for s in line_spans)
+            line_height = line_bottom - line_top
+
+            # 이전 줄과의 간격이 줄 높이의 2배를 넘으면 제목 블록과 분리된 다른 블록(저자/소속 등)으로 간주
+            if prev_line_bottom is not None and prev_line_height and (line_top - prev_line_bottom) > prev_line_height * 2.0:
+                break
+
+            kept_lines.append(line_spans)
+            prev_line_bottom = line_bottom
+            prev_line_height = line_height
+
+        sorted_spans = [s for line_spans in kept_lines for s in line_spans]
         
         # 2. 정렬된 스팬들을 결합할 때, 단어 중간에 폰트 크기 변경으로 쪼개진 스팬(gap < 2.5px)은 공백 없이 결합하고,
         #    일반적인 띄어쓰기는 공백을 유지하여 자연스러운 문장으로 결합합니다.

--- a/backend/tests/test_pdf_parser_title_extraction.py
+++ b/backend/tests/test_pdf_parser_title_extraction.py
@@ -1,0 +1,79 @@
+"""services/pdf_parser.py의 _extract_paper_title() 테스트 - 논문 제목 추출 시
+저자 이름이나 "1. Introduction" 같은 번호 매겨진 섹션 헤더가 제목에 섞여
+들어가지 않는지 확인."""
+
+import fitz
+
+from services.pdf_parser import _extract_paper_title
+
+
+def test_numbered_section_header_not_included_in_title(tmp_path):
+    """제목과 "1. Introduction" 섹션 헤더의 폰트 크기가 비슷한 경우에도
+    섹션 헤더는 제목에서 제외되어야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    title = "A Novel Approach to Efficient Neural Network Training"
+    page.insert_text((50, 80), title, fontsize=18)
+    page.insert_text((50, 200), "1. Introduction", fontsize=15)
+    page.insert_text((50, 230), "This paper studies the problem of...", fontsize=11)
+
+    path = tmp_path / "with_section_header.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result_doc = fitz.open(str(path))
+    extracted_title = _extract_paper_title(result_doc)
+    result_doc.close()
+
+    assert extracted_title == title
+    assert "Introduction" not in extracted_title
+
+
+def test_author_line_not_included_in_title(tmp_path):
+    """제목 아래에 큰 폰트로 표기된 저자 이름 줄은 제목에서 제외되어야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    title = "Understanding Deep Learning Generalization"
+    page.insert_text((50, 80), title, fontsize=18)
+    page.insert_text((50, 200), "John Smith, Jane Doe, Alex Kim", fontsize=15)
+    page.insert_text((50, 230), "Department of Computer Science, University of Example", fontsize=10)
+    page.insert_text((50, 280), "Abstract", fontsize=11)
+
+    path = tmp_path / "with_author_line.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result_doc = fitz.open(str(path))
+    extracted_title = _extract_paper_title(result_doc)
+    result_doc.close()
+
+    assert extracted_title == title
+    assert "Smith" not in extracted_title
+    assert "University" not in extracted_title
+
+
+def test_multiline_title_without_extra_gap_still_extracted_fully(tmp_path):
+    """줄바꿈 간격이 일반적인 다줄 제목은 그대로 온전히 추출되어야 한다
+    (간격 기반 컷오프가 정상적인 제목까지 잘라내지 않는지 확인)."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    line1 = "A Comprehensive Study of Transformer Architectures"
+    line2 = "for Long-Context Language Modeling"
+    page.insert_text((50, 80), line1, fontsize=18)
+    page.insert_text((50, 105), line2, fontsize=18)
+    page.insert_text((50, 200), "John Smith", fontsize=15)
+
+    path = tmp_path / "multiline_title.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result_doc = fitz.open(str(path))
+    extracted_title = _extract_paper_title(result_doc)
+    result_doc.close()
+
+    assert line1 in extracted_title
+    assert line2 in extracted_title
+    assert "Smith" not in extracted_title


### PR DESCRIPTION
## Summary
- 제목 추출 시 폰트 크기 기준 후보 span 중 "1. Introduction" 같은 번호 매겨진 섹션 헤더나 저자명/소속 줄이 완전 일치 필터(`abstract`/`introduction` 등)를 통과하지 못해 제목에 섞여 들어가던 버그 수정
- span을 줄 단위로 그룹화한 뒤, 섹션 헤더 정규식/저자·소속 힌트 키워드/비정상적으로 큰 줄 간격을 만나면 그 지점에서 제목 수집을 중단하도록 개선
- 정상적인 여러 줄 제목은 그대로 온전히 추출됨을 테스트로 확인

## Test plan
- [x] `backend/tests/test_pdf_parser_title_extraction.py` 신규 테스트 3개 추가 (섹션 헤더 제외 / 저자 이름 제외 / 정상 다줄 제목 유지) - 통과 확인
- [x] 기존 `backend/tests/test_pdf_parser_figure_text.py` 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)