### PR TITLE
feat: 개인화된 지식 그래프(Research Graph) 2차 구현 추가

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
@@ -106,9 +107,10 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
     history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
 
     # Save user message to database
+    question_chat_id = None
     if data.messages:
         latest_msg = data.messages[-1]
-        db_save_chat_message(session_id, latest_msg.role, latest_msg.content)
+        question_chat_id = db_save_chat_message(session_id, latest_msg.role, latest_msg.content)
 
     async def event_generator():
         yield " "
@@ -125,6 +127,13 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
             assistant_content = "".join(full_response).strip()
             if assistant_content:
                 db_save_chat_message(session_id, "assistant", assistant_content)
+                # 지식 그래프: 이 질문을 논문의 기존 개념과 연결한다(fire-and-forget -
+                # 실패해도 채팅 응답 자체에는 영향 없음).
+                if question_chat_id is not None:
+                    from services.knowledge_graph import sync_question_for_graph
+                    asyncio.create_task(
+                        sync_question_for_graph(question_chat_id, session_id, latest_msg.content)
+                    )
         except Exception as e:
             yield f"\n[오류 발생: {str(e)}]"
 
@@ -230,9 +239,10 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
 
     history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
 
+    question_chat_id = None
     if data.messages:
         latest_msg = data.messages[-1]
-        db_save_chat_message(compare_id, latest_msg.role, latest_msg.content)
+        question_chat_id = db_save_chat_message(compare_id, latest_msg.role, latest_msg.content)
 
     async def event_generator():
         yield " "
@@ -245,6 +255,11 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
             assistant_content = "".join(full_response).strip()
             if assistant_content:
                 db_save_chat_message(compare_id, "assistant", assistant_content)
+                if question_chat_id is not None:
+                    from services.knowledge_graph import sync_question_for_graph
+                    asyncio.create_task(
+                        sync_question_for_graph(question_chat_id, compare_id, latest_msg.content)
+                    )
         except Exception as e:
             yield f"\n[오류 발생: {str(e)}]"
 

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -77,13 +77,30 @@ async def search_library(q: str = "", current_user: str = Depends(get_current_us
 
 @router.get("/library/graph")
 async def get_library_graph(current_user: str = Depends(get_current_user)):
-    """개인 지식 그래프(논문/개념 노드 + 인용/카테고리 엣지)를 반환합니다.
+    """개인 지식 그래프(논문/개념/메모 노드 + 인용/카테고리/개념보유/유사개념 엣지)를 반환합니다.
 
     /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
     이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
     """
     from services.knowledge_graph import get_graph_data
     return await get_graph_data(current_user)
+
+
+@router.get("/library/graph/questions")
+async def get_library_graph_questions(node_id: str, current_user: str = Depends(get_current_user)):
+    """지식 그래프의 Concept/Paper 노드 클릭 시 상세 패널에 보여줄 관련 질문
+    목록을 반환합니다. node_id는 "concept:{id}" 또는 "paper:{doc_id}" 형태."""
+    from services.knowledge_graph import get_related_questions
+    return {"questions": await get_related_questions(current_user, node_id)}
+
+
+@router.get("/library/graph/search")
+async def search_library_graph(q: str = "", current_user: str = Depends(get_current_user)):
+    """지식 그래프 탭 전용 통합 검색(논문/개념/메모/질문)입니다. 질문은
+    그래프 노드가 아니므로 매칭되면 그 질문이 연결된 concept/paper 노드로
+    대체 매핑됩니다."""
+    from services.knowledge_graph import search_graph_nodes
+    return await search_graph_nodes(current_user, q)
 
 
 @router.get("/library/{doc_id}")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -95,6 +95,16 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+        # chats 테이블 동적 스키마 마이그레이션 (graph_synced_at 컬럼 추가).
+        # 질문이 어떤 Concept과도 매칭되지 않는 것은 정상 케이스라
+        # question_concepts에 행이 없다는 사실만으로는 "아직 처리 안 됨"과
+        # "처리했지만 매칭 결과 없음"을 구분할 수 없다 - documents.metadata의
+        # graph_synced_at과 동일한 목적의 처리 완료 마커.
+        try:
+            cursor.execute("ALTER TABLE chats ADD COLUMN graph_synced_at TEXT")
+        except sqlite3.OperationalError:
+            pass
+
         # 6. app_meta 테이블 (자동 업데이트 확인 주기/마지막 확인 시각/마지막으로
         #    "업데이트 완료" 알림을 보여준 버전 등, 자주 바뀌는 앱 내부 상태를
         #    저장하는 범용 key-value 테이블)
@@ -185,6 +195,55 @@ def init_db():
         )
         """)
 
+        # 11. question_papers / question_concepts 테이블 (지식 그래프 2차: 질문
+        #     노드). 질문(chats.role='user' 행) 하나가 어떤 논문(들)에 대한
+        #     것인지는 다대다다 - 단일 논문 채팅은 1행이지만, 비교(compare)
+        #     채팅은 doc_id가 "cmp_"+hash 가상 id라 compare_sessions.doc_ids로
+        #     역매핑한 실제 문서마다 1행씩 생긴다. nullable FK 두 개를 두는
+        #     대신 다대다 정규화로 단일/비교 케이스를 동일한 구조로 다룬다.
+        #     question_concepts는 질문이 어떤 기존 Concept과 관련 있는지를
+        #     나타내며, 새 개념을 여기서 만들지 않고 이미 sync_document_for_graph가
+        #     추출해둔 개념 중에서만 고르는 폐쇄형 매칭이다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS question_papers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            doc_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+            UNIQUE(chat_id, doc_id)
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS question_concepts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            concept_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE,
+            FOREIGN KEY (concept_id) REFERENCES concepts (id) ON DELETE CASCADE,
+            UNIQUE(chat_id, concept_id)
+        )
+        """)
+
+        # 12. concept_edges 테이블 (지식 그래프 2차: AI Graph Linking). 의미가
+        #     유사한 Concept끼리의 비파괴적 연결(병합이 아니다 - LLM 판단만으로
+        #     결정하므로 오판이 나도 데이터 손실이 없도록 엣지만 추가한다).
+        #     대칭 관계라 (a,b)/(b,a) 중복이 생기지 않도록 삽입 시 항상
+        #     concept_id_a < concept_id_b로 정렬해서 저장한다(db_upsert_concept_edge).
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS concept_edges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            concept_id_a INTEGER NOT NULL,
+            concept_id_b INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (concept_id_a) REFERENCES concepts (id) ON DELETE CASCADE,
+            FOREIGN KEY (concept_id_b) REFERENCES concepts (id) ON DELETE CASCADE,
+            UNIQUE(concept_id_a, concept_id_b)
+        )
+        """)
+
         # 라이브러리 목록/문서 조회가 doc_id(+suffix)로 translations를,
         # doc_id로 documents/page_insights/chats를 매번 훑는데(문서 수 x
         # 페이지 수만큼 뻥튀기됨) 인덱스가 없어 전부 풀스캔이었다. 목록
@@ -198,6 +257,12 @@ def init_db():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_concepts_concept ON paper_concepts(concept_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_edges_a ON paper_edges(doc_id_a)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_edges_b ON paper_edges(doc_id_b)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_question_papers_doc ON question_papers(doc_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_question_papers_chat ON question_papers(chat_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_question_concepts_concept ON question_concepts(concept_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_question_concepts_chat ON question_concepts(chat_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_concept_edges_a ON concept_edges(concept_id_a)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_concept_edges_b ON concept_edges(concept_id_b)")
 
         conn.commit()
 
@@ -490,7 +555,11 @@ def db_bulk_translation_rows(doc_ids: List[str]) -> Dict[str, List[tuple]]:
 
 # ── 채팅 (Chats) ──────────────────────────────────────────────────────────────
 
-def db_save_chat_message(doc_id: str, role: str, content: str) -> None:
+def db_save_chat_message(doc_id: str, role: str, content: str) -> Optional[int]:
+    """저장된 chats 행의 id를 반환한다(지식 그래프 2차: Question 노드 연결에
+    필요한 chat_id를 얻기 위함). 직전 메시지와 완전히 동일해 저장을 건너뛰거나
+    이미 존재하는 경우 None을 반환하며, 이 반환값을 쓰지 않는 기존 호출부는
+    영향받지 않는다."""
     created_at = datetime.now(timezone.utc).isoformat()
     with get_db() as conn:
         cursor = conn.cursor()
@@ -501,13 +570,14 @@ def db_save_chat_message(doc_id: str, role: str, content: str) -> None:
         )
         last_msg = cursor.fetchone()
         if last_msg and last_msg["role"] == role and last_msg["content"] == content:
-            return
-            
+            return None
+
         cursor.execute(
             "INSERT INTO chats (doc_id, role, content, created_at) VALUES (?, ?, ?, ?)",
             (doc_id, role, content, created_at)
         )
         conn.commit()
+        return cursor.lastrowid
 
 def db_get_chat_history(doc_id: str) -> List[Dict[str, str]]:
     with get_db() as conn:
@@ -570,6 +640,18 @@ def db_upsert_compare_session(compare_id: str, username: str, doc_ids: List[str]
             (compare_id, username, doc_ids_json, now, now)
         )
         conn.commit()
+
+
+def db_get_compare_doc_ids(compare_id: str) -> List[str]:
+    """비교 세션 가상 id(cmp_+hash)를 실제 문서 id 목록으로 역매핑한다.
+    이 해시는 단방향이라 compare_sessions 테이블 조회 없이는 복원할 수 없다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT doc_ids FROM compare_sessions WHERE id = ?", (compare_id,))
+        row = cursor.fetchone()
+        if not row:
+            return []
+        return json.loads(row["doc_ids"])
 
 
 def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
@@ -782,6 +864,257 @@ def db_get_paper_edges_for_docs(doc_ids: List[str]) -> List[Dict[str, Any]]:
             row["detail"] = json.loads(row["detail"]) if row["detail"] else None
             edges.append(row)
         return edges
+
+
+def db_upsert_concept_edge(concept_id_x: int, concept_id_y: int) -> None:
+    """의미가 유사한 두 Concept을 비파괴적으로 연결한다(병합 아님). 대칭
+    관계이므로 (a,b)/(b,a) 중복이 생기지 않도록 항상 작은 id를 concept_id_a로
+    정렬해서 저장한다."""
+    if concept_id_x == concept_id_y:
+        return
+    concept_id_a, concept_id_b = sorted([concept_id_x, concept_id_y])
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO concept_edges (concept_id_a, concept_id_b, created_at) VALUES (?, ?, ?)",
+            (concept_id_a, concept_id_b, created_at)
+        )
+        conn.commit()
+
+
+def db_get_concept_edges_for_concepts(concept_ids: List[int]) -> List[Dict[str, Any]]:
+    """양쪽 concept_id가 모두 주어진 집합에 속하는 유사 개념 엣지만 반환한다
+    (다른 사용자 소유 문서에서만 등장하는 개념으로 향하는 엣지가 섞이지
+    않도록, 호출부에서 concept_ids를 "이 사용자의 그래프에 실제로 등장하는
+    concept id 목록"으로 제한해서 넘겨야 한다)."""
+    if not concept_ids:
+        return []
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in concept_ids)
+        cursor.execute(
+            f"""
+            SELECT concept_id_a, concept_id_b
+            FROM concept_edges
+            WHERE concept_id_a IN ({placeholders}) AND concept_id_b IN ({placeholders})
+            """,
+            concept_ids + concept_ids
+        )
+        return [dict(r) for r in cursor.fetchall()]
+
+
+# ── 지식 그래프 (질문 노드) ──────────────────────────────────────────────────
+
+def db_link_question_paper(chat_id: int, doc_id: str) -> None:
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO question_papers (chat_id, doc_id, created_at) VALUES (?, ?, ?)",
+            (chat_id, doc_id, created_at)
+        )
+        conn.commit()
+
+
+def db_link_question_concept(chat_id: int, concept_id: int) -> None:
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO question_concepts (chat_id, concept_id, created_at) VALUES (?, ?, ?)",
+            (chat_id, concept_id, created_at)
+        )
+        conn.commit()
+
+
+def db_mark_question_synced(chat_id: int) -> None:
+    synced_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("UPDATE chats SET graph_synced_at = ? WHERE id = ?", (synced_at, chat_id))
+        conn.commit()
+
+
+def db_get_unsynced_questions(doc_ids: List[str], limit: int = 20) -> List[Dict[str, Any]]:
+    """주어진 문서들에 속한 질문(role='user') 중 아직 개념 매칭이 안 된
+    것을 오래된 순으로 최대 limit개 반환한다. 비교 세션 채팅은 doc_id가
+    documents 테이블에 없는 가상 id(cmp_...)라 이 함수의 doc_ids 스캔에는
+    잡히지 않는다 - 비교 채팅의 backfill은 compare_sessions를 별도로
+    순회해야 하며, 지식 그래프 조회 시점 backfill(get_graph_data)은
+    사용자 소유 문서 기준으로만 동작하므로 범위 밖이다."""
+    if not doc_ids:
+        return []
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in doc_ids)
+        cursor.execute(
+            f"""
+            SELECT id, doc_id, content
+            FROM chats
+            WHERE doc_id IN ({placeholders}) AND role = 'user' AND graph_synced_at IS NULL
+            ORDER BY id ASC
+            LIMIT ?
+            """,
+            doc_ids + [limit]
+        )
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def db_get_question_count_for_concepts(concept_ids: List[int]) -> Dict[int, int]:
+    if not concept_ids:
+        return {}
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in concept_ids)
+        cursor.execute(
+            f"""
+            SELECT concept_id, COUNT(*) AS cnt
+            FROM question_concepts
+            WHERE concept_id IN ({placeholders})
+            GROUP BY concept_id
+            """,
+            concept_ids
+        )
+        return {r["concept_id"]: r["cnt"] for r in cursor.fetchall()}
+
+
+def db_get_related_questions_for_concept(concept_id: int, limit: int = 50) -> List[Dict[str, Any]]:
+    """이 Concept과 연결된 질문들을 최신순으로 반환한다(소속 논문 제목 포함)."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT c.content, c.created_at, d.id AS doc_id, d.filename, d.metadata
+            FROM question_concepts qc
+            JOIN chats c ON c.id = qc.chat_id
+            LEFT JOIN question_papers qp ON qp.chat_id = c.id
+            LEFT JOIN documents d ON d.id = qp.doc_id
+            WHERE qc.concept_id = ?
+            ORDER BY c.id DESC
+            LIMIT ?
+            """,
+            (concept_id, limit)
+        )
+        results = []
+        for r in cursor.fetchall():
+            row = dict(r)
+            metadata = json.loads(row["metadata"]) if row.get("metadata") else {}
+            results.append({
+                "content": row["content"],
+                "created_at": row["created_at"],
+                "doc_id": row.get("doc_id"),
+                "doc_title": metadata.get("title") or row.get("filename"),
+            })
+        return results
+
+
+def db_get_related_questions_for_doc(doc_id: str, limit: int = 50) -> List[Dict[str, Any]]:
+    """이 논문에 대해 오간 질문들을 최신순으로 반환한다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT c.content, c.created_at
+            FROM question_papers qp
+            JOIN chats c ON c.id = qp.chat_id
+            WHERE qp.doc_id = ?
+            ORDER BY c.id DESC
+            LIMIT ?
+            """,
+            (doc_id, limit)
+        )
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def db_get_all_concepts() -> List[Dict[str, Any]]:
+    """전체 개념 목록을 반환한다. concepts 테이블은 normalized_name으로만
+    전역 중복 제거되며(사용자별로 분리되지 않음, paper_concepts를 통해 어떤
+    문서에 연결됐는지로만 사용자 범위가 결정된다), AI Graph Linking(새 개념과
+    기존 개념의 유사도 비교)에 필요한 "기존 개념 전체 이름 목록"을 얻기 위해
+    쓰인다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, name, normalized_name FROM concepts")
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def db_search_graph_nodes(doc_ids: List[str], query: str) -> Dict[str, List[str]]:
+    """이 사용자가 소유한 doc_ids 범위 안에서 논문/개념/메모(Note)/질문을
+    검색해 매칭된 그래프 노드 id를 타입별로 반환한다. 질문은 그래프 노드가
+    아니므로, 매칭되면 그 질문이 연결된 concept/paper 노드로 대체 매핑한다."""
+    if not doc_ids or not (query or "").strip():
+        return {"paper": [], "concept": [], "note": []}
+
+    like_query = f"%{_escape_like(query)}%"
+    needle = query.strip().lower()
+    paper_ids: set = set()
+    concept_ids: set = set()
+    note_ids: set = set()
+
+    with get_db() as conn:
+        cursor = conn.cursor()
+        placeholders = ",".join("?" for _ in doc_ids)
+
+        cursor.execute(
+            f"""
+            SELECT id FROM documents
+            WHERE id IN ({placeholders})
+              AND (filename LIKE ? ESCAPE '\\' OR metadata LIKE ? ESCAPE '\\')
+            """,
+            doc_ids + [like_query, like_query]
+        )
+        paper_ids.update(r["id"] for r in cursor.fetchall())
+
+        cursor.execute(
+            f"""
+            SELECT DISTINCT c.id FROM concepts c
+            JOIN paper_concepts pc ON pc.concept_id = c.id
+            WHERE pc.doc_id IN ({placeholders}) AND c.name LIKE ? ESCAPE '\\'
+            """,
+            doc_ids + [like_query]
+        )
+        concept_ids.update(r["id"] for r in cursor.fetchall())
+
+        cursor.execute(
+            f"SELECT doc_id, data FROM memos WHERE doc_id IN ({placeholders}) AND data LIKE ? ESCAPE '\\'",
+            doc_ids + [like_query]
+        )
+        for r in cursor.fetchall():
+            try:
+                blob = json.loads(r["data"])
+            except (TypeError, ValueError):
+                continue
+            for items in (blob or {}).values():
+                for item in items or []:
+                    if not isinstance(item, dict):
+                        continue
+                    if needle in (item.get("text") or "").lower() and item.get("id"):
+                        note_ids.add(f"{r['doc_id']}:{item['id']}")
+
+        cursor.execute(
+            f"SELECT id FROM chats WHERE doc_id IN ({placeholders}) AND role = 'user' AND content LIKE ? ESCAPE '\\'",
+            doc_ids + [like_query]
+        )
+        chat_ids = [r["id"] for r in cursor.fetchall()]
+        if chat_ids:
+            chat_placeholders = ",".join("?" for _ in chat_ids)
+            cursor.execute(
+                f"SELECT DISTINCT doc_id FROM question_papers WHERE chat_id IN ({chat_placeholders})",
+                chat_ids
+            )
+            paper_ids.update(r["doc_id"] for r in cursor.fetchall())
+            cursor.execute(
+                f"SELECT DISTINCT concept_id FROM question_concepts WHERE chat_id IN ({chat_placeholders})",
+                chat_ids
+            )
+            concept_ids.update(r["concept_id"] for r in cursor.fetchall())
+
+    return {
+        "paper": [f"paper:{d}" for d in paper_ids],
+        "concept": [f"concept:{c}" for c in concept_ids],
+        "note": [f"note:{n}" for n in note_ids],
+    }
 
 
 # ── 메모 / 하이라이트 서버 미러 ───────────────────────────────────────────────

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -1,11 +1,18 @@
 """
 개인 지식 그래프(Knowledge Graph) 오케스트레이션.
 
-논문(Paper) 노드, LLM이 추출한 개념(Concept) 노드, 그리고 두 종류의 엣지
-(인용 citation / 카테고리 category)로 구성된 그래프를 만든다.
+논문(Paper)/개념(Concept)/메모(Note) 노드와, 인용(citation)/카테고리(category)/
+개념 보유(has_concept)/유사 개념(similar_to)/메모 소속(notes_on) 엣지로
+구성된 그래프를 만든다. 질문(Question)은 그래프 캔버스에는 그리지 않는다 -
+채팅이 많은 사용자는 수백 개가 쌓일 수 있어 노드로 표시하면 그래프가
+지저분해지므로, Concept/Paper 노드 클릭 시 상세 패널에 "관련 질문" 목록으로만
+노출한다(get_related_questions).
 
 - 개념 노드: 번역 완료 시(translation_job.py) 한 번 LLM으로 추출해
   concepts/paper_concepts 테이블에 영구 저장한다(sync_document_for_graph).
+  새로 만들어진 개념은 그 자리에서 기존 개념 전체와 LLM으로 비교해, 의미가
+  사실상 같은 것이 있으면 concept_edges에 비파괴적으로 연결한다(AI Graph
+  Linking - 병합이 아니라 엣지 추가라 오판이 나도 데이터 손실이 없다).
 - 인용 엣지: 참고문헌 파싱 + 라이브러리 내 텍스트 매칭(primer.py의
   _match_library_references 재사용)으로 계산해 paper_edges에 영구 저장한다.
   라이브러리 전체를 스캔하는 매칭이라 요청마다 다시 돌리기엔 비용이 있고,
@@ -15,11 +22,15 @@
   카테고리 리스트만 비교하면 되는 저렴한 연산인 반면, 저장해두면 논문이
   나중에 재분류될 때마다 이전 엣지를 무효화하는 로직이 추가로 필요해진다.
   "비용 대비 정합성 유지 부담"을 저울질했을 때 인용 엣지와는 반대 선택.
+- 질문-개념 연결: 채팅 응답이 저장된 직후(chat.py) 해당 질문이 그 논문(들)의
+  기존 개념 중 무엇과 관련 있는지 폐쇄형으로 분류한다(새 개념을 만들지 않음).
+- Note 노드: 이미 서버 DB에 미러링된 memos 테이블을 그대로 노출한다(LLM
+  호출 불필요 - 순수 데이터 노출).
 """
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +38,13 @@ logger = logging.getLogger(__name__)
 # 백그라운드로 백필한다. 같은 문서에 대해 중복으로 백필 태스크가 여러 개
 # 뜨는 것을 막기 위한 in-flight 집합.
 _syncing: set = set()
+
+# 질문(chats.role='user') 배치 백필용 in-flight 집합(chat_id 단위).
+_syncing_questions: set = set()
+
+# 그래프 조회 시점에 한 번에 처리할 미동기화 질문 상한 - 오래된 질문이 아주
+# 많이 쌓여도 그래프 조회 한 번에 LLM 호출이 무한정 늘어나지 않도록 방지.
+_QUESTION_BACKFILL_BATCH_SIZE = 20
 
 
 async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> None:
@@ -39,17 +57,41 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
         return
     username = doc["username"]
 
-    from services.llm_client import extract_paper_concepts
-    from services.db import db_upsert_concept, db_link_paper_concept
+    from services.llm_client import extract_paper_concepts, find_similar_concepts
+    from services.db import db_upsert_concept, db_link_paper_concept, db_get_all_concepts, db_upsert_concept_edge
     concepts = await extract_paper_concepts(
         doc_title, "\n".join(p.get("text", "") for p in pages[:2]), session_id=doc_id
     )
+
+    # AI Graph Linking: 새로 만들어진 개념만, 그 시점까지의 전체 개념 이름과
+    # 비교해 유사한 것이 있으면 연결한다. 개념 하나당 LLM 호출 1회로 비용을
+    # 제한한다(쌍마다 호출하지 않음). 같은 배치 안에서 먼저 처리된 개념도
+    # existing_by_normalized에 누적되므로, 한 논문에서 유사/중복 개념이 여러 개
+    # 추출된 경우도 자연히 연결된다.
+    existing_by_normalized = {c["normalized_name"]: c for c in db_get_all_concepts()}
+
     for c in concepts:
         name = (c.get("concept") or "").strip()
         if not name:
             continue
-        concept_id = db_upsert_concept(name, name.lower(), c.get("kind"))
+        normalized = name.lower()
+        is_new = normalized not in existing_by_normalized
+        concept_id = db_upsert_concept(name, normalized, c.get("kind"))
         db_link_paper_concept(doc_id, concept_id)
+
+        if is_new and existing_by_normalized:
+            try:
+                candidate_names = [c2["name"] for c2 in existing_by_normalized.values()]
+                matches = await find_similar_concepts(name, candidate_names, session_id=doc_id)
+                for m in matches:
+                    matched_name = (m.get("concept") or "").strip()
+                    matched = existing_by_normalized.get(matched_name.lower())
+                    if matched:
+                        db_upsert_concept_edge(concept_id, matched["id"])
+            except Exception:
+                pass  # 유사 개념 탐색 실패는 조용히 무시한다 - 부가 정보일 뿐
+
+        existing_by_normalized[normalized] = {"id": concept_id, "name": name, "normalized_name": normalized}
 
     try:
         from services.reference_parser import extract_reference_list
@@ -65,6 +107,55 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
     meta = doc.get("metadata", {})
     meta["graph_synced_at"] = datetime.now(timezone.utc).isoformat()
     update_document_metadata(doc_id, meta)
+
+
+async def sync_question_for_graph(chat_id: int, doc_id_or_compare_id: str, question_text: str) -> None:
+    """채팅 응답 저장 직후 호출되어, 이 질문이 어떤 논문(들)에 대한 것인지
+    연결하고(question_papers), 그 논문(들)에 이미 추출된 개념 중 무엇과
+    관련 있는지 폐쇄형으로 분류해 연결한다(question_concepts). 새 개념을
+    만들지 않는다 - 개념 추출은 sync_document_for_graph의 몫이다.
+    실패해도 채팅 응답 자체에는 영향 없도록 호출부(routers/chat.py)에서
+    fire-and-forget(asyncio.create_task)으로 호출하고 예외를 삼킨다."""
+    from services.db import (
+        db_get_compare_doc_ids, db_link_question_paper, db_get_concepts_for_docs,
+        db_link_question_concept, db_mark_question_synced,
+    )
+
+    if doc_id_or_compare_id.startswith("cmp_"):
+        doc_ids = db_get_compare_doc_ids(doc_id_or_compare_id)
+    else:
+        doc_ids = [doc_id_or_compare_id]
+
+    if not doc_ids:
+        db_mark_question_synced(chat_id)
+        return
+
+    for doc_id in doc_ids:
+        db_link_question_paper(chat_id, doc_id)
+
+    concept_links = db_get_concepts_for_docs(doc_ids)
+    if concept_links:
+        from services.llm_client import match_question_to_concepts
+        seen_concept_ids = set()
+        concept_by_name = {}
+        for link in concept_links:
+            if link["concept_id"] not in seen_concept_ids:
+                seen_concept_ids.add(link["concept_id"])
+                concept_by_name[link["name"].lower()] = link["concept_id"]
+
+        try:
+            matches = await match_question_to_concepts(
+                question_text, list({link["name"] for link in concept_links}), session_id=chat_id
+            )
+            for m in matches:
+                matched_name = (m.get("concept") or "").strip().lower()
+                concept_id = concept_by_name.get(matched_name)
+                if concept_id:
+                    db_link_question_concept(chat_id, concept_id)
+        except Exception:
+            pass  # 질문-개념 매칭 실패는 조용히 무시한다 - 부가 정보일 뿐
+
+    db_mark_question_synced(chat_id)
 
 
 async def _backfill_one(doc_id: str) -> None:
@@ -94,6 +185,43 @@ async def _backfill_one(doc_id: str) -> None:
         logger.warning(f"지식 그래프 백필 실패 (doc_id={doc_id}): {e}")
     finally:
         _syncing.discard(doc_id)
+
+
+async def _backfill_question(chat_id: int, doc_id: str, content: str) -> None:
+    try:
+        await sync_question_for_graph(chat_id, doc_id, content)
+    except Exception as e:
+        logger.warning(f"질문 지식 그래프 백필 실패 (chat_id={chat_id}): {e}")
+    finally:
+        _syncing_questions.discard(chat_id)
+
+
+def _queue_note_nodes(doc_ids: List[str], nodes: list, edges: list) -> None:
+    """이 사용자 소유 문서들의 메모(memos)를 Note 노드로 노출한다. LLM 호출이
+    필요 없는 순수 데이터 노출이라 백필/pending 개념이 없다 - annotations/memos
+    서버 미러(1차)가 이미 최신 상태를 best-effort로 유지하고 있으므로 그걸
+    그대로 읽기만 한다."""
+    from services.db import db_get_memos
+    for doc_id in doc_ids:
+        mirrored = db_get_memos(doc_id)
+        if not mirrored or not mirrored.get("data"):
+            continue
+        for items in mirrored["data"].values():
+            for item in items or []:
+                if not isinstance(item, dict) or not item.get("id"):
+                    continue
+                note_id = f"note:{doc_id}:{item['id']}"
+                nodes.append({
+                    "id": note_id,
+                    "type": "note",
+                    "label": (item.get("text") or "")[:80],
+                    "doc_id": doc_id,
+                })
+                edges.append({
+                    "source": note_id,
+                    "target": f"paper:{doc_id}",
+                    "type": "notes_on",
+                })
 
 
 async def get_graph_data(username: str) -> dict:
@@ -151,8 +279,8 @@ async def get_graph_data(username: str) -> dict:
             "type": "citation",
         })
 
-    # 개념 노드/엣지
-    from services.db import db_get_concepts_for_docs
+    # 개념 노드/엣지 (+ 질문 연결 수)
+    from services.db import db_get_concepts_for_docs, db_get_question_count_for_concepts, db_get_concept_edges_for_concepts
     concept_links = db_get_concepts_for_docs(doc_ids)
     seen_concept_ids = set()
     for link in concept_links:
@@ -171,9 +299,26 @@ async def get_graph_data(username: str) -> dict:
             "type": "has_concept",
         })
 
-    # 아직 개념/인용 동기화가 안 된 문서는 pending으로 표시하고, 백그라운드로
-    # 백필을 걸어둔다(fire-and-forget - 이번 응답에는 반영되지 않고, 클라이언트가
-    # 잠시 뒤 다시 조회하면 반영된다).
+    concept_id_list = list(seen_concept_ids)
+    question_counts = db_get_question_count_for_concepts(concept_id_list)
+    for node in nodes:
+        if node["type"] == "concept":
+            node["question_count"] = question_counts.get(int(node["id"].split(":", 1)[1]), 0)
+
+    # AI Graph Linking: 유사 개념 엣지(비파괴적, 병합 아님)
+    for e in db_get_concept_edges_for_concepts(concept_id_list):
+        edges.append({
+            "source": f"concept:{e['concept_id_a']}",
+            "target": f"concept:{e['concept_id_b']}",
+            "type": "similar_to",
+        })
+
+    # Note 노드: LLM 호출 불필요, memos 서버 미러를 그대로 노출.
+    _queue_note_nodes(doc_ids, nodes, edges)
+
+    # 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서는 pending으로
+    # 표시하고, 백그라운드로 백필을 걸어둔다(fire-and-forget - 이번 응답에는
+    # 반영되지 않고, 클라이언트가 잠시 뒤 다시 조회하면 반영된다).
     pending_docs = []
     for doc in docs:
         if (doc.get("metadata", {}) or {}).get("graph_synced_at"):
@@ -184,8 +329,49 @@ async def get_graph_data(username: str) -> dict:
         _syncing.add(doc["id"])
         asyncio.create_task(_backfill_one(doc["id"]))
 
+    # 아직 개념 매칭이 안 된 질문 배치 백필(오래된 것부터, 상한 있음).
+    from services.db import db_get_unsynced_questions
+    for q in db_get_unsynced_questions(doc_ids, limit=_QUESTION_BACKFILL_BATCH_SIZE):
+        if q["id"] in _syncing_questions:
+            continue
+        _syncing_questions.add(q["id"])
+        asyncio.create_task(_backfill_question(q["id"], q["doc_id"], q["content"]))
+
     return {
         "nodes": nodes,
         "edges": edges,
         "pending_docs": pending_docs,
     }
+
+
+async def get_related_questions(username: str, node_id: str) -> List[dict]:
+    """상세 패널에서 Concept/Paper 노드를 클릭했을 때 보여줄 관련 질문 목록을
+    반환한다. node_id는 "concept:{id}" 또는 "paper:{doc_id}" 형태. 다른
+    사용자 데이터가 섞이지 않도록, concept 조회는 이 사용자가 소유한 문서
+    범위로 한 번 더 필터링한다."""
+    from services.library import list_documents
+    owned_doc_ids = {d["id"] for d in list_documents(username=username)}
+
+    if node_id.startswith("paper:"):
+        doc_id = node_id.split(":", 1)[1]
+        if doc_id not in owned_doc_ids:
+            return []
+        from services.db import db_get_related_questions_for_doc
+        return db_get_related_questions_for_doc(doc_id)
+
+    if node_id.startswith("concept:"):
+        concept_id = int(node_id.split(":", 1)[1])
+        from services.db import db_get_related_questions_for_concept
+        questions = db_get_related_questions_for_concept(concept_id)
+        return [q for q in questions if q.get("doc_id") in owned_doc_ids]
+
+    return []
+
+
+async def search_graph_nodes(username: str, query: str) -> dict:
+    """이 사용자가 소유한 범위 안에서 논문/개념/메모/질문을 검색해 매칭된
+    그래프 노드 id를 반환한다."""
+    from services.library import list_documents
+    from services.db import db_search_graph_nodes
+    doc_ids = [d["id"] for d in list_documents(username=username)]
+    return db_search_graph_nodes(doc_ids, query)

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2190,15 +2190,64 @@ def _parse_json_array_response(raw: str) -> list:
     return parsed
 
 
+async def _llm_json_array_with_retry(prompt: str, session_id: str = None, attempts: int = 3, log_label: str = "LLM JSON 배열 응답") -> list:
+    """공용: 프롬프트를 보내 JSON 배열 응답을 받아 파싱까지 재시도한다
+    (extract_paper_concepts/match_question_to_concepts/find_similar_concepts가
+    공유하는 멀티 프로바이더 분기 + 재시도 로직). LLM이 마크다운 펜스를
+    씌우거나 출력이 중간에 잘리면 파싱이 깨지기 쉬워서 최대 `attempts`회
+    재시도하고, 모두 실패해도 예외를 던지지 않고 빈 리스트를 반환한다 -
+    이 계열 기능은 전부 부가 정보일 뿐이라 파이프라인 자체를 막아서는 안 된다."""
+    messages = [{"role": "user", "content": prompt}]
+    provider = get_trans_provider()
+    model = get_trans_model()
+
+    for attempt in range(attempts):
+        tokens = []
+        try:
+            if provider == "openai":
+                async for token in stream_openai(messages, model=model, temperature=0.1):
+                    tokens.append(token)
+            elif provider == "gemini":
+                async for token in stream_gemini(messages, model=model, temperature=0.1):
+                    tokens.append(token)
+            elif provider == "claude":
+                async for token in stream_claude(messages, model=model, temperature=0.1):
+                    tokens.append(token)
+            elif provider == "antigravity":
+                async for token in stream_antigravity(prompt, model=model, session_id=session_id):
+                    tokens.append(token)
+            elif provider == "claude_code":
+                async for token in stream_claude_code(prompt, model=model, session_id=session_id):
+                    tokens.append(token)
+            elif provider == "codex":
+                async for token in stream_codex(prompt, model=model, session_id=session_id):
+                    tokens.append(token)
+            else:
+                # Fallback to Ollama chat api
+                payload = {
+                    "model": model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"temperature": 0.1}
+                }
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
+                    if response.status_code == 200:
+                        data = response.json()
+                        tokens.append(data.get("message", {}).get("content", ""))
+
+            raw = "".join(tokens).strip()
+            return _parse_json_array_response(raw)
+        except Exception as e:
+            logger.warning(f"{log_label} 파싱 실패 (시도 {attempt + 1}/{attempts}): {e}")
+            continue
+
+    return []
+
+
 async def extract_paper_concepts(title: str, text: str, session_id: str = None) -> List[dict]:
     """논문 제목과 서두 텍스트에서 핵심 개념 3~7개를 추출한다.
-    반환값: [{"concept": str, "kind": str|None}, ...]
-
-    classify_paper_category와 달리 결과를 JSON으로 파싱해야 하는데, LLM이
-    마크다운 펜스를 씌우거나 출력이 중간에 잘리면 파싱이 깨지기 쉬워서 최대
-    3회까지 재시도한다. 3회 모두 실패해도 예외를 던지지 않고 빈 리스트를
-    반환한다 - classify_paper_category와 동일하게 이 기능은 부가 정보일 뿐
-    번역 파이프라인 자체를 실패시켜서는 안 된다."""
+    반환값: [{"concept": str, "kind": str|None}, ...]"""
     prompt = f"""You are an academic paper analyst. Analyze the following paper title and beginning text (abstract/introduction) and extract 3 to 7 core concepts (methods, tasks, datasets, metrics, or theories) discussed in the paper.
 
 Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "concept" key (the concept name, in a few words) and a "kind" key (one of: "method", "task", "dataset", "metric", "theory", or null if unclear).
@@ -2211,59 +2260,47 @@ Beginning Text:
 {text[:2000]}
 
 JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="논문 개념 추출")
 
-    messages = [
-        {"role": "user", "content": prompt}
-    ]
 
-    provider = get_trans_provider()
-    model = get_trans_model()
-
-    try:
-        for attempt in range(3):
-            tokens = []
-            try:
-                if provider == "openai":
-                    async for token in stream_openai(messages, model=model, temperature=0.1):
-                        tokens.append(token)
-                elif provider == "gemini":
-                    async for token in stream_gemini(messages, model=model, temperature=0.1):
-                        tokens.append(token)
-                elif provider == "claude":
-                    async for token in stream_claude(messages, model=model, temperature=0.1):
-                        tokens.append(token)
-                elif provider == "antigravity":
-                    async for token in stream_antigravity(prompt, model=model, session_id=session_id):
-                        tokens.append(token)
-                elif provider == "claude_code":
-                    async for token in stream_claude_code(prompt, model=model, session_id=session_id):
-                        tokens.append(token)
-                elif provider == "codex":
-                    async for token in stream_codex(prompt, model=model, session_id=session_id):
-                        tokens.append(token)
-                else:
-                    # Fallback to Ollama chat api
-                    payload = {
-                        "model": model,
-                        "messages": messages,
-                        "stream": False,
-                        "options": {"temperature": 0.1}
-                    }
-                    async with httpx.AsyncClient(timeout=30.0) as client:
-                        response = await client.post(f"{get_ollama_host()}/api/chat", json=payload)
-                        if response.status_code == 200:
-                            data = response.json()
-                            tokens.append(data.get("message", {}).get("content", ""))
-
-                raw = "".join(tokens).strip()
-                parsed = _parse_json_array_response(raw)
-                return parsed
-            except Exception as e:
-                logger.warning(f"논문 개념 추출 파싱 실패 (시도 {attempt + 1}/3): {e}")
-                continue
-    except Exception as e:
-        logger.warning(f"논문 개념 추출 실패: {e}")
+async def match_question_to_concepts(question: str, concept_names: List[str], session_id: str = None) -> List[dict]:
+    """질문이 주어진 기존 개념 목록 중 어떤 것과 관련 있는지 고른다(폐쇄형
+    분류 - 새 개념을 만들지 않는다. concept_names에 없는 이름을 만들어내면
+    안 된다는 것을 프롬프트로 명시한다). 반환값: [{"concept": str}, ...]
+    (concept_names의 부분집합)."""
+    if not concept_names:
         return []
+    names_list = "\n".join(f"- {n}" for n in concept_names)
+    prompt = f"""You are an academic assistant. A user asked the following question about a paper. From the list of concepts already identified for this paper, pick ONLY the ones this question is actually about. Do not invent new concepts - only choose from the given list, and if none apply, return an empty array.
 
-    return []
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "concept" key whose value is copied EXACTLY (verbatim) from the list below.
+
+Concept List:
+{names_list}
+
+Question: {question}
+
+JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="질문-개념 매칭")
+
+
+async def find_similar_concepts(new_name: str, existing_names: List[str], session_id: str = None) -> List[dict]:
+    """new_name과 의미상 사실상 같은 개념(동의어/약어 관계 등, 예: "LLM"과
+    "Large Language Model")을 existing_names 중에서 고른다. 느슨하게 관련된
+    정도로는 고르지 않고, 정말 같은 개념을 가리키는 경우만 선택하도록
+    프롬프트에 명시한다. 반환값: [{"concept": str}, ...] (existing_names의 부분집합)."""
+    if not existing_names:
+        return []
+    names_list = "\n".join(f"- {n}" for n in existing_names)
+    prompt = f"""You are an academic terminology expert. Given a new concept name and a list of existing concept names, identify ONLY the existing names that refer to the EXACT SAME concept as the new one (synonyms, abbreviations, or equivalent phrasing - e.g. "LLM" and "Large Language Model"). Do not include merely related-but-distinct concepts. If none match, return an empty array.
+
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "concept" key whose value is copied EXACTLY (verbatim) from the existing list below.
+
+New Concept: {new_name}
+
+Existing Concepts:
+{names_list}
+
+JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="유사 개념 탐색")
 

--- a/backend/tests/test_knowledge_graph_v2.py
+++ b/backend/tests/test_knowledge_graph_v2.py
@@ -1,0 +1,237 @@
+"""지식 그래프 2차(Question 노드 / Note 노드 / Node Search / AI Graph Linking)
+회귀 테스트. test_library_graph_api.py와 동일한 fixture 패턴(test_client/
+isolated_dirs)을 사용한다.
+"""
+import pytest
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str, metadata: dict = None):
+    db = isolated_dirs["db"]
+    meta = metadata if metadata is not None else {"title": f"{doc_id} title"}
+    db.db_save_document(doc_id, username, f"{doc_id}.pdf", "/x/nonexistent.pdf", 3, meta)
+
+
+# ── Question → Concept 매칭 ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_sync_question_for_graph_links_single_doc(isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+    from services import db
+
+    _create_doc_owned_by(isolated_dirs, "doc-q-1", "testuser", {"title": "Paper Q1"})
+    concept_id = db.db_upsert_concept("Sharpness Aware Minimization", "sharpness aware minimization", "method")
+    db.db_link_paper_concept("doc-q-1", concept_id)
+
+    chat_id = db.db_save_chat_message("doc-q-1", "user", "Why does SAM improve generalization?")
+    assert chat_id is not None
+
+    async def fake_match(question, concept_names, session_id=None):
+        assert "Sharpness Aware Minimization" in concept_names
+        return [{"concept": "Sharpness Aware Minimization"}]
+
+    monkeypatch.setattr(llm_client, "match_question_to_concepts", fake_match)
+
+    await knowledge_graph.sync_question_for_graph(chat_id, "doc-q-1", "Why does SAM improve generalization?")
+
+    with db.get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT graph_synced_at FROM chats WHERE id = ?", (chat_id,))
+        assert cursor.fetchone()["graph_synced_at"] is not None
+
+    linked_concepts = db.db_get_related_questions_for_concept(concept_id)
+    assert any(q["content"] == "Why does SAM improve generalization?" for q in linked_concepts)
+
+    papers = db.db_get_related_questions_for_doc("doc-q-1")
+    assert any(q["content"] == "Why does SAM improve generalization?" for q in papers)
+
+
+@pytest.mark.asyncio
+async def test_sync_question_for_graph_resolves_compare_session(isolated_dirs, monkeypatch):
+    """비교 세션의 가상 doc_id(cmp_...)는 compare_sessions를 통해 실제 문서
+    id 목록으로 역매핑되어, 각 문서마다 question_papers 행이 생겨야 한다."""
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+    from services import db
+
+    _create_doc_owned_by(isolated_dirs, "doc-cmp-a", "testuser", {"title": "Paper A"})
+    _create_doc_owned_by(isolated_dirs, "doc-cmp-b", "testuser", {"title": "Paper B"})
+    compare_id = "cmp_testhash"
+    db.db_upsert_compare_session(compare_id, "testuser", ["doc-cmp-a", "doc-cmp-b"])
+
+    chat_id = db.db_save_chat_message(compare_id, "user", "Compare these two papers")
+    assert chat_id is not None
+
+    async def fake_match(question, concept_names, session_id=None):
+        return []
+
+    monkeypatch.setattr(llm_client, "match_question_to_concepts", fake_match)
+
+    await knowledge_graph.sync_question_for_graph(chat_id, compare_id, "Compare these two papers")
+
+    assert any(q["content"] == "Compare these two papers" for q in db.db_get_related_questions_for_doc("doc-cmp-a"))
+    assert any(q["content"] == "Compare these two papers" for q in db.db_get_related_questions_for_doc("doc-cmp-b"))
+
+
+@pytest.mark.asyncio
+async def test_sync_question_for_graph_skips_llm_when_no_concepts_yet(isolated_dirs, monkeypatch):
+    """해당 논문에 아직 추출된 개념이 없으면 매칭 LLM 호출 자체를 하지 않고
+    question_papers 연결만 하고 넘어가야 한다(다음 backfill 때 다시 시도됨)."""
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+    from services import db
+
+    _create_doc_owned_by(isolated_dirs, "doc-q-noconcepts", "testuser", {"title": "No concepts yet"})
+    chat_id = db.db_save_chat_message("doc-q-noconcepts", "user", "What is this paper about?")
+
+    called = {"n": 0}
+
+    async def fake_match(question, concept_names, session_id=None):
+        called["n"] += 1
+        return []
+
+    monkeypatch.setattr(llm_client, "match_question_to_concepts", fake_match)
+    await knowledge_graph.sync_question_for_graph(chat_id, "doc-q-noconcepts", "What is this paper about?")
+
+    assert called["n"] == 0
+    assert any(q["content"] == "What is this paper about?" for q in db.db_get_related_questions_for_doc("doc-q-noconcepts"))
+
+
+# ── AI Graph Linking (concept_edges) ────────────────────────────────────
+
+def test_concept_edge_is_symmetric_and_deduplicated(isolated_dirs):
+    db = isolated_dirs["db"]
+    id_a = db.db_upsert_concept("LLM", "llm", "concept")
+    id_b = db.db_upsert_concept("Large Language Model", "large language model", "concept")
+
+    db.db_upsert_concept_edge(id_a, id_b)
+    db.db_upsert_concept_edge(id_b, id_a)  # 반대 순서로 다시 넣어도 중복 생성되면 안 됨
+
+    edges = db.db_get_concept_edges_for_concepts([id_a, id_b])
+    assert len(edges) == 1
+    assert {edges[0]["concept_id_a"], edges[0]["concept_id_b"]} == {id_a, id_b}
+
+
+def test_concept_edge_self_loop_is_noop(isolated_dirs):
+    db = isolated_dirs["db"]
+    concept_id = db.db_upsert_concept("Diffusion", "diffusion", "concept")
+    db.db_upsert_concept_edge(concept_id, concept_id)
+    assert db.db_get_concept_edges_for_concepts([concept_id]) == []
+
+
+# ── Note 노드 (memos) ────────────────────────────────────────────────────
+
+def test_graph_endpoint_includes_note_nodes_from_memos(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-note-1", "testuser",
+        {"title": "Paper With Memo", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    db.db_put_memos("doc-note-1", {"page_1": [{"id": "memo-abc", "text": "Figure 4가 핵심"}]})
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+
+    note_nodes = [n for n in data["nodes"] if n["type"] == "note"]
+    assert any(n["id"] == "note:doc-note-1:memo-abc" for n in note_nodes)
+
+    notes_on_edges = [e for e in data["edges"] if e["type"] == "notes_on"]
+    assert any(
+        e["source"] == "note:doc-note-1:memo-abc" and e["target"] == "paper:doc-note-1"
+        for e in notes_on_edges
+    )
+
+
+def test_graph_endpoint_excludes_other_users_notes(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-other-note", "otheruser",
+        {"title": "Not Mine", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    db.db_put_memos("doc-other-note", {"page_1": [{"id": "memo-other", "text": "다른 사용자 메모"}]})
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+    note_nodes = [n for n in data["nodes"] if n["type"] == "note"]
+    assert not any(n["id"] == "note:doc-other-note:memo-other" for n in note_nodes)
+
+
+# ── Node Search ──────────────────────────────────────────────────────────
+
+def test_graph_search_finds_paper_and_concept(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-search-1", "testuser",
+        {"title": "Vision Transformer Study", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    concept_id = db.db_upsert_concept("Vision Transformer", "vision transformer", "method")
+    db.db_link_paper_concept("doc-search-1", concept_id)
+
+    res = test_client.get("/api/library/graph/search?q=Vision Transformer")
+    assert res.status_code == 200
+    data = res.json()
+    assert "paper:doc-search-1" in data["paper"]
+    assert f"concept:{concept_id}" in data["concept"]
+
+
+def test_graph_search_excludes_other_users_documents(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-search-mine", "testuser", {"title": "Shared Keyword Paper"})
+    _create_doc_owned_by(isolated_dirs, "doc-search-other", "otheruser", {"title": "Shared Keyword Paper"})
+
+    res = test_client.get("/api/library/graph/search?q=Shared Keyword")
+    assert res.status_code == 200
+    data = res.json()
+    assert "paper:doc-search-mine" in data["paper"]
+    assert "paper:doc-search-other" not in data["paper"]
+
+
+def test_graph_search_empty_query_returns_empty(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-search-empty", "testuser", {"title": "Anything"})
+    res = test_client.get("/api/library/graph/search?q=")
+    assert res.status_code == 200
+    data = res.json()
+    assert data == {"paper": [], "concept": [], "note": []}
+
+
+# ── 관련 질문 상세 패널 ────────────────────────────────────────────────────
+
+def test_graph_questions_endpoint_for_concept(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-detail-1", "testuser", {"title": "Detail Paper"})
+    concept_id = db.db_upsert_concept("Loss Landscape", "loss landscape", "theory")
+    db.db_link_paper_concept("doc-detail-1", concept_id)
+    chat_id = db.db_save_chat_message("doc-detail-1", "user", "What is Loss Landscape?")
+    db.db_link_question_paper(chat_id, "doc-detail-1")
+    db.db_link_question_concept(chat_id, concept_id)
+
+    res = test_client.get(f"/api/library/graph/questions?node_id=concept:{concept_id}")
+    assert res.status_code == 200
+    questions = res.json()["questions"]
+    assert any(q["content"] == "What is Loss Landscape?" for q in questions)
+
+
+def test_graph_questions_endpoint_excludes_other_users_concept_links(test_client, isolated_dirs):
+    """다른 사용자 문서에 연결된 질문이, 같은 concept_id를 공유하더라도
+    이 사용자의 상세 패널 조회 결과에 섞여 나오면 안 된다."""
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-detail-other", "otheruser", {"title": "Other User Paper"})
+    concept_id = db.db_upsert_concept("Shared Concept", "shared concept", "theory")
+    db.db_link_paper_concept("doc-detail-other", concept_id)
+    chat_id = db.db_save_chat_message("doc-detail-other", "user", "Other user's question")
+    db.db_link_question_paper(chat_id, "doc-detail-other")
+    db.db_link_question_concept(chat_id, concept_id)
+
+    res = test_client.get(f"/api/library/graph/questions?node_id=concept:{concept_id}")
+    assert res.status_code == 200
+    questions = res.json()["questions"]
+    assert not any(q["content"] == "Other user's question" for q in questions)
+
+
+def test_graph_questions_endpoint_for_other_users_paper_returns_empty(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-detail-notmine", "otheruser", {"title": "Not Mine"})
+    res = test_client.get("/api/library/graph/questions?node_id=paper:doc-detail-notmine")
+    assert res.status_code == 200
+    assert res.json()["questions"] == []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -144,11 +144,12 @@
         <div id="annotation-list" class="chat-session-list"></div>
       </div>
 
-      <!-- 지식 그래프 (논문 + LLM 추출 개념 노드, 인용/카테고리 엣지) -->
+      <!-- 지식 그래프 (논문 + LLM 추출 개념/메모 노드, 인용/카테고리/유사개념 엣지) -->
       <div id="library-graph-section" class="hidden">
         <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
           일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
         </div>
+        <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
         <div style="display: flex; gap: 16px; align-items: stretch;">
           <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
           <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">

--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -12,12 +12,17 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
     style: [
       { selector: 'node[type="paper"]', style: { shape: 'ellipse', 'background-color': '#4f8ef7', label: 'data(label)' } },
       { selector: 'node[type="concept"]', style: { shape: 'diamond', 'background-color': '#f7b34f', width: 24, height: 24, label: 'data(label)' } },
+      { selector: 'node[type="note"]', style: { shape: 'round-rectangle', 'background-color': '#8b5cf6', width: 16, height: 16, label: 'data(label)', 'font-size': 8 } },
       { selector: 'edge[type="citation"]', style: { 'line-style': 'solid', 'target-arrow-shape': 'triangle', width: 1.5 } },
       { selector: 'edge[type="category"]', style: { 'line-style': 'dashed', width: 1, 'line-color': '#ccc' } },
       { selector: 'edge[type="has_concept"]', style: { 'line-style': 'dotted', width: 1 } },
+      { selector: 'edge[type="notes_on"]', style: { 'line-style': 'dotted', width: 1, 'line-color': '#8b5cf6' } },
+      { selector: 'edge[type="similar_to"]', style: { 'line-style': 'dashed', width: 1.5, 'line-color': '#f7b34f', 'curve-style': 'bezier' } },
       // 노드 클릭 시 직접 연결된 이웃만 부각하고 나머지는 흐리게 처리한다.
       { selector: '.kg-dimmed', style: { opacity: 0.2 } },
       { selector: 'node.kg-selected', style: { 'border-width': 3, 'border-color': '#2563eb' } },
+      // Node Search로 매칭된 노드를 강조한다.
+      { selector: 'node.kg-search-match', style: { 'border-width': 3, 'border-color': '#16a34a' } },
     ],
     layout: { name: 'fcose', quality: 'proof', animate: true },
   })
@@ -37,4 +42,23 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
     }
   })
   return cy
+}
+
+// Node Search 결과로 매칭된 노드만 강조하고(kg-search-match) 나머지는 흐리게
+// 처리한 뒤, 매칭된 노드가 모두 보이도록 화면을 맞춘다. nodeIds가 비어 있으면
+// (검색어를 지웠을 때) 하이라이트를 전부 초기화한다.
+export function highlightSearchMatches(cy, nodeIds) {
+  cy.elements().removeClass('kg-dimmed kg-search-match')
+  if (!nodeIds || nodeIds.length === 0) return
+
+  const matched = cy.collection()
+  for (const id of nodeIds) {
+    const ele = cy.getElementById(id)
+    if (ele && ele.length) matched.merge(ele)
+  }
+  if (matched.length === 0) return
+
+  cy.elements().addClass('kg-dimmed')
+  matched.removeClass('kg-dimmed').addClass('kg-search-match')
+  cy.fit(matched, 60)
 }

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -175,6 +175,18 @@ export async function fetchLibraryGraph() {
   return res.json()
 }
 
+export async function fetchGraphNodeQuestions(nodeId) {
+  const res = await fetch(`${API_BASE}/library/graph/questions?node_id=${encodeURIComponent(nodeId)}`)
+  if (!res.ok) throw new Error('관련 질문 조회 실패')
+  return res.json()
+}
+
+export async function searchGraphNodes(query) {
+  const res = await fetch(`${API_BASE}/library/graph/search?q=${encodeURIComponent(query)}`)
+  if (!res.ok) throw new Error('지식 그래프 검색 실패')
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,9 +3,9 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes } from './library.js'
 import { icon } from './icons.js'
-import { renderKnowledgeGraph } from './knowledgeGraph.js'
+import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -233,6 +233,7 @@ const libraryGraphSection       = $('library-graph-section')
 const libraryGraphCanvas        = $('library-graph-canvas')
 const libraryGraphDetailPanel   = $('library-graph-detail-panel')
 const libraryGraphPendingBanner = $('library-graph-pending-banner')
+const libraryGraphSearchInput   = $('library-graph-search-input')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
 const compareSelectBar      = $('compare-select-bar')
@@ -4321,6 +4322,7 @@ async function renderLibraryGraphTab() {
   if (libraryGraphDetailPanel) {
     libraryGraphDetailPanel.innerHTML = '<p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>'
   }
+  if (libraryGraphSearchInput) libraryGraphSearchInput.value = ''
 
   try {
     const data = await fetchLibraryGraph()
@@ -4351,6 +4353,22 @@ async function renderLibraryGraphTab() {
   }
 }
 
+function renderRelatedQuestionsList(questions) {
+  if (!questions || questions.length === 0) {
+    return '<p style="margin:8px 0 0;color:var(--text-tertiary)">관련 질문이 없습니다.</p>'
+  }
+  return `
+    <ul style="margin:8px 0 0;padding-left:16px;max-height:220px;overflow-y:auto">
+      ${questions.map(q => `
+        <li style="margin-bottom:10px">
+          <div>${escapeHtml(q.content || '')}</div>
+          ${q.doc_title ? `<div style="color:var(--text-tertiary);font-size:11px">${escapeHtml(q.doc_title)}</div>` : ''}
+        </li>
+      `).join('')}
+    </ul>
+  `
+}
+
 function showGraphDetailPanel(nodeData) {
   if (!libraryGraphDetailPanel) return
   if (nodeData.type === 'paper') {
@@ -4359,16 +4377,66 @@ function showGraphDetailPanel(nodeData) {
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
       <p style="margin:0 0 6px"><strong>유형:</strong> 논문</p>
       <p style="margin:0"><strong>카테고리:</strong> ${escapeHtml(categories)}</p>
+      <button id="kg-related-questions-btn" style="margin-top:10px;padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 보기</button>
+      <div id="kg-related-questions-list"></div>
     `
   } else if (nodeData.type === 'concept') {
+    const questionCount = nodeData.question_count || 0
     libraryGraphDetailPanel.innerHTML = `
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
       <p style="margin:0 0 6px"><strong>유형:</strong> 개념</p>
       <p style="margin:0"><strong>분류:</strong> ${escapeHtml(nodeData.kind || '미상')}</p>
+      <button id="kg-related-questions-btn" style="margin-top:10px;padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 ${questionCount}개 보기</button>
+      <div id="kg-related-questions-list"></div>
+    `
+  } else if (nodeData.type === 'note') {
+    libraryGraphDetailPanel.innerHTML = `
+      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">메모</h4>
+      <p style="margin:0">${escapeHtml(nodeData.label || '')}</p>
     `
   } else {
     libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
   }
+
+  const questionsBtn = $('kg-related-questions-btn')
+  if (questionsBtn) {
+    questionsBtn.addEventListener('click', async () => {
+      const listEl = $('kg-related-questions-list')
+      if (!listEl) return
+      listEl.innerHTML = '<p style="margin:8px 0 0;color:var(--text-tertiary)">불러오는 중...</p>'
+      try {
+        const { questions } = await fetchGraphNodeQuestions(nodeData.id)
+        listEl.innerHTML = renderRelatedQuestionsList(questions)
+      } catch (err) {
+        listEl.innerHTML = '<p style="margin:8px 0 0;color:var(--error)">질문을 불러오지 못했습니다.</p>'
+      }
+    })
+  }
+}
+
+// 지식 그래프 Node Search - 기존 라이브러리 검색창(librarySearchInput)과
+// 동일한 디바운스 패턴을 그대로 따른다. 매칭된 노드는 highlightSearchMatches로
+// 강조하고 화면에 맞춘다(knowledgeGraph.js).
+let libraryGraphSearchTimer = null
+if (libraryGraphSearchInput) {
+  libraryGraphSearchInput.addEventListener('input', () => {
+    clearTimeout(libraryGraphSearchTimer)
+    const query = libraryGraphSearchInput.value.trim()
+    libraryGraphSearchTimer = setTimeout(async () => {
+      if (!libraryGraphCyInstance) return
+      if (!query) {
+        highlightSearchMatches(libraryGraphCyInstance, [])
+        return
+      }
+      try {
+        const result = await searchGraphNodes(query)
+        const nodeIds = [...(result.paper || []), ...(result.concept || []), ...(result.note || [])]
+        highlightSearchMatches(libraryGraphCyInstance, nodeIds)
+      } catch (err) {
+        console.error('지식 그래프 검색 실패:', err)
+      }
+    }, 300)
+  })
 }
 
 async function renderAnnotationsBrowser() {


### PR DESCRIPTION
## Summary
- Question 노드: 채팅 응답 저장 직후(단일/비교 세션 모두) 질문을 논문에 연결하고, 이미 추출된 개념 중 관련된 것과 폐쇄형으로 매칭(`question_papers`/`question_concepts`, `sync_question_for_graph`). 채팅이 많으면 질문이 수백 개 쌓일 수 있어 그래프 캔버스에는 그리지 않고, Concept/Paper 노드 클릭 시 상세 패널에 "관련 질문 보기"로만 노출(`GET /library/graph/questions`).
- AI Graph Linking: 새로 만들어진 개념만 기존 개념 전체와 LLM으로 비교해 의미가 사실상 같으면 `concept_edges`로 비파괴적 연결(병합 아님 - 오판이 나도 데이터 손실 없음). 개념당 LLM 호출 1회로 비용 제한.
- Note 노드: 1차에서 이미 서버 미러링된 `memos` 테이블을 LLM 호출 없이 그대로 그래프에 노출.
- Node Search: 논문/개념/메모/질문을 사용자 소유 범위 안에서 통합 검색(`GET /library/graph/search`), 매칭 노드 하이라이트.
- 원본 기획서(`ask/knowledge_graph_plan.md`)의 MVP 목록 중 1차에서 남겨뒀던 4개(Question Node/Note Node/Node Search/AI Graph Linking)를 모두 구현.
- 전부 신규 테이블/엔드포인트라 기존 기능에는 영향 없음.

## Test plan
- [x] 신규 pytest 13개 통과 (`test_knowledge_graph_v2.py`) - 질문-개념 매칭(단일/비교 세션), concept_edges 대칭성/자기루프 방지, Note 노드 소유권 스코핑, 검색 스코핑, 관련 질문 조회 소유권 스코핑
- [x] 전체 백엔드 테스트 스위트 254 passed / 1 failed - 실패 1건은 1차와 동일하게 이 브랜치와 무관한 기존 환경 이슈(admin/admin 보안 경고 배너 stdout 오염)
- [x] `npm run build` 정상 완료
- [ ] `/run`으로 실제 채팅 후 지식 그래프 탭에서 관련 질문 패널/검색/Note 노드 수동 확인 (권장 후속 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)