### PR TITLE
fix: 지식 그래프 노드 라벨을 호버 시에만 표시

### DIFF
--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -3,6 +3,13 @@ import fcose from 'cytoscape-fcose'
 cytoscape.use(fcose)
 
 export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {}) {
+  // 테마(다크/라이트)에 맞는 색상을 CSS 변수에서 읽어온다. cytoscape는 캔버스에
+  // 직접 그리므로 style 객체에 var(...)를 그대로 넣을 수 없어 계산된 값을 사용한다.
+  const rootStyle = getComputedStyle(document.documentElement)
+  const hoverBg = rootStyle.getPropertyValue('--bg-panel').trim() || '#fff'
+  const hoverBorder = rootStyle.getPropertyValue('--border-strong').trim() || '#d1d5db'
+  const hoverText = rootStyle.getPropertyValue('--text-primary').trim() || '#111'
+
   const cy = cytoscape({
     container,
     elements: [
@@ -10,10 +17,13 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
       ...graphData.edges.map(e => ({ data: e })),
     ],
     style: [
-      { selector: 'node[type="paper"]', style: { shape: 'ellipse', 'background-color': '#4f8ef7', label: 'data(label)' } },
-      { selector: 'node[type="concept"]', style: { shape: 'diamond', 'background-color': '#f7b34f', width: 24, height: 24, label: 'data(label)' } },
-      { selector: 'node[type="note"]', style: { shape: 'round-rectangle', 'background-color': '#8b5cf6', width: 16, height: 16, label: 'data(label)', 'font-size': 8 } },
-      { selector: 'node[type="figure"]', style: { shape: 'triangle', 'background-color': '#10b981', width: 16, height: 16, label: 'data(label)', 'font-size': 8 } },
+      // 기본적으로는 라벨을 그리지 않는다 — 논문 제목처럼 긴 텍스트가 항상 떠 있으면
+      // 그래프 가독성이 떨어지므로, 노드에 마우스를 올렸을 때만(.kg-hover) 표시한다.
+      { selector: 'node', style: { label: '' } },
+      { selector: 'node[type="paper"]', style: { shape: 'ellipse', 'background-color': '#4f8ef7' } },
+      { selector: 'node[type="concept"]', style: { shape: 'diamond', 'background-color': '#f7b34f', width: 24, height: 24 } },
+      { selector: 'node[type="note"]', style: { shape: 'round-rectangle', 'background-color': '#8b5cf6', width: 16, height: 16 } },
+      { selector: 'node[type="figure"]', style: { shape: 'triangle', 'background-color': '#10b981', width: 16, height: 16 } },
       { selector: 'edge[type="citation"]', style: { 'line-style': 'solid', 'target-arrow-shape': 'triangle', width: 1.5 } },
       { selector: 'edge[type="category"]', style: { 'line-style': 'dashed', width: 1, 'line-color': '#ccc' } },
       { selector: 'edge[type="has_concept"]', style: { 'line-style': 'dotted', width: 1 } },
@@ -25,6 +35,27 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
       { selector: 'node.kg-selected', style: { 'border-width': 3, 'border-color': '#2563eb' } },
       // Node Search로 매칭된 노드를 강조한다.
       { selector: 'node.kg-search-match', style: { 'border-width': 3, 'border-color': '#16a34a' } },
+      // 노드에 마우스를 올렸을 때만 라벨(논문 제목 등)을 표시한다.
+      {
+        selector: 'node.kg-hover',
+        style: {
+          label: 'data(label)',
+          'font-size': 11,
+          color: hoverText,
+          'text-wrap': 'wrap',
+          'text-max-width': '140px',
+          'text-valign': 'top',
+          'text-halign': 'center',
+          'text-margin-y': -6,
+          'text-background-color': hoverBg,
+          'text-background-opacity': 0.95,
+          'text-background-padding': '3px',
+          'text-border-width': 1,
+          'text-border-color': hoverBorder,
+          'text-border-opacity': 1,
+          'z-index': 999,
+        },
+      },
     ],
     layout: { name: 'fcose', quality: 'proof', animate: true },
   })
@@ -42,6 +73,13 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
     if (evt.target === cy) {
       cy.elements().removeClass('kg-dimmed kg-selected')
     }
+  })
+  // 노드에 마우스를 올리면 라벨을 표시하고, 벗어나면 다시 숨긴다.
+  cy.on('mouseover', 'node', evt => {
+    evt.target.addClass('kg-hover')
+  })
+  cy.on('mouseout', 'node', evt => {
+    evt.target.removeClass('kg-hover')
   })
   return cy
 }


### PR DESCRIPTION
## Summary
- 지식 그래프(Research Graph)에서 논문 제목 등 노드 라벨이 항상 렌더링되어 폰트가 크고 텍스트가 길어 그래프 가독성이 떨어지던 문제 수정
- 기본적으로는 노드 라벨을 숨기고, 사용자가 노드 위에 마우스를 올렸을 때(`mouseover`)만 라벨을 표시하도록 변경
- 다크/라이트 테마에 맞춰 라벨 배경·테두리·글자색을 CSS 변수(`--bg-panel`, `--border-strong`, `--text-primary`) 기반으로 렌더링

## Test plan
- [x] `npx vite build` 로 빌드 성공 확인
- [ ] 로컬에서 지식 그래프 탭을 열어 노드 호버 시 라벨이 나타나고, 벗어나면 사라지는지 확인
- [ ] 기존 클릭 시 이웃 강조/노드 검색 하이라이트 동작에 회귀가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)