### PR TITLE
fix: 지식 그래프 타임라인 탭 스크롤 안 되던 문제 수정

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1233,6 +1233,17 @@ body.light-theme .toast.error { color: #dc2626; }
 .library-grid::-webkit-scrollbar-track { background: transparent; }
 .library-grid::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 100px; }
 
+/* 지식 그래프 탭 - .library-grid와 마찬가지로 .library-container(overflow:hidden
+   flex column)의 직계 자식이라 자체 overflow-y:auto가 없으면 타임라인/히트맵/
+   대시보드처럼 내용이 늘어나는 서브뷰가 스크롤 없이 그냥 잘려 보인다. */
+#library-graph-section {
+  overflow-y: auto;
+  padding-bottom: 30px;
+}
+#library-graph-section::-webkit-scrollbar { width: 6px; }
+#library-graph-section::-webkit-scrollbar-track { background: transparent; }
+#library-graph-section::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 100px; }
+
 /* 빈 상태 */
 .lib-empty {
   grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
- `.library-container`(overflow:hidden인 flex column)의 직계 자식 `#library-graph-section`(그래프/타임라인/히트맵/대시보드 탭)에 자체 스크롤 컨테이너가 없어 콘텐츠가 화면보다 길어지면 스크롤 없이 잘려 보이던 문제 수정
- `.library-grid`(보관함 탭)와 동일한 패턴으로 `#library-graph-section`에 `overflow-y: auto` + 스크롤바 스타일 추가

## Test plan
- [x] Playwright로 목업 타임라인 데이터를 채운 뒤 마우스 휠 스크롤 시뮬레이션 - 수정 전 scrollTop 미동작, 수정 후 정상 스크롤 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)