### PR TITLE
feat: 지식 그래프 Figure/개념 노드 상세 패널에 실제 콘텐츠 표시 기능 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Depends
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from services.auth import get_current_user
 from services.library import (
     list_documents, search_documents, get_document, permanently_delete_document,
@@ -385,6 +385,31 @@ async def get_library_document_images(doc_id: str, current_user: str = Depends(g
         return {"images": images}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"이미지 좌표 추출 실패: {str(e)}")
+
+
+@router.get("/library/{doc_id}/figure-image/{index}")
+async def get_library_figure_image(doc_id: str, index: int, current_user: str = Depends(get_current_user)):
+    """지식 그래프의 Figure/Table 노드 상세보기에서 실제 그림/표 영역을 PNG로
+    크롭해 서빙합니다. 좌표는 클라이언트가 아니라 서버에 캐시된 좌표
+    (get_cached_images)에서만 가져와, 신뢰할 수 없는 클라이언트 입력으로
+    임의 좌표를 렌더링하지 않습니다."""
+    from services.cache import get_cached_images
+    from services.pdf_parser import render_image_crop_bytes
+
+    _require_owned_document(doc_id, current_user)
+    pdf_path = get_pdf_path(doc_id)
+    if not pdf_path:
+        raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
+
+    images = get_cached_images(doc_id, pdf_path)
+    if images is None or index < 0 or index >= len(images):
+        raise HTTPException(status_code=404, detail="Figure 정보를 찾을 수 없습니다.")
+
+    img = images[index]
+    png_bytes = render_image_crop_bytes(pdf_path, img["page"], img)
+    if png_bytes is None:
+        raise HTTPException(status_code=404, detail="Figure 이미지를 생성할 수 없습니다.")
+    return Response(content=png_bytes, media_type="image/png", headers={"Cache-Control": "public, max-age=86400"})
 
 
 @router.get("/library/{doc_id}/references")

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -251,6 +251,9 @@ def _queue_figure_nodes(doc_ids: List[str], nodes: list, edges: list) -> None:
                 "type": "figure",
                 "label": img["label"],
                 "doc_id": doc_id,
+                "index": idx,
+                "page": img.get("page"),
+                "caption": img.get("caption"),
             })
             edges.append({
                 "source": figure_id,

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -609,6 +609,22 @@ def _rect_mostly_inside_any(x0: float, y0: float, x1: float, y1: float, rects: L
     return False
 
 
+def _crop_page_pixmap(doc: "fitz.Document", page_num: int, bbox_percent: Dict[str, float], zoom: float):
+    """render_image_crop/render_image_crop_bytes가 공유하는 크롭 좌표 계산 및
+    렌더링 로직입니다. 페이지 범위를 벗어나면 None을 반환합니다."""
+    if page_num < 1 or page_num > doc.page_count:
+        return None
+    page = doc[page_num - 1]
+    rect = page.rect
+    x0 = rect.x0 + rect.width * (bbox_percent["left"] / 100)
+    y0 = rect.y0 + rect.height * (bbox_percent["top"] / 100)
+    x1 = x0 + rect.width * (bbox_percent["width"] / 100)
+    y1 = y0 + rect.height * (bbox_percent["height"] / 100)
+    clip = fitz.Rect(x0, y0, x1, y1)
+    matrix = fitz.Matrix(zoom, zoom)
+    return page.get_pixmap(matrix=matrix, clip=clip)
+
+
 def render_image_crop(pdf_path: str, page_num: int, bbox_percent: Dict[str, float], output_path: str, zoom: float = 2.0) -> bool:
     """
     지정한 페이지에서 백분율 좌표(bbox_percent: left, top, width, height, extract_pdf_images와
@@ -617,19 +633,25 @@ def render_image_crop(pdf_path: str, page_num: int, bbox_percent: Dict[str, floa
     """
     doc = fitz.open(pdf_path)
     try:
-        if page_num < 1 or page_num > doc.page_count:
+        pix = _crop_page_pixmap(doc, page_num, bbox_percent, zoom)
+        if pix is None:
             return False
-        page = doc[page_num - 1]
-        rect = page.rect
-        x0 = rect.x0 + rect.width * (bbox_percent["left"] / 100)
-        y0 = rect.y0 + rect.height * (bbox_percent["top"] / 100)
-        x1 = x0 + rect.width * (bbox_percent["width"] / 100)
-        y1 = y0 + rect.height * (bbox_percent["height"] / 100)
-        clip = fitz.Rect(x0, y0, x1, y1)
-        matrix = fitz.Matrix(zoom, zoom)
-        pix = page.get_pixmap(matrix=matrix, clip=clip)
         pix.save(output_path)
         return True
+    finally:
+        doc.close()
+
+
+def render_image_crop_bytes(pdf_path: str, page_num: int, bbox_percent: Dict[str, float], zoom: float = 2.0) -> Optional[bytes]:
+    """render_image_crop과 동일한 크롭 결과를 디스크에 저장하지 않고 PNG 바이트로
+    반환합니다. 지식 그래프의 Figure/Table 노드 상세보기처럼, 캐시 파일 없이
+    요청 시점에 바로 이미지를 서빙하면 되는 경우에 사용합니다."""
+    doc = fitz.open(pdf_path)
+    try:
+        pix = _crop_page_pixmap(doc, page_num, bbox_percent, zoom)
+        if pix is None:
+            return None
+        return pix.tobytes("png")
     finally:
         doc.close()
 

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -35,6 +35,11 @@ def test_graph_endpoint_includes_labeled_figure_nodes(test_client, isolated_dirs
     assert len(figure_nodes) == 1
     assert figure_nodes[0]["id"] == "figure:doc-fig-1:0"
     assert figure_nodes[0]["label"] == "Figure 1"
+    # 상세 패널에서 실제 이미지를 크롭 서빙(figure-image 엔드포인트)하고 캡션을
+    # 보여주려면 index/page/caption이 노드 데이터에 그대로 실려 있어야 한다.
+    assert figure_nodes[0]["index"] == 0
+    assert figure_nodes[0]["page"] == 1
+    assert figure_nodes[0]["caption"] == "설명"
 
     shows_figure_edges = [e for e in data["edges"] if e["type"] == "shows_figure"]
     assert any(e["source"] == "figure:doc-fig-1:0" and e["target"] == "paper:doc-fig-1" for e in shows_figure_edges)

--- a/backend/tests/test_library_figure_image_api.py
+++ b/backend/tests/test_library_figure_image_api.py
@@ -1,0 +1,63 @@
+"""GET /library/{doc_id}/figure-image/{index} HTTP 레벨 테스트.
+
+지식 그래프 Figure/Table 노드 상세 패널에서 실제 이미지를 보여주기 위한
+엔드포인트. 좌표는 클라이언트가 아니라 서버에 캐시된 get_cached_images
+결과에서만 가져오므로, 캐시에 없는 index나 다른 사용자 문서는 전부
+404여야 한다."""
+
+from unittest.mock import patch
+
+
+def _create_doc(isolated_dirs, doc_id="doc-1", username="testuser"):
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 3, {"title": "Test Paper"})
+
+
+def test_get_figure_image_returns_png(test_client, isolated_dirs, tmp_path):
+    _create_doc(isolated_dirs)
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 200)
+
+    cached_images = [
+        {"page": 1, "left": 10.0, "top": 10.0, "width": 30.0, "height": 20.0, "label": "Figure 1", "caption": "설명"},
+    ]
+    fake_png = b"\x89PNG fake bytes"
+    with patch("routers.library.get_pdf_path", return_value=str(pdf_path)), \
+         patch("services.cache.get_cached_images", return_value=cached_images), \
+         patch("services.pdf_parser.render_image_crop_bytes", return_value=fake_png) as mock_render:
+        res = test_client.get("/api/library/doc-1/figure-image/0")
+
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "image/png"
+    assert res.content == fake_png
+    mock_render.assert_called_once_with(str(pdf_path), 1, cached_images[0])
+
+
+def test_get_figure_image_out_of_range_index_returns_404(test_client, isolated_dirs, tmp_path):
+    _create_doc(isolated_dirs)
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 200)
+
+    with patch("routers.library.get_pdf_path", return_value=str(pdf_path)), \
+         patch("services.cache.get_cached_images", return_value=[{"page": 1, "label": "Figure 1"}]):
+        res = test_client.get("/api/library/doc-1/figure-image/5")
+
+    assert res.status_code == 404
+
+
+def test_get_figure_image_no_cache_returns_404(test_client, isolated_dirs, tmp_path):
+    _create_doc(isolated_dirs)
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 200)
+
+    with patch("routers.library.get_pdf_path", return_value=str(pdf_path)), \
+         patch("services.cache.get_cached_images", return_value=None):
+        res = test_client.get("/api/library/doc-1/figure-image/0")
+
+    assert res.status_code == 404
+
+
+def test_get_figure_image_other_users_document_returns_404(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, doc_id="doc-other", username="otheruser")
+    res = test_client.get("/api/library/doc-other/figure-image/0")
+    assert res.status_code == 404

--- a/frontend/src/knowledgeGraph.js
+++ b/frontend/src/knowledgeGraph.js
@@ -66,7 +66,10 @@ export function renderKnowledgeGraph(container, graphData, { onNodeClick } = {})
     neighborhood.removeClass('kg-dimmed')
     cy.nodes().removeClass('kg-selected')
     node.addClass('kg-selected')
-    onNodeClick && onNodeClick(node.data())
+    // 상세 패널에서 "관련 논문"/"유사 개념" 같은 1촌 이웃 목록을 다시 조회하지
+    // 않고 바로 보여줄 수 있도록, 이미 계산해둔 이웃 노드 데이터를 함께 넘긴다.
+    const neighborNodes = neighborhood.nodes().filter(n => n.id() !== node.id()).map(n => n.data())
+    onNodeClick && onNodeClick(node.data(), neighborNodes)
   })
   // 빈 캔버스(배경)를 탭하면 하이라이트를 초기화한다.
   cy.on('tap', evt => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4564,7 +4564,22 @@ function renderRelatedQuestionsList(questions) {
   `
 }
 
-function showGraphDetailPanel(nodeData) {
+// 개념의 "관련 논문"/"유사 개념"처럼, 상세 패널에서 보여줄 1촌 이웃 노드
+// 목록을 렌더링한다. neighborNodes는 knowledgeGraph.js의 tap 핸들러가
+// closedNeighborhood()로 이미 계산해 넘겨준 것이라 별도 API 조회가 필요 없다.
+function renderRelatedNodesList(neighborNodes, type, emptyText) {
+  const matches = (neighborNodes || []).filter(n => n.type === type)
+  if (matches.length === 0) {
+    return `<p style="margin:6px 0 0;color:var(--text-tertiary)">${escapeHtml(emptyText)}</p>`
+  }
+  return `
+    <ul style="margin:6px 0 0;padding-left:16px">
+      ${matches.map(n => `<li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(n.label || '')}</li>`).join('')}
+    </ul>
+  `
+}
+
+function showGraphDetailPanel(nodeData, neighborNodes = []) {
   if (!libraryGraphDetailPanel) return
   if (nodeData.type === 'paper') {
     const categories = (nodeData.categories && nodeData.categories.length) ? nodeData.categories.join(', ') : '없음'
@@ -4580,8 +4595,16 @@ function showGraphDetailPanel(nodeData) {
     libraryGraphDetailPanel.innerHTML = `
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
       <p style="margin:0 0 6px"><strong>유형:</strong> 개념</p>
-      <p style="margin:0"><strong>분류:</strong> ${escapeHtml(nodeData.kind || '미상')}</p>
-      <button id="kg-related-questions-btn" style="margin-top:10px;padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 ${questionCount}개 보기</button>
+      <p style="margin:0 0 10px"><strong>분류:</strong> ${escapeHtml(nodeData.kind || '미상')}</p>
+      <div style="margin-bottom:10px">
+        <h5 style="margin:0 0 4px;font-size:12px;color:var(--text-primary)">이 개념을 다루는 논문</h5>
+        ${renderRelatedNodesList(neighborNodes, 'paper', '연결된 논문이 없습니다.')}
+      </div>
+      <div style="margin-bottom:10px">
+        <h5 style="margin:0 0 4px;font-size:12px;color:var(--text-primary)">유사 개념</h5>
+        ${renderRelatedNodesList(neighborNodes, 'concept', '유사한 개념이 없습니다.')}
+      </div>
+      <button id="kg-related-questions-btn" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 ${questionCount}개 보기</button>
       <div id="kg-related-questions-list"></div>
     `
   } else if (nodeData.type === 'note') {
@@ -4590,10 +4613,26 @@ function showGraphDetailPanel(nodeData) {
       <p style="margin:0">${escapeHtml(nodeData.label || '')}</p>
     `
   } else if (nodeData.type === 'figure') {
+    const captionHtml = nodeData.caption
+      ? `<p style="margin:0 0 10px;color:var(--text-secondary);font-size:12px">${escapeHtml(nodeData.caption)}</p>`
+      : ''
+    const hasCrop = nodeData.doc_id != null && nodeData.index != null
     libraryGraphDetailPanel.innerHTML = `
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
-      <p style="margin:0"><strong>유형:</strong> Figure/Table</p>
+      <p style="margin:0 0 10px"><strong>유형:</strong> Figure/Table</p>
+      ${hasCrop ? `<img id="kg-figure-img" class="primer-figure-img" style="margin-bottom:10px" alt="${escapeHtml(nodeData.label || '')}">` : ''}
+      ${captionHtml}
     `
+    const figureImg = $('kg-figure-img')
+    if (figureImg) {
+      figureImg.addEventListener('error', () => {
+        figureImg.replaceWith(Object.assign(document.createElement('p'), {
+          textContent: '이미지를 불러올 수 없습니다.',
+          style: 'margin:0 0 10px;color:var(--text-tertiary);font-size:12px',
+        }))
+      })
+      figureImg.src = `/api/library/${encodeURIComponent(nodeData.doc_id)}/figure-image/${encodeURIComponent(nodeData.index)}`
+    }
   } else {
     libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
   }


### PR DESCRIPTION
# Summary
## 1. 지식 그래프 Figure/Table 노드 상세 패널에 실제 이미지 표시
- `backend/services/pdf_parser.py`: `render_image_crop`의 크롭 좌표 계산 로직을 `_crop_page_pixmap`으로 추출하고, 디스크에 저장하지 않고 PNG 바이트를 바로 반환하는 `render_image_crop_bytes` 함수 추가
- `backend/services/knowledge_graph.py`: `_queue_figure_nodes`가 만드는 Figure 노드 데이터에 `index`/`page`/`caption` 필드 추가 (기존엔 `label`/`doc_id`만 있어 실제 이미지·캡션을 노출할 방법이 없었음)
- `backend/routers/library.py`: `GET /library/{doc_id}/figure-image/{index}` 엔드포인트 신규 추가 — 좌표는 클라이언트 입력이 아니라 서버에 캐시된 `get_cached_images` 결과에서만 가져와 크롭 PNG를 서빙
- `frontend/src/main.js`: `showGraphDetailPanel`의 figure 분기에 실제 크롭 이미지(`<img>`)와 캡션 텍스트를 추가하고, 이미지 로드 실패 시 안내 텍스트로 대체하는 처리 추가

## 2. 개념 노드 상세 패널에 관련 논문·유사 개념 목록 추가
- `frontend/src/knowledgeGraph.js`: cytoscape 노드 클릭 시 이미 계산되는 `closedNeighborhood()` 결과를 `onNodeClick` 콜백에 함께 전달해, 추가 API 호출 없이 1촌 이웃 노드 정보를 상세 패널에서 바로 쓸 수 있게 함
- `frontend/src/main.js`: `showGraphDetailPanel`의 concept 분기에 "이 개념을 다루는 논문"/"유사 개념" 목록(`renderRelatedNodesList`)을 추가 (기존엔 이름/분류/질문 수만 표시)

## 3. 테스트
- `backend/tests/test_knowledge_graph_v3.py`: Figure 노드에 `index`/`page`/`caption` 필드가 포함되는지 검증하는 assertion 추가
- `backend/tests/test_library_figure_image_api.py` 신규 작성: 정상 크롭 서빙, 범위를 벗어난 index, 캐시 없음, 다른 사용자 문서 접근 시 전부 404 처리되는지 검증
- 백엔드 전체 테스트 스위트 통과 확인, 프론트엔드 `npm run build` 성공 확인
- Playwright로 로그인 후 지식 그래프 탭에서 figure/concept 노드를 직접 클릭해 상세 패널이 의도대로 렌더링되는지 스크린샷으로 확인
