### PR TITLE
fix: 지식 그래프 상세 패널 리사이즈/이미지 클릭 이동/캡션 마크다운/수식 해상도 개선

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -406,7 +406,9 @@ async def get_library_figure_image(doc_id: str, index: int, current_user: str = 
         raise HTTPException(status_code=404, detail="Figure 정보를 찾을 수 없습니다.")
 
     img = images[index]
-    png_bytes = render_image_crop_bytes(pdf_path, img["page"], img)
+    # min_output_width: 상세 패널이 이미지를 패널 폭에 맞춰 확대 표시하므로,
+    # 수식처럼 원본 영역이 작은 크롭도 최소 해상도를 보장해 흐려 보이지 않게 한다.
+    png_bytes = render_image_crop_bytes(pdf_path, img["page"], img, min_output_width=900)
     if png_bytes is None:
         raise HTTPException(status_code=404, detail="Figure 이미지를 생성할 수 없습니다.")
     return Response(content=png_bytes, media_type="image/png", headers={"Cache-Control": "public, max-age=86400"})

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -642,13 +642,34 @@ def render_image_crop(pdf_path: str, page_num: int, bbox_percent: Dict[str, floa
         doc.close()
 
 
-def render_image_crop_bytes(pdf_path: str, page_num: int, bbox_percent: Dict[str, float], zoom: float = 2.0) -> Optional[bytes]:
+def render_image_crop_bytes(
+    pdf_path: str,
+    page_num: int,
+    bbox_percent: Dict[str, float],
+    zoom: float = 2.0,
+    min_output_width: Optional[int] = None,
+    max_zoom: float = 6.0,
+) -> Optional[bytes]:
     """render_image_crop과 동일한 크롭 결과를 디스크에 저장하지 않고 PNG 바이트로
     반환합니다. 지식 그래프의 Figure/Table 노드 상세보기처럼, 캐시 파일 없이
-    요청 시점에 바로 이미지를 서빙하면 되는 경우에 사용합니다."""
+    요청 시점에 바로 이미지를 서빙하면 되는 경우에 사용합니다.
+
+    min_output_width가 주어지면, 번호 매겨진 수식처럼 원본 영역이 아주 작은
+    경우에도 최소 출력 픽셀 폭을 보장하도록 zoom을 자동으로 키운다(상한은
+    max_zoom). 상세 패널에서 이미지를 패널 폭(width:100%)에 맞춰 확대
+    표시하는데 원본 해상도가 낮으면 작은 영역일수록 더 심하게 흐려 보이기
+    때문 - 큰 그림/표는 애초에 zoom=2.0로도 충분히 선명해 영향이 없다.
+    """
     doc = fitz.open(pdf_path)
     try:
-        pix = _crop_page_pixmap(doc, page_num, bbox_percent, zoom)
+        if page_num < 1 or page_num > doc.page_count:
+            return None
+        effective_zoom = zoom
+        if min_output_width:
+            crop_width_pt = doc[page_num - 1].rect.width * (bbox_percent["width"] / 100)
+            if crop_width_pt > 0:
+                effective_zoom = max(zoom, min(max_zoom, min_output_width / crop_width_pt))
+        pix = _crop_page_pixmap(doc, page_num, bbox_percent, effective_zoom)
         if pix is None:
             return None
         return pix.tobytes("png")

--- a/backend/tests/test_library_figure_image_api.py
+++ b/backend/tests/test_library_figure_image_api.py
@@ -30,7 +30,7 @@ def test_get_figure_image_returns_png(test_client, isolated_dirs, tmp_path):
     assert res.status_code == 200
     assert res.headers["content-type"] == "image/png"
     assert res.content == fake_png
-    mock_render.assert_called_once_with(str(pdf_path), 1, cached_images[0])
+    mock_render.assert_called_once_with(str(pdf_path), 1, cached_images[0], min_output_width=900)
 
 
 def test_get_figure_image_out_of_range_index_returns_404(test_client, isolated_dirs, tmp_path):

--- a/backend/tests/test_pdf_parser_crop.py
+++ b/backend/tests/test_pdf_parser_crop.py
@@ -1,0 +1,64 @@
+"""render_image_crop_bytes()의 min_output_width 자동 확대 동작 테스트.
+
+지식 그래프 Figure/Table 노드 상세 패널이 이미지를 패널 폭에 맞춰 확대
+표시하는데(width:100%), 번호 매겨진 수식처럼 원본 크롭 영역이 아주 작으면
+고정 zoom으로는 저해상도로 렌더링되어 확대 시 흐려 보였다. min_output_width를
+주면 작은 영역일수록 zoom을 자동으로 키워 최소 출력 폭을 보장해야 한다."""
+
+import io
+
+import fitz
+from PIL import Image
+
+from services.pdf_parser import render_image_crop_bytes
+
+
+def _make_pdf(tmp_path, width=595, height=842):
+    doc = fitz.open()
+    page = doc.new_page(width=width, height=height)
+    page.insert_text((72, 72), "Hello world, this is a test PDF page.")
+    pdf_path = tmp_path / "test.pdf"
+    doc.save(str(pdf_path))
+    doc.close()
+    return str(pdf_path)
+
+
+def _png_size(png_bytes):
+    return Image.open(io.BytesIO(png_bytes)).size
+
+
+def test_render_image_crop_bytes_without_min_width_uses_flat_zoom(tmp_path):
+    pdf_path = _make_pdf(tmp_path)
+    # 페이지 폭(595pt)의 50%를 zoom=2.0으로 크롭하면 출력 폭은 약 595px가 되어야 한다.
+    bbox = {"left": 0.0, "top": 0.0, "width": 50.0, "height": 20.0}
+    png_bytes = render_image_crop_bytes(pdf_path, 1, bbox, zoom=2.0)
+    assert png_bytes is not None
+    width_px, _ = _png_size(png_bytes)
+    assert abs(width_px - 595) <= 2
+
+
+def test_render_image_crop_bytes_small_bbox_scales_up_to_min_width(tmp_path):
+    pdf_path = _make_pdf(tmp_path)
+    # 페이지 폭의 30%(약 178.5pt)인 영역 - zoom=2.0이면 357px밖에 안 나와
+    # 패널에서 확대 표시(width:100%)하면 흐려진다. min_output_width=900을 주면
+    # 필요한 zoom(약 5.04, max_zoom 6.0 이내)까지 자동으로 키워 900px 근처로
+    # 렌더링돼야 한다.
+    bbox = {"left": 0.0, "top": 0.0, "width": 30.0, "height": 10.0}
+    png_bytes = render_image_crop_bytes(pdf_path, 1, bbox, zoom=2.0, min_output_width=900)
+    assert png_bytes is not None
+    width_px, _ = _png_size(png_bytes)
+    assert 890 <= width_px <= 910
+
+
+def test_render_image_crop_bytes_min_width_respects_max_zoom_cap(tmp_path):
+    pdf_path = _make_pdf(tmp_path)
+    # 극단적으로 작은 영역(페이지 폭의 1%)에 아주 큰 min_output_width를 요구해도
+    # max_zoom 상한을 넘어서면 안 된다(과도한 렌더링 비용 방지).
+    bbox = {"left": 0.0, "top": 0.0, "width": 1.0, "height": 1.0}
+    png_bytes = render_image_crop_bytes(
+        pdf_path, 1, bbox, zoom=2.0, min_output_width=5000, max_zoom=6.0
+    )
+    assert png_bytes is not None
+    width_px, _ = _png_size(png_bytes)
+    # 페이지 폭 595pt * 1% = 5.95pt, zoom 상한 6.0 적용 시 약 35.7px 정도만 나와야 한다.
+    assert width_px <= 40

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -161,9 +161,10 @@
             <div id="library-recommendations-list" style="margin-top:10px"></div>
           </div>
           <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
-          <div style="display: flex; gap: 16px; align-items: stretch;">
+          <div id="library-graph-row" style="display: flex; align-items: stretch;">
             <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
-            <div id="library-graph-detail-panel" style="flex: 0 0 260px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
+            <div id="library-graph-resizer" class="chat-resizer" style="border-radius: 3px;"></div>
+            <div id="library-graph-detail-panel" style="flex: 0 0 auto; width: 260px; max-width: 70%; overflow-y: auto; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
               <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
             </div>
           </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -230,7 +230,9 @@ const annotationSubtabHighlight = $('annotation-subtab-highlight')
 const annotationSubtabUnderline = $('annotation-subtab-underline')
 const annotationList            = $('annotation-list')
 const libraryGraphSection       = $('library-graph-section')
+const libraryGraphRow           = $('library-graph-row')
 const libraryGraphCanvas        = $('library-graph-canvas')
+const libraryGraphResizer       = $('library-graph-resizer')
 const libraryGraphDetailPanel   = $('library-graph-detail-panel')
 const libraryGraphPendingBanner = $('library-graph-pending-banner')
 const libraryGraphSearchInput   = $('library-graph-search-input')
@@ -4613,14 +4615,17 @@ function showGraphDetailPanel(nodeData, neighborNodes = []) {
       <p style="margin:0">${escapeHtml(nodeData.label || '')}</p>
     `
   } else if (nodeData.type === 'figure') {
+    // 캡션은 backend(_spans_to_bold_markdown)가 **볼드**만 마크다운으로 감싸
+    // 넘겨준다 - Figure/Table 오버레이 툴팁(renderBoldText 최초 도입 지점)과
+    // 동일한 방식으로 렌더링해야 캡션 안의 볼드 서식이 살아난다.
     const captionHtml = nodeData.caption
-      ? `<p style="margin:0 0 10px;color:var(--text-secondary);font-size:12px">${escapeHtml(nodeData.caption)}</p>`
+      ? `<p style="margin:0 0 10px;color:var(--text-secondary);font-size:12px">${renderBoldText(nodeData.caption)}</p>`
       : ''
     const hasCrop = nodeData.doc_id != null && nodeData.index != null
     libraryGraphDetailPanel.innerHTML = `
       <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
       <p style="margin:0 0 10px"><strong>유형:</strong> Figure/Table</p>
-      ${hasCrop ? `<img id="kg-figure-img" class="primer-figure-img" style="margin-bottom:10px" alt="${escapeHtml(nodeData.label || '')}">` : ''}
+      ${hasCrop ? `<img id="kg-figure-img" class="primer-figure-img" style="margin-bottom:10px;width:100%;cursor:pointer" alt="${escapeHtml(nodeData.label || '')}" title="클릭하면 논문의 해당 페이지로 이동합니다">` : ''}
       ${captionHtml}
     `
     const figureImg = $('kg-figure-img')
@@ -4632,6 +4637,13 @@ function showGraphDetailPanel(nodeData, neighborNodes = []) {
         }))
       })
       figureImg.src = `/api/library/${encodeURIComponent(nodeData.doc_id)}/figure-image/${encodeURIComponent(nodeData.index)}`
+      // 이미지(그림/표/수식 캡처 전부 포함)를 클릭하면 실제 논문의 해당 페이지로
+      // 이동한다 - annotation 목록 항목 클릭과 동일한 경로(openAnnotationTarget).
+      if (nodeData.page != null) {
+        figureImg.addEventListener('click', () => {
+          openAnnotationTarget({ id: nodeData.doc_id }, nodeData.page)
+        })
+      }
     }
   } else {
     libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
@@ -9982,6 +9994,48 @@ function initChatListeners() {
       document.body.style.userSelect = ''
       if (chatSidebar.style.width) {
         localStorage.setItem('easypaper_chat_sidebar_width', parseInt(chatSidebar.style.width))
+      }
+    })
+  }
+
+  // 지식 그래프 상세 패널 리사이저 - 채팅 사이드바 리사이저와 동일한 드래그
+  // 패턴이되, 패널이 창 오른쪽 끝이 아니라 그래프 영역(libraryGraphRow) 안에
+  // 있으므로 window.innerWidth가 아니라 그 행(row)의 오른쪽 끝을 기준으로
+  // 폭을 계산한다.
+  const savedGraphPanelWidth = localStorage.getItem('easypaper_graph_detail_panel_width')
+  if (savedGraphPanelWidth && libraryGraphDetailPanel) {
+    libraryGraphDetailPanel.style.width = `${savedGraphPanelWidth}px`
+  }
+
+  let isDraggingGraphPanel = false
+  if (libraryGraphResizer && libraryGraphDetailPanel && libraryGraphRow) {
+    libraryGraphResizer.addEventListener('mousedown', (e) => {
+      e.preventDefault()
+      isDraggingGraphPanel = true
+      libraryGraphResizer.classList.add('dragging')
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    })
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isDraggingGraphPanel) return
+      const rowRect = libraryGraphRow.getBoundingClientRect()
+      const newWidth = rowRect.right - e.clientX
+      const minWidth = 220
+      const maxWidth = Math.min(720, rowRect.width * 0.7)
+      if (newWidth >= minWidth && newWidth <= maxWidth) {
+        libraryGraphDetailPanel.style.width = `${newWidth}px`
+      }
+    })
+
+    document.addEventListener('mouseup', () => {
+      if (!isDraggingGraphPanel) return
+      isDraggingGraphPanel = false
+      libraryGraphResizer.classList.remove('dragging')
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      if (libraryGraphDetailPanel.style.width) {
+        localStorage.setItem('easypaper_graph_detail_panel_width', parseInt(libraryGraphDetailPanel.style.width, 10))
       }
     })
   }


### PR DESCRIPTION
# Summary
## 1. 지식 그래프 상세 패널을 드래그로 리사이즈 가능하게 수정
- `frontend/index.html`: `#library-graph-canvas`와 `#library-graph-detail-panel` 사이에 리사이저 핸들(`#library-graph-resizer`, 기존 채팅 사이드바와 동일한 `.chat-resizer` 스타일 재사용) 추가, 두 요소를 감싸는 `#library-graph-row` id 부여
- `frontend/src/main.js`: 채팅 사이드바 리사이저와 동일한 드래그 패턴으로 `#library-graph-detail-panel` 폭 조절 로직 추가, 폭을 `localStorage`(`easypaper_graph_detail_panel_width`)에 저장해 다음 방문 시에도 유지
- 패널의 `flex: 0 0 260px`(고정 flex-basis)가 JS로 설정한 `style.width`를 무시하던 버그를 `flex: 0 0 auto`로 수정해, 실제로 드래그한 폭이 반영되도록 함

## 2. 패널을 넓히면 Figure/Table 이미지도 함께 커지도록 수정
- `frontend/src/main.js`: 상세 패널의 크롭 이미지에 `width:100%`를 추가(기존엔 `max-width:100%`만 있어 원본보다 작아지기만 하고 커지지는 않았음)

## 3. 이미지(그림/표/수식 캡처) 클릭 시 논문의 해당 페이지로 이동
- `frontend/src/main.js`: 크롭 이미지에 클릭 리스너를 추가해 주석 목록 항목과 동일한 경로(`openAnnotationTarget({ id: doc_id }, page)`)로 해당 논문을 열고 해당 페이지로 스크롤

## 4. 캡션 내 마크다운(볼드) 렌더링 안 되던 문제 수정
- `frontend/src/main.js`: 캡션을 `escapeHtml`로만 그리던 것을, 기존 Figure/Table 오버레이 툴팁 캡션에 이미 쓰이던 `renderBoldText`(backend가 `**볼드**`로 감싸 보내는 서식을 되살리는 함수)로 교체

## 5. 수식처럼 작은 캡처 영역이 확대 표시 시 흐려 보이던 문제 개선
- `backend/services/pdf_parser.py`: `render_image_crop_bytes`에 `min_output_width`/`max_zoom` 옵션 추가 - 원본 크롭 영역이 작을수록(수식 등) zoom을 자동으로 키워 최소 출력 해상도를 보장(상한 `max_zoom`으로 과도한 렌더링 비용은 방지), 큰 그림/표는 기존 zoom=2.0 그대로 영향 없음
- `backend/routers/library.py`: `/library/{doc_id}/figure-image/{index}` 엔드포인트가 `min_output_width=900`을 사용하도록 적용

## 6. 테스트
- `backend/tests/test_pdf_parser_crop.py` 신규 작성: 실제 PDF를 만들어 min_output_width 없는 기본 동작, 작은 영역이 목표 폭까지 확대되는 동작, max_zoom 상한이 지켜지는 동작을 검증
- `backend/tests/test_library_figure_image_api.py`: 엔드포인트가 `min_output_width=900`을 넘겨 호출하는지 검증하도록 갱신
- 백엔드 전체 테스트 280/281 통과(나머지 1개는 이 브랜치와 무관한 기존 실패), 프론트엔드 `npm run build` 성공
- Playwright로 실제 서버에서 로그인 후 리사이저 드래그(패널·이미지 폭이 함께 커짐 확인), 캡션 볼드 렌더링, 이미지 클릭 시 논문 조회 요청 발생을 직접 확인
