### PR TITLE
feat: 개인화된 지식 그래프(Research Graph) 4차 구현 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -127,6 +127,40 @@ async def get_library_timeline(current_user: str = Depends(get_current_user)):
     return {"events": await get_activity_timeline(current_user)}
 
 
+@router.get("/library/graph/heatmap")
+async def get_library_concept_heatmap(current_user: str = Depends(get_current_user)):
+    """개념별 논문 수/질문 수를 활동량 순으로 반환합니다(Concept Heatmap).
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_concept_heatmap
+    return {"heatmap": await get_concept_heatmap(current_user)}
+
+
+@router.get("/library/graph/gaps")
+async def get_library_knowledge_gaps(current_user: str = Depends(get_current_user)):
+    """질문이 거의 없는 개념, 메모 없이 읽음 표시된 논문 등 격차를 감지합니다
+    (Knowledge Gap Detection, 순수 규칙 기반 - LLM 호출 없음).
+
+    /library/{doc_id}보다 먼저 등록해야 한다.
+    """
+    from services.knowledge_graph import get_knowledge_gaps
+    return {"gaps": await get_knowledge_gaps(current_user)}
+
+
+@router.get("/library/dashboard")
+async def get_library_dashboard(current_user: str = Depends(get_current_user)):
+    """지식 그래프 탭의 "대시보드" 뷰에 필요한 통계/히트맵/격차/최근 활동을
+    한 번에 반환합니다.
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "dashboard"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_dashboard_summary
+    return await get_dashboard_summary(current_user)
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1167,3 +1167,19 @@ def db_put_memos(doc_id: str, data: dict) -> None:
             (doc_id, data_str, updated_at)
         )
         conn.commit()
+
+
+def db_get_memo_counts_for_docs(doc_ids: List[str]) -> Dict[str, int]:
+    """문서별 메모 개수를 반환한다. 메모는 문서당 1개의 JSON blob으로
+    저장되어 있어(_queue_note_nodes와 동일한 이유) SQL COUNT로 셀 수 없고
+    각 blob을 순회해 항목 수를 더해야 한다. 메모가 0개인 문서는 결과에
+    포함하지 않는다(호출부가 .get(doc_id, 0)으로 기본값을 다루도록)."""
+    if not doc_ids:
+        return {}
+    counts = {}
+    for doc_id in doc_ids:
+        mirrored = db_get_memos(doc_id)
+        total = sum(len(items or []) for items in (mirrored or {}).get("data", {}).values())
+        if total:
+            counts[doc_id] = total
+    return counts

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -505,3 +505,112 @@ async def get_reading_recommendations(username: str) -> List[dict]:
             continue  # 이미 읽은 논문과 같은 논문이면 제외
         results.append({**resolved, "reason": r.get("reason", "")})
     return results
+
+
+async def get_concept_heatmap(username: str) -> List[dict]:
+    """개념별로 몇 편의 논문에 등장했고 몇 개의 질문과 연결됐는지 집계해
+    활동량(paper_count + question_count) 순으로 정렬한다. 1차의
+    db_get_concepts_for_docs와 2차의 db_get_question_count_for_concepts를
+    그대로 조합할 뿐 새 SQL이 필요 없다."""
+    from services.library import list_documents
+    from services.db import db_get_concepts_for_docs, db_get_question_count_for_concepts
+    doc_ids = [d["id"] for d in list_documents(username=username)]
+    concept_links = db_get_concepts_for_docs(doc_ids)
+
+    by_concept = {}
+    for link in concept_links:
+        cid = link["concept_id"]
+        entry = by_concept.setdefault(
+            cid, {"concept_id": cid, "name": link["name"], "kind": link.get("kind"), "doc_ids": set()}
+        )
+        entry["doc_ids"].add(link["doc_id"])
+
+    question_counts = db_get_question_count_for_concepts(list(by_concept.keys()))
+    result = []
+    for cid, entry in by_concept.items():
+        paper_count = len(entry["doc_ids"])
+        question_count = question_counts.get(cid, 0)
+        result.append({
+            "concept_id": cid,
+            "name": entry["name"],
+            "kind": entry["kind"],
+            "paper_count": paper_count,
+            "question_count": question_count,
+            "score": paper_count + question_count,
+        })
+    result.sort(key=lambda r: r["score"], reverse=True)
+    return result
+
+
+async def get_knowledge_gaps(username: str) -> List[dict]:
+    """두 종류의 격차를 순수 규칙 기반(LLM 불필요)으로 감지한다:
+    1. 논문 여러 편에 등장하는 개념인데 관련 질문이 하나도 없음
+    2. 읽음 표시된 논문인데 메모가 하나도 없음
+    각각 상위 5개까지만 반환해 너무 많은 항목으로 압도하지 않는다."""
+    from services.library import list_documents
+    from services.db import db_get_memo_counts_for_docs
+
+    docs = list_documents(username=username)
+    doc_ids = [d["id"] for d in docs]
+
+    heatmap = await get_concept_heatmap(username)
+    concept_gaps = [
+        {
+            "type": "low_question_concept",
+            "concept_id": c["concept_id"],
+            "message": f"'{c['name']}' 관련 질문이 거의 없습니다.",
+        }
+        for c in heatmap if c["paper_count"] >= 2 and c["question_count"] == 0
+    ][:5]
+
+    memo_counts = db_get_memo_counts_for_docs(doc_ids)
+    paper_gaps = []
+    for doc in docs:
+        meta = doc.get("metadata") or {}
+        if not meta.get("read"):
+            continue
+        if memo_counts.get(doc["id"], 0) == 0:
+            title = meta.get("title") or doc["filename"]
+            paper_gaps.append({
+                "type": "no_notes_paper",
+                "doc_id": doc["id"],
+                "message": f"'{title}' 논문을 읽었지만 메모가 없습니다.",
+            })
+    return concept_gaps + paper_gaps[:5]
+
+
+async def get_dashboard_summary(username: str) -> dict:
+    """지식 그래프 탭의 "대시보드" 뷰에 필요한 데이터를 한 번에 모은다.
+    새 집계 로직 없이 get_concept_heatmap/get_knowledge_gaps/
+    get_activity_timeline을 조합할 뿐이다."""
+    from services.library import list_documents
+    docs = list_documents(username=username)  # 이미 created_at DESC 정렬됨
+
+    heatmap = await get_concept_heatmap(username)
+    gaps = await get_knowledge_gaps(username)
+    timeline = await get_activity_timeline(username)
+
+    recent_questions = [e for e in timeline if e["type"] == "question"][:10]
+    recent_notes = [e for e in timeline if e["type"] == "note"][:10]
+    recent_papers = [
+        {"doc_id": d["id"], "title": (d.get("metadata") or {}).get("title") or d["filename"], "created_at": d["created_at"]}
+        for d in docs[:10]
+    ]
+
+    stats = {
+        "total_papers": len(docs),
+        "total_pages": sum(d.get("total_pages") or 0 for d in docs),
+        "read_papers": sum(1 for d in docs if (d.get("metadata") or {}).get("read")),
+        "total_concepts": len(heatmap),
+        "total_questions": len([e for e in timeline if e["type"] == "question"]),
+        "total_notes": len([e for e in timeline if e["type"] == "note"]),
+    }
+
+    return {
+        "stats": stats,
+        "heatmap": heatmap[:10],
+        "gaps": gaps,
+        "recent_questions": recent_questions,
+        "recent_notes": recent_notes,
+        "recent_papers": recent_papers,
+    }

--- a/backend/tests/test_knowledge_graph_v4.py
+++ b/backend/tests/test_knowledge_graph_v4.py
@@ -1,0 +1,165 @@
+"""지식 그래프 4차(Concept Heatmap / Knowledge Gap Detection / Research
+Dashboard) 회귀 테스트. 이전 차수와 동일한 fixture 패턴(test_client/
+isolated_dirs)을 사용한다. 이번 차수는 LLM/외부 API 호출이 전혀 없어
+monkeypatch 없이 순수 데이터로 검증한다.
+"""
+
+
+def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str, metadata: dict = None):
+    db = isolated_dirs["db"]
+    meta = metadata if metadata is not None else {"title": f"{doc_id} title"}
+    db.db_save_document(doc_id, username, f"{doc_id}.pdf", "/x/nonexistent.pdf", 3, meta)
+
+
+# ── Concept Heatmap ──────────────────────────────────────────────────────
+
+def test_heatmap_counts_papers_and_questions_per_concept(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-hm-1", "testuser", {"title": "Paper A"})
+    _create_doc_owned_by(isolated_dirs, "doc-hm-2", "testuser", {"title": "Paper B"})
+
+    concept_id = db.db_upsert_concept("Attention", "attention", "method")
+    db.db_link_paper_concept("doc-hm-1", concept_id)
+    db.db_link_paper_concept("doc-hm-2", concept_id)
+
+    chat_id = db.db_save_chat_message("doc-hm-1", "user", "How does attention work?")
+    db.db_link_question_concept(chat_id, concept_id)
+
+    res = test_client.get("/api/library/graph/heatmap")
+    assert res.status_code == 200
+    heatmap = res.json()["heatmap"]
+
+    entry = next(h for h in heatmap if h["concept_id"] == concept_id)
+    assert entry["paper_count"] == 2
+    assert entry["question_count"] == 1
+    assert entry["score"] == 3
+
+
+def test_heatmap_sorted_by_score_descending(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-hm-3", "testuser", {"title": "Paper C"})
+
+    low_id = db.db_upsert_concept("Rare Concept", "rare concept", "theory")
+    high_id = db.db_upsert_concept("Popular Concept", "popular concept", "method")
+    db.db_link_paper_concept("doc-hm-3", low_id)
+    db.db_link_paper_concept("doc-hm-3", high_id)
+    for i in range(3):
+        chat_id = db.db_save_chat_message("doc-hm-3", "user", f"question {i}")
+        db.db_link_question_concept(chat_id, high_id)
+
+    res = test_client.get("/api/library/graph/heatmap")
+    heatmap = res.json()["heatmap"]
+    ids_in_order = [h["concept_id"] for h in heatmap]
+    assert ids_in_order.index(high_id) < ids_in_order.index(low_id)
+
+
+def test_heatmap_excludes_other_users_data(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-hm-other", "otheruser", {"title": "Not Mine"})
+    concept_id = db.db_upsert_concept("Other Concept", "other concept", "method")
+    db.db_link_paper_concept("doc-hm-other", concept_id)
+
+    res = test_client.get("/api/library/graph/heatmap")
+    heatmap = res.json()["heatmap"]
+    assert not any(h["concept_id"] == concept_id for h in heatmap)
+
+
+# ── Knowledge Gap Detection ──────────────────────────────────────────────
+
+def test_gap_detects_low_question_concept(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-gap-1", "testuser", {"title": "Paper A"})
+    _create_doc_owned_by(isolated_dirs, "doc-gap-2", "testuser", {"title": "Paper B"})
+    concept_id = db.db_upsert_concept("Diffusion", "diffusion", "method")
+    db.db_link_paper_concept("doc-gap-1", concept_id)
+    db.db_link_paper_concept("doc-gap-2", concept_id)  # 논문 2편에 등장, 질문은 0개
+
+    res = test_client.get("/api/library/graph/gaps")
+    gaps = res.json()["gaps"]
+    assert any(g["type"] == "low_question_concept" and g["concept_id"] == concept_id for g in gaps)
+
+
+def test_gap_skips_concept_with_only_one_paper(test_client, isolated_dirs):
+    """논문 1편에만 등장하는 개념은 임계값(paper_count>=2) 미달이라 격차로 잡히면 안 된다."""
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-gap-single", "testuser", {"title": "Paper A"})
+    concept_id = db.db_upsert_concept("New Idea", "new idea", "theory")
+    db.db_link_paper_concept("doc-gap-single", concept_id)
+
+    res = test_client.get("/api/library/graph/gaps")
+    gaps = res.json()["gaps"]
+    assert not any(g.get("concept_id") == concept_id for g in gaps)
+
+
+def test_gap_detects_read_paper_without_notes(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-gap-nonotes", "testuser",
+        {"title": "Mamba Paper", "read": True, "read_at": "2026-01-01T00:00:00+00:00"},
+    )
+
+    res = test_client.get("/api/library/graph/gaps")
+    gaps = res.json()["gaps"]
+    assert any(g["type"] == "no_notes_paper" and g["doc_id"] == "doc-gap-nonotes" for g in gaps)
+
+
+def test_gap_skips_read_paper_with_notes(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-gap-hasnotes", "testuser",
+        {"title": "Well Noted Paper", "read": True, "read_at": "2026-01-01T00:00:00+00:00"},
+    )
+    db.db_put_memos("doc-gap-hasnotes", {"page_1": [{"id": "memo_1700000000000", "content": "메모 있음"}]})
+
+    res = test_client.get("/api/library/graph/gaps")
+    gaps = res.json()["gaps"]
+    assert not any(g.get("doc_id") == "doc-gap-hasnotes" for g in gaps)
+
+
+def test_gap_skips_unread_paper_without_notes(test_client, isolated_dirs):
+    """읽음 표시를 안 한 논문은 메모가 없어도 격차로 잡히면 안 된다(아직 안 읽었을 뿐)."""
+    _create_doc_owned_by(isolated_dirs, "doc-gap-unread", "testuser", {"title": "Unread Paper"})
+
+    res = test_client.get("/api/library/graph/gaps")
+    gaps = res.json()["gaps"]
+    assert not any(g.get("doc_id") == "doc-gap-unread" for g in gaps)
+
+
+# ── Research Dashboard ───────────────────────────────────────────────────
+
+def test_dashboard_stats_and_recent_lists(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-dash-1", "testuser",
+        {"title": "Dashboard Paper", "read": True, "read_at": "2026-01-01T00:00:00+00:00"},
+    )
+    concept_id = db.db_upsert_concept("Dashboard Concept", "dashboard concept", "method")
+    db.db_link_paper_concept("doc-dash-1", concept_id)
+    chat_id = db.db_save_chat_message("doc-dash-1", "user", "질문 테스트")
+    db.db_link_question_paper(chat_id, "doc-dash-1")
+    db.db_link_question_concept(chat_id, concept_id)
+    db.db_put_memos("doc-dash-1", {"page_1": [{"id": "memo_1700000000000", "content": "메모 테스트"}]})
+
+    res = test_client.get("/api/library/dashboard")
+    assert res.status_code == 200
+    data = res.json()
+
+    assert data["stats"]["total_papers"] == 1
+    assert data["stats"]["read_papers"] == 1
+    assert data["stats"]["total_concepts"] == 1
+    assert data["stats"]["total_questions"] == 1
+    assert data["stats"]["total_notes"] == 1
+
+    assert any(h["concept_id"] == concept_id for h in data["heatmap"])
+    assert any(q["summary"] == "질문 테스트" for q in data["recent_questions"])
+    assert any(n["summary"] == "메모 테스트" for n in data["recent_notes"])
+    assert any(p["doc_id"] == "doc-dash-1" for p in data["recent_papers"])
+
+
+def test_dashboard_excludes_other_users_data(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-dash-other", "otheruser", {"title": "Not Mine"})
+
+    res = test_client.get("/api/library/dashboard")
+    data = res.json()
+    assert data["stats"]["total_papers"] == 0
+    assert not any(p["doc_id"] == "doc-dash-other" for p in data["recent_papers"])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -149,6 +149,8 @@
         <div style="display: flex; gap: 8px; margin-bottom: 12px;">
           <button id="library-graph-view-toggle-graph" class="library-tab-btn active" data-view="graph">그래프</button>
           <button id="library-graph-view-toggle-timeline" class="library-tab-btn" data-view="timeline">타임라인</button>
+          <button id="library-graph-view-toggle-heatmap" class="library-tab-btn" data-view="heatmap">히트맵</button>
+          <button id="library-graph-view-toggle-dashboard" class="library-tab-btn" data-view="dashboard">대시보드</button>
         </div>
         <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
           일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
@@ -168,6 +170,12 @@
         </div>
         <div id="library-timeline-view" class="hidden">
           <div id="library-timeline-list"></div>
+        </div>
+        <div id="library-heatmap-view" class="hidden">
+          <div id="library-heatmap-list"></div>
+        </div>
+        <div id="library-dashboard-view" class="hidden">
+          <div id="library-dashboard-content"></div>
         </div>
       </div>
     </div>

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -193,6 +193,24 @@ export async function fetchLibraryTimeline() {
   return res.json()
 }
 
+export async function fetchLibraryHeatmap() {
+  const res = await fetch(`${API_BASE}/library/graph/heatmap`)
+  if (!res.ok) throw new Error('개념 히트맵 조회 실패')
+  return res.json()
+}
+
+export async function fetchLibraryGaps() {
+  const res = await fetch(`${API_BASE}/library/graph/gaps`)
+  if (!res.ok) throw new Error('지식 격차 조회 실패')
+  return res.json()
+}
+
+export async function fetchLibraryDashboard() {
+  const res = await fetch(`${API_BASE}/library/dashboard`)
+  if (!res.ok) throw new Error('대시보드 조회 실패')
+  return res.json()
+}
+
 export async function fetchReadingRecommendations() {
   const res = await fetch(`${API_BASE}/library/graph/recommendations`)
   if (!res.ok) throw new Error('추천 논문 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchLibraryTimeline, fetchReadingRecommendations } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchLibraryTimeline, fetchReadingRecommendations, fetchLibraryHeatmap, fetchLibraryDashboard } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 
@@ -234,11 +234,17 @@ const libraryGraphCanvas        = $('library-graph-canvas')
 const libraryGraphDetailPanel   = $('library-graph-detail-panel')
 const libraryGraphPendingBanner = $('library-graph-pending-banner')
 const libraryGraphSearchInput   = $('library-graph-search-input')
-const libraryGraphViewToggleGraph    = $('library-graph-view-toggle-graph')
-const libraryGraphViewToggleTimeline = $('library-graph-view-toggle-timeline')
+const libraryGraphViewToggleGraph     = $('library-graph-view-toggle-graph')
+const libraryGraphViewToggleTimeline  = $('library-graph-view-toggle-timeline')
+const libraryGraphViewToggleHeatmap   = $('library-graph-view-toggle-heatmap')
+const libraryGraphViewToggleDashboard = $('library-graph-view-toggle-dashboard')
 const libraryGraphView         = $('library-graph-view')
 const libraryTimelineView      = $('library-timeline-view')
 const libraryTimelineList      = $('library-timeline-list')
+const libraryHeatmapView       = $('library-heatmap-view')
+const libraryHeatmapList       = $('library-heatmap-list')
+const libraryDashboardView     = $('library-dashboard-view')
+const libraryDashboardContent  = $('library-dashboard-content')
 const libraryRecommendationsBtn  = $('library-recommendations-btn')
 const libraryRecommendationsList = $('library-recommendations-list')
 
@@ -4320,24 +4326,32 @@ function truncateForList(text, maxLen) {
 let libraryGraphCyInstance = null
 let libraryGraphPollTimeout = null
 
-// 그래프 탭 안의 "그래프/타임라인" 서브뷰 전환. 완전히 새 최상위 탭을 만드는
-// 대신 같은 섹션 안에서 뷰만 바꾼다(기획서의 "Research Dashboard"가 Graph
-// View/Timeline View를 한 화면의 다른 뷰로 묶어 다루는 것과 일치).
-function switchGraphSubView(view) {
-  const isTimeline = view === 'timeline'
-  if (libraryGraphViewToggleGraph) libraryGraphViewToggleGraph.classList.toggle('active', !isTimeline)
-  if (libraryGraphViewToggleTimeline) libraryGraphViewToggleTimeline.classList.toggle('active', isTimeline)
-  if (libraryGraphView) libraryGraphView.classList.toggle('hidden', isTimeline)
-  if (libraryTimelineView) libraryTimelineView.classList.toggle('hidden', !isTimeline)
-  if (libraryGraphPendingBanner && isTimeline) libraryGraphPendingBanner.classList.add('hidden')
-  if (isTimeline) renderLibraryTimelineView()
+// 그래프 탭 안의 "그래프/타임라인/히트맵/대시보드" 서브뷰 전환. 완전히 새
+// 최상위 탭을 만드는 대신 같은 섹션 안에서 뷰만 바꾼다(기획서의 "Research
+// Dashboard"가 이 뷰들을 한 화면의 다른 뷰로 묶어 다루는 것과 일치). 표
+// 기반으로 짜서 서브뷰가 늘어나도 분기를 추가하지 않고 항목만 추가하면 된다.
+const GRAPH_SUBVIEWS = {
+  graph:     { btn: () => libraryGraphViewToggleGraph,     el: () => libraryGraphView },
+  timeline:  { btn: () => libraryGraphViewToggleTimeline,  el: () => libraryTimelineView,  onShow: () => renderLibraryTimelineView() },
+  heatmap:   { btn: () => libraryGraphViewToggleHeatmap,   el: () => libraryHeatmapView,   onShow: () => renderLibraryHeatmapView() },
+  dashboard: { btn: () => libraryGraphViewToggleDashboard, el: () => libraryDashboardView, onShow: () => renderLibraryDashboardView() },
 }
 
-if (libraryGraphViewToggleGraph) {
-  libraryGraphViewToggleGraph.addEventListener('click', () => switchGraphSubView('graph'))
+function switchGraphSubView(view) {
+  for (const [key, cfg] of Object.entries(GRAPH_SUBVIEWS)) {
+    const btn = cfg.btn()
+    const el = cfg.el()
+    if (btn) btn.classList.toggle('active', key === view)
+    if (el) el.classList.toggle('hidden', key !== view)
+  }
+  if (libraryGraphPendingBanner && view !== 'graph') libraryGraphPendingBanner.classList.add('hidden')
+  const cfg = GRAPH_SUBVIEWS[view]
+  if (cfg && cfg.onShow) cfg.onShow()
 }
-if (libraryGraphViewToggleTimeline) {
-  libraryGraphViewToggleTimeline.addEventListener('click', () => switchGraphSubView('timeline'))
+
+for (const [view, cfg] of Object.entries(GRAPH_SUBVIEWS)) {
+  const btn = cfg.btn()
+  if (btn) btn.addEventListener('click', () => switchGraphSubView(view))
 }
 
 const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
@@ -4381,6 +4395,115 @@ async function renderLibraryTimelineView() {
   } catch (err) {
     console.error('타임라인 로드 실패:', err)
     libraryTimelineList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">타임라인을 불러오지 못했습니다</p></div>'
+  }
+}
+
+// 히트맵 막대 하나. 크기(활동량)는 막대 "길이"로만 인코딩하고(색으로는
+// 인코딩하지 않음 - 단일 시리즈라 앱의 기존 accent 색 하나로 충분), 정확한
+// 수치는 옆 텍스트 라벨과 title(hover 시 네이티브 툴팁)로 함께 노출한다.
+function renderHeatmapBar(item, maxScore) {
+  const pct = maxScore > 0 ? Math.max(4, Math.round((item.score / maxScore) * 100)) : 0
+  const kindLabel = item.kind ? escapeHtml(item.kind) : ''
+  return `
+    <div style="margin-bottom:10px" title="${escapeHtml(item.name)} · 논문 ${item.paper_count}편 · 질문 ${item.question_count}개">
+      <div style="display:flex;justify-content:space-between;font-size:12px;margin-bottom:3px">
+        <span style="color:var(--text-primary)">${escapeHtml(item.name)}${kindLabel ? ` <span style="color:var(--text-tertiary)">(${kindLabel})</span>` : ''}</span>
+        <span style="color:var(--text-tertiary)">논문 ${item.paper_count} · 질문 ${item.question_count}</span>
+      </div>
+      <div style="height:10px;border-radius:5px;background:var(--border-strong);overflow:hidden">
+        <div style="height:100%;width:${pct}%;border-radius:5px;background:var(--accent-mid)"></div>
+      </div>
+    </div>
+  `
+}
+
+async function renderLibraryHeatmapView() {
+  if (!libraryHeatmapList) return
+  libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
+  try {
+    const { heatmap } = await fetchLibraryHeatmap()
+    if (state.currentLibraryTab !== 'graph') return
+    if (!heatmap || heatmap.length === 0) {
+      libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>아직 추출된 개념이 없습니다.</p></div>'
+      return
+    }
+    const maxScore = Math.max(...heatmap.map(h => h.score))
+    libraryHeatmapList.innerHTML = heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')
+  } catch (err) {
+    console.error('개념 히트맵 로드 실패:', err)
+    libraryHeatmapList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">히트맵을 불러오지 못했습니다</p></div>'
+  }
+}
+
+function renderDashboardStats(stats) {
+  const items = [
+    ['논문', stats.total_papers], ['읽음', stats.read_papers], ['페이지', stats.total_pages],
+    ['개념', stats.total_concepts], ['질문', stats.total_questions], ['메모', stats.total_notes],
+  ]
+  return `
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:10px;margin-bottom:16px">
+      ${items.map(([label, value]) => `
+        <div style="padding:10px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:10px;text-align:center">
+          <div style="font-size:20px;font-weight:700;color:var(--text-primary)">${value}</div>
+          <div style="font-size:11px;color:var(--text-tertiary)">${label}</div>
+        </div>
+      `).join('')}
+    </div>
+  `
+}
+
+function renderDashboardGaps(gaps) {
+  if (!gaps || gaps.length === 0) return ''
+  return `
+    <div style="margin-bottom:16px;padding:12px 14px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:10px">
+      <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">인사이트</h4>
+      <ul style="margin:0;padding-left:16px">
+        ${gaps.map(g => `<li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(g.message)}</li>`).join('')}
+      </ul>
+    </div>
+  `
+}
+
+function renderDashboardRecentSection(title, items, renderItem) {
+  if (!items || items.length === 0) return ''
+  return `
+    <div style="margin-bottom:16px">
+      <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">${escapeHtml(title)}</h4>
+      <ul style="margin:0;padding-left:16px">
+        ${items.map(renderItem).join('')}
+      </ul>
+    </div>
+  `
+}
+
+async function renderLibraryDashboardView() {
+  if (!libraryDashboardContent) return
+  libraryDashboardContent.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
+  try {
+    const data = await fetchLibraryDashboard()
+    if (state.currentLibraryTab !== 'graph') return
+
+    const maxScore = data.heatmap.length ? Math.max(...data.heatmap.map(h => h.score)) : 0
+    libraryDashboardContent.innerHTML = `
+      ${renderDashboardStats(data.stats)}
+      ${renderDashboardGaps(data.gaps)}
+      <div style="margin-bottom:16px">
+        <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">자주 다룬 개념</h4>
+        ${data.heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}
+      </div>
+      ${renderDashboardRecentSection('최근 질문', data.recent_questions, e => `
+        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(e.summary || '')} <span style="color:var(--text-tertiary)">— ${escapeHtml(e.doc_title || '')}</span></li>
+      `)}
+      ${renderDashboardRecentSection('최근 메모', data.recent_notes, e => `
+        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(e.summary || '')} <span style="color:var(--text-tertiary)">— ${escapeHtml(e.doc_title || '')}</span></li>
+      `)}
+      ${renderDashboardRecentSection('최근 논문', data.recent_papers, p => `
+        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(p.title || '')}</li>
+      `)}
+    `
+  } catch (err) {
+    console.error('대시보드 로드 실패:', err)
+    libraryDashboardContent.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">대시보드를 불러오지 못했습니다</p></div>'
   }
 }
 


### PR DESCRIPTION
## Summary
- Concept Heatmap: 개념별 논문 수+질문 수를 활동량 순으로 집계(`get_concept_heatmap`, `GET /library/graph/heatmap`). 1차 `db_get_concepts_for_docs`와 2차 `db_get_question_count_for_concepts`를 조합할 뿐 새 SQL 없음.
- Knowledge Gap Detection: 순수 규칙 기반(LLM 불필요) 격차 감지(`get_knowledge_gaps`, `GET /library/graph/gaps`) - 논문 2편 이상에 등장하지만 질문 없는 개념, 읽음 표시했지만 메모 없는 논문.
- Research Dashboard: 통계 + 히트맵 상위 10개 + 격차 인사이트 + 최근 질문/메모/논문을 한 번에 반환(`get_dashboard_summary`, `GET /library/dashboard`) - 새 집계 로직 없이 위 두 함수와 3차 `get_activity_timeline`을 조합.
- 프론트: 지식 그래프 탭 토글을 2개(그래프/타임라인)에서 4개(+히트맵/대시보드)로 확장, `switchGraphSubView`를 표 기반으로 일반화. 히트맵은 앱 기존 accent 색으로 그린 단일 계열 막대 차트(막대 길이로 크기 인코딩, 수치는 텍스트+hover로 노출).
- 이번 3개 기능 모두 LLM/외부 API 호출이 없어 지금까지 중 가장 리스크가 낮음. 전부 신규 엔드포인트/읽기 전용 로직이라 기존 기능에는 영향 없음.

## Test plan
- [x] 신규 pytest 10개 통과 (`test_knowledge_graph_v4.py`) - 히트맵 집계/정렬/소유권 스코핑, Gap Detection 임계값(개념 paper_count>=2, 읽음+메모 0개) 및 오탐 방지(문서 1편만인 개념, 안 읽은 논문 제외), 대시보드 통계/최근 목록 정확성 및 소유권 스코핑
- [x] 전체 백엔드 테스트 스위트 273 passed / 1 failed - 실패 1건은 이전 차수들과 동일하게 이 브랜치와 무관한 기존 환경 이슈(admin/admin 보안 경고 배너 stdout 오염)
- [x] `npm run build` 정상 완료
- [ ] `/run`으로 실제 지식 그래프 탭에서 히트맵/대시보드 토글, 통계 수치와 실제 라이브러리 상태 일치 여부 수동 확인 (권장 후속 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)