### PR TITLE
fix: 수식 캡처가 실제 수식보다 넓은 영역까지 잡히던 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -960,13 +960,18 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
     번호가 매겨진 수식(예: "... = mc^2   (3)")을 찾아 오버레이 대상 bbox를 반환합니다.
 
     수식 번호 "(N)"는 텍스트로 존재하지만, 그 앞의 실제 수식 본문(분수/합/적분
-    기호 등)은 번호 자체보다 훨씬 크고 - 특히 세로로 - 수식 번호 한 글자 줄의
-    bbox만 그대로 쓰면 번호만 딱 잘려 보이는 문제가 있었다. 이를 보정하기 위해:
-    - 세로: 위/아래로 가장 가까운 다른 텍스트 줄까지의 중간 지점까지 확장해,
-      본문 문단과 수식 사이의 여백(display equation 특유의 공백)을 최대한 포함한다.
-    - 가로: 페이지에서 같은 쪽(2단 레이아웃이면 좌/우 중 같은 쪽)에 속한 주변
-      줄들의 최소 x0을 찾아, 수식 번호만이 아니라 수식 본문이 시작되는 좌측
-      여백까지 폭을 넓힌다.
+    기호 등)은 번호 자체보다 훨씬 클 수 있다 - 특히 세로로, 분자/분모처럼 같은
+    수식이 여러 줄(베이스라인)에 걸쳐 있으면 번호가 매겨진 줄의 bbox만 그대로
+    쓸 때 번호만 딱 잘려 보이는 문제가 있었다. 이를 보정하기 위해 위/아래로
+    가장 가까운 다른 텍스트 줄까지의 중간 지점까지 세로로만 확장해, 본문
+    문단과 수식 사이의 여백(display equation 특유의 공백)을 포함한다.
+
+    가로는 확장하지 않는다 - 번호가 매겨진 줄의 bbox(lx0~lx1)는 PyMuPDF가 같은
+    베이스라인의 글리프를 전부 하나의 line으로 묶어 반환하므로 수식 본문+번호
+    전체를 이미 정확히 감싼다. 예전엔 주변 문단 줄들 중 가장 왼쪽 x0을 찾아
+    좌측으로 더 넓히려 했지만, 수식이 컬럼 왼쪽 여백보다 안쪽에서 시작하는
+    흔한 경우(들여쓰기/중앙 정렬된 수식)에 그 문단 줄들의 여백까지 통째로
+    캡처되어 실제 수식보다 훨씬 넓은 영역이 잘리는 문제가 있었다.
     """
     page_width = page.rect.width
     blocks = page.get_text("dict")["blocks"]
@@ -1014,17 +1019,9 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
         else:
             y1 = ly1 + 40.0
 
-        # 세로로 40pt 이내에 있는 같은 쪽 줄들 중 가장 왼쪽 x0을 수식 본문의
-        # 좌측 여백으로 채택 (수식 번호 자신의 x0보다 훨씬 왼쪽일 가능성이 높음)
-        nearby_left_edges = [
-            ox0 for (ox0, oy0, ox1, oy1) in same_side_lines
-            if not (oy1 < ly0 - 40 or oy0 > ly1 + 40)
-        ]
-        x0 = min(nearby_left_edges) if nearby_left_edges else lx0
-
         equations.append({
             "label": f"Equation {number}",
-            "bbox": [x0, y0, lx1, y1],
+            "bbox": [lx0, y0, lx1, y1],
         })
     return equations
 

--- a/backend/tests/test_pdf_parser_equation_crop.py
+++ b/backend/tests/test_pdf_parser_equation_crop.py
@@ -1,0 +1,39 @@
+"""extract_pdf_images()가 만드는 "Equation N" 항목의 가로 폭 회귀 테스트.
+
+_find_page_equations()는 예전엔 번호 매겨진 수식 줄 주변(세로 40pt 이내)의
+다른 텍스트 줄들 중 가장 왼쪽 x0을 찾아 좌측으로 폭을 넓혔다. 그런데 수식이
+문단 본문의 왼쪽 여백보다 안쪽에서 시작하는 흔한 경우(들여쓰기/중앙 정렬된
+수식)엔, 위아래 문단 줄의 여백까지 통째로 캡처되어 실제 수식보다 훨씬 넓은
+영역이 잘리는 문제가 있었다. 이 테스트는 그 회귀를 막는다 - 크롭 영역의
+왼쪽 경계가 수식 자신의 시작 위치를 벗어나지 않아야 한다."""
+
+import fitz
+
+from services.pdf_parser import extract_pdf_images
+
+
+def test_equation_crop_does_not_widen_to_paragraph_margin(tmp_path):
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    # 문단 본문 줄들 - 왼쪽 여백(x=50)에서 시작하고, 수식 위/아래 40pt 이내에 위치
+    page.insert_text((50, 200), "This paragraph line sits above the equation and starts at the left margin.", fontsize=9)
+    page.insert_text((50, 260), "This paragraph line sits below the equation and also starts at the left margin.", fontsize=9)
+
+    # 수식은 문단 여백보다 훨씬 안쪽(x=220)에서 시작 - 들여쓰기/중앙 정렬된 수식 흉내
+    page.insert_text((220, 230), "x = y + z    (3)", fontsize=11)
+
+    path = tmp_path / "equation.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    eq_entries = [r for r in result if r.get("label") == "Equation 3"]
+    assert len(eq_entries) == 1
+    entry = eq_entries[0]
+
+    page_width = 595
+    paragraph_left_pct = (50 / page_width) * 100
+    # 수식 자신의 시작 위치(x=220 부근)보다 왼쪽으로는 확장되지 않아야 한다 -
+    # 특히 문단 왼쪽 여백(50pt)까지 통째로 캡처되면 안 된다.
+    assert entry["left"] > paragraph_left_pct + 10


### PR DESCRIPTION
# Summary
## 1. 수식(Equation) 캡처가 실제 수식보다 넓은 영역까지 잡히던 문제 수정
- `backend/services/pdf_parser.py`의 `_find_page_equations()`: 번호 매겨진 수식 줄(예: "x = y + z    (3)") 주변(세로 40pt 이내)의 다른 문단 텍스트 줄들 중 가장 왼쪽 x0을 찾아 좌측 경계를 넓히던 로직(`nearby_left_edges`)을 제거
- 원인: 수식이 문단 왼쪽 여백보다 안쪽에서 시작하는 흔한 경우(들여쓰기/중앙 정렬된 수식)에, 그 위아래 문단 줄들의 왼쪽 여백까지 통째로 캡처되어 실제 수식보다 훨씬 넓은 영역이 크롭됨
- 수정: 번호 매겨진 텍스트 줄 자신의 bbox(`lx0`~`lx1`)를 그대로 사용 - PyMuPDF가 같은 베이스라인의 글리프를 전부 하나의 line으로 묶어 반환하므로 수식 본문+번호 전체를 이미 정확히 감쌈
- 세로 확장 로직(분자/분모처럼 여러 줄에 걸친 수식이 잘리지 않도록 위/아래 인접 줄까지 확장)은 그대로 유지 - 이번에 신고된 문제와 무관하고 별도의 정당한 이유가 있음

## 2. 테스트
- `backend/tests/test_pdf_parser_equation_crop.py` 신규 작성: 문단이 왼쪽 여백(x=50)에서 시작하고 수식은 그보다 안쪽(x=220)에서 시작하는 PDF를 만들어, 크롭된 "Equation N" 영역의 왼쪽 경계가 문단 여백까지 확장되지 않는지 검증
- 수정 전 코드로 되돌려 이 테스트가 실제로 실패하는지 직접 확인(회귀 테스트로서 유효함을 검증) 후 수정 복원
- 기존 `test_pdf_parser_images.py`/`test_pdf_parser_figure_text.py`/`test_primer.py` 포함 회귀 없음 확인, 백엔드 전체 테스트 281/282 통과(나머지 1개는 이 브랜치와 무관한 기존 실패)
