### PR TITLE
feat: 개인화된 지식 그래프(Research Graph) 3차 구현 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -103,6 +103,30 @@ async def search_library_graph(q: str = "", current_user: str = Depends(get_curr
     return await search_graph_nodes(current_user, q)
 
 
+@router.get("/library/graph/recommendations")
+async def get_library_reading_recommendations(current_user: str = Depends(get_current_user)):
+    """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천합니다. LLM+OpenAlex
+    호출이 여러 번 들어가는 무거운 작업이라 프론트에서 사용자가 명시적으로
+    요청했을 때만 호출해야 합니다(그래프 조회 시 자동 호출 안 함).
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_reading_recommendations
+    return {"recommendations": await get_reading_recommendations(current_user)}
+
+
+@router.get("/library/timeline")
+async def get_library_timeline(current_user: str = Depends(get_current_user)):
+    """업로드/읽음/질문/메모를 시간순으로 병합한 개인 활동 타임라인을 반환합니다.
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "timeline"이 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_activity_timeline
+    return {"events": await get_activity_timeline(current_user)}
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -224,6 +224,41 @@ def _queue_note_nodes(doc_ids: List[str], nodes: list, edges: list) -> None:
                 })
 
 
+def _queue_figure_nodes(doc_ids: List[str], nodes: list, edges: list) -> None:
+    """이미 캐시된 Figure/Table 데이터(extract_pdf_images, 뷰어에서 문서를
+    한 번이라도 열면 생성됨)를 그래프에 노출한다. 캐시가 없는 문서를 위해
+    PDF 파싱(비용 큼)을 여기서 강제로 트리거하지 않는다 - Note 노드와 동일한
+    "이미 있는 데이터만 노출" 철학. extract_pdf_images 응답에는 안정적인 id가
+    없어 캐시가 살아있는 동안의 리스트 인덱스를 합성 id로 쓴다(캐시가
+    재생성되면 바뀔 수 있음 - 인용 매칭처럼 완벽하지 않아도 되는 수준으로
+    받아들인다). 라벨이 없는(캡션 매칭 실패) 사각형은 사용자에게 의미가
+    없으므로 노드로 만들지 않는다."""
+    from services.library import get_pdf_path
+    from services.cache import get_cached_images
+    for doc_id in doc_ids:
+        pdf_path = get_pdf_path(doc_id)
+        if not pdf_path:
+            continue
+        images = get_cached_images(doc_id, pdf_path)
+        if not images:
+            continue
+        for idx, img in enumerate(images):
+            if not img.get("label"):
+                continue
+            figure_id = f"figure:{doc_id}:{idx}"
+            nodes.append({
+                "id": figure_id,
+                "type": "figure",
+                "label": img["label"],
+                "doc_id": doc_id,
+            })
+            edges.append({
+                "source": figure_id,
+                "target": f"paper:{doc_id}",
+                "type": "shows_figure",
+            })
+
+
 async def get_graph_data(username: str) -> dict:
     """현재 로그인한 사용자가 소유한 문서만으로 그래프를 구성한다.
     list_documents(username=username)로 소유 문서만 가져오는 것 자체가
@@ -316,6 +351,9 @@ async def get_graph_data(username: str) -> dict:
     # Note 노드: LLM 호출 불필요, memos 서버 미러를 그대로 노출.
     _queue_note_nodes(doc_ids, nodes, edges)
 
+    # Figure 노드: LLM 호출 불필요, 이미 캐시된 것만 노출(강제 파싱 트리거 안 함).
+    _queue_figure_nodes(doc_ids, nodes, edges)
+
     # 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서는 pending으로
     # 표시하고, 백그라운드로 백필을 걸어둔다(fire-and-forget - 이번 응답에는
     # 반영되지 않고, 클라이언트가 잠시 뒤 다시 조회하면 반영된다).
@@ -375,3 +413,95 @@ async def search_graph_nodes(username: str, query: str) -> dict:
     from services.db import db_search_graph_nodes
     doc_ids = [d["id"] for d in list_documents(username=username)]
     return db_search_graph_nodes(doc_ids, query)
+
+
+async def get_activity_timeline(username: str) -> List[dict]:
+    """업로드/읽음/질문/메모를 시간순(최신순)으로 병합한 활동 타임라인을
+    반환한다. 전부 이미 존재하는 타임스탬프를 재구성한 것이라 신규 저장소가
+    필요 없다 - 메모는 id가 "memo_{ms}" 형식(frontend의 createFloatingMemoForSentence)
+    이라는 점을 이용해 별도 스키마 변경 없이 생성 시각을 그대로 복원한다."""
+    from services.library import list_documents
+    from services.db import db_get_memos, db_get_related_questions_for_doc
+
+    docs = list_documents(username=username)
+    titles_by_doc = {d["id"]: (d.get("metadata") or {}).get("title") or d["filename"] for d in docs}
+
+    events = []
+    for doc in docs:
+        doc_id = doc["id"]
+        title = titles_by_doc[doc_id]
+        events.append({
+            "type": "uploaded", "doc_id": doc_id, "doc_title": title,
+            "timestamp": doc["created_at"],
+        })
+
+        meta = doc.get("metadata") or {}
+        if meta.get("read") and meta.get("read_at"):
+            events.append({
+                "type": "read", "doc_id": doc_id, "doc_title": title,
+                "timestamp": meta["read_at"],
+            })
+
+        mirrored = db_get_memos(doc_id)
+        for items in (mirrored or {}).get("data", {}).values():
+            for item in items or []:
+                item_id = (item or {}).get("id", "") if isinstance(item, dict) else ""
+                if not item_id.startswith("memo_"):
+                    continue
+                try:
+                    ts_ms = int(item_id[len("memo_"):])
+                except ValueError:
+                    continue
+                events.append({
+                    "type": "note", "doc_id": doc_id, "doc_title": title,
+                    "timestamp": datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).isoformat(),
+                    "summary": (item.get("content") or "")[:80],
+                })
+
+        for q in db_get_related_questions_for_doc(doc_id, limit=200):
+            events.append({
+                "type": "question", "doc_id": doc_id, "doc_title": title,
+                "timestamp": q["created_at"], "summary": (q["content"] or "")[:80],
+            })
+
+    events.sort(key=lambda e: e["timestamp"], reverse=True)
+    return events
+
+
+async def get_reading_recommendations(username: str) -> List[dict]:
+    """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천한다. Primer 기능의
+    기존 OpenAlex 검증 로직(_is_plausible_match, resolve_reference)을 그대로
+    재사용해 LLM 환각(존재하지 않는 논문을 추천)을 걸러낸다 - 1차의
+    _match_library_references 재사용과 동일한 패턴. LLM+OpenAlex 호출이
+    여러 번 들어가는 무거운 작업이라 그래프 조회 시 자동 실행하지 않고,
+    프론트에서 사용자가 명시적으로 요청했을 때만 호출한다."""
+    from services.library import list_documents
+    docs = list_documents(username=username)
+    if len(docs) < 2:
+        return []  # 근거가 너무 적으면 추천하지 않는다
+
+    titles = [(d.get("metadata") or {}).get("title") or d["filename"] for d in docs]
+    categories = sorted({c for d in docs for c in (d.get("metadata") or {}).get("categories", []) or []})
+
+    from services.llm_client import generate_reading_recommendations
+    from services.primer import _normalize_words, _is_plausible_match
+    from services.reference_linker import resolve_reference
+
+    raw = await generate_reading_recommendations(titles, categories, session_id=username)
+    exclude_word_sets = [w for w in (_normalize_words(t) for t in titles) if w]
+
+    results = []
+    for r in raw:
+        title = (r.get("title") or "").strip()
+        if not title:
+            continue
+        resolved = await resolve_reference(title)
+        if not resolved or not _is_plausible_match(title, resolved):
+            continue
+        result_words = _normalize_words(resolved.get("title", ""))
+        if not result_words:
+            continue
+        if any(len(result_words & seen) / len(result_words) >= 0.6 for seen in exclude_word_sets):
+            continue  # 이미 읽은 논문과 같은 논문이면 제외
+        results.append({**resolved, "reason": r.get("reason", "")})
+    return results

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2170,12 +2170,14 @@ Category Tags:"""
     return tags
 
 
-def _parse_json_array_response(raw: str) -> list:
+def _parse_json_array_response(raw: str, required_key: str = "concept") -> list:
     """LLM 응답에서 JSON 배열을 뽑아낸다. 마크다운 코드펜스(```json ... ```)로
     감싸져 오는 경우가 흔하고, 프롬프트로 순수 JSON만 요구해도 모델이 종종
     설명 문구를 앞뒤에 붙이거나 펜스를 씌우므로, 우선 펜스를 제거한 뒤
     json.loads를 시도한다. 파싱된 결과가 dict 리스트가 아니거나 각 항목에
-    "concept" 키가 없으면 호출부가 재시도할 수 있도록 ValueError를 던진다."""
+    required_key 키가 없으면 호출부가 재시도할 수 있도록 ValueError를 던진다.
+    기본값 "concept"은 extract_paper_concepts 계열이 쓰던 것 그대로이며,
+    다른 배열 형태(예: 추천 논문의 "title")를 검증할 때는 이 값을 바꿔 넣는다."""
     text = (raw or "").strip()
     text = re.sub(r"^```(?:json)?\s*", "", text)
     text = re.sub(r"\s*```$", "", text)
@@ -2185,12 +2187,12 @@ def _parse_json_array_response(raw: str) -> list:
     if not isinstance(parsed, list):
         raise ValueError("JSON 응답이 배열이 아닙니다.")
     for item in parsed:
-        if not isinstance(item, dict) or "concept" not in item:
-            raise ValueError("배열 항목이 dict가 아니거나 'concept' 키가 없습니다.")
+        if not isinstance(item, dict) or required_key not in item:
+            raise ValueError(f"배열 항목이 dict가 아니거나 '{required_key}' 키가 없습니다.")
     return parsed
 
 
-async def _llm_json_array_with_retry(prompt: str, session_id: str = None, attempts: int = 3, log_label: str = "LLM JSON 배열 응답") -> list:
+async def _llm_json_array_with_retry(prompt: str, session_id: str = None, attempts: int = 3, log_label: str = "LLM JSON 배열 응답", required_key: str = "concept") -> list:
     """공용: 프롬프트를 보내 JSON 배열 응답을 받아 파싱까지 재시도한다
     (extract_paper_concepts/match_question_to_concepts/find_similar_concepts가
     공유하는 멀티 프로바이더 분기 + 재시도 로직). LLM이 마크다운 펜스를
@@ -2237,7 +2239,7 @@ async def _llm_json_array_with_retry(prompt: str, session_id: str = None, attemp
                         tokens.append(data.get("message", {}).get("content", ""))
 
             raw = "".join(tokens).strip()
-            return _parse_json_array_response(raw)
+            return _parse_json_array_response(raw, required_key=required_key)
         except Exception as e:
             logger.warning(f"{log_label} 파싱 실패 (시도 {attempt + 1}/{attempts}): {e}")
             continue
@@ -2303,4 +2305,23 @@ Existing Concepts:
 
 JSON Array:"""
     return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="유사 개념 탐색")
+
+
+async def generate_reading_recommendations(titles: List[str], categories: List[str], session_id: str = None) -> List[dict]:
+    """읽은 논문 제목/카테고리를 근거로 다음에 읽으면 좋을 논문 3~5개와 그
+    이유를 추천한다. 반환값: [{"title": str, "reason": str}, ...]. 여기서
+    추천된 제목은 LLM의 환각(존재하지 않는 논문을 지어내는 것)이 섞여 있을
+    수 있으므로, 호출부(knowledge_graph.get_reading_recommendations)가
+    OpenAlex로 실존 여부를 검증한 뒤에만 채택해야 한다."""
+    titles_list = "\n".join(f"- {t}" for t in titles)
+    categories_line = ", ".join(categories) if categories else "(알 수 없음)"
+    prompt = f"""You are an expert research advisor. A researcher has read the following papers (research areas: {categories_line}). Recommend 3 to 5 OTHER real, existing academic papers they should read next to deepen or extend this line of research, with a short reason for each.
+
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "title" key (the paper's real title) and a "reason" key (one short sentence, in Korean, explaining why it's a good next read).
+
+Already Read:
+{titles_list}
+
+JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="읽을 논문 추천", required_key="title")
 

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -1,0 +1,188 @@
+"""지식 그래프 3차(Figure 노드 / Timeline View / Reading Recommendation)
+회귀 테스트. 이전 차수와 동일한 fixture 패턴(test_client/isolated_dirs)을
+사용한다.
+"""
+import pytest
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str, metadata: dict = None):
+    db = isolated_dirs["db"]
+    meta = metadata if metadata is not None else {"title": f"{doc_id} title"}
+    db.db_save_document(doc_id, username, f"{doc_id}.pdf", "/x/nonexistent.pdf", 3, meta)
+
+
+# ── Figure 노드 ──────────────────────────────────────────────────────────
+
+def test_graph_endpoint_includes_labeled_figure_nodes(test_client, isolated_dirs, monkeypatch):
+    import services.library as library
+    import services.cache as cache
+
+    _create_doc_owned_by(
+        isolated_dirs, "doc-fig-1", "testuser",
+        {"title": "Figure Paper", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    monkeypatch.setattr(library, "get_pdf_path", lambda doc_id: "/fake/path.pdf")
+    monkeypatch.setattr(cache, "get_cached_images", lambda doc_id, pdf_path: [
+        {"page": 1, "label": "Figure 1", "caption": "설명"},
+        {"page": 2, "label": None, "caption": None},  # 라벨 없는 항목은 제외돼야 함
+    ])
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+
+    figure_nodes = [n for n in data["nodes"] if n["type"] == "figure"]
+    assert len(figure_nodes) == 1
+    assert figure_nodes[0]["id"] == "figure:doc-fig-1:0"
+    assert figure_nodes[0]["label"] == "Figure 1"
+
+    shows_figure_edges = [e for e in data["edges"] if e["type"] == "shows_figure"]
+    assert any(e["source"] == "figure:doc-fig-1:0" and e["target"] == "paper:doc-fig-1" for e in shows_figure_edges)
+
+
+def test_graph_endpoint_skips_figures_without_cache(test_client, isolated_dirs, monkeypatch):
+    """캐시가 없는 문서는 PDF를 강제로 파싱하지 않고 그냥 Figure 노드 없이 넘어가야 한다."""
+    import services.library as library
+    import services.cache as cache
+
+    _create_doc_owned_by(
+        isolated_dirs, "doc-fig-2", "testuser",
+        {"title": "No Cache Yet", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    monkeypatch.setattr(library, "get_pdf_path", lambda doc_id: "/fake/path.pdf")
+    monkeypatch.setattr(cache, "get_cached_images", lambda doc_id, pdf_path: None)
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+    assert not any(n["type"] == "figure" for n in data["nodes"])
+
+
+def test_graph_endpoint_excludes_other_users_figures(test_client, isolated_dirs, monkeypatch):
+    import services.library as library
+    import services.cache as cache
+
+    _create_doc_owned_by(
+        isolated_dirs, "doc-fig-other", "otheruser",
+        {"title": "Not Mine", "graph_synced_at": "2026-01-01T00:00:00+00:00"},
+    )
+    monkeypatch.setattr(library, "get_pdf_path", lambda doc_id: "/fake/path.pdf")
+    monkeypatch.setattr(cache, "get_cached_images", lambda doc_id, pdf_path: [{"page": 1, "label": "Figure 1"}])
+
+    res = test_client.get("/api/library/graph")
+    assert res.status_code == 200
+    data = res.json()
+    assert not any(n["type"] == "figure" for n in data["nodes"])
+
+
+# ── Timeline View ────────────────────────────────────────────────────────
+
+def test_timeline_endpoint_merges_event_types(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-tl-1", "testuser",
+        {
+            "title": "Timeline Paper", "read": True, "read_at": "2026-02-02T00:00:00+00:00",
+        },
+    )
+    chat_id = db.db_save_chat_message("doc-tl-1", "user", "What is this about?")
+    db.db_link_question_paper(chat_id, "doc-tl-1")
+    db.db_put_memos("doc-tl-1", {"page_1": [{"id": "memo_1700000000000", "content": "핵심 메모"}]})
+
+    res = test_client.get("/api/library/timeline")
+    assert res.status_code == 200
+    events = res.json()["events"]
+
+    types = {e["type"] for e in events}
+    assert types == {"uploaded", "read", "question", "note"}
+    assert any(e["type"] == "note" and e["summary"] == "핵심 메모" for e in events)
+    assert any(e["type"] == "question" and e["summary"] == "What is this about?" for e in events)
+
+
+def test_timeline_ignores_malformed_memo_ids(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-tl-2", "testuser", {"title": "Bad Memo Id"})
+    db.db_put_memos("doc-tl-2", {"page_1": [{"id": "not-a-timestamp-id", "content": "무시되어야 함"}]})
+
+    res = test_client.get("/api/library/timeline")
+    assert res.status_code == 200
+    events = res.json()["events"]
+    assert not any(e.get("summary") == "무시되어야 함" for e in events)
+
+
+def test_timeline_excludes_other_users_events(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-tl-other", "otheruser", {"title": "Not Mine"})
+
+    res = test_client.get("/api/library/timeline")
+    assert res.status_code == 200
+    events = res.json()["events"]
+    assert not any(e["doc_id"] == "doc-tl-other" for e in events)
+
+
+# ── Reading Recommendation ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reading_recommendations_skips_when_too_few_docs(isolated_dirs):
+    import services.knowledge_graph as knowledge_graph
+    _create_doc_owned_by(isolated_dirs, "doc-rec-only-one", "testuser", {"title": "Only One Paper"})
+    result = await knowledge_graph.get_reading_recommendations("testuser")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_reading_recommendations_filters_implausible_and_duplicate(isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.reference_linker as reference_linker
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-rec-1", "testuser", {"title": "Vision Transformer", "categories": ["CV"]})
+    _create_doc_owned_by(isolated_dirs, "doc-rec-2", "testuser", {"title": "Masked Autoencoders", "categories": ["CV"]})
+
+    async def fake_generate(titles, categories, session_id=None):
+        assert "Vision Transformer" in titles
+        return [
+            {"title": "DINO Self-Supervised Vision Transformers", "reason": "자기지도학습 확장"},
+            {"title": "Hallucinated Nonexistent Paper", "reason": "가짜 추천"},
+            {"title": "Vision Transformer", "reason": "이미 읽은 논문과 동일"},
+        ]
+
+    async def fake_resolve(query_text):
+        if query_text == "DINO Self-Supervised Vision Transformers":
+            return {"title": "DINO Self-Supervised Vision Transformers", "url": "https://example.com/dino", "year": 2021}
+        if query_text == "Vision Transformer":
+            return {"title": "Vision Transformer", "url": "https://example.com/vit", "year": 2020}
+        return None  # OpenAlex에 없는(존재하지 않는) 논문 - 환각으로 취급
+
+    monkeypatch.setattr(llm_client, "generate_reading_recommendations", fake_generate)
+    monkeypatch.setattr(reference_linker, "resolve_reference", fake_resolve)
+
+    results = await knowledge_graph.get_reading_recommendations("testuser")
+
+    titles = [r["title"] for r in results]
+    assert "DINO Self-Supervised Vision Transformers" in titles
+    assert "Hallucinated Nonexistent Paper" not in titles  # OpenAlex 검증 실패
+    assert "Vision Transformer" not in titles  # 이미 읽은 논문과 중복
+    assert any(r["reason"] == "자기지도학습 확장" for r in results)
+
+
+def test_reading_recommendations_endpoint(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.reference_linker as reference_linker
+
+    _create_doc_owned_by(isolated_dirs, "doc-rec-api-1", "testuser", {"title": "Vision Transformer"})
+    _create_doc_owned_by(isolated_dirs, "doc-rec-api-2", "testuser", {"title": "Masked Autoencoders"})
+
+    async def fake_generate(titles, categories, session_id=None):
+        return [{"title": "DINO Self-Supervised Vision Transformers", "reason": "다음 단계"}]
+
+    async def fake_resolve(query_text):
+        return {"title": "DINO Self-Supervised Vision Transformers", "url": "https://example.com/dino", "year": 2021}
+
+    monkeypatch.setattr(llm_client, "generate_reading_recommendations", fake_generate)
+    monkeypatch.setattr(reference_linker, "resolve_reference", fake_resolve)
+
+    res = test_client.get("/api/library/graph/recommendations")
+    assert res.status_code == 200
+    recs = res.json()["recommendations"]
+    assert any(r["title"] == "DINO Self-Supervised Vision Transformers" and r["reason"] == "다음 단계" for r in recs)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -144,17 +144,30 @@
         <div id="annotation-list" class="chat-session-list"></div>
       </div>
 
-      <!-- 지식 그래프 (논문 + LLM 추출 개념/메모 노드, 인용/카테고리/유사개념 엣지) -->
+      <!-- 지식 그래프 (논문 + LLM 추출 개념/메모/Figure 노드, 인용/카테고리/유사개념 엣지) -->
       <div id="library-graph-section" class="hidden">
+        <div style="display: flex; gap: 8px; margin-bottom: 12px;">
+          <button id="library-graph-view-toggle-graph" class="library-tab-btn active" data-view="graph">그래프</button>
+          <button id="library-graph-view-toggle-timeline" class="library-tab-btn" data-view="timeline">타임라인</button>
+        </div>
         <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
           일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
         </div>
-        <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
-        <div style="display: flex; gap: 16px; align-items: stretch;">
-          <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
-          <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
-            <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+        <div id="library-graph-view">
+          <div style="margin-bottom: 12px; padding: 12px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px;">
+            <button id="library-recommendations-btn" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-primary);color:var(--text-primary);font-size:12px;cursor:pointer">다음에 읽을 논문 추천받기</button>
+            <div id="library-recommendations-list" style="margin-top:10px"></div>
           </div>
+          <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
+          <div style="display: flex; gap: 16px; align-items: stretch;">
+            <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
+            <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
+              <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+            </div>
+          </div>
+        </div>
+        <div id="library-timeline-view" class="hidden">
+          <div id="library-timeline-list"></div>
         </div>
       </div>
     </div>

--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -13,10 +13,12 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
       { selector: 'node[type="paper"]', style: { shape: 'ellipse', 'background-color': '#4f8ef7', label: 'data(label)' } },
       { selector: 'node[type="concept"]', style: { shape: 'diamond', 'background-color': '#f7b34f', width: 24, height: 24, label: 'data(label)' } },
       { selector: 'node[type="note"]', style: { shape: 'round-rectangle', 'background-color': '#8b5cf6', width: 16, height: 16, label: 'data(label)', 'font-size': 8 } },
+      { selector: 'node[type="figure"]', style: { shape: 'triangle', 'background-color': '#10b981', width: 16, height: 16, label: 'data(label)', 'font-size': 8 } },
       { selector: 'edge[type="citation"]', style: { 'line-style': 'solid', 'target-arrow-shape': 'triangle', width: 1.5 } },
       { selector: 'edge[type="category"]', style: { 'line-style': 'dashed', width: 1, 'line-color': '#ccc' } },
       { selector: 'edge[type="has_concept"]', style: { 'line-style': 'dotted', width: 1 } },
       { selector: 'edge[type="notes_on"]', style: { 'line-style': 'dotted', width: 1, 'line-color': '#8b5cf6' } },
+      { selector: 'edge[type="shows_figure"]', style: { 'line-style': 'dotted', width: 1, 'line-color': '#10b981' } },
       { selector: 'edge[type="similar_to"]', style: { 'line-style': 'dashed', width: 1.5, 'line-color': '#f7b34f', 'curve-style': 'bezier' } },
       // 노드 클릭 시 직접 연결된 이웃만 부각하고 나머지는 흐리게 처리한다.
       { selector: '.kg-dimmed', style: { opacity: 0.2 } },

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -187,6 +187,18 @@ export async function searchGraphNodes(query) {
   return res.json()
 }
 
+export async function fetchLibraryTimeline() {
+  const res = await fetch(`${API_BASE}/library/timeline`)
+  if (!res.ok) throw new Error('타임라인 조회 실패')
+  return res.json()
+}
+
+export async function fetchReadingRecommendations() {
+  const res = await fetch(`${API_BASE}/library/graph/recommendations`)
+  if (!res.ok) throw new Error('추천 논문 조회 실패')
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchLibraryTimeline, fetchReadingRecommendations } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 
@@ -234,6 +234,13 @@ const libraryGraphCanvas        = $('library-graph-canvas')
 const libraryGraphDetailPanel   = $('library-graph-detail-panel')
 const libraryGraphPendingBanner = $('library-graph-pending-banner')
 const libraryGraphSearchInput   = $('library-graph-search-input')
+const libraryGraphViewToggleGraph    = $('library-graph-view-toggle-graph')
+const libraryGraphViewToggleTimeline = $('library-graph-view-toggle-timeline')
+const libraryGraphView         = $('library-graph-view')
+const libraryTimelineView      = $('library-timeline-view')
+const libraryTimelineList      = $('library-timeline-list')
+const libraryRecommendationsBtn  = $('library-recommendations-btn')
+const libraryRecommendationsList = $('library-recommendations-list')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
 const compareSelectBar      = $('compare-select-bar')
@@ -4313,6 +4320,70 @@ function truncateForList(text, maxLen) {
 let libraryGraphCyInstance = null
 let libraryGraphPollTimeout = null
 
+// 그래프 탭 안의 "그래프/타임라인" 서브뷰 전환. 완전히 새 최상위 탭을 만드는
+// 대신 같은 섹션 안에서 뷰만 바꾼다(기획서의 "Research Dashboard"가 Graph
+// View/Timeline View를 한 화면의 다른 뷰로 묶어 다루는 것과 일치).
+function switchGraphSubView(view) {
+  const isTimeline = view === 'timeline'
+  if (libraryGraphViewToggleGraph) libraryGraphViewToggleGraph.classList.toggle('active', !isTimeline)
+  if (libraryGraphViewToggleTimeline) libraryGraphViewToggleTimeline.classList.toggle('active', isTimeline)
+  if (libraryGraphView) libraryGraphView.classList.toggle('hidden', isTimeline)
+  if (libraryTimelineView) libraryTimelineView.classList.toggle('hidden', !isTimeline)
+  if (libraryGraphPendingBanner && isTimeline) libraryGraphPendingBanner.classList.add('hidden')
+  if (isTimeline) renderLibraryTimelineView()
+}
+
+if (libraryGraphViewToggleGraph) {
+  libraryGraphViewToggleGraph.addEventListener('click', () => switchGraphSubView('graph'))
+}
+if (libraryGraphViewToggleTimeline) {
+  libraryGraphViewToggleTimeline.addEventListener('click', () => switchGraphSubView('timeline'))
+}
+
+const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
+
+function groupTimelineEventsByDate(events) {
+  const groups = {}
+  for (const e of events) {
+    const date = (e.timestamp || '').slice(0, 10) || '날짜 미상'
+    if (!groups[date]) groups[date] = []
+    groups[date].push(e)
+  }
+  return groups
+}
+
+async function renderLibraryTimelineView() {
+  if (!libraryTimelineList) return
+  libraryTimelineList.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
+  try {
+    const { events } = await fetchLibraryTimeline()
+    if (state.currentLibraryTab !== 'graph') return
+    if (!events || events.length === 0) {
+      libraryTimelineList.innerHTML = '<div class="lib-empty"><p>아직 활동 기록이 없습니다.</p></div>'
+      return
+    }
+    const groups = groupTimelineEventsByDate(events)
+    const dates = Object.keys(groups).sort((a, b) => b.localeCompare(a))
+    libraryTimelineList.innerHTML = dates.map(date => `
+      <div style="margin-bottom:16px">
+        <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-secondary)">${escapeHtml(date)}</h4>
+        <ul style="margin:0;padding-left:16px">
+          ${groups[date].map(e => `
+            <li style="margin-bottom:8px">
+              <span style="color:var(--text-tertiary);font-size:11px">[${escapeHtml(TIMELINE_TYPE_LABEL[e.type] || e.type)}]</span>
+              <strong>${escapeHtml(e.doc_title || '')}</strong>
+              ${e.summary ? `<div style="color:var(--text-secondary);font-size:12px">${escapeHtml(e.summary)}</div>` : ''}
+            </li>
+          `).join('')}
+        </ul>
+      </div>
+    `).join('')
+  } catch (err) {
+    console.error('타임라인 로드 실패:', err)
+    libraryTimelineList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">타임라인을 불러오지 못했습니다</p></div>'
+  }
+}
+
 async function renderLibraryGraphTab() {
   if (libraryGraphPollTimeout) {
     clearTimeout(libraryGraphPollTimeout)
@@ -4323,6 +4394,7 @@ async function renderLibraryGraphTab() {
     libraryGraphDetailPanel.innerHTML = '<p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>'
   }
   if (libraryGraphSearchInput) libraryGraphSearchInput.value = ''
+  switchGraphSubView('graph')
 
   try {
     const data = await fetchLibraryGraph()
@@ -4394,6 +4466,11 @@ function showGraphDetailPanel(nodeData) {
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">메모</h4>
       <p style="margin:0">${escapeHtml(nodeData.label || '')}</p>
     `
+  } else if (nodeData.type === 'figure') {
+    libraryGraphDetailPanel.innerHTML = `
+      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
+      <p style="margin:0"><strong>유형:</strong> Figure/Table</p>
+    `
   } else {
     libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
   }
@@ -4436,6 +4513,35 @@ if (libraryGraphSearchInput) {
         console.error('지식 그래프 검색 실패:', err)
       }
     }, 300)
+  })
+}
+
+// 추천은 LLM+OpenAlex 호출이 여러 번 들어가는 무거운 작업이라 그래프 탭
+// 진입 시 자동 실행하지 않고, 사용자가 버튼을 눌렀을 때만 요청한다(2차의
+// "관련 질문 보기" 지연 로드와 동일한 절제 원칙).
+if (libraryRecommendationsBtn) {
+  libraryRecommendationsBtn.addEventListener('click', async () => {
+    if (!libraryRecommendationsList) return
+    libraryRecommendationsBtn.disabled = true
+    libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--text-tertiary);font-size:12px">추천 논문을 찾는 중... (시간이 걸릴 수 있습니다)</p>'
+    try {
+      const { recommendations } = await fetchReadingRecommendations()
+      if (!recommendations || recommendations.length === 0) {
+        libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--text-tertiary);font-size:12px">추천할 만한 논문을 찾지 못했습니다.</p>'
+      } else {
+        libraryRecommendationsList.innerHTML = recommendations.map(r => `
+          <div style="padding:8px 0;border-top:1px solid var(--border-strong)">
+            <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" style="font-size:13px;font-weight:600;color:var(--text-primary)">${escapeHtml(r.title || '')}</a>
+            ${r.reason ? `<div style="font-size:12px;color:var(--text-secondary);margin-top:4px">${escapeHtml(r.reason)}</div>` : ''}
+          </div>
+        `).join('')
+      }
+    } catch (err) {
+      console.error('추천 논문 조회 실패:', err)
+      libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--error);font-size:12px">추천 논문을 불러오지 못했습니다.</p>'
+    } finally {
+      libraryRecommendationsBtn.disabled = false
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- Figure 노드: 뷰어에서 이미 연 문서의 캐시된 Figure/Table 데이터(`extract_pdf_images`)를 그래프에 노출. 캐시 없는 문서를 위한 강제 PDF 파싱 없음, 라벨 없는(캡션 매칭 실패) 항목은 노드로 만들지 않음.
- Timeline View: 지식 그래프 탭 안에 "그래프/타임라인" 토글 추가. 업로드/읽음/질문/메모를 시간순으로 병합한 활동 기록(`GET /library/timeline`) - 전부 기존 타임스탬프 재구성이라 신규 스키마 불필요.
- Reading Recommendation: "다음에 읽을 논문 추천받기" 버튼(지연 로드) - Primer 기능의 기존 OpenAlex 검증 로직(`_is_plausible_match`, `resolve_reference`)을 재사용해 LLM 환각을 걸러내고 이유와 함께 반환(`GET /library/graph/recommendations`).
- 원본 기획서(`ask/knowledge_graph_plan.md`)의 "MVP 이후" 항목(Figure/Dataset/Timeline/Recommendation) 중 Dataset은 1차 Concept `kind`로 이미 커버되어 나머지 3개를 구현. Highlight 노드는 하이라이트 생성 코드에 안정 id 부여가 선행돼야 하는 리스크가 있어 이번에도 제외.
- 전부 신규 엔드포인트/읽기 전용 로직이라 기존 기능에는 영향 없음.

## Test plan
- [x] 신규 pytest 9개 통과 (`test_knowledge_graph_v3.py`) - Figure 캐시 유무/라벨 유무/소유권 스코핑, 타임라인 이벤트 병합/잘못된 메모 id 처리/소유권 스코핑, 추천 논문 필터링(환각 제외)/중복 제외/최소 문서 수 체크
- [x] 전체 백엔드 테스트 스위트 263 passed / 1 failed - 실패 1건은 이전 차수와 동일하게 이 브랜치와 무관한 기존 환경 이슈(admin/admin 보안 경고 배너 stdout 오염)
- [x] `npm run build` 정상 완료
- [ ] `/run`으로 실제 뷰어에서 Figure 캐시 생성 후 그래프 탭에서 Figure 노드 확인, 그래프/타임라인 토글, 추천 논문 버튼 수동 확인 (권장 후속 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)