### PR TITLE
feat: 개인화된 지식 그래프(Research Graph) 1차 구현 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -75,6 +75,17 @@ async def search_library(q: str = "", current_user: str = Depends(get_current_us
     return {"documents": docs, "total": len(docs)}
 
 
+@router.get("/library/graph")
+async def get_library_graph(current_user: str = Depends(get_current_user)):
+    """개인 지식 그래프(논문/개념 노드 + 인용/카테고리 엣지)를 반환합니다.
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_graph_data
+    return await get_graph_data(current_user)
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -386,6 +386,46 @@ async def resolve_library_reference(doc_id: str, ref_num: str, current_user: str
     return result
 
 
+@router.get("/library/{doc_id}/annotations")
+async def get_library_annotations(doc_id: str, current_user: str = Depends(get_current_user)):
+    """문서의 하이라이트/주석 서버 미러 데이터를 반환합니다.
+
+    localStorage가 원본(source of truth)이며 이 데이터는 다중 기기 동기화를
+    위한 best-effort 백업일 뿐이다. 저장된 적이 없으면 빈 데이터를 반환한다.
+    """
+    _require_owned_document(doc_id, current_user)
+    from services.db import db_get_annotations
+    result = db_get_annotations(doc_id)
+    return result or {"data": {}, "updated_at": None}
+
+
+@router.put("/library/{doc_id}/annotations")
+async def put_library_annotations(doc_id: str, payload: dict, current_user: str = Depends(get_current_user)):
+    """하이라이트/주석 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
+    _require_owned_document(doc_id, current_user)
+    from services.db import db_put_annotations
+    db_put_annotations(doc_id, payload.get("data", {}))
+    return {"status": "ok"}
+
+
+@router.get("/library/{doc_id}/memos")
+async def get_library_memos(doc_id: str, current_user: str = Depends(get_current_user)):
+    """문서의 메모 서버 미러 데이터를 반환합니다. (annotations와 동일한 성격)"""
+    _require_owned_document(doc_id, current_user)
+    from services.db import db_get_memos
+    result = db_get_memos(doc_id)
+    return result or {"data": {}, "updated_at": None}
+
+
+@router.put("/library/{doc_id}/memos")
+async def put_library_memos(doc_id: str, payload: dict, current_user: str = Depends(get_current_user)):
+    """메모 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
+    _require_owned_document(doc_id, current_user)
+    from services.db import db_put_memos
+    db_put_memos(doc_id, payload.get("data", {}))
+    return {"status": "ok"}
+
+
 @router.put("/library/{doc_id}/metadata")
 async def update_doc_metadata(
     doc_id: str,

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -120,6 +120,71 @@ def init_db():
         )
         """)
 
+        # 8. concepts / paper_concepts 테이블 (지식 그래프의 개념 노드, 다대다).
+        #    LLM이 뽑는 개념명 표기가 들쭉날쭉하므로 normalized_name(소문자+trim)
+        #    으로만 얕게 중복 제거한다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS concepts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            normalized_name TEXT NOT NULL UNIQUE,
+            kind TEXT,
+            created_at TEXT NOT NULL
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS paper_concepts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            doc_id TEXT NOT NULL,
+            concept_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+            FOREIGN KEY (concept_id) REFERENCES concepts (id) ON DELETE CASCADE,
+            UNIQUE(doc_id, concept_id)
+        )
+        """)
+
+        # 9. paper_edges 테이블 (논문 간 인용 관계 영속화). 카테고리 공유 엣지는
+        #    영속화하지 않는다 - documents.metadata.categories로 조회 시마다
+        #    즉석 그룹핑하면 되고(LLM 재호출 없이 저비용), 영속화하면 재분류 시
+        #    무효화 로직이 별도로 필요해져 정합성 리스크만 늘어난다. 인용 관계는
+        #    자카드 매칭 계산이 상대적으로 무거워 캐시 가치가 있다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS paper_edges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            doc_id_a TEXT NOT NULL,
+            doc_id_b TEXT NOT NULL,
+            edge_type TEXT NOT NULL,
+            detail TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id_a) REFERENCES documents (id) ON DELETE CASCADE,
+            FOREIGN KEY (doc_id_b) REFERENCES documents (id) ON DELETE CASCADE,
+            UNIQUE(doc_id_a, doc_id_b, edge_type)
+        )
+        """)
+
+        # 10. annotations / memos 테이블 (하이라이트/메모의 서버 미러). 프론트의
+        #     loadAnnotations/saveAnnotations, loadMemos/saveMemos는 항상 "문서
+        #     전체" 단위로 통째로 읽고 쓰며, 하이라이트는 안정적인 id 필드조차
+        #     없어 관계형 키 설계가 오히려 복잡해진다. documents.metadata와
+        #     동일한 "1 row = 1 blob, 통째로 덮어쓰기" 방식을 쓴다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS annotations (
+            doc_id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS memos (
+            doc_id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+
         # 라이브러리 목록/문서 조회가 doc_id(+suffix)로 translations를,
         # doc_id로 documents/page_insights/chats를 매번 훑는데(문서 수 x
         # 페이지 수만큼 뻥튀기됨) 인덱스가 없어 전부 풀스캔이었다. 목록
@@ -129,6 +194,10 @@ def init_db():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_page_insights_doc ON page_insights(doc_id, kind, suffix)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_documents_username_deleted ON documents(username, is_deleted, created_at)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_chats_doc ON chats(doc_id, id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_concepts_doc ON paper_concepts(doc_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_concepts_concept ON paper_concepts(concept_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_edges_a ON paper_edges(doc_id_a)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_edges_b ON paper_edges(doc_id_b)")
 
         conn.commit()
 
@@ -620,5 +689,148 @@ def db_set_meta(key: str, value: str) -> None:
             "INSERT INTO app_meta (key, value) VALUES (?, ?) "
             "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             (key, value)
+        )
+        conn.commit()
+
+
+# ── 지식 그래프 (개념 / 논문 간 인용 엣지) ───────────────────────────────────────
+
+def db_upsert_concept(name: str, normalized_name: str, kind: Optional[str] = None) -> int:
+    """개념을 normalized_name 기준으로 upsert하고 concept id를 반환한다."""
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO concepts (name, normalized_name, kind, created_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(normalized_name) DO UPDATE SET kind = COALESCE(excluded.kind, concepts.kind)
+            """,
+            (name, normalized_name, kind, created_at)
+        )
+        cursor.execute("SELECT id FROM concepts WHERE normalized_name = ?", (normalized_name,))
+        conn.commit()
+        return cursor.fetchone()["id"]
+
+
+def db_link_paper_concept(doc_id: str, concept_id: int) -> None:
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO paper_concepts (doc_id, concept_id, created_at) VALUES (?, ?, ?)",
+            (doc_id, concept_id, created_at)
+        )
+        conn.commit()
+
+
+def db_get_concepts_for_docs(doc_ids: List[str]) -> List[Dict[str, Any]]:
+    """주어진 문서들에 연결된 (doc_id, concept) 쌍을 모두 반환한다."""
+    if not doc_ids:
+        return []
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in doc_ids)
+        cursor.execute(
+            f"""
+            SELECT pc.doc_id, c.id AS concept_id, c.name, c.kind
+            FROM paper_concepts pc
+            JOIN concepts c ON c.id = pc.concept_id
+            WHERE pc.doc_id IN ({placeholders})
+            """,
+            doc_ids
+        )
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def db_upsert_paper_edge(doc_id_a: str, doc_id_b: str, edge_type: str, detail: Optional[dict] = None) -> None:
+    created_at = datetime.now(timezone.utc).isoformat()
+    detail_str = json.dumps(detail, ensure_ascii=False) if detail else None
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO paper_edges (doc_id_a, doc_id_b, edge_type, detail, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(doc_id_a, doc_id_b, edge_type) DO UPDATE SET detail = excluded.detail
+            """,
+            (doc_id_a, doc_id_b, edge_type, detail_str, created_at)
+        )
+        conn.commit()
+
+
+def db_get_paper_edges_for_docs(doc_ids: List[str]) -> List[Dict[str, Any]]:
+    """양쪽 doc_id가 모두 주어진 집합에 속하는 엣지만 반환한다(다른 사용자
+    소유 문서로 향하는 엣지가 섞여 나오지 않도록 호출부에서 doc_ids를
+    "이 사용자가 소유한 문서 id 목록"으로 제한해서 넘겨야 한다)."""
+    if not doc_ids:
+        return []
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in doc_ids)
+        cursor.execute(
+            f"""
+            SELECT doc_id_a, doc_id_b, edge_type, detail
+            FROM paper_edges
+            WHERE doc_id_a IN ({placeholders}) AND doc_id_b IN ({placeholders})
+            """,
+            doc_ids + doc_ids
+        )
+        edges = []
+        for r in cursor.fetchall():
+            row = dict(r)
+            row["detail"] = json.loads(row["detail"]) if row["detail"] else None
+            edges.append(row)
+        return edges
+
+
+# ── 메모 / 하이라이트 서버 미러 ───────────────────────────────────────────────
+
+def db_get_annotations(doc_id: str) -> Optional[Dict[str, Any]]:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT data, updated_at FROM annotations WHERE doc_id = ?", (doc_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {"data": json.loads(row["data"]), "updated_at": row["updated_at"]}
+
+
+def db_put_annotations(doc_id: str, data: dict) -> None:
+    updated_at = datetime.now(timezone.utc).isoformat()
+    data_str = json.dumps(data, ensure_ascii=False)
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO annotations (doc_id, data, updated_at) VALUES (?, ?, ?)
+            ON CONFLICT(doc_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
+            """,
+            (doc_id, data_str, updated_at)
+        )
+        conn.commit()
+
+
+def db_get_memos(doc_id: str) -> Optional[Dict[str, Any]]:
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT data, updated_at FROM memos WHERE doc_id = ?", (doc_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {"data": json.loads(row["data"]), "updated_at": row["updated_at"]}
+
+
+def db_put_memos(doc_id: str, data: dict) -> None:
+    updated_at = datetime.now(timezone.utc).isoformat()
+    data_str = json.dumps(data, ensure_ascii=False)
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO memos (doc_id, data, updated_at) VALUES (?, ?, ?)
+            ON CONFLICT(doc_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
+            """,
+            (doc_id, data_str, updated_at)
         )
         conn.commit()

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -1,0 +1,191 @@
+"""
+개인 지식 그래프(Knowledge Graph) 오케스트레이션.
+
+논문(Paper) 노드, LLM이 추출한 개념(Concept) 노드, 그리고 두 종류의 엣지
+(인용 citation / 카테고리 category)로 구성된 그래프를 만든다.
+
+- 개념 노드: 번역 완료 시(translation_job.py) 한 번 LLM으로 추출해
+  concepts/paper_concepts 테이블에 영구 저장한다(sync_document_for_graph).
+- 인용 엣지: 참고문헌 파싱 + 라이브러리 내 텍스트 매칭(primer.py의
+  _match_library_references 재사용)으로 계산해 paper_edges에 영구 저장한다.
+  라이브러리 전체를 스캔하는 매칭이라 요청마다 다시 돌리기엔 비용이 있고,
+  결과가 자주 바뀌지 않아 캐싱 가치가 크다.
+- 카테고리 엣지: metadata.categories가 겹치는 문서끼리 매 요청마다 메모리에서
+  즉석으로 계산한다(get_graph_data) - DB에 저장하지 않는다. LLM 호출 없이
+  카테고리 리스트만 비교하면 되는 저렴한 연산인 반면, 저장해두면 논문이
+  나중에 재분류될 때마다 이전 엣지를 무효화하는 로직이 추가로 필요해진다.
+  "비용 대비 정합성 유지 부담"을 저울질했을 때 인용 엣지와는 반대 선택.
+"""
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+# 그래프 조회 시점에 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서를
+# 백그라운드로 백필한다. 같은 문서에 대해 중복으로 백필 태스크가 여러 개
+# 뜨는 것을 막기 위한 in-flight 집합.
+_syncing: set = set()
+
+
+async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> None:
+    """번역 완료 직후 호출되어, 해당 문서의 개념을 추출하고 라이브러리 내
+    다른 논문과의 인용 관계를 매칭해 DB에 저장한다. 실패해도 번역 파이프라인
+    자체는 영향받지 않도록 호출부(translation_job.py)에서 try/except로 감싼다."""
+    from services.library import get_document, update_document_metadata
+    doc = get_document(doc_id)
+    if not doc:
+        return
+    username = doc["username"]
+
+    from services.llm_client import extract_paper_concepts
+    from services.db import db_upsert_concept, db_link_paper_concept
+    concepts = await extract_paper_concepts(
+        doc_title, "\n".join(p.get("text", "") for p in pages[:2]), session_id=doc_id
+    )
+    for c in concepts:
+        name = (c.get("concept") or "").strip()
+        if not name:
+            continue
+        concept_id = db_upsert_concept(name, name.lower(), c.get("kind"))
+        db_link_paper_concept(doc_id, concept_id)
+
+    try:
+        from services.reference_parser import extract_reference_list
+        from services.primer import _match_library_references
+        from services.db import db_upsert_paper_edge
+        reference_map = extract_reference_list(pages)
+        matches = _match_library_references(reference_map, doc_id, username)
+        for m in matches:
+            db_upsert_paper_edge(doc_id, m["doc_id"], "citation", {"ref_num": m["ref_num"]})
+    except Exception:
+        pass  # 참고문헌 파싱/매칭 실패는 조용히 무시한다 (primer.py와 동일한 철학)
+
+    meta = doc.get("metadata", {})
+    meta["graph_synced_at"] = datetime.now(timezone.utc).isoformat()
+    update_document_metadata(doc_id, meta)
+
+
+async def _backfill_one(doc_id: str) -> None:
+    """graph_synced_at이 없는 구 문서를 그래프 조회 시점에 뒤늦게 동기화한다.
+    /library/{doc_id}/references 라우트(routers/library.py)가 페이지 텍스트를
+    얻는 방식과 동일한 패턴(캐시 우선, 없으면 추출 후 캐싱)을 그대로 따른다."""
+    try:
+        from services.library import get_document, get_pdf_path
+        doc = get_document(doc_id)
+        if not doc:
+            return
+
+        pdf_path = get_pdf_path(doc_id)
+        if not pdf_path:
+            return  # PDF가 없으면 이번엔 스킵 - 다음 조회 때 다시 시도된다
+
+        from services.cache import get_cached_pages, save_pages_cache
+        from services.pdf_parser import extract_pages
+        pages = get_cached_pages(doc_id, pdf_path)
+        if pages is None:
+            pages = await asyncio.to_thread(extract_pages, pdf_path)
+            save_pages_cache(doc_id, pdf_path, pages)
+
+        doc_title = doc.get("metadata", {}).get("title") or doc.get("filename")
+        await sync_document_for_graph(doc_id, pages, doc_title)
+    except Exception as e:
+        logger.warning(f"지식 그래프 백필 실패 (doc_id={doc_id}): {e}")
+    finally:
+        _syncing.discard(doc_id)
+
+
+async def get_graph_data(username: str) -> dict:
+    """현재 로그인한 사용자가 소유한 문서만으로 그래프를 구성한다.
+    list_documents(username=username)로 소유 문서만 가져오는 것 자체가
+    보안 경계다(routers/library.py의 _require_owned_document 패턴과 동일한
+    "존재 자체를 노출하지 않는다" 원칙 - 여기서는 다른 사용자 문서는 애초에
+    쿼리 결과에 들어오지도 않는다)."""
+    from services.library import list_documents
+    docs = list_documents(username=username)
+    doc_ids = [d["id"] for d in docs]
+
+    nodes = []
+    for doc in docs:
+        meta = doc.get("metadata", {}) or {}
+        nodes.append({
+            "id": f"paper:{doc['id']}",
+            "type": "paper",
+            "label": meta.get("title") or doc["filename"],
+            "doc_id": doc["id"],
+            "categories": meta.get("categories", []),
+        })
+
+    edges = []
+
+    # 카테고리 엣지: DB에 저장하지 않고 매 요청마다 메모리에서 계산한다
+    # (모듈 docstring의 설계 근거 참고).
+    seen_category_pairs = set()
+    for i in range(len(docs)):
+        cats_i = set((docs[i].get("metadata", {}) or {}).get("categories", []) or [])
+        if not cats_i:
+            continue
+        for j in range(i + 1, len(docs)):
+            cats_j = set((docs[j].get("metadata", {}) or {}).get("categories", []) or [])
+            shared = cats_i & cats_j
+            for cat in shared:
+                pair_key = (docs[i]["id"], docs[j]["id"], cat)
+                if pair_key in seen_category_pairs:
+                    continue
+                seen_category_pairs.add(pair_key)
+                edges.append({
+                    "source": f"paper:{docs[i]['id']}",
+                    "target": f"paper:{docs[j]['id']}",
+                    "type": "category",
+                    "category": cat,
+                })
+
+    # 인용 엣지: sync_document_for_graph가 미리 계산해 저장해둔 것을 그대로 읽는다.
+    from services.db import db_get_paper_edges_for_docs
+    paper_edges = db_get_paper_edges_for_docs(doc_ids)
+    for e in paper_edges:
+        edges.append({
+            "source": f"paper:{e['doc_id_a']}",
+            "target": f"paper:{e['doc_id_b']}",
+            "type": "citation",
+        })
+
+    # 개념 노드/엣지
+    from services.db import db_get_concepts_for_docs
+    concept_links = db_get_concepts_for_docs(doc_ids)
+    seen_concept_ids = set()
+    for link in concept_links:
+        cid = link["concept_id"]
+        if cid not in seen_concept_ids:
+            seen_concept_ids.add(cid)
+            nodes.append({
+                "id": f"concept:{cid}",
+                "type": "concept",
+                "label": link["name"],
+                "kind": link.get("kind"),
+            })
+        edges.append({
+            "source": f"paper:{link['doc_id']}",
+            "target": f"concept:{cid}",
+            "type": "has_concept",
+        })
+
+    # 아직 개념/인용 동기화가 안 된 문서는 pending으로 표시하고, 백그라운드로
+    # 백필을 걸어둔다(fire-and-forget - 이번 응답에는 반영되지 않고, 클라이언트가
+    # 잠시 뒤 다시 조회하면 반영된다).
+    pending_docs = []
+    for doc in docs:
+        if (doc.get("metadata", {}) or {}).get("graph_synced_at"):
+            continue
+        pending_docs.append(doc["id"])
+        if doc["id"] in _syncing:
+            continue
+        _syncing.add(doc["id"])
+        asyncio.create_task(_backfill_one(doc["id"]))
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "pending_docs": pending_docs,
+    }

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2169,3 +2169,101 @@ Category Tags:"""
     tags = [t.strip() for t in result.split(",") if t.strip()]
     return tags
 
+
+def _parse_json_array_response(raw: str) -> list:
+    """LLM 응답에서 JSON 배열을 뽑아낸다. 마크다운 코드펜스(```json ... ```)로
+    감싸져 오는 경우가 흔하고, 프롬프트로 순수 JSON만 요구해도 모델이 종종
+    설명 문구를 앞뒤에 붙이거나 펜스를 씌우므로, 우선 펜스를 제거한 뒤
+    json.loads를 시도한다. 파싱된 결과가 dict 리스트가 아니거나 각 항목에
+    "concept" 키가 없으면 호출부가 재시도할 수 있도록 ValueError를 던진다."""
+    text = (raw or "").strip()
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    text = text.strip()
+
+    parsed = json.loads(text)
+    if not isinstance(parsed, list):
+        raise ValueError("JSON 응답이 배열이 아닙니다.")
+    for item in parsed:
+        if not isinstance(item, dict) or "concept" not in item:
+            raise ValueError("배열 항목이 dict가 아니거나 'concept' 키가 없습니다.")
+    return parsed
+
+
+async def extract_paper_concepts(title: str, text: str, session_id: str = None) -> List[dict]:
+    """논문 제목과 서두 텍스트에서 핵심 개념 3~7개를 추출한다.
+    반환값: [{"concept": str, "kind": str|None}, ...]
+
+    classify_paper_category와 달리 결과를 JSON으로 파싱해야 하는데, LLM이
+    마크다운 펜스를 씌우거나 출력이 중간에 잘리면 파싱이 깨지기 쉬워서 최대
+    3회까지 재시도한다. 3회 모두 실패해도 예외를 던지지 않고 빈 리스트를
+    반환한다 - classify_paper_category와 동일하게 이 기능은 부가 정보일 뿐
+    번역 파이프라인 자체를 실패시켜서는 안 된다."""
+    prompt = f"""You are an academic paper analyst. Analyze the following paper title and beginning text (abstract/introduction) and extract 3 to 7 core concepts (methods, tasks, datasets, metrics, or theories) discussed in the paper.
+
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "concept" key (the concept name, in a few words) and a "kind" key (one of: "method", "task", "dataset", "metric", "theory", or null if unclear).
+
+Example output:
+[{{"concept": "Attention Mechanism", "kind": "method"}}, {{"concept": "Machine Translation", "kind": "task"}}]
+
+Title: {title}
+Beginning Text:
+{text[:2000]}
+
+JSON Array:"""
+
+    messages = [
+        {"role": "user", "content": prompt}
+    ]
+
+    provider = get_trans_provider()
+    model = get_trans_model()
+
+    try:
+        for attempt in range(3):
+            tokens = []
+            try:
+                if provider == "openai":
+                    async for token in stream_openai(messages, model=model, temperature=0.1):
+                        tokens.append(token)
+                elif provider == "gemini":
+                    async for token in stream_gemini(messages, model=model, temperature=0.1):
+                        tokens.append(token)
+                elif provider == "claude":
+                    async for token in stream_claude(messages, model=model, temperature=0.1):
+                        tokens.append(token)
+                elif provider == "antigravity":
+                    async for token in stream_antigravity(prompt, model=model, session_id=session_id):
+                        tokens.append(token)
+                elif provider == "claude_code":
+                    async for token in stream_claude_code(prompt, model=model, session_id=session_id):
+                        tokens.append(token)
+                elif provider == "codex":
+                    async for token in stream_codex(prompt, model=model, session_id=session_id):
+                        tokens.append(token)
+                else:
+                    # Fallback to Ollama chat api
+                    payload = {
+                        "model": model,
+                        "messages": messages,
+                        "stream": False,
+                        "options": {"temperature": 0.1}
+                    }
+                    async with httpx.AsyncClient(timeout=30.0) as client:
+                        response = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
+                        if response.status_code == 200:
+                            data = response.json()
+                            tokens.append(data.get("message", {}).get("content", ""))
+
+                raw = "".join(tokens).strip()
+                parsed = _parse_json_array_response(raw)
+                return parsed
+            except Exception as e:
+                logger.warning(f"논문 개념 추출 파싱 실패 (시도 {attempt + 1}/3): {e}")
+                continue
+    except Exception as e:
+        logger.warning(f"논문 개념 추출 실패: {e}")
+        return []
+
+    return []
+

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -277,6 +277,13 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
         except Exception as ex:
             print(f"[Job {session_id}] Category classification failed: {ex}")
 
+        # 지식 그래프 동기화 (개념 추출 + 인용 엣지 매칭, 번역 완료 후)
+        try:
+            from services.knowledge_graph import sync_document_for_graph
+            await sync_document_for_graph(session_id, pages, doc_title)
+        except Exception as ex:
+            print(f"[Job {session_id}] Knowledge graph sync failed: {ex}")
+
     except asyncio.CancelledError:
         job["status"] = "cancelled"
         _save_job(session_id, job)

--- a/backend/tests/test_library_annotations_memos_api.py
+++ b/backend/tests/test_library_annotations_memos_api.py
@@ -1,0 +1,99 @@
+"""annotations/memos 서버 미러 엔드포인트 테스트.
+
+localStorage가 원본이고 서버는 best-effort 백업/동기화 미러일 뿐이므로,
+1) 저장된 적 없는 문서는 빈 데이터를 에러 없이 반환하고,
+2) PUT 후 GET이 동일한 데이터를 그대로 왕복시키며,
+3) 다른 사용자 소유 문서는 GET/PUT 모두 404로 막히는지(존재 여부 노출 없이)
+확인한다. test_library_ownership_api.py의 fixture/스타일을 그대로 따른다.
+"""
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "Other's Paper"})
+
+
+def test_get_annotations_with_no_saved_data_returns_empty_shape(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-anno-empty", "testuser")
+    res = test_client.get("/api/library/doc-anno-empty/annotations")
+    assert res.status_code == 200
+    assert res.json() == {"data": {}, "updated_at": None}
+
+
+def test_get_memos_with_no_saved_data_returns_empty_shape(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-memo-empty", "testuser")
+    res = test_client.get("/api/library/doc-memo-empty/memos")
+    assert res.status_code == 200
+    assert res.json() == {"data": {}, "updated_at": None}
+
+
+def test_put_then_get_annotations_round_trips(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-anno-rt", "testuser")
+    payload = {"data": {"page_1": [{"id": "h1", "text": "hello"}]}}
+
+    put_res = test_client.put("/api/library/doc-anno-rt/annotations", json=payload)
+    assert put_res.status_code == 200
+    assert put_res.json() == {"status": "ok"}
+
+    get_res = test_client.get("/api/library/doc-anno-rt/annotations")
+    assert get_res.status_code == 200
+    body = get_res.json()
+    assert body["data"] == payload["data"]
+    assert body["updated_at"] is not None
+
+
+def test_put_then_get_memos_round_trips(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-memo-rt", "testuser")
+    payload = {"data": {"page_1": [{"id": "m1", "text": "note", "x": 10, "y": 20}]}}
+
+    put_res = test_client.put("/api/library/doc-memo-rt/memos", json=payload)
+    assert put_res.status_code == 200
+    assert put_res.json() == {"status": "ok"}
+
+    get_res = test_client.get("/api/library/doc-memo-rt/memos")
+    assert get_res.status_code == 200
+    body = get_res.json()
+    assert body["data"] == payload["data"]
+    assert body["updated_at"] is not None
+
+
+def test_get_annotations_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-anno-other", "otheruser")
+    res = test_client.get("/api/library/doc-anno-other/annotations")
+    assert res.status_code == 404
+
+
+def test_put_annotations_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-anno-other-2", "otheruser")
+    res = test_client.put("/api/library/doc-anno-other-2/annotations", json={"data": {"page_1": []}})
+    assert res.status_code == 404
+
+    # 실제로 저장되지 않았어야 한다
+    db = isolated_dirs["db"]
+    assert db.db_get_annotations("doc-anno-other-2") is None
+
+
+def test_get_memos_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-memo-other", "otheruser")
+    res = test_client.get("/api/library/doc-memo-other/memos")
+    assert res.status_code == 404
+
+
+def test_put_memos_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-memo-other-2", "otheruser")
+    res = test_client.put("/api/library/doc-memo-other-2/memos", json={"data": {"page_1": []}})
+    assert res.status_code == 404
+
+    db = isolated_dirs["db"]
+    assert db.db_get_memos("doc-memo-other-2") is None
+
+
+def test_annotations_and_memos_on_nonexistent_document_return_404(test_client, isolated_dirs):
+    res_get = test_client.get("/api/library/doc-does-not-exist/annotations")
+    assert res_get.status_code == 404
+    res_put = test_client.put("/api/library/doc-does-not-exist/annotations", json={"data": {}})
+    assert res_put.status_code == 404
+    res_get_m = test_client.get("/api/library/doc-does-not-exist/memos")
+    assert res_get_m.status_code == 404
+    res_put_m = test_client.put("/api/library/doc-does-not-exist/memos", json={"data": {}})
+    assert res_put_m.status_code == 404

--- a/backend/tests/test_library_graph_api.py
+++ b/backend/tests/test_library_graph_api.py
@@ -1,0 +1,140 @@
+"""/api/library/graph 엔드포인트 회귀 테스트.
+
+test_library_ownership_api.py와 동일한 fixture 패턴(test_client/isolated_dirs)을
+사용한다: get_current_user를 "testuser"로 고정한 TestClient 위에서, 다른
+사용자("otheruser") 소유 문서가 그래프 응답에 절대 섞여 나오지 않는지, 그리고
+개념/인용 데이터가 DB에 저장된 뒤 그래프 응답에 정상적으로 반영되는지 확인한다.
+"""
+import pytest
+
+from services.llm_client import _parse_json_array_response
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str, metadata: dict = None):
+    db = isolated_dirs["db"]
+    meta = metadata if metadata is not None else {"title": f"{doc_id} title"}
+    db.db_save_document(doc_id, username, f"{doc_id}.pdf", "/x/nonexistent.pdf", 3, meta)
+
+
+def test_graph_endpoint_returns_expected_keys(test_client, isolated_dirs):
+    _create_doc_owned_by(
+        isolated_dirs, "doc-mine-graph-1", "testuser",
+        {"title": "My Paper", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+    assert "nodes" in data
+    assert "edges" in data
+    assert "pending_docs" in data
+    assert isinstance(data["nodes"], list)
+    assert isinstance(data["edges"], list)
+    assert isinstance(data["pending_docs"], list)
+
+    # 동기화 완료 표시가 있는 문서는 pending_docs에 들어가지 않아야 한다
+    assert "doc-mine-graph-1" not in data["pending_docs"]
+    paper_ids = {n["id"] for n in data["nodes"] if n["type"] == "paper"}
+    assert "paper:doc-mine-graph-1" in paper_ids
+
+
+def test_graph_endpoint_excludes_other_users_documents(test_client, isolated_dirs):
+    _create_doc_owned_by(
+        isolated_dirs, "doc-mine-graph-2", "testuser",
+        {"title": "Mine", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    _create_doc_owned_by(
+        isolated_dirs, "doc-other-graph-1", "otheruser",
+        {"title": "Not Mine", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+
+    paper_doc_ids = {n["doc_id"] for n in data["nodes"] if n["type"] == "paper"}
+    assert "doc-mine-graph-2" in paper_doc_ids
+    assert "doc-other-graph-1" not in paper_doc_ids
+
+    all_node_ids = {n["id"] for n in data["nodes"]}
+    assert "paper:doc-other-graph-1" not in all_node_ids
+
+    for edge in data["edges"]:
+        assert "doc-other-graph-1" not in edge["source"]
+        assert "doc-other-graph-1" not in edge["target"]
+
+
+def test_graph_endpoint_reflects_concepts_and_citation_edges(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-mine-graph-3", "testuser",
+        {"title": "Paper A", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    _create_doc_owned_by(
+        isolated_dirs, "doc-mine-graph-4", "testuser",
+        {"title": "Paper B", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+
+    concept_id = db.db_upsert_concept("Attention Mechanism", "attention mechanism", "method")
+    db.db_link_paper_concept("doc-mine-graph-3", concept_id)
+    db.db_upsert_paper_edge("doc-mine-graph-3", "doc-mine-graph-4", "citation", {"ref_num": "1"})
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+
+    concept_nodes = [n for n in data["nodes"] if n["type"] == "concept"]
+    assert any(n["id"] == f"concept:{concept_id}" and n["label"] == "Attention Mechanism" for n in concept_nodes)
+
+    has_concept_edges = [e for e in data["edges"] if e["type"] == "has_concept"]
+    assert any(
+        e["source"] == "paper:doc-mine-graph-3" and e["target"] == f"concept:{concept_id}"
+        for e in has_concept_edges
+    )
+
+    citation_edges = [e for e in data["edges"] if e["type"] == "citation"]
+    assert any(
+        e["source"] == "paper:doc-mine-graph-3" and e["target"] == "paper:doc-mine-graph-4"
+        for e in citation_edges
+    )
+
+
+def test_graph_endpoint_marks_unsynced_docs_as_pending(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-mine-graph-5", "testuser", {"title": "Unsynced"})
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+    assert "doc-mine-graph-5" in data["pending_docs"]
+
+
+class TestParseJsonArrayResponse:
+    def test_clean_json(self):
+        result = _parse_json_array_response(
+            '[{"concept": "Attention Mechanism", "kind": "method"}, {"concept": "Machine Translation", "kind": "task"}]'
+        )
+        assert result == [
+            {"concept": "Attention Mechanism", "kind": "method"},
+            {"concept": "Machine Translation", "kind": "task"},
+        ]
+
+    def test_fenced_json(self):
+        raw = '```json\n[{"concept": "Transformer", "kind": "method"}]\n```'
+        result = _parse_json_array_response(raw)
+        assert result == [{"concept": "Transformer", "kind": "method"}]
+
+    def test_fenced_json_without_language_tag(self):
+        raw = '```\n[{"concept": "GAN", "kind": null}]\n```'
+        result = _parse_json_array_response(raw)
+        assert result == [{"concept": "GAN", "kind": None}]
+
+    def test_garbage_raises(self):
+        with pytest.raises(Exception):
+            _parse_json_array_response("this is not json at all")
+
+    def test_non_list_json_raises(self):
+        with pytest.raises(ValueError):
+            _parse_json_array_response('{"concept": "not a list"}')
+
+    def test_missing_concept_key_raises(self):
+        with pytest.raises(ValueError):
+            _parse_json_array_response('[{"name": "missing concept key"}]')

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-C_G4vtnx.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DBOn9QUY.css">
+  <script type="module" crossorigin src="/assets/index-CIGeF9Fz.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BqeWs-sn.css">
 </head>
 <body>
 
@@ -93,6 +93,7 @@
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
         <button id="lib-tab-chat" class="library-tab-btn" data-tab="chat"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>채팅</button>
         <button id="lib-tab-annotations" class="library-tab-btn" data-tab="annotations"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>주석</button>
+        <button id="lib-tab-graph" class="library-tab-btn" data-tab="graph"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="6" r="3"/><circle cx="12" cy="18" r="3"/><path d="M7.5 7.5 10.5 16"/><path d="M16.5 7.5 13.5 16"/></svg>지식 그래프</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
@@ -142,6 +143,19 @@
           <button id="annotation-subtab-underline" class="chat-session-subtab-btn" data-subtab="underline">언더라인</button>
         </div>
         <div id="annotation-list" class="chat-session-list"></div>
+      </div>
+
+      <!-- 지식 그래프 (논문 + LLM 추출 개념 노드, 인용/카테고리 엣지) -->
+      <div id="library-graph-section" class="hidden">
+        <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
+          일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
+        </div>
+        <div style="display: flex; gap: 16px; align-items: stretch;">
+          <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
+          <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
+            <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+          </div>
+        </div>
       </div>
     </div>
     <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
@@ -195,24 +209,24 @@
   <div id="viewer-screen" class="screen">
 
     <!-- 상단 바 -->
-    <header class="topbar">
+    <header class="topbar" id="viewer-topbar">
       <div class="topbar-left">
         <button id="back-btn" class="icon-btn" title="처음으로">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:4px"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg>EasyPaper</button>
         <!-- 독서 완료 토글 버튼 -->
-        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글" style="margin-left: 8px;">
+        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10"></circle>
             <path d="m9 12 2 2 4-4"></path>
           </svg>
           <span class="read-btn-text">독서 완료</span>
         </button>
-        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기" style="margin-left: 6px;">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
+        <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
-        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기" style="margin-left: 6px;">
+        <button id="viewer-primer-btn" class="icon-btn hidden" title="읽기 전 브리핑 다시 보기">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
@@ -227,21 +241,6 @@
         </span>
       </div>
       <div class="topbar-right">
-        <!-- 번역 작업 상태 정보 -->
-        <div id="translation-progress-mini" class="progress-mini hidden">
-          <div class="progress-mini-bar" id="progress-mini-bar"></div>
-          <span id="progress-mini-text">0%</span>
-        </div>
-        <div class="translation-status" id="translation-status">
-          <div class="spinner hidden" id="translate-spinner"></div>
-          <span id="translate-status-text"></span>
-        </div>
-
-        <!-- AI 번역 모델 선택 드롭다운 -->
-        <div id="viewer-trans-provider"></div>
-
-        <div class="toolbar-divider"></div>
-
         <!-- 뷰 확대/축소 조작 그룹 -->
         <div class="toolbar-group view-group">
           <button id="zoom-out-btn" class="icon-btn" title="축소">
@@ -274,33 +273,55 @@
 
         <div class="toolbar-divider"></div>
 
-        <!-- 번역 작업 관리 그룹 -->
-        <div class="toolbar-group action-group">
-          <button id="retranslate-btn" class="icon-btn" title="처음부터 다시 번역하기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+        <!-- 추가 메뉴(케밥): 번역 상태/모델, 번역 관리(다시 번역/중지/이어서/다운로드),
+             메모 숨기기, 테마 전환을 한데 모아 툴바를 간결하게 유지한다. -->
+        <div class="kebab-wrapper">
+          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>
           </button>
-          <button id="cancel-trans-btn" class="icon-btn hidden" title="번역 작업 중지" style="color: var(--error);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-          </button>
-          <button id="resume-trans-btn" class="icon-btn hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-          </button>
-          <button id="export-btn" class="icon-btn" title="번역본 내보내기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
-          </button>
-          <button id="memos-hide-all-btn" class="icon-btn" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
-          </button>
-        </div>
+          <div id="toolbar-kebab-menu" class="kebab-menu hidden">
+            <!-- 번역 작업 상태 정보 -->
+            <div id="translation-progress-mini" class="progress-mini hidden">
+              <div class="progress-mini-bar" id="progress-mini-bar"></div>
+              <span id="progress-mini-text">0%</span>
+            </div>
+            <!-- AI 번역 모델 선택 드롭다운 -->
+            <div class="kebab-menu-row">
+              <span class="kebab-menu-label">번역 모델</span>
+              <div id="viewer-trans-provider"></div>
+            </div>
 
-        <div class="toolbar-divider"></div>
+            <div class="kebab-menu-divider"></div>
 
-        <!-- 기타 환경 조작 그룹 -->
-        <div class="toolbar-group config-group">
-          <button id="theme-toggle-btn" class="icon-btn" title="화이트/다크 테마 토글">
-            <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-            <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-          </button>
+            <button id="retranslate-btn" class="kebab-menu-item" title="처음부터 다시 번역하기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+              <span>처음부터 다시 번역하기</span>
+            </button>
+            <button id="cancel-trans-btn" class="kebab-menu-item hidden" title="번역 작업 중지" style="color: var(--error);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+              <span>번역 작업 중지</span>
+            </button>
+            <button id="resume-trans-btn" class="kebab-menu-item hidden" title="중단된 부분부터 이어서 번역" style="color: var(--success);">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+              <span>이어서 번역하기</span>
+            </button>
+            <button id="export-btn" class="kebab-menu-item" title="번역본 내보내기">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
+              <span>번역본 다운로드</span>
+            </button>
+
+            <div class="kebab-menu-divider"></div>
+
+            <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+              <span>메모 숨기기</span>
+            </button>
+            <button id="theme-toggle-btn" class="kebab-menu-item" title="화이트/다크 테마 토글">
+              <svg class="sun-icon hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+              <svg class="moon-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+              <span>테마 전환</span>
+            </button>
+          </div>
         </div>
       </div>
     </header>
@@ -321,6 +342,22 @@
       <!-- 단일 뷰어 스크롤 컨테이너 -->
       <div class="viewer-scroll-container" id="viewer-scroll-container">
         <!-- page-pair 요소가 동적으로 생성됨 -->
+      </div>
+
+      <!-- 우측 하단 floating 스크롤 내비게이션 -->
+      <div class="floating-scroll-nav" id="floating-scroll-nav">
+        <button id="scroll-top-btn" class="floating-nav-btn" title="맨 위로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
+        </button>
+        <button id="scroll-page-up-btn" class="floating-nav-btn" title="이전 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+        </button>
+        <button id="scroll-page-down-btn" class="floating-nav-btn" title="다음 페이지">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <button id="scroll-bottom-btn" class="floating-nav-btn" title="맨 아래로">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg>
+        </button>
       </div>
 
       <!-- AI Chat Sidebar Resizer -->
@@ -598,16 +635,31 @@
           </div>
           
           <div class="form-group">
-            <label>번역 제외 문서 요소</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-math" /> 수식 (LaTeX 수식 생략)
+            <label for="setting-translation-mode">번역 모드</label>
+            <select id="setting-translation-mode" class="form-select">
+              <option value="auto">업로드 시 자동 번역 (기본)</option>
+              <option value="pane">번역 창을 펼칠 때만 번역</option>
+              <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>번역에서 제외할 요소</label>
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-math" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">수식(LaTeX) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-table" checked /> 표 (Table 데이터 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-table" checked />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">표(Table) 제외</span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-ignore-refs" /> 참고문헌 (References 생략)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-ignore-refs" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">참고문헌 제외</span>
               </label>
             </div>
           </div>
@@ -619,6 +671,16 @@
               <option value="1.5">100% (기본)</option>
               <option value="2.0">130%</option>
               <option value="2.5">170%</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label for="setting-toolbar-position">툴바 위치</label>
+            <select id="setting-toolbar-position" class="form-select">
+              <option value="top">위 (기본)</option>
+              <option value="bottom">아래</option>
+              <option value="left">왼쪽</option>
+              <option value="right">오른쪽</option>
             </select>
           </div>
 
@@ -636,24 +698,41 @@
 
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
             <label>뷰어 편의 설정</label>
-            <div class="checkbox-group">
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-hover-tooltip" /> PDF 원문에 마우스를 올려도 자동으로 문장이 선택되지 않도록 하기 (드래그로 직접 선택할 때만 툴팁 표시)
+            <div class="toggle-switch-group">
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-hover-tooltip" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마우스를 올리면 자동으로 문장 선택<small>끄면 드래그로 직접 선택할 때만 툴팁이 뜸</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-bookmark" /> 마지막으로 읽던 위치 자동 저장/이동 끄기 (항상 1페이지부터 시작)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-bookmark" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">마지막으로 읽던 위치 자동 이동<small>끄면 항상 1페이지부터 시작</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-insights" /> 번역 패널의 "키워드·단어" / "요약" 탭 끄기 (토큰 절약, 탭을 열 때만 생성됨)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-insights" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">번역 패널의 키워드·요약 탭<small>탭을 열 때만 생성되지만 토큰을 추가로 사용함</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-citation-overlay" /> 본문 인용([1], (Smith, 2020) 등) 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-citation-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">본문 인용 표기 호버 미리보기<small>예: [1], (Smith, 2020)</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-figure-overlay" /> Figure/Table/수식 참조 표기 호버 미리보기 끄기
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-figure-overlay" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">Figure/Table/수식 참조 호버 미리보기<small>예: Fig. 1, Table 2, Eq. (3)</small></span>
               </label>
-              <label class="checkbox-label">
-                <input type="checkbox" id="setting-disable-primer" /> 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 팝업 끄기 (툴바 버튼으로는 계속 다시 볼 수 있음)
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-primer" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
+              </label>
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-toolbar-autohide" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label">스크롤 시 상단 툴바 자동 숨김<small>아래로 스크롤하면 숨겨지고, 위로 스크롤하면 다시 표시됨</small></span>
               </label>
             </div>
           </div>
@@ -669,12 +748,9 @@
             <p style="font-size: 11px; color: var(--text-secondary); margin: 6px 0 0; line-height: 1.5;">서버(또는 앱) 재시작 후 문서를 처음 열 때 빠르게 뜨도록 저장해두는 캐시입니다. 비워도 데이터가 사라지지 않고, 다음에 열람할 때 자동으로 다시 채워집니다.</p>
           </div>
           
-          <div class="form-actions" style="margin-top: 15px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%;">일반 설정 저장</button>
-          </div>
         </form>
       </div>
-      
+
       <!-- 모델 설정 탭 -->
       <div id="tab-model" class="tab-pane">
         <!-- 시스템 설정 폼 (Ollama, OpenAI, Gemini, Claude 통합 및 번역/대화 분리) -->
@@ -739,9 +815,6 @@
             </div>
           </div>
 
-          <div class="form-actions" style="margin-top: 20px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%; justify-content: center;">시스템 설정 저장</button>
-          </div>
         </form>
 
         <!-- Ollama 미설치 안내 및 설치 섹션 -->
@@ -851,7 +924,7 @@
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:3px"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg><strong>직관적인 번역 어투 및 스타일 수정 방법:</strong><br>
               아래 프롬프트 입력창 내부의 원하는 위치(예: <strong>번역 규칙</strong> 목록 밑에 직접 줄을 추가)에<br>
               <code style="background: rgba(255,255,255,0.08); padding: 2px 4px; border-radius: 3px; font-weight: bold; color: var(--accent-mid);">- 번역 시 어미는 무조건 경어체(~합니다, ~입니다)로 일관되게 끝맺으세요.</code><br>
-              또는 특정 전문 용어 번역 강제 등 <strong>원하는 번역 지시사항을 직접 입력한 후 하단의 저장 버튼</strong>을 누르시면 됩니다.<br>
+              또는 특정 전문 용어 번역 강제 등 <strong>원하는 번역 지시사항을 직접 입력</strong>하면 됩니다. 입력창에서 벗어나면(포커스 아웃) 자동으로 저장됩니다.<br>
               <span style="font-size: 11px; color: var(--text-secondary); display: block; margin-top: 6px;">※ <code>{{ ... }}</code> 형식의 중괄호 태그들은 시스템 치환용 매개변수이므로 형태를 그대로 유지해 주세요.</span>
             </div>
             <textarea id="setting-prompt-template" rows="12" style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-md); color: var(--text-primary); outline: none; font-size: 13px; font-family: var(--font-mono); resize: vertical; line-height: 1.6;">당신은 학술 논문 번역 전문가입니다. {{LANG_INSTRUCTION}}
@@ -874,9 +947,6 @@
 {{TARGET_LANG}} 번역:</textarea>
           </div>
           
-          <div class="form-actions" style="margin-top: 15px;">
-            <button type="submit" class="btn btn-primary" style="width: 100%;">고급 설정 저장</button>
-          </div>
         </form>
       </div>
 
@@ -1032,7 +1102,12 @@
   <!-- 읽기 전 브리핑(Reading Primer) 모달 -->
   <div id="primer-modal" class="modal-overlay hidden">
     <div class="primer-content">
-      <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
+      <div class="primer-modal-actions">
+        <button id="primer-regenerate-btn" class="close-btn primer-regenerate-btn" title="다시 생성하기">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M8 16H3v5"/></svg>
+        </button>
+        <button id="primer-close-btn" class="close-btn primer-close-btn" title="닫기">&times;</button>
+      </div>
 
       <div id="primer-loading" class="primer-loading">
         <div class="spinner"></div>
@@ -1054,41 +1129,96 @@
           </div>
         </div>
 
-        <div id="primer-hook-section" class="primer-hook-section hidden">
-          <span class="primer-hook-quote">&ldquo;</span>
-          <p id="primer-hook-text" class="primer-hook-text"></p>
+        <div id="primer-tabs" class="primer-tabs" role="tablist">
+          <button type="button" class="primer-tab-btn active" data-tab="overview">개요</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="lineage">계보</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="feynman">쉽게 이해하기</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="experiment">실험 흐름</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="glossary">용어집</button>
+          <button type="button" class="primer-tab-btn hidden" data-tab="graph">관련 논문</button>
         </div>
 
-        <div id="primer-questions-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
-            <span>읽기 전에 스스로 답해보기</span>
-          </div>
-          <ol id="primer-questions" class="primer-list"></ol>
-        </div>
+        <div class="primer-tab-panels">
+          <div class="primer-tab-panel active" data-panel="overview">
+            <div id="primer-hook-section" class="primer-hook-section hidden">
+              <span class="primer-hook-quote">&ldquo;</span>
+              <p id="primer-hook-text" class="primer-hook-text"></p>
+            </div>
 
-        <div id="primer-figure-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
-            <span>핵심 그림 먼저 보기</span>
-          </div>
-          <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
-        </div>
+            <div id="primer-questions-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+                <span>읽기 전에 스스로 답해보기</span>
+              </div>
+              <ol id="primer-questions" class="primer-list"></ol>
+            </div>
 
-        <div id="primer-checklist-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
-            <span>읽으면서 확인할 것</span>
-          </div>
-          <ul id="primer-checklist" class="primer-checklist"></ul>
-        </div>
+            <div id="primer-figure-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg></span>
+                <span>핵심 그림 먼저 보기</span>
+              </div>
+              <img id="primer-figure-img" class="primer-figure-img" src="" alt="대표 Figure" />
+            </div>
 
-        <div id="primer-graph-section" class="hidden">
-          <div class="primer-label">
-            <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
-            <span>이 논문과 연결된 논문</span>
+            <div id="primer-checklist-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></span>
+                <span>읽으면서 확인할 것</span>
+              </div>
+              <ul id="primer-checklist" class="primer-checklist"></ul>
+            </div>
           </div>
-          <div id="primer-graph" class="primer-graph"></div>
+
+          <div class="primer-tab-panel" data-panel="lineage">
+            <div id="primer-lineage-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg></span>
+                <span>이 논문의 연구 계보</span>
+              </div>
+              <p id="primer-lineage-text" class="primer-lineage-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="feynman">
+            <div id="primer-feynman-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/></svg></span>
+                <span>파인만 기법으로 쉽게 이해하기</span>
+              </div>
+              <p id="primer-feynman-text" class="primer-feynman-text"></p>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="experiment">
+            <div id="primer-experiment-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/></svg></span>
+                <span>가설 → 실험 → 결과 흐름</span>
+              </div>
+              <ol id="primer-experiment-flow" class="primer-experiment-flow"></ol>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="glossary">
+            <div id="primer-glossary-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span>
+                <span>이 논문이 새로 정의한 용어</span>
+              </div>
+              <div id="primer-glossary" class="primer-glossary"></div>
+            </div>
+          </div>
+
+          <div class="primer-tab-panel" data-panel="graph">
+            <div id="primer-graph-section" class="hidden">
+              <div class="primer-label">
+                <span class="primer-label-icon"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/></svg></span>
+                <span>이 논문과 연결된 논문</span>
+              </div>
+              <div id="primer-graph" class="primer-graph"></div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,6 +92,7 @@
         <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
         <button id="lib-tab-chat" class="library-tab-btn" data-tab="chat"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>채팅</button>
         <button id="lib-tab-annotations" class="library-tab-btn" data-tab="annotations"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>주석</button>
+        <button id="lib-tab-graph" class="library-tab-btn" data-tab="graph"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="6" r="3"/><circle cx="12" cy="18" r="3"/><path d="M7.5 7.5 10.5 16"/><path d="M16.5 7.5 13.5 16"/></svg>지식 그래프</button>
       </div>
 
       <!-- 독서 통계 위젯 영역 -->
@@ -141,6 +142,19 @@
           <button id="annotation-subtab-underline" class="chat-session-subtab-btn" data-subtab="underline">언더라인</button>
         </div>
         <div id="annotation-list" class="chat-session-list"></div>
+      </div>
+
+      <!-- 지식 그래프 (논문 + LLM 추출 개념 노드, 인용/카테고리 엣지) -->
+      <div id="library-graph-section" class="hidden">
+        <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
+          일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
+        </div>
+        <div style="display: flex; gap: 16px; align-items: stretch;">
+          <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
+          <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
+            <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+          </div>
+        </div>
       </div>
     </div>
     <!-- 우하단 휴지통 비우기 플로팅 버튼 -->

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
+        "cytoscape": "^3.34.0",
+        "cytoscape-fcose": "^2.2.0",
         "dompurify": "^3.4.12",
         "marked": "^18.0.5"
       },
@@ -519,9 +521,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,9 +535,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -553,9 +549,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,9 +563,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +577,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,9 +591,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +605,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,9 +619,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,9 +633,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,9 +647,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +661,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +675,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +689,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,6 +830,36 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.12",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
@@ -929,6 +922,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
     },
     "node_modules/marked": {
       "version": "18.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,8 @@
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
+    "cytoscape": "^3.34.0",
+    "cytoscape-fcose": "^2.2.0",
     "dompurify": "^3.4.12",
     "marked": "^18.0.5"
   }

--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -1,0 +1,23 @@
+import cytoscape from 'cytoscape'
+import fcose from 'cytoscape-fcose'
+cytoscape.use(fcose)
+
+export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {}) {
+  const cy = cytoscape({
+    container,
+    elements: [
+      ...graphData.nodes.map(n => ({ data: n })),
+      ...graphData.edges.map(e => ({ data: e })),
+    ],
+    style: [
+      { selector: 'node[type="paper"]', style: { shape: 'ellipse', 'background-color': '#4f8ef7', label: 'data(label)' } },
+      { selector: 'node[type="concept"]', style: { shape: 'diamond', 'background-color': '#f7b34f', width: 24, height: 24, label: 'data(label)' } },
+      { selector: 'edge[type="citation"]', style: { 'line-style': 'solid', 'target-arrow-shape': 'triangle', width: 1.5 } },
+      { selector: 'edge[type="category"]', style: { 'line-style': 'dashed', width: 1, 'line-color': '#ccc' } },
+      { selector: 'edge[type="has_concept"]', style: { 'line-style': 'dotted', width: 1 } },
+    ],
+    layout: { name: 'fcose', quality: 'proof', animate: true },
+  })
+  cy.on('tap', 'node', evt => onNodeClick && onNodeClick(evt.target.data()))
+  return cy
+}

--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -15,9 +15,26 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
       { selector: 'edge[type="citation"]', style: { 'line-style': 'solid', 'target-arrow-shape': 'triangle', width: 1.5 } },
       { selector: 'edge[type="category"]', style: { 'line-style': 'dashed', width: 1, 'line-color': '#ccc' } },
       { selector: 'edge[type="has_concept"]', style: { 'line-style': 'dotted', width: 1 } },
+      // 노드 클릭 시 직접 연결된 이웃만 부각하고 나머지는 흐리게 처리한다.
+      { selector: '.kg-dimmed', style: { opacity: 0.2 } },
+      { selector: 'node.kg-selected', style: { 'border-width': 3, 'border-color': '#2563eb' } },
     ],
     layout: { name: 'fcose', quality: 'proof', animate: true },
   })
-  cy.on('tap', 'node', evt => onNodeClick && onNodeClick(evt.target.data()))
+  cy.on('tap', 'node', evt => {
+    const node = evt.target
+    const neighborhood = node.closedNeighborhood()
+    cy.elements().addClass('kg-dimmed')
+    neighborhood.removeClass('kg-dimmed')
+    cy.nodes().removeClass('kg-selected')
+    node.addClass('kg-selected')
+    onNodeClick && onNodeClick(node.data())
+  })
+  // 빈 캔버스(배경)를 탭하면 하이라이트를 초기화한다.
+  cy.on('tap', evt => {
+    if (evt.target === cy) {
+      cy.elements().removeClass('kg-dimmed kg-selected')
+    }
+  })
   return cy
 }

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -99,6 +99,12 @@ export async function resolveLibraryReference(docId, refNum) {
   return res.json()
 }
 
+export async function fetchLibraryGraph() {
+  const res = await fetch(`${API_BASE}/library/graph`)
+  if (!res.ok) throw new Error('지식 그래프 조회 실패')
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -78,6 +78,76 @@ export async function exportAnnotatedPdf(docId, payload) {
   return res.blob()
 }
 
+// 하이라이트/주석·메모의 서버 미러. localStorage가 원본(source of truth)이며
+// 이 함수들은 다중 기기 동기화를 위한 best-effort 백업 용도로만 쓰인다.
+export async function fetchLibraryAnnotations(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/annotations`)
+  if (!res.ok) {
+    let message = '주석 조회 실패'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  return res.json()
+}
+
+export async function putLibraryAnnotations(docId, data) {
+  const res = await fetch(`${API_BASE}/library/${docId}/annotations`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data })
+  })
+  if (!res.ok) {
+    let message = '주석 저장 실패'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  return res.json()
+}
+
+export async function fetchLibraryMemos(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/memos`)
+  if (!res.ok) {
+    let message = '메모 조회 실패'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  return res.json()
+}
+
+export async function putLibraryMemos(docId, data) {
+  const res = await fetch(`${API_BASE}/library/${docId}/memos`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data })
+  })
+  if (!res.ok) {
+    let message = '메모 저장 실패'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  return res.json()
+}
+
 export async function searchLibrary(query) {
   const res = await fetch(`${API_BASE}/library/search?q=${encodeURIComponent(query)}`)
   if (!res.ok) throw new Error('검색 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos } from './library.js'
 import { icon } from './icons.js'
 
 
@@ -5372,6 +5372,33 @@ async function loadDocumentReferences(docId) {
 // 것과 동일한 패턴으로, 같은 문서를 여는 재진입 호출을 걸러낸다.
 let docOpeningId = null
 
+// 하이라이트/메모는 localStorage가 원본이고 서버 저장은 다중 기기 동기화를
+// 위한 best-effort 백업일 뿐이다. 로컬에 이미 데이터가 있으면(가장 흔한
+// 케이스: 같은 브라우저에서 계속 쓰던 문서) 절대 덮어쓰지 않고, 로컬에 해당
+// 키가 아예 없을 때만(다른 브라우저/설치에서 처음 여는 경우) 서버 데이터를
+// 채워 넣는다 - 병합 로직 없음, 로컬이 있으면 항상 로컬이 우선한다. 문서당
+// 한 번만 시도하도록 마커를 남긴다(매번 열 때마다 재조회하지 않기 위함).
+async function hydrateAnnotationsAndMemosFromServer(docId) {
+  const marker = `easypaper_hydrated_${docId}`
+  if (localStorage.getItem(marker)) return
+  try {
+    if (!localStorage.getItem(`easypaper_annotations_${docId}`)) {
+      const server = await fetchLibraryAnnotations(docId).catch(() => null)
+      if (server?.data && Object.keys(server.data).length) {
+        localStorage.setItem(`easypaper_annotations_${docId}`, JSON.stringify(server.data))
+      }
+    }
+    if (!localStorage.getItem(`easypaper_memos_${docId}`)) {
+      const server = await fetchLibraryMemos(docId).catch(() => null)
+      if (server?.data && Object.keys(server.data).length) {
+        localStorage.setItem(`easypaper_memos_${docId}`, JSON.stringify(server.data))
+      }
+    }
+  } finally {
+    localStorage.setItem(marker, '1')
+  }
+}
+
 async function openFromLibrary(doc, shouldPushState = true) {
   if (docOpeningId === doc.id) return
   docOpeningId = doc.id
@@ -5424,6 +5451,12 @@ async function openFromLibrary(doc, shouldPushState = true) {
         }
       }
     }
+
+    // 이 지점 이후로는 gating 리다이렉트 없이 실제로 이 문서를 열 것이 확정된
+    // 상태다. loadAnnotations/loadMemos가 이 문서 데이터를 처음 읽기 전에
+    // (아래 loadPDF에서 페이지를 렌더링하며 바로 참조한다) 서버 미러 데이터를
+    // 먼저 끌어와야 다른 기기에서 저장한 하이라이트/메모가 반영된다.
+    await hydrateAnnotationsAndMemosFromServer(doc.id)
 
     if (viewerReadToggleBtn) {
       const isRead = state.currentDocMetadata.read === true
@@ -5740,8 +5773,20 @@ function loadAnnotations(sessionId) {
 }
 
 // 로컬 스토리지에 어노테이션 정보 저장하기
+// localStorage 쓰기는 항상 동기로 즉시 수행하고(이 함수의 호출부 다수가
+// mousemove/keydown 같은 동기 이벤트 핸들러라 async로 바꾸면 입력 지연이
+// 생긴다), 서버 미러 동기화는 디바운스해 fire-and-forget으로 보낸다. 서버는
+// 항상 전체 블롭을 덮어쓰므로(시퀀스 번호 불필요) 마지막에 도착한 요청이
+// 이기고 다음 저장 때 자연히 정합성이 맞춰진다.
+const _annotationMirrorTimers = {}
 function saveAnnotations(sessionId, annotations) {
   localStorage.setItem(`easypaper_annotations_${sessionId}`, JSON.stringify(annotations))
+  if (!sessionId) return
+  clearTimeout(_annotationMirrorTimers[sessionId])
+  _annotationMirrorTimers[sessionId] = setTimeout(() => {
+    delete _annotationMirrorTimers[sessionId]
+    putLibraryAnnotations(sessionId, annotations).catch(err => console.warn('서버 동기화 실패(로컬은 유지됨):', err))
+  }, 1000)
 }
 
 // textLayer 내 텍스트 전체에 대한 선택 위치(Character Offset) 구하기
@@ -6142,10 +6187,16 @@ function loadMemos(sessionId) {
   }
 }
 
+const _memoMirrorTimers = {}
 function saveMemos(sessionId, memos) {
   if (!sessionId) return
   const key = `easypaper_memos_${sessionId}`
   localStorage.setItem(key, JSON.stringify(memos))
+  clearTimeout(_memoMirrorTimers[sessionId])
+  _memoMirrorTimers[sessionId] = setTimeout(() => {
+    delete _memoMirrorTimers[sessionId]
+    putLibraryMemos(sessionId, memos).catch(err => console.warn('서버 동기화 실패(로컬은 유지됨):', err))
+  }, 1000)
 }
 
 // ── 하이라이트/밑줄/메모 삭제 실행취소(Ctrl+Z) ──────────────────────

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,8 +3,9 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryGraph } from './library.js'
 import { icon } from './icons.js'
+import { renderKnowledgeGraph } from './knowledgeGraph.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -215,6 +216,7 @@ const libTabHistory     = $('lib-tab-history')
 const libTabTrash       = $('lib-tab-trash')
 const libTabChat        = $('lib-tab-chat')
 const libTabAnnotations = $('lib-tab-annotations')
+const libTabGraph       = $('lib-tab-graph')
 const libEmptyTrashBtn  = $('lib-empty-trash-btn')
 const libraryStatsContainer = $('library-stats-container')
 const librarySearchBox  = $('library-search-box')
@@ -227,6 +229,10 @@ const annotationSubtabMemo      = $('annotation-subtab-memo')
 const annotationSubtabHighlight = $('annotation-subtab-highlight')
 const annotationSubtabUnderline = $('annotation-subtab-underline')
 const annotationList            = $('annotation-list')
+const libraryGraphSection       = $('library-graph-section')
+const libraryGraphCanvas        = $('library-graph-canvas')
+const libraryGraphDetailPanel   = $('library-graph-detail-panel')
+const libraryGraphPendingBanner = $('library-graph-pending-banner')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
 const compareSelectBar      = $('compare-select-bar')
@@ -3593,6 +3599,7 @@ function updateTabUI(activeTab) {
   if (libTabTrash) libTabTrash.classList.toggle('active', activeTab === 'trash')
   if (libTabChat) libTabChat.classList.toggle('active', activeTab === 'chat')
   if (libTabAnnotations) libTabAnnotations.classList.toggle('active', activeTab === 'annotations')
+  if (libTabGraph) libTabGraph.classList.toggle('active', activeTab === 'graph')
 
   if (libEmptyTrashBtn) {
     if (activeTab === 'trash') {
@@ -3602,8 +3609,8 @@ function updateTabUI(activeTab) {
     }
   }
 
-  // 휴지통/채팅/주석 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
-  const isListOnlyTab = activeTab === 'trash' || activeTab === 'chat' || activeTab === 'annotations'
+  // 휴지통/채팅/주석/그래프 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
+  const isListOnlyTab = activeTab === 'trash' || activeTab === 'chat' || activeTab === 'annotations' || activeTab === 'graph'
   if (libUploadBtn) {
     if (isListOnlyTab) {
       libUploadBtn.classList.add('hidden')
@@ -3616,14 +3623,16 @@ function updateTabUI(activeTab) {
   }
   setCompareSelectMode(false)
 
-  // 채팅/주석 탭은 문서 그리드 대신 목록을 보여주므로, 검색/필터 등 논문 목록
-  // 전용 UI는 숨긴다.
+  // 채팅/주석/그래프 탭은 문서 그리드 대신 목록(또는 그래프)을 보여주므로,
+  // 검색/필터 등 논문 목록 전용 UI는 숨긴다.
   const isChatTab = activeTab === 'chat'
   const isAnnotationsTab = activeTab === 'annotations'
-  const hidesGrid = isChatTab || isAnnotationsTab
+  const isGraphTab = activeTab === 'graph'
+  const hidesGrid = isChatTab || isAnnotationsTab || isGraphTab
   if (libraryGrid) libraryGrid.classList.toggle('hidden', hidesGrid)
   if (libraryChatSection) libraryChatSection.classList.toggle('hidden', !isChatTab)
   if (libraryAnnotationsSection) libraryAnnotationsSection.classList.toggle('hidden', !isAnnotationsTab)
+  if (libraryGraphSection) libraryGraphSection.classList.toggle('hidden', !isGraphTab)
   if (librarySearchBox) librarySearchBox.classList.toggle('hidden', hidesGrid)
   if (librarySearchStatus && hidesGrid) librarySearchStatus.classList.add('hidden')
   if (libraryFilterRow) libraryFilterRow.classList.toggle('hidden', hidesGrid)
@@ -3664,6 +3673,12 @@ if (libTabAnnotations) {
   libTabAnnotations.addEventListener('click', () => {
     if (state.currentLibraryTab === 'annotations') return
     updateTabUI('annotations')
+  })
+}
+if (libTabGraph) {
+  libTabGraph.addEventListener('click', () => {
+    if (state.currentLibraryTab === 'graph') return
+    updateTabUI('graph')
   })
 }
 
@@ -4031,6 +4046,10 @@ async function renderLibrary() {
     await renderAnnotationsBrowser()
     return
   }
+  if (state.currentLibraryTab === 'graph') {
+    await renderLibraryGraphTab()
+    return
+  }
 
   // 탭 전환 등으로 목록을 새로 불러올 때는 검색 상태를 초기화한다 - 검색
   // 결과가 다른 탭의 목록과 뒤섞여 보이는 것을 방지
@@ -4286,6 +4305,70 @@ function truncateForList(text, maxLen) {
   if (!text) return ''
   const trimmed = text.trim()
   return trimmed.length > maxLen ? trimmed.substring(0, maxLen) + '...' : trimmed
+}
+
+// 지식 그래프 탭: Cytoscape 인스턴스는 탭을 재방문할 때마다 새로 만들면
+// 이전 인스턴스가 DOM/이벤트 리스너를 계속 붙들고 있으므로 반드시 destroy 후 재생성한다.
+let libraryGraphCyInstance = null
+let libraryGraphPollTimeout = null
+
+async function renderLibraryGraphTab() {
+  if (libraryGraphPollTimeout) {
+    clearTimeout(libraryGraphPollTimeout)
+    libraryGraphPollTimeout = null
+  }
+  if (!libraryGraphCanvas) return
+  if (libraryGraphDetailPanel) {
+    libraryGraphDetailPanel.innerHTML = '<p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>'
+  }
+
+  try {
+    const data = await fetchLibraryGraph()
+    // 응답을 기다리는 사이 사용자가 다른 탭으로 이동했다면 그리지 않는다.
+    if (state.currentLibraryTab !== 'graph') return
+
+    if (libraryGraphCyInstance) {
+      libraryGraphCyInstance.destroy()
+      libraryGraphCyInstance = null
+    }
+    libraryGraphCanvas.innerHTML = ''
+    libraryGraphCyInstance = renderKnowledgeGraph(libraryGraphCanvas, data, { onNodeClick: showGraphDetailPanel })
+
+    const pending = data.pending_docs || []
+    if (libraryGraphPendingBanner) {
+      libraryGraphPendingBanner.classList.toggle('hidden', pending.length === 0)
+    }
+    // 아직 개념/인용 동기화가 안 된 문서가 있으면 5초 뒤 다시 조회해
+    // 백그라운드 백필 결과가 반영되는지 확인한다(비어질 때까지 반복).
+    if (pending.length > 0) {
+      libraryGraphPollTimeout = setTimeout(() => {
+        if (state.currentLibraryTab === 'graph') renderLibraryGraphTab()
+      }, 5000)
+    }
+  } catch (err) {
+    console.error('지식 그래프 로드 실패:', err)
+    libraryGraphCanvas.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">지식 그래프를 불러오지 못했습니다</p></div>'
+  }
+}
+
+function showGraphDetailPanel(nodeData) {
+  if (!libraryGraphDetailPanel) return
+  if (nodeData.type === 'paper') {
+    const categories = (nodeData.categories && nodeData.categories.length) ? nodeData.categories.join(', ') : '없음'
+    libraryGraphDetailPanel.innerHTML = `
+      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
+      <p style="margin:0 0 6px"><strong>유형:</strong> 논문</p>
+      <p style="margin:0"><strong>카테고리:</strong> ${escapeHtml(categories)}</p>
+    `
+  } else if (nodeData.type === 'concept') {
+    libraryGraphDetailPanel.innerHTML = `
+      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
+      <p style="margin:0 0 6px"><strong>유형:</strong> 개념</p>
+      <p style="margin:0"><strong>분류:</strong> ${escapeHtml(nodeData.kind || '미상')}</p>
+    `
+  } else {
+    libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
+  }
 }
 
 async function renderAnnotationsBrowser() {


### PR DESCRIPTION
## Summary
- 논문(Paper)과 LLM이 추출한 핵심 개념(Concept) 노드, 카테고리 공유/인용 관계 엣지로 구성된 개인화 지식 그래프를 신규 DB 테이블(concepts, paper_concepts, paper_edges)로 저장하고 `GET /library/graph`로 조회합니다.
- 번역 완료 시 기존 카테고리 분류와 같은 지점에서 개념 추출 + 인용 관계 매칭(Primer의 `_match_library_references` 재사용)을 실행하고, 과거 문서는 그래프 조회 시점에 백그라운드로 백필합니다.
- 라이브러리 화면에 Cytoscape.js 기반 "지식 그래프" 탭을 추가해 노드 클릭 시 상세 패널과 인접 노드 하이라이트를 제공합니다.
- 하이라이트/메모를 서버 DB에도 미러링합니다(localStorage를 원본으로 유지한 채 디바운스된 fire-and-forget 백업, 다른 기기에서 열 때만 하이드레이션) - 다중 기기 동기화 기반 마련.
- 전부 신규 테이블/엔드포인트/탭이라 기존 기능에는 영향이 없습니다.

## Test plan
- [x] 신규 테스트 19개 통과 (`test_library_graph_api.py`, `test_library_annotations_memos_api.py`)
- [x] 전체 백엔드 테스트 스위트 241 passed / 1 failed - 실패 1건은 이 브랜치와 무관하게 `main`에서도 동일하게 재현되는 기존 환경 이슈(admin/admin 보안 경고 배너가 stdout에 섞이는 테스트 격리 문제)임을 확인
- [ ] `/run`으로 실제 라이브러리 화면에서 지식 그래프 탭 렌더링 및 하이라이트/메모 다중 기기 동기화 수동 확인 (권장 후속 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)