### PR TITLE
fix: AI 추천 질문 칩에서 LaTeX 수식이 렌더링되지 않는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9187,7 +9187,12 @@ function renderSuggestedQuestionChips(msgEl, questions) {
     const chip = document.createElement('button')
     chip.type = 'button'
     chip.className = 'suggested-question-chip'
-    chip.textContent = q
+    // 추천 질문에 LaTeX 수식($...$ 등)이 섞여 나오는 경우가 있어, 일반
+    // 채팅 메시지와 동일하게 마크다운/KaTeX 파이프라인을 태운다. marked가
+    // 단일 문장을 <p>로 감싸는데 <button> 안에 블록 요소가 들어가면 접근성
+    // 트리가 깨지므로 감싸는 <p> 태그는 제거한다.
+    chip.innerHTML = formatChatHtml(q).replace(/^<p>([\s\S]*)<\/p>\s*$/, '$1')
+    applyKatexToElement(chip)
     chip.addEventListener('click', () => {
       if (state.chatActiveStream) return
       chatInput.value = q


### PR DESCRIPTION
## Summary
- 추천 질문 칩(`renderSuggestedQuestionChips`)이 `chip.textContent`로 원문을 그대로 넣어, 일반 채팅 메시지와 달리 marked/KaTeX 파이프라인(`formatChatHtml`)을 거치지 않던 문제 수정
- LLM이 생성한 추천 질문에 `$...$` 형태의 LaTeX 수식이 섞여 있으면 원문 그대로 노출되던 것을, `formatChatHtml` + `applyKatexToElement` 적용으로 정상 렌더링되도록 수정
- `<button>` 안에 marked가 만드는 `<p>` 블록 태그가 그대로 들어가지 않도록 감싸는 `<p>...</p>`는 정규식으로 제거

## Test plan
- [x] `node --check frontend/src/main.js` 구문 검증 통과
- [x] `npm run build` 번들 빌드 성공 확인 (빌드 산출물은 커밋에서 제외)
- [ ] 실제 앱에서 수식이 포함된 추천 질문 클릭/렌더링 확인 (필요 시 리뷰어 확인 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)