### PR TITLE
fix: 메모 점선 커넥터가 선택 범위가 아닌 문장 전체 시작점에서 그려지던 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6314,10 +6314,15 @@ function updateMemoConnectorLine(pageWrapper, memo) {
   const textLayerForConn = pageWrapper.querySelector('.textLayer')
 
   if (vtm && sentenceRanges && textLayerForConn) {
-    const sRange = sentenceRanges.find(r => {
-      const idx = r.sentenceIdx >= 10000 ? (r.originalSentenceIdx ?? r.sentenceIdx) : r.sentenceIdx
-      return idx === sentenceIdx || r.sentenceIdx === sentenceIdx
-    })
+    // 사용자가 실제로 드래그해서 선택한 범위(charStart/charEnd)가 저장돼 있으면
+    // 그 범위의 시작점을 앵커로 쓰고, 없으면(드웰 호버 등) 문장 전체로 대체한다.
+    const hasExplicitRange = memo.charStart != null && memo.charEnd != null
+    const sRange = hasExplicitRange
+      ? { charStart: memo.charStart, charEnd: memo.charEnd }
+      : sentenceRanges.find(r => {
+          const idx = r.sentenceIdx >= 10000 ? (r.originalSentenceIdx ?? r.sentenceIdx) : r.sentenceIdx
+          return idx === sentenceIdx || r.sentenceIdx === sentenceIdx
+        })
     if (sRange) {
       const rects = getSentenceRects(sRange, vtm, textLayerForConn)
       if (rects.length > 0) {


### PR DESCRIPTION
## Summary
- #269에서 메모 하이라이트 자체는 실제 드래그 선택 범위를 쓰도록 고쳤지만, 카드로 이어지는 점선 커넥터(`updateMemoConnectorLine`)는 여전히 `sentenceIdx`로 문장 전체 범위를 다시 찾아 그 시작점을 앵커로 사용하고 있었음
- 메모에 저장된 `charStart`/`charEnd`가 있으면 그 범위를 앵커 계산에 우선 사용하도록 수정 (드웰 호버로 만든 기존 문장 단위 메모는 그대로 유지)

## Test plan
- [x] `node --check frontend/src/main.js` 구문 검사 통과
- [ ] 실제 앱에서 문장 일부만 드래그 선택 → 메모 생성 시 점선이 실제 선택 시작 지점에서 뻗어나오는지 확인 (백엔드/PDF 세션 필요로 이번 환경에서는 미실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)