### PR TITLE
refactor: 지식 그래프 타임라인 카드 디자인으로 개선

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4357,6 +4357,7 @@ for (const [view, cfg] of Object.entries(GRAPH_SUBVIEWS)) {
 }
 
 const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
+const TIMELINE_TYPE_ICON  = { uploaded: 'archive', read: 'bookOpen', question: 'messageCircle', note: 'edit3' }
 
 function groupTimelineEventsByDate(events) {
   const groups = {}
@@ -4366,6 +4367,53 @@ function groupTimelineEventsByDate(events) {
     groups[date].push(e)
   }
   return groups
+}
+
+// 날짜 그룹 헤더에 쓸 라벨. "오늘/어제"는 상대적으로, 그 밖에는 "8월 1일" +
+// 요일로 표기해 리스트를 죽 훑을 때 날짜 감각을 유지하기 쉽게 한다.
+function formatTimelineDayLabel(dateKey) {
+  const day = new Date(`${dateKey}T00:00:00`)
+  if (isNaN(day.getTime())) return { primary: dateKey, secondary: '' }
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffDays = Math.round((today - day) / 86400000)
+  const primary = diffDays === 0 ? '오늘' : diffDays === 1 ? '어제' : day.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })
+  return { primary, secondary: day.toLocaleDateString('ko-KR', { weekday: 'long' }) }
+}
+
+function formatTimelineTime(timestamp) {
+  const d = new Date(timestamp)
+  return isNaN(d.getTime()) ? '' : d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+}
+
+// 하루 안의 이벤트들을 세로선으로 잇는 카드 타임라인. 이벤트 종류는 색이
+// 아니라 아이콘+라벨로만 구분한다 - 문서 카드(.doc-card-tag)와 동일하게
+// "카테고리마다 색을 바꾸지 않고 브랜드 색 하나만 쓴다"는 원칙을 따른다.
+function renderTimelineDayGroup(date, events) {
+  const { primary, secondary } = formatTimelineDayLabel(date)
+  return `
+    <div class="kg-timeline-day">
+      <div class="kg-timeline-day-header">
+        <span class="kg-timeline-day-date">${escapeHtml(primary)}</span>
+        ${secondary ? `<span class="kg-timeline-day-weekday">${escapeHtml(secondary)}</span>` : ''}
+      </div>
+      <div class="kg-timeline-track">
+        ${events.map(e => `
+          <div class="kg-timeline-entry">
+            <div class="kg-timeline-dot">${icon(TIMELINE_TYPE_ICON[e.type] || 'clock', 13)}</div>
+            <div class="kg-timeline-card">
+              <div class="kg-timeline-card-top">
+                <span class="kg-timeline-type">${escapeHtml(TIMELINE_TYPE_LABEL[e.type] || e.type)}</span>
+                <span class="kg-timeline-time">${escapeHtml(formatTimelineTime(e.timestamp))}</span>
+              </div>
+              <div class="kg-timeline-card-title">${escapeHtml(e.doc_title || '')}</div>
+              ${e.summary ? `<p class="kg-timeline-card-summary">${escapeHtml(e.summary)}</p>` : ''}
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    </div>
+  `
 }
 
 async function renderLibraryTimelineView() {
@@ -4380,20 +4428,7 @@ async function renderLibraryTimelineView() {
     }
     const groups = groupTimelineEventsByDate(events)
     const dates = Object.keys(groups).sort((a, b) => b.localeCompare(a))
-    libraryTimelineList.innerHTML = dates.map(date => `
-      <div style="margin-bottom:16px">
-        <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-secondary)">${escapeHtml(date)}</h4>
-        <ul style="margin:0;padding-left:16px">
-          ${groups[date].map(e => `
-            <li style="margin-bottom:8px">
-              <span style="color:var(--text-tertiary);font-size:11px">[${escapeHtml(TIMELINE_TYPE_LABEL[e.type] || e.type)}]</span>
-              <strong>${escapeHtml(e.doc_title || '')}</strong>
-              ${e.summary ? `<div style="color:var(--text-secondary);font-size:12px">${escapeHtml(e.summary)}</div>` : ''}
-            </li>
-          `).join('')}
-        </ul>
-      </div>
-    `).join('')
+    libraryTimelineList.innerHTML = `<div class="kg-timeline">${dates.map(date => renderTimelineDayGroup(date, groups[date])).join('')}</div>`
   } catch (err) {
     console.error('타임라인 로드 실패:', err)
     libraryTimelineList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">타임라인을 불러오지 못했습니다</p></div>'

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3458,6 +3458,122 @@ body.light-theme .provider-picker-panel {
   border: 1px solid transparent;
 }
 
+/* ── 지식 그래프 · 타임라인 (카드형) ── 세로선 + 원형 아이콘 마커 + 카드로
+   구성한다. 이벤트 종류는 .doc-card-tag와 같은 원칙으로 색이 아닌 아이콘/
+   라벨로만 구분해 브랜드 색 하나로 통일감을 유지한다. */
+.kg-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  max-width: 640px;
+  padding-bottom: 30px;
+}
+
+.kg-timeline-day-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.kg-timeline-day-date {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.kg-timeline-day-weekday {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.kg-timeline-track {
+  position: relative;
+  padding-left: 36px;
+}
+.kg-timeline-track::before {
+  content: '';
+  position: absolute;
+  left: 13px;
+  top: 2px;
+  bottom: 2px;
+  width: 2px;
+  background: var(--border-strong);
+}
+
+.kg-timeline-entry {
+  position: relative;
+}
+.kg-timeline-entry + .kg-timeline-entry {
+  margin-top: 12px;
+}
+
+.kg-timeline-dot {
+  position: absolute;
+  left: -36px;
+  top: 2px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  color: var(--control-accent-text);
+  box-sizing: border-box;
+}
+
+.kg-timeline-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px 14px;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.kg-timeline-card:hover {
+  transform: translateX(3px);
+  box-shadow: var(--shadow-hover);
+  border-color: var(--border-strong);
+}
+
+.kg-timeline-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+}
+.kg-timeline-type {
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 3px 9px;
+  border-radius: 100px;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.kg-timeline-time {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.kg-timeline-card-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+.kg-timeline-card-summary {
+  margin: 5px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
 /* ── Google Drive Style Upload Popup ── */
 .upload-popup {
   position: fixed;


### PR DESCRIPTION
## Summary
- 지식 그래프 탭의 타임라인 서브뷰를 인라인 스타일의 단순 목록에서 카드 기반 타임라인으로 리디자인
- 날짜별 그룹 헤더(오늘/어제/N월 N일 + 요일), 세로 연결선, 원형 아이콘 마커, 카드로 구성
- 이벤트 종류(업로드/읽음/질문/메모)는 색이 아닌 아이콘+라벨 칩으로만 구분 - 기존 문서 카드(.doc-card-tag)의 "카테고리마다 색을 바꾸지 않고 브랜드 색 하나만 쓴다" 원칙을 그대로 따름

## Test plan
- [x] Mock 데이터로 정적 프리뷰를 만들어 Playwright로 다크/라이트 테마 스크린샷 확인
- [ ] 실제 앱에서 지식 그래프 > 타임라인 탭 열어 데이터 있는 계정으로 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)