### PR TITLE
fix: 실제 논문 PDF에서 수식 크롭이 여전히 잘못되던 세 가지 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1036,6 +1036,7 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
     column_blocks = []  # _detect_two_column이 기대하는 (x0,y0,x1,y1,text) 블록 목록
     for b in blocks:
         block_text_parts = []
+        body_bbox = None  # 번호가 붙은 줄을 제외한 "본문" 줄들의 합집합 bbox
         for ln in b.get("lines", []):
             bbox = ln.get("bbox")
             if not bbox:
@@ -1048,9 +1049,30 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
             m = _EQUATION_LINE_RE.search(line_text)
             if m and m.group(1):
                 candidates.append((bbox, m.group(1)))
-        if "bbox" in b:
-            bx0, by0, bx1, by1 = b["bbox"]
-            column_blocks.append((bx0, by0, bx1, by1, "".join(block_text_parts)))
+                continue  # 번호 붙은 줄 자신은 아래 본문 bbox 계산에서 제외
+            if body_bbox is None:
+                body_bbox = list(bbox)
+            else:
+                body_bbox[0] = min(body_bbox[0], bbox[0])
+                body_bbox[1] = min(body_bbox[1], bbox[1])
+                body_bbox[2] = max(body_bbox[2], bbox[2])
+                body_bbox[3] = max(body_bbox[3], bbox[3])
+        # 2단 레이아웃 판정용 블록 bbox는 번호가 붙은 줄을 제외한 "본문"
+        # 부분만으로 계산한다. PyMuPDF 블록 단위에서는 수식 본문+번호가 한
+        # 블록으로 합쳐지는데, 번호가 페이지 오른쪽 끝 여백까지 멀리 붙어
+        # 있어 블록 bbox 전체를 쓰면 폭이 넓어지고 중심이 오른쪽으로 쏠린다
+        # - 페이지 폭의 55~60% 정도면 "wide" 블록 판정(_WIDE_BLOCK_RATIO=0.6)
+        # 문턱을 살짝 못 넘어 "right" 컬럼 블록으로 잘못 집계되고, 수식이
+        # 많은 페이지에서는 이런 블록만으로 2단 레이아웃 문턱(각 200자)을
+        # 넘기면서 실제로는 1단인 논문이 2단으로 오판되는 문제가 실제로
+        # 있었다. 번호가 붙은 줄만 있고 본문 줄이 아예 없는 블록(body_bbox
+        # 없음)은 열 판정에 기여할 정보가 없으므로 건너뛴다 - 통째로
+        # 제외하면 실제 2단 논문에서 그 블록이 속한 컬럼의 글자 수 집계가
+        # 너무 줄어 2단 감지 자체가 실패하는 회귀가 있었다(문단 안에서
+        # 우연히 줄바꿈이 "(MI)"처럼 괄호로 끝나 오탐지되는 경우, 그 문단의
+        # 나머지 줄들은 여전히 진짜 컬럼 신호이기 때문).
+        if body_bbox is not None:
+            column_blocks.append((body_bbox[0], body_bbox[1], body_bbox[2], body_bbox[3], "".join(block_text_parts)))
 
     # 2단 레이아웃인 페이지에서만 좌/우 컬럼을 구분해 흡수를 제한한다(아래
     # same_column 헬퍼). 1단 레이아웃 논문은 수식 본문이 왼쪽에서 시작해
@@ -1108,6 +1130,35 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
         row_groups.append(group)
         row_rects.append(rect)
 
+    # 각 후보의 행 재구성은 서로 독립적으로 계산되기 때문에, 억양 부호(¯ 등)가
+    # 붙은 글자처럼 줄의 bbox가 유난히 위/아래로 큰 경우 그 줄 하나가 "자기
+    # 수식의 번호"와도 겹치고 "바로 아래 다른 수식의 번호"와도 겹쳐 두 수식
+    # 모두에 중복으로 흡수될 수 있다(실제 관찰됨 - (22)의 본문 줄이 (23)에도
+    # 잘못 흡수됨). 겹치는 줄은 "자기 자신의 원래 후보 줄"과 겹침 비율이 가장
+    # 높은 쪽에만 남기고 나머지에서는 제거한 뒤, 줄어든 그룹의 rect를 남은
+    # 구성원만으로 다시 계산한다.
+    line_owner_indices: Dict[tuple, List[int]] = {}
+    for idx, group in enumerate(row_groups):
+        for ln in group:
+            line_owner_indices.setdefault(ln, []).append(idx)
+
+    shrunk_indices = set()
+    for ln, owner_indices in line_owner_indices.items():
+        if len(owner_indices) <= 1:
+            continue
+        best_idx = max(owner_indices, key=lambda i: _vertical_overlap_ratio(candidates[i][0], ln))
+        for i in owner_indices:
+            if i != best_idx:
+                row_groups[i].discard(ln)
+                shrunk_indices.add(i)
+
+    for idx in shrunk_indices:
+        group = row_groups[idx]
+        row_rects[idx] = [
+            min(g[0] for g in group), min(g[1] for g in group),
+            max(g[2] for g in group), max(g[3] for g in group),
+        ]
+
     # ── 2단계: 여러 행에 걸친 수식(분수/피스와이즈 등) 흡수 ───────────────
     # 세로로 아주 가깝고 문단 줄만큼 넓지 않은 이웃 줄을 추가로 흡수하되,
     # 다른 수식의 행(1단계에서 이미 확정된 row_groups)에 속한 줄은 절대
@@ -1125,12 +1176,19 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
             and _same_column(eq_center_x, ln)
         ]
         # 문단 본문 줄의 전형적인 폭 추정치 - 반드시 이 수식과 같은 컬럼(2단
-        # 레이아웃이면 좌/우 중 한쪽, 1단이면 페이지 전체)에서 관찰된 줄들
-        # 중 가장 넓은 것을 기준으로 삼아야 한다. 페이지 전체에서 가장 넓은
-        # 줄(예: 제목처럼 두 컬럼을 가로지르는 wide 블록)을 기준으로 삼으면
-        # 임계값이 너무 커져, 같은 문단의 온전한 줄까지 "수식만큼 좁다"고
-        # 잘못 판단해 흡수해버린다(실제 관찰된 회귀).
-        column_widths = [ln[2] - ln[0] for ln in remaining]
+        # 레이아웃이면 좌/우 중 한쪽, 1단이면 페이지 전체)에서 관찰된 "진짜
+        # 한 컬럼 안에 들어가는" 줄들 중 가장 넓은 것을 기준으로 삼아야 한다.
+        # Figure/Table 캡션처럼 두 컬럼을 가로질러 페이지 폭 대부분을 차지하는
+        # 줄(_WIDE_BLOCK_RATIO 이상)은 _same_column 판정이 중심점 하나로만
+        # 좌/우를 가르다 보니 우연히 "같은 컬럼"으로 분류될 수 있는데, 이런
+        # wide 줄을 기준으로 삼으면 임계값이 페이지 폭 절반 가까이까지
+        # 커져버려 문단의 온전한 줄까지 전부 "수식만큼 좁다"고 잘못 판단해
+        # 흡수해버린다(실제 관찰된 회귀 - Figure 캡션 때문에 문단 전체가
+        # 수식 크롭에 딸려 들어감).
+        column_widths = [
+            ln[2] - ln[0] for ln in remaining
+            if ln[2] - ln[0] < page_width * _WIDE_BLOCK_RATIO
+        ]
         column_width_estimate = max(column_widths) if column_widths else page_width
 
         for _ in range(_EQ_ABSORB_MAX_ITERATIONS):

--- a/backend/tests/test_pdf_parser_equation_crop.py
+++ b/backend/tests/test_pdf_parser_equation_crop.py
@@ -11,6 +11,12 @@ _find_page_equations()의 진화 과정에서 실제로 관찰된 네 가지 오
    bbox만 잡혀 숫자만 확대되어 잘리는 문제.
 5. 2단 레이아웃에서 번호처럼 보이는 오탐지(예: "(MI)")가 좌/우 컬럼을
    가리지 않고 양쪽 문단을 통째로 삼키는 문제.
+6. 유난히 위/아래로 큰 bbox를 가진 줄(억양 부호 등)이 자기 수식뿐 아니라
+   바로 아래/위 다른 수식의 번호와도 겹쳐, 두 수식 모두에 중복으로
+   흡수되는 문제(실제 관찰 - (22)의 본문 줄이 (23)에도 잘못 흡수됨).
+7. Figure/Table 캡션처럼 페이지 폭 대부분을 차지하는 줄이 "문단 줄 폭
+   추정치"를 부풀려, 정상 크기의 문단 줄까지 "수식만큼 좁다"고 잘못
+   판단해 흡수해버리는 문제.
 """
 
 import fitz
@@ -129,27 +135,30 @@ def test_piecewise_equation_captures_all_case_lines(tmp_path):
 def test_false_positive_equation_number_does_not_bridge_columns(tmp_path):
     """2단 레이아웃에서 로마 숫자로 오인식될 수 있는 괄호 약어(예: "(MI)")가
     실제 수식이 아니더라도, 좌/우 컬럼을 가로질러 양쪽 문단을 통째로
-    삼키면 안 된다."""
+    삼키면 안 된다.
+
+    insert_textbox()로 각 컬럼을 한 문단(하나의 PyMuPDF 블록에 여러 줄이
+    자동 줄바꿈되어 들어감)으로 만든다 - insert_text()를 줄마다 따로
+    호출하면 줄마다 별도 블록이 생겨 실제 PDF의 문단 블록 구조(여러 줄이
+    한 블록으로 묶임)와 달라지고, "(MI)"로 끝나는 줄이 속한 문단의 나머지
+    줄들이 2단 감지에 기여하지 못해 테스트가 실제 동작을 반영하지 못한다."""
     doc = fitz.open()
     page = doc.new_page(width=612, height=792)
-    # 왼쪽 컬럼 - 여러 줄의 본문 문단(2단 레이아웃 감지를 위해 충분한 글자 수 필요)
-    left_lines = [
-        "Subsequently the simple classifier module based on fully connected",
-        "layers is followed to predict the categories for EEG signals here we",
-        "also devise a visualization strategy to project the class activation",
-        "mapping onto the brain topography finally we have conducted many",
-    ]
-    for i, text in enumerate(left_lines):
-        page.insert_text((50, 100 + i * 14), text, fontsize=9)
-    # 오른쪽 컬럼 - "(MI)"로 끝나는 줄을 포함
-    right_lines = [
-        "these methods extract features and perform classification for",
-        "different tasks for example common spatial pattern csp is used",
-        "to enhance spatial features for motor imagery tasks called (MI)",
-        "the filter bank is further embedded for frequency rhythms here",
-    ]
-    for i, text in enumerate(right_lines):
-        page.insert_text((320, 100 + i * 14), text, fontsize=9)
+    left_text = (
+        "Subsequently the simple classifier module based on fully connected "
+        "layers is followed to predict the categories for EEG signals here we "
+        "also devise a visualization strategy to project the class activation "
+        "mapping onto the brain topography finally we have conducted many experiments."
+    )
+    # "(MI)"로 끝나는 줄바꿈이 자연스럽게 생기도록 자동 줄바꿈에 맡긴다.
+    right_text = (
+        "these methods extract features and perform classification for "
+        "different tasks for example common spatial pattern csp is used "
+        "to enhance spatial features for motor imagery tasks called (MI) "
+        "the filter bank is further embedded for frequency rhythms here."
+    )
+    page.insert_textbox(fitz.Rect(50, 90, 300, 200), left_text, fontsize=9)
+    page.insert_textbox(fitz.Rect(320, 90, 570, 200), right_text, fontsize=9)
     path = tmp_path / "two_column.pdf"
     doc.save(str(path))
     doc.close()
@@ -160,3 +169,60 @@ def test_false_positive_equation_number_does_not_bridge_columns(tmp_path):
     x0, _, x1, _ = _pt(entries[0], page_width=612, page_height=792)
     # 왼쪽 컬럼(약 50~300pt)까지 번져서는 안 된다 - 오른쪽 컬럼(약 320pt~) 안에만 있어야 한다.
     assert x0 > 300
+
+
+def test_tall_shared_line_is_not_double_claimed_by_two_equations(tmp_path):
+    """억양 부호 등으로 인해 유난히 위/아래로 큰 bbox를 가진 줄은, 자기
+    수식뿐 아니라 바로 아래 다른 수식의 번호와도 겹칠 수 있다. 이런 줄은
+    "자기 자신의 원래 후보 줄"과 겹침이 더 강한 쪽에만 귀속돼야 하고, 두
+    수식 모두에 중복으로 흡수되면 안 된다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((150, 200), "x = y (", fontsize=11)
+    # 큰 폰트로 그린 조각 - PyMuPDF가 "x = y (" 옆줄과 합쳐 유난히 키가 큰
+    # line을 만든다(억양 부호가 있는 실제 글리프의 bbox 오버슈트를 흉내).
+    page.insert_text((200, 205), "TALLBIT", fontsize=26)
+    page.insert_text((520, 200), "(1)", fontsize=11)
+    # 바로 아래, 촘촘히 쌓인 별개의 수식
+    page.insert_text((250, 218), "p = q", fontsize=11)
+    page.insert_text((520, 218), "(2)", fontsize=11)
+    path = tmp_path / "tall_shared_line.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    eq1 = [r for r in result if r.get("label") == "Equation 1"][0]
+    eq2 = [r for r in result if r.get("label") == "Equation 2"][0]
+    eq1_x0, _, _, _ = _pt(eq1)
+    eq2_x0, _, _, _ = _pt(eq2)
+    # 키 큰 조각("x = y (TALLBIT", x=150 부근)은 Equation 1에만 속해야 한다.
+    # Equation 2는 자기 자신의 본문("p = q", x=250 부근)에서만 시작해야
+    # 하고, 위로 번져서 Equation 1의 내용까지 포함하면 안 된다.
+    assert eq1_x0 < 160
+    assert eq2_x0 > 240
+
+
+def test_wide_caption_line_does_not_inflate_paragraph_width_estimate(tmp_path):
+    """Figure/Table 캡션처럼 페이지 폭 대부분을 차지하는 줄이 있으면,
+    "정상 크기 문단 줄" 판단 기준(문단 줄 폭 추정치)이 그 캡션 폭까지
+    부풀려져서 진짜 온전한 문단 줄까지 수식에 흡수돼버리는 회귀가 있었다."""
+    doc = fitz.open()
+    page = doc.new_page(width=612, height=792)
+    # 페이지 폭 대부분을 차지하는 캡션 줄(약 500pt, 페이지 폭의 82%)
+    page.insert_text((55, 300), "Figure 1. A very long caption that spans almost the entire page width here.", fontsize=9)
+    # 문단 줄 - 페이지 폭의 약 55%(수식과 무관한 온전한 문장)
+    page.insert_text((55, 340), "This paragraph line describes the context around the equation below fully.", fontsize=9)
+    page.insert_text((55, 400), "This paragraph line comes right after the equation and continues the text.", fontsize=9)
+    page.insert_text((220, 370), "a = b + c", fontsize=11)
+    page.insert_text((520, 370), "(1)", fontsize=11)
+    path = tmp_path / "wide_caption.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    entries = [r for r in result if r.get("label") == "Equation 1"]
+    assert len(entries) == 1
+    _, y0, _, y1 = _pt(entries[0], page_width=612, page_height=792)
+    # 위/아래 문단 줄(각각 y~300-450 부근)까지 통째로 흡수되면 안 된다 -
+    # 수식 자신의 좁은 높이(수십 pt 이내)만 캡처해야 한다.
+    assert y1 - y0 < 60


### PR DESCRIPTION
# Summary
## 1. 실제 논문 PDF로 직접 검증해 발견한 세 가지 추가 문제 수정
지난 PR(#280)이 합성(synthetic) PDF로만 검증되어, 사용자가 신고했던 실제 논문(EEG 스파이킹 신경망 논문, Harmonic RF 상태공간 모델 논문)에서는 여전히 수식이 잘못 잘리는 문제가 남아 있었음. `data/easypaper`에 업로드된 실제 PDF로 직접 재현·디버깅해 근본 원인 세 가지를 찾아 수정:

- **2단 레이아웃 오판 (`backend/services/pdf_parser.py`)**: `_detect_two_column`이 수식이 많은 페이지를 2단으로 잘못 판단 - PyMuPDF 블록 단위에서는 수식 본문+번호가 한 블록으로 합쳐지는데, 번호가 페이지 오른쪽 끝까지 멀리 붙어 있어 블록 중심이 오른쪽으로 쏠려 "right" 컬럼으로 잘못 집계됨(1단 논문인데 2단으로 오판 → Equation 22가 다시 잘림). 번호 붙은 줄을 제외한 "본문" 부분만으로 블록 bbox를 계산하도록 수정 - 2단 논문에서의 정상 감지(로마 숫자 오탐지 "(MI)" 방지)는 그대로 유지됨
- **행(row) 재구성 시 중복 흡수**: 억양 부호(¯) 등으로 유난히 위/아래로 큰 bbox를 가진 줄이 자기 수식뿐 아니라 바로 아래 다른 수식의 번호와도 겹쳐, 두 수식 모두에 중복으로 흡수됨(각 후보의 행 재구성이 서로 독립적으로 계산되기 때문). 겹치는 줄은 "자기 자신의 원래 후보 줄"과 겹침 비율이 가장 높은 쪽에만 남기는 충돌 해소 단계 추가
- **문단 줄 폭 추정치 오염**: Figure/Table 캡션처럼 페이지 폭 대부분을 차지하는 줄이 있으면 "정상 크기 문단 줄" 판단 기준이 부풀려져, 진짜 온전한 문단 줄까지 수식에 흡수됨. 폭 추정치 계산에서 `_WIDE_BLOCK_RATIO`(60%) 이상인 줄을 제외

## 2. 테스트
- `backend/tests/test_pdf_parser_equation_crop.py`에 신규 시나리오 2개 추가(기존 5개 유지, 총 7개):
  - 유난히 큰 bbox를 가진 줄이 두 인접 수식 중 하나에만 배타적으로 귀속되는지
  - 넓은 캡션 줄이 있어도 문단 줄 폭 추정치가 부풀려지지 않는지
- 기존 "(MI)" 2단 레이아웃 테스트를 `insert_textbox()` 기반으로 다시 작성 - `insert_text()`를 줄마다 호출하면 각 줄이 별도 PyMuPDF 블록이 되어 실제 PDF의 문단 블록 구조(여러 줄이 한 블록으로 자동 줄바꿈되어 묶임)를 반영하지 못해, 테스트가 실제 동작과 다른 결과를 낼 수 있었음
- 실제 두 논문(Harmonic RF 34개 수식 + EEG Conformer 5개 수식, 총 39개)을 전부 렌더링해 육안으로 확인 - 이상치(지나치게 작거나 극단적인 가로세로 비율) 자동 스캔 결과 없음
- 백엔드 전체 테스트 287/288 통과(나머지 1개는 이 브랜치와 무관한 기존 실패)
