### PR TITLE
refactor: 지식 그래프 대시보드 UI를 카드형 레이아웃으로 리디자인

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4462,14 +4462,10 @@ function renderHeatmapBar(item, maxScore) {
   const pct = maxScore > 0 ? Math.max(4, Math.round((item.score / maxScore) * 100)) : 0
   const kindLabel = item.kind ? escapeHtml(item.kind) : ''
   return `
-    <div style="margin-bottom:10px" title="${escapeHtml(item.name)} · 논문 ${item.paper_count}편 · 질문 ${item.question_count}개">
-      <div style="display:flex;justify-content:space-between;font-size:12px;margin-bottom:3px">
-        <span style="color:var(--text-primary)">${escapeHtml(item.name)}${kindLabel ? ` <span style="color:var(--text-tertiary)">(${kindLabel})</span>` : ''}</span>
-        <span style="color:var(--text-tertiary)">논문 ${item.paper_count} · 질문 ${item.question_count}</span>
-      </div>
-      <div style="height:10px;border-radius:5px;background:var(--border-strong);overflow:hidden">
-        <div style="height:100%;width:${pct}%;border-radius:5px;background:var(--accent-mid)"></div>
-      </div>
+    <div class="kg-heatmap-row" title="${escapeHtml(item.name)} · 논문 ${item.paper_count}편 · 질문 ${item.question_count}개">
+      <span class="kg-heatmap-label">${escapeHtml(item.name)}${kindLabel ? ` <span class="kg-heatmap-kind">(${kindLabel})</span>` : ''}</span>
+      <div class="kg-heatmap-track"><div class="kg-heatmap-fill" style="width:${pct}%"></div></div>
+      <span class="kg-heatmap-meta">논문 ${item.paper_count} · 질문 ${item.question_count}</span>
     </div>
   `
 }
@@ -4485,24 +4481,36 @@ async function renderLibraryHeatmapView() {
       return
     }
     const maxScore = Math.max(...heatmap.map(h => h.score))
-    libraryHeatmapList.innerHTML = heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')
+    libraryHeatmapList.innerHTML = `<div class="kg-heatmap-list">${heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}</div>`
   } catch (err) {
     console.error('개념 히트맵 로드 실패:', err)
     libraryHeatmapList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">히트맵을 불러오지 못했습니다</p></div>'
   }
 }
 
+const KG_STAT_ICONS = {
+  papers:   '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>',
+  read:     '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>',
+  pages:    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M6 2h9l5 5v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Z"/><path d="M10 12h4"/><path d="M10 16h4"/></svg>',
+  concepts: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/></svg>',
+  questions:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+  notes:    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"/></svg>',
+  insight:  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/></svg>',
+  tag:      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42Z"/><circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" stroke="none"/></svg>',
+}
+
 function renderDashboardStats(stats) {
   const items = [
-    ['논문', stats.total_papers], ['읽음', stats.read_papers], ['페이지', stats.total_pages],
-    ['개념', stats.total_concepts], ['질문', stats.total_questions], ['메모', stats.total_notes],
+    ['papers', '논문', stats.total_papers], ['read', '읽음', stats.read_papers], ['pages', '페이지', stats.total_pages],
+    ['concepts', '개념', stats.total_concepts], ['questions', '질문', stats.total_questions], ['notes', '메모', stats.total_notes],
   ]
   return `
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:10px;margin-bottom:16px">
-      ${items.map(([label, value]) => `
-        <div style="padding:10px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:10px;text-align:center">
-          <div style="font-size:20px;font-weight:700;color:var(--text-primary)">${value}</div>
-          <div style="font-size:11px;color:var(--text-tertiary)">${label}</div>
+    <div class="kg-stat-grid">
+      ${items.map(([icon, label, value]) => `
+        <div class="kg-stat-card">
+          <div class="kg-stat-icon">${KG_STAT_ICONS[icon]}</div>
+          <div class="kg-stat-value">${value}</div>
+          <div class="kg-stat-label">${label}</div>
         </div>
       `).join('')}
     </div>
@@ -4512,10 +4520,10 @@ function renderDashboardStats(stats) {
 function renderDashboardGaps(gaps) {
   if (!gaps || gaps.length === 0) return ''
   return `
-    <div style="margin-bottom:16px;padding:12px 14px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:10px">
-      <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">인사이트</h4>
-      <ul style="margin:0;padding-left:16px">
-        ${gaps.map(g => `<li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(g.message)}</li>`).join('')}
+    <div class="kg-section">
+      <h4 class="kg-section-title">${KG_STAT_ICONS.insight}인사이트</h4>
+      <ul class="kg-insight-list">
+        ${gaps.map(g => `<li class="kg-insight-item">${KG_STAT_ICONS.insight}<span>${escapeHtml(g.message)}</span></li>`).join('')}
       </ul>
     </div>
   `
@@ -4524,9 +4532,9 @@ function renderDashboardGaps(gaps) {
 function renderDashboardRecentSection(title, items, renderItem) {
   if (!items || items.length === 0) return ''
   return `
-    <div style="margin-bottom:16px">
-      <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">${escapeHtml(title)}</h4>
-      <ul style="margin:0;padding-left:16px">
+    <div class="kg-section">
+      <h4 class="kg-section-title">${title}</h4>
+      <ul class="kg-recent-list">
         ${items.map(renderItem).join('')}
       </ul>
     </div>
@@ -4541,22 +4549,31 @@ async function renderLibraryDashboardView() {
     if (state.currentLibraryTab !== 'graph') return
 
     const maxScore = data.heatmap.length ? Math.max(...data.heatmap.map(h => h.score)) : 0
+    const hasRecent = data.recent_questions?.length || data.recent_notes?.length || data.recent_papers?.length
     libraryDashboardContent.innerHTML = `
-      ${renderDashboardStats(data.stats)}
-      ${renderDashboardGaps(data.gaps)}
-      <div style="margin-bottom:16px">
-        <h4 style="margin:0 0 8px;font-size:13px;color:var(--text-primary)">자주 다룬 개념</h4>
-        ${data.heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}
+      <div class="kg-dashboard">
+        ${renderDashboardStats(data.stats)}
+        ${renderDashboardGaps(data.gaps)}
+        ${data.heatmap.length ? `
+          <div class="kg-section">
+            <h4 class="kg-section-title">${KG_STAT_ICONS.tag}자주 다룬 개념</h4>
+            <div class="kg-heatmap-list">${data.heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}</div>
+          </div>
+        ` : ''}
+        ${hasRecent ? `
+          <div class="kg-recent-grid">
+            ${renderDashboardRecentSection(`${KG_STAT_ICONS.questions}최근 질문`, data.recent_questions, e => `
+              <li class="kg-recent-item">${escapeHtml(e.summary || '')}<span class="kg-recent-item-doc">${escapeHtml(e.doc_title || '')}</span></li>
+            `)}
+            ${renderDashboardRecentSection(`${KG_STAT_ICONS.notes}최근 메모`, data.recent_notes, e => `
+              <li class="kg-recent-item">${escapeHtml(e.summary || '')}<span class="kg-recent-item-doc">${escapeHtml(e.doc_title || '')}</span></li>
+            `)}
+            ${renderDashboardRecentSection(`${KG_STAT_ICONS.papers}최근 논문`, data.recent_papers, p => `
+              <li class="kg-recent-item">${escapeHtml(p.title || '')}</li>
+            `)}
+          </div>
+        ` : ''}
       </div>
-      ${renderDashboardRecentSection('최근 질문', data.recent_questions, e => `
-        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(e.summary || '')} <span style="color:var(--text-tertiary)">— ${escapeHtml(e.doc_title || '')}</span></li>
-      `)}
-      ${renderDashboardRecentSection('최근 메모', data.recent_notes, e => `
-        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(e.summary || '')} <span style="color:var(--text-tertiary)">— ${escapeHtml(e.doc_title || '')}</span></li>
-      `)}
-      ${renderDashboardRecentSection('최근 논문', data.recent_papers, p => `
-        <li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(p.title || '')}</li>
-      `)}
     `
   } catch (err) {
     console.error('대시보드 로드 실패:', err)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -30,6 +30,7 @@
 
   --text-primary:   #f3f4f6;
   --text-secondary: #a1a1aa;
+  --text-tertiary:  #86868f;
   --text-muted:     #6b7280;
 
   --success:        #10b981;
@@ -80,6 +81,7 @@ body.light-theme {
 
   --text-primary:   #0f172a;
   --text-secondary: #475569;
+  --text-tertiary:  #64748b;
   --text-muted:     #94a3b8;
 
   --control-accent-text: #1e40af;
@@ -5341,6 +5343,161 @@ body.light-theme .floating-memo.color-red .floating-memo-render {
 }
 body.light-theme .library-tab-btn.active {
   color: #fff !important;
+}
+
+/* ── 지식 그래프 대시보드 (Knowledge Graph Dashboard) ── */
+.kg-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.kg-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+  gap: 10px;
+}
+
+.kg-stat-card {
+  position: relative;
+  padding: 16px 12px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  overflow: hidden;
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.2s ease;
+}
+.kg-stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  opacity: 0.65;
+}
+.kg-stat-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-glow);
+}
+.kg-stat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.kg-stat-value {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.1;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.kg-stat-label {
+  margin-top: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+}
+
+.kg-section {
+  padding: 15px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+}
+.kg-section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.kg-section-title svg { color: var(--control-accent-text); flex-shrink: 0; }
+
+.kg-insight-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 7px; }
+.kg-insight-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--control-accent-soft);
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.kg-insight-item svg { flex-shrink: 0; margin-top: 2px; color: var(--control-accent-text); }
+
+.kg-heatmap-list { display: flex; flex-direction: column; gap: 11px; }
+.kg-heatmap-row { display: flex; align-items: center; gap: 10px; }
+.kg-heatmap-label {
+  flex: 0 0 auto;
+  max-width: 42%;
+  font-size: 12.5px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kg-heatmap-kind { color: var(--text-tertiary); font-weight: 400; }
+.kg-heatmap-track {
+  flex: 1 1 auto;
+  height: 8px;
+  border-radius: 5px;
+  background: var(--border-strong);
+  overflow: hidden;
+}
+.kg-heatmap-fill {
+  height: 100%;
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.kg-heatmap-meta {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.kg-recent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.kg-recent-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.kg-recent-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+.kg-recent-item:last-child { border-bottom: none; padding-bottom: 0; }
+.kg-recent-item-doc {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.kg-empty-hint {
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+  padding: 10px 2px;
 }
 
 /* ── Custom Checked Badge on Document Card ── */


### PR DESCRIPTION
## Summary
- 지식 그래프 탭의 대시보드 서브뷰가 테두리만 있는 밋밋한 박스/세로 리스트 위주라 정보를 한눈에 파악하기 어려웠던 문제를 개선
- 통계 6항목에 아이콘 + 그라디언트 숫자 카드 적용, 인사이트를 강조 배경 카드로 변경, 히트맵 바에 그라디언트 채움 적용, 최근 질문/메모/논문을 3열 그리드로 재배치
- `--text-tertiary` CSS 변수가 대시보드 전반에서 참조만 되고 다크/라이트 테마 어디에도 정의돼 있지 않던 버그 수정

## Test plan
- [x] `npx vite build` 성공 확인
- [x] Playwright로 실제 렌더 결과를 다크/라이트 테마 양쪽 스크린샷으로 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>