### PR TITLE
fix: 수식 오버레이가 도미노 흡수로 인접 문단/제목까지 캡처하던 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -995,6 +995,38 @@ _EQ_ABSORB_MAX_TOTAL_WIDTH_RATIO = 0.95
 # 않으면서 폭주만 막는다.
 _EQ_ABSORB_MAX_TOTAL_HEIGHT = 120.0
 
+# 흡수 후보 줄의 텍스트가 "일반 산문 문장"처럼 보이면(도입/설명 문장 등)
+# 흡수 대상에서 제외한다. 공백으로 나눈 토큰이 일정 개수 이상이고 그중
+# 다수가 순수 알파벳 단어면서, 그 알파벳 단어들 중 다수가 3글자 이상이면
+# 산문으로 판정한다. 두 번째 조건(단어 길이)이 필요한 이유: "x = y (
+# TALLBIT"처럼 한 글자짜리 수식 변수명(x, y)과 기호 이름이 섞인 줄도
+# 토큰의 알파벳 비율만 보면 우연히 높게 나올 수 있는데("x", "y",
+# "TALLBIT" 셋 다 순수 알파벳), 진짜 영어 문장은 "the", "with", "where"
+# 같은 3글자 이상 단어가 다수를 차지하는 반면 수식 변수 나열은 1~2글자
+# 토큰이 대부분이라 이 기준으로 구분된다. 첫 번째 조건만으로는 진짜
+# 수식 구성 요소(밑줄 첨자·연산자·그리스 문자가 섞인 토큰)는 알파벳
+# 비율이 낮아 이미 걸러지고, "Z t"/"x = y" 같은 아주 짧은 변수 나열은
+# 토큰 수 자체가 적어 걸러진다. 실제 논문 PDF에서 "The process can be
+# expressed as", "where MHA stands for..." 같은 수식 직전/직후 짧은
+# 문장이 폭 비율 가드(아래 _EQ_ABSORB_MAX_WIDTH_RATIO)만으로는 걸러지지
+# 않고 거의 항상 흡수되는 문제를 이 판별로 막는다.
+_PROSE_WORD_RE = re.compile(r"^[A-Za-z]+$")
+_EQ_PROSE_MIN_WORDS = 3
+_EQ_PROSE_MIN_ALPHA_RATIO = 0.6
+_EQ_PROSE_MIN_LONG_WORD_RATIO = 0.5
+
+
+def _looks_like_prose(text: str) -> bool:
+    words = text.split()
+    if len(words) < _EQ_PROSE_MIN_WORDS:
+        return False
+    alpha_words = [w.strip(",.;:") for w in words]
+    alpha_words = [w for w in alpha_words if _PROSE_WORD_RE.match(w)]
+    if len(alpha_words) < len(words) * _EQ_PROSE_MIN_ALPHA_RATIO:
+        return False
+    long_words = [w for w in alpha_words if len(w) >= 3]
+    return len(long_words) >= len(alpha_words) * _EQ_PROSE_MIN_LONG_WORD_RATIO
+
 
 def _vertical_overlap_ratio(a: list, b: list) -> float:
     """_horizontal_overlap_ratio와 대칭인 세로 버전 - 더 좁은 쪽 높이를
@@ -1032,6 +1064,7 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
     blocks = page.get_text("dict")["blocks"]
 
     all_lines = []  # (x0, y0, x1, y1) - 페이지 내 모든 텍스트 줄
+    line_texts: Dict[tuple, str] = {}  # bbox -> 그 줄의 텍스트 (산문 판별용)
     candidates = []  # (line_bbox, number)
     column_blocks = []  # _detect_two_column이 기대하는 (x0,y0,x1,y1,text) 블록 목록
     for b in blocks:
@@ -1043,6 +1076,7 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
                 continue
             all_lines.append(bbox)
             line_text = "".join(span.get("text", "") for span in ln.get("spans", [])).strip()
+            line_texts[tuple(bbox)] = line_text
             block_text_parts.append(line_text)
             if not line_text:
                 continue
@@ -1117,6 +1151,18 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
                 if ln in group or ln in candidate_bboxes:
                     continue
                 if not _same_column(eq_center_x, ln):
+                    continue
+                # 전체 폭(컬럼 마진-투-마진)에 가까운 줄은 justified 문단
+                # 특유의 폭이지 같은 행에서 쪼개진 수식 조각일 수 없다. 이
+                # 가드가 없으면, 세로로 유난히 큰 줄(억양 부호·합/적분 기호
+                # 렌더링 등) 하나가 먼저 흡수되며 rect 세로 범위가 급격히
+                # 커지고, 그 순간 위/아래 문단 줄과도 새로 겹침 비율
+                # 임계값을 넘겨버려 다음 반복에서 또 흡수되는 도미노가
+                # 실제 논문 PDF에서 재현되었다(문단+섹션 제목까지 통째로
+                # 캡처됨).
+                if ln[2] - ln[0] >= page_width * _WIDE_BLOCK_RATIO:
+                    continue
+                if _looks_like_prose(line_texts.get(tuple(ln), "")):
                     continue
                 if _vertical_overlap_ratio(rect, ln) >= _EQ_ABSORB_MIN_VOVERLAP:
                     group.add(ln)
@@ -1197,6 +1243,14 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
             absorbed_any = False
             still_remaining = []
             for ln in remaining:
+                # 폭이 좁아 아래 width 가드는 통과하지만("The process can be
+                # expressed as" 같은 짧은 도입/설명 문장) 명백히 산문인 줄은
+                # 수식 구성 요소가 아니므로 제외한다. 실제 논문 PDF에서
+                # 수식 직전/직후의 짧은 문장이 gap·width 조건을 모두
+                # 통과해 거의 항상 흡수되는 문제를 막는다.
+                if _looks_like_prose(line_texts.get(tuple(ln), "")):
+                    still_remaining.append(ln)
+                    continue
                 merged_x0 = min(rect[0], ln[0])
                 merged_x1 = max(rect[2], ln[2])
                 merged_y0 = min(rect[1], ln[1])

--- a/backend/tests/test_pdf_parser_equation_crop.py
+++ b/backend/tests/test_pdf_parser_equation_crop.py
@@ -17,6 +17,13 @@ _find_page_equations()의 진화 과정에서 실제로 관찰된 네 가지 오
 7. Figure/Table 캡션처럼 페이지 폭 대부분을 차지하는 줄이 "문단 줄 폭
    추정치"를 부풀려, 정상 크기의 문단 줄까지 "수식만큼 좁다"고 잘못
    판단해 흡수해버리는 문제.
+8. 억양 부호·합/적분 기호 렌더링 등으로 세로로 유난히 큰 bbox를 가진
+   줄이 흡수되면서 growing rect가 급격히 커지고, 그 순간 위/아래 문단
+   줄과도 겹침 비율 임계값을 넘겨 연쇄적으로 흡수되는 도미노 문제
+   (실제 논문 PDF 전수 조사로 재발견, 3차 수정 이후에도 남아있었음).
+9. 수식 직전/직후의 짧은 도입·설명 문장이 폭이 좁아 기존 폭 비율
+   가드를 통과해 gap 조건만으로 거의 항상 흡수되는 문제(위와 같은
+   조사로 재발견).
 """
 
 import fitz
@@ -200,6 +207,60 @@ def test_tall_shared_line_is_not_double_claimed_by_two_equations(tmp_path):
     # 하고, 위로 번져서 Equation 1의 내용까지 포함하면 안 된다.
     assert eq1_x0 < 160
     assert eq2_x0 > 240
+
+
+def test_equation_does_not_cascade_via_tall_glyph_line(tmp_path):
+    """억양 부호·합/적분 기호 렌더링 등으로 세로로 유난히 큰 bbox를 가진
+    줄 하나가 1단계에서 먼저 흡수되면, growing rect의 세로 범위가 급격히
+    커지면서 그 순간 위/아래 문단 줄과도 새로 겹침 비율 임계값을 넘겨
+    다음 반복에서 또 흡수되는 도미노가 실제 논문 PDF(Kingma & Welling
+    VAE 논문)에서 재현되었다 - 섹션 제목+문단 두 개가 통째로 캡처됨.
+    여기서는 위/아래 문단 줄과 세로로 겹치는 큰 폰트 기호("BIGSYM")를
+    수식 옆에 배치해 같은 조건을 재현한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((50, 200), "This paragraph line sits above the equation naturally.", fontsize=9)
+    page.insert_text((220, 225), "x = y", fontsize=11)
+    page.insert_text((260, 220), "BIGSYM", fontsize=24)
+    page.insert_text((400, 225), "(1)", fontsize=11)
+    page.insert_text((50, 270), "This paragraph line sits below the equation naturally.", fontsize=9)
+    path = tmp_path / "tall_glyph_domino.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    entries = [r for r in result if r.get("label") == "Equation 1"]
+    assert len(entries) == 1
+    x0, _, _, _ = _pt(entries[0])
+    # 문단 왼쪽 여백(x=50)까지 흡수되면 안 된다 - 흡수 전이라면 수식 자신의
+    # 시작 위치(x=220 부근)에서 크게 벗어나지 않아야 한다.
+    assert x0 > 150, f"위쪽 문단 줄이 도미노로 흡수되어 좌측 경계가 넓어짐: {entries[0]}"
+
+
+def test_equation_does_not_absorb_short_lead_in_sentence(tmp_path):
+    """수식 바로 위의 짧은 도입 문장("The process can be expressed as")은
+    폭이 좁아 기존 폭 비율 가드(_EQ_ABSORB_MAX_WIDTH_RATIO)만으로는
+    걸러지지 않고 gap 조건까지 통과해 거의 항상 흡수되는 문제가 실제
+    논문 PDF(EEG Conformer 논문 등) 다수에서 재현되었다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    # 정상적인 컬럼 폭 추정치를 위한 참조 문단 줄 (수식과는 멀리 떨어짐)
+    page.insert_text((49, 100), "This is body paragraph line filling most of the column width here now please.", fontsize=10)
+    page.insert_text((49, 200), "The process can be expressed as", fontsize=10)
+    page.insert_text((90, 220), "f(x) = a x + b", fontsize=11)
+    page.insert_text((300, 220), "(1)", fontsize=11)
+    path = tmp_path / "lead_in_sentence.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    entries = [r for r in result if r.get("label") == "Equation 1"]
+    assert len(entries) == 1
+    x0, y0, _, _ = _pt(entries[0])
+    # 도입 문장의 좌측 여백(x=49)이나 그 줄 자체(y=189~203)까지 확장되면
+    # 안 된다 - 수식 자신의 시작 위치(x=90, y=208) 근처에 머물러야 한다.
+    assert x0 > 70, f"도입 문장의 좌측 여백까지 확장됨: {entries[0]}"
+    assert y0 > 195, f"도입 문장 줄까지 흡수됨: {entries[0]}"
 
 
 def test_wide_caption_line_does_not_inflate_paragraph_width_estimate(tmp_path):


### PR DESCRIPTION
## Summary
- `_find_page_equations()`의 반복 흡수(iterative absorption) 알고리즘에서, 1단계(같은 행 재구성)에 가로 폭 안전판이 없어 세로로 유난히 큰 줄(억양 부호·합/적분 기호 렌더링 등)이 흡수되면 growing rect가 급격히 커지며 인접 문단·섹션 제목까지 연쇄 흡수되는 도미노 버그를 수정
- 2단계(여러 행 흡수)의 폭 비율 가드를 통과하는 짧은 도입/설명 문장("The process can be expressed as" 등)이 gap 조건만으로 상시 흡수되던 문제도 함께 수정
- 두 단계 모두에 "전체 폭 줄 배제" + "산문처럼 보이는 줄 배제" 가드를 추가

## 근거
`/home/ubuntu/data/easypaper/uploads`에 실제 업로드된 논문 PDF(고유 20종·209개 감지 수식)를 전수 스캔 및 개별 추적(trace)해 재현·검증함. Kingma & Welling VAE 논문 "Equation 1"이 섹션 제목("2.2 The variational bound") + 앞뒤 문단까지 통째로 캡처하는 사례를 정확히 재현하고 수정 후 해소를 확인. 재스캔 결과 오염 비율 13.4%(28/209) → 8.6%(18/209).

기존 3차례 수정(#279, #280, #281)으로 해결되지 않고 남아있던 회귀였으며, 이번 수정은 그 알고리즘 구조를 유지한 채 두 안전판만 보강한다.

의도적으로 범위에서 제외한 것(후속 과제로 분리):
- 거짓 양성 수식 번호(일반 열거형 텍스트가 수식 번호로 오인식되는 경우) — 지오메트리 기반으로 정탐지와 신뢰성 있게 구분할 방법을 못 찾음
- 리뷰용 원고의 여백 줄번호 흡수 — 20종 중 1개 문서에서만 관찰, 원인이 위치 기반이라 별도 가드 필요

## Test plan
- [x] `pytest tests/test_pdf_parser_equation_crop.py -v` — 기존 7개 + 신규 2개(도미노 흡수, 도입 문장 흡수) 회귀 테스트 전부 통과
- [x] `pytest tests/ -v` — 전체 스위트 290개 중 289개 통과(나머지 1개는 이 변경과 무관한 사전 존재 환경 이슈, `test_config_cross_platform.py`)
- [x] 실사용 PDF 20종 재스캔으로 오염 비율 개선 정량 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)