### PR TITLE
fix: 수식이 페이지 하단 가까이 있을 때 페이지 쪽수까지 캡처되던 문제 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1015,6 +1015,14 @@ _EQ_PROSE_MIN_WORDS = 3
 _EQ_PROSE_MIN_ALPHA_RATIO = 0.6
 _EQ_PROSE_MIN_LONG_WORD_RATIO = 0.5
 
+# 페이지 상/하단 여백에 있는 페이지 쪽수(running header/footer)는 짧고
+# 고립된 토큰이라 폭 비율 가드(_EQ_ABSORB_MAX_WIDTH_RATIO)를 쉽게
+# 통과하고, 수식이 페이지 하단 가까이에 있으면 간격(gap)도 작아 그대로
+# 흡수되는 문제가 실제 논문 PDF에서 재현되었다(페이지 하단 쪽수 "7"이
+# 수식 바로 아래에 함께 캡처됨). 표 구분선 탐지에 이미 쓰이고 있는 동일
+# 관례(페이지 상/하단 65pt 이내 = 헤더/푸터 영역)를 그대로 재사용한다.
+_EQ_PAGE_MARGIN_EXCLUDE = 65.0
+
 
 def _looks_like_prose(text: str) -> bool:
     words = text.split()
@@ -1061,6 +1069,7 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
     로직(_PANEL_ABSORB_*)과 같은 반복 흡수 패턴을 재사용한다.
     """
     page_width = page.rect.width
+    page_height = page.rect.height
     blocks = page.get_text("dict")["blocks"]
 
     all_lines = []  # (x0, y0, x1, y1) - 페이지 내 모든 텍스트 줄
@@ -1164,6 +1173,13 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
                     continue
                 if _looks_like_prose(line_texts.get(tuple(ln), "")):
                     continue
+                # 페이지 여백(_EQ_PAGE_MARGIN_EXCLUDE) 배제는 여기서는 필요
+                # 없다 - 1단계는 세로 겹침 비율로만 판단하는데, 페이지
+                # 쪽수(footer)는 수식 본문과 같은 행에 있을 수 없어(항상
+                # 아래쪽에 별도로 떨어져 있음) 애초에 겹침 조건을 만족하지
+                # 않는다. 여기서 필터를 걸면 수식 자신이 페이지 하단
+                # 여백 가까이 있을 때 진짜 같은 행 조각까지 함께 배제되는
+                # 회귀가 생긴다 - 아래 2단계에서만 적용한다.
                 if _vertical_overlap_ratio(rect, ln) >= _EQ_ABSORB_MIN_VOVERLAP:
                     group.add(ln)
                     rect[0] = min(rect[0], ln[0])
@@ -1249,6 +1265,14 @@ def _find_page_equations(page: "fitz.Page") -> List[Dict[str, Any]]:
                 # 수식 직전/직후의 짧은 문장이 gap·width 조건을 모두
                 # 통과해 거의 항상 흡수되는 문제를 막는다.
                 if _looks_like_prose(line_texts.get(tuple(ln), "")):
+                    still_remaining.append(ln)
+                    continue
+                # 페이지 상/하단 여백(running header/footer 영역)에 걸친
+                # 줄은 폭이 좁아 width 가드를 쉽게 통과하고, 수식이 페이지
+                # 가장자리 가까이 있으면 gap도 작아 그대로 흡수되기 쉽다
+                # (페이지 하단 쪽수가 수식 바로 아래에 함께 캡처되는 문제가
+                # 실제 논문 PDF에서 재현됨).
+                if ln[1] < _EQ_PAGE_MARGIN_EXCLUDE or ln[3] > page_height - _EQ_PAGE_MARGIN_EXCLUDE:
                     still_remaining.append(ln)
                     continue
                 merged_x0 = min(rect[0], ln[0])

--- a/backend/tests/test_pdf_parser_equation_crop.py
+++ b/backend/tests/test_pdf_parser_equation_crop.py
@@ -24,6 +24,9 @@ _find_page_equations()의 진화 과정에서 실제로 관찰된 네 가지 오
 9. 수식 직전/직후의 짧은 도입·설명 문장이 폭이 좁아 기존 폭 비율
    가드를 통과해 gap 조건만으로 거의 항상 흡수되는 문제(위와 같은
    조사로 재발견).
+10. 수식이 페이지 하단 가까이 있으면, 그 아래 페이지 쪽수(running
+    footer)가 좁고 gap도 작아 2단계 흡수 조건을 통과해 함께 캡처되는
+    문제(실사용 스크린샷으로 재발견).
 """
 
 import fitz
@@ -261,6 +264,39 @@ def test_equation_does_not_absorb_short_lead_in_sentence(tmp_path):
     # 안 된다 - 수식 자신의 시작 위치(x=90, y=208) 근처에 머물러야 한다.
     assert x0 > 70, f"도입 문장의 좌측 여백까지 확장됨: {entries[0]}"
     assert y0 > 195, f"도입 문장 줄까지 흡수됨: {entries[0]}"
+
+
+def test_equation_does_not_absorb_page_footer_number(tmp_path):
+    """수식이 페이지 하단 여백(running footer 영역) 가까이 있으면, 그
+    아래 고립된 페이지 쪽수가 폭이 좁고 gap도 작아 2단계 흡수 조건을
+    통과해 함께 캡처되는 문제가 실사용 스크린샷(원 논문의 Equation 3,
+    Equation 7)에서 재현되었다. 페이지 상/하단 65pt 이내 = 헤더/푸터
+    영역이라는 기존 관례(표 구분선 탐지에 이미 쓰임)를 재사용해 막는다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    # 정상적인 컬럼 폭 추정치를 위한 참조 문단 줄 (수식과는 멀리 떨어짐) -
+    # 없으면 페이지에 남는 줄이 쪽수 하나뿐이라 폭 비율 추정치가 그
+    # 쪽수 자신의 폭으로 수렴해버려(자기 참조), 흡수 여부와 무관하게
+    # 항상 배제되는 것처럼 보이는 착시가 생긴다.
+    page.insert_text((49, 100), "This is body paragraph line filling most of the column width here now please.", fontsize=10)
+    # 수식을 페이지 하단 65pt 여백(842-65=777) 안쪽에 배치해 실제 사례와
+    # 같은 조건(수식과 쪽수 사이 간격이 좁음)을 재현한다.
+    page.insert_text((220, 800), "f(x) = a x + b", fontsize=11)
+    page.insert_text((450, 800), "(1)", fontsize=11)
+    page.insert_text((295, 818), "5", fontsize=10)
+    path = tmp_path / "page_footer.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    entries = [r for r in result if r.get("label") == "Equation 1"]
+    assert len(entries) == 1
+    x0, _, _, y1 = _pt(entries[0])
+    # 수식 본문("f(x) = a x + b", x=220 부근)은 여전히 온전히 포함돼야
+    # 하고(페이지 여백 배제가 같은 행 재구성까지 막으면 안 됨), 쪽수
+    # 줄(y=807~821)까지 아래로 번지면 안 된다.
+    assert x0 < 230, f"수식 본문 조각이 잘못 배제됨: {entries[0]}"
+    assert y1 < 815, f"페이지 쪽수가 함께 캡처됨: {entries[0]}"
 
 
 def test_wide_caption_line_does_not_inflate_paragraph_width_estimate(tmp_path):


### PR DESCRIPTION
## Summary
PR #282 머지 시점에 GitHub의 PR head 추적이 지연되어(브랜치 자체는 최신이었으나 PR 메타데이터가 이전 커밋을 가리키고 있었음), 그 브랜치의 두 번째 커밋(페이지 쪽수 흡수 수정)이 main에 반영되지 않고 누락됐습니다. 이 PR은 그 누락된 커밋 하나만 main에 마저 반영합니다.

- 수식이 페이지 하단 여백 가까이 있을 때, 그 아래 고립된 페이지 쪽수가 좁은 폭 + 작은 gap 조건을 모두 통과해 2단계 흡수 루프에서 함께 캡처되던 문제 수정
- 실사용 스크린샷(원 논문 Equation 3, Equation 7)으로 재현·검증
- 표 구분선 탐지에 이미 쓰이던 "페이지 상하단 65pt = 헤더/푸터" 관례를 재사용해 2단계에만 배제 조건 추가 (1단계에 적용했다가 수식 자신이 페이지 하단 가까이 있을 때 본문 조각까지 잘못 배제되는 회귀를 발견해 되돌림)

## Test plan
- [x] pytest tests/test_pdf_parser_equation_crop.py -v — 회귀 테스트 1개 추가 포함 전부 통과
- [x] pytest tests/ -v — 전체 스위트 통과(무관한 사전 존재 환경 이슈 1건 제외)
- [x] Equation 3, Equation 7 재크롭해 페이지 쪽수가 사라진 것을 시각적으로 확인

Generated with Claude Code