### PR TITLE
EasyPaper를 사이드바 기반 Research Workspace로 리디자인

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -161,6 +161,25 @@ async def get_library_dashboard(current_user: str = Depends(get_current_user)):
     return await get_dashboard_summary(current_user)
 
 
+class ReadingHeartbeatRequest(BaseModel):
+    seconds: int
+    category: str = "reading"
+
+
+@router.get("/library/reading-stats")
+async def get_library_reading_stats(since_days: Optional[int] = None, current_user: str = Depends(get_current_user)):
+    """Reading History 페이지의 "읽은 시간" 관련 위젯(총 읽기 시간, 카테고리별
+    시간 분포, 논문별 읽기 시간 랭킹)에 쓰이는 실측 집계를 반환합니다. 프론트가
+    뷰어/비교 화면에서 보낸 하트비트(POST /library/{doc_id}/reading-heartbeat)를
+    누적한 값이며, since_days를 주면 최근 N일로 제한합니다.
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "reading-stats"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.db import db_get_reading_time_stats
+    return db_get_reading_time_stats(current_user, since_days)
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,
@@ -338,6 +357,21 @@ async def delete_library_document(doc_id: str, current_user: str = Depends(get_c
     if not soft_delete_document(doc_id):
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return {"message": "문서가 휴지통으로 이동되었습니다."}
+
+@router.post("/library/{doc_id}/reading-heartbeat")
+async def post_reading_heartbeat(doc_id: str, body: ReadingHeartbeatRequest, current_user: str = Depends(get_current_user)):
+    """뷰어/비교 화면이 보이고 포커스된 동안 프론트가 주기적으로 보내는 경과
+    시간(초)을 누적합니다. category는 'reading'(뷰어 기본) / 'chat'(채팅
+    사이드바가 열려있는 동안) / 'compare'(논문 비교 채팅 화면) 중 하나입니다.
+    한 번의 하트비트 간격(예: 20초) 이상을 보내는 조작을 막기 위해 상한을 둡니다."""
+    _require_owned_document(doc_id, current_user)
+    if body.category not in ("reading", "chat", "compare"):
+        raise HTTPException(status_code=400, detail="알 수 없는 category입니다.")
+    seconds = max(0, min(body.seconds, 120))
+    from services.db import db_add_reading_time
+    db_add_reading_time(doc_id, current_user, body.category, seconds)
+    return {"message": "ok"}
+
 
 @router.post("/library/{doc_id}/restore")
 async def restore_library_document(doc_id: str, current_user: str = Depends(get_current_user)):
@@ -537,6 +571,31 @@ async def put_library_memos(doc_id: str, payload: dict, current_user: str = Depe
     from services.db import db_put_memos
     db_put_memos(doc_id, payload.get("data", {}))
     return {"status": "ok"}
+
+
+@router.get("/library/{doc_id}/bibliography")
+async def get_library_bibliography(doc_id: str, current_user: str = Depends(get_current_user)):
+    """Library 상세 패널 Quick Info의 Venue/DOI/ArXiv/Citations를 채운다. 논문
+    자체의 서지 정보는 데이터베이스에 없으므로, 제목으로 OpenAlex를 검색해서
+    찾는다(참고문헌 링크 연결과 동일한 무료/키 불필요 API - services/
+    reference_linker.py). 첫 조회 때만 실제로 검색하고 결과를(못 찾은 경우도
+    포함해서) documents.metadata.bibliography에 캐시해, 상세 패널을 열 때마다
+    매번 외부 API를 다시 호출하지 않는다."""
+    doc = _require_owned_document(doc_id, current_user)
+    meta = doc.get("metadata") or {}
+
+    cached = meta.get("bibliography")
+    if cached:
+        return cached
+
+    from services.reference_linker import resolve_paper_metadata
+    title = meta.get("title") or doc.get("filename") or ""
+    result = await resolve_paper_metadata(title)
+
+    bibliography = result or {"venue": None, "doi": None, "arxiv_id": None, "citation_count": None}
+    meta["bibliography"] = bibliography
+    update_document_metadata(doc_id, meta)
+    return bibliography
 
 
 @router.put("/library/{doc_id}/metadata")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1,7 +1,7 @@
 import sqlite3
 import os
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Optional, List, Dict, Any
 
 # DB_PATH 환경변수가 있으면 그대로 쓰고(Docker 등에서 데이터 볼륨 경로로
@@ -244,6 +244,26 @@ def init_db():
         )
         """)
 
+        # 13. reading_time 테이블 (Reading History의 "읽은 시간" 실측치). 뷰어/비교
+        #     화면이 화면에 보이고 포커스된 동안 프런트가 일정 간격(하트비트)으로
+        #     경과 초를 보내오면 (doc_id, username, day, category) 단위로 누적한다.
+        #     category는 'reading'(뷰어 기본)/'chat'(채팅 사이드바가 열려있는 동안)/
+        #     'compare'(논문 비교 채팅 화면) 중 하나 - 실제로 구분 가능한 화면
+        #     상태만 카테고리로 쓰고, 근거 없는 세부 항목(예: "메모 작성 시간")은
+        #     만들지 않는다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS reading_time (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            doc_id TEXT NOT NULL,
+            username TEXT NOT NULL,
+            day TEXT NOT NULL,
+            category TEXT NOT NULL,
+            seconds INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL,
+            UNIQUE(doc_id, username, day, category)
+        )
+        """)
+
         # 라이브러리 목록/문서 조회가 doc_id(+suffix)로 translations를,
         # doc_id로 documents/page_insights/chats를 매번 훑는데(문서 수 x
         # 페이지 수만큼 뻥튀기됨) 인덱스가 없어 전부 풀스캔이었다. 목록
@@ -263,6 +283,8 @@ def init_db():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_question_concepts_chat ON question_concepts(chat_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_concept_edges_a ON concept_edges(concept_id_a)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_concept_edges_b ON concept_edges(concept_id_b)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_time_username_day ON reading_time(username, day)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_time_doc ON reading_time(doc_id, username)")
 
         conn.commit()
 
@@ -1183,3 +1205,63 @@ def db_get_memo_counts_for_docs(doc_ids: List[str]) -> Dict[str, int]:
         if total:
             counts[doc_id] = total
     return counts
+
+
+def db_add_reading_time(doc_id: str, username: str, category: str, seconds: int) -> None:
+    """뷰어/비교 화면 하트비트로 들어온 경과 초를 (doc_id, username, 오늘 날짜,
+    category) 버킷에 누적한다. 하루 단위로 쌓아두면 캘린더 히트맵/기간별 통계를
+    reading_time만으로 바로 집계할 수 있다."""
+    if seconds <= 0:
+        return
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    now = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO reading_time (doc_id, username, day, category, seconds, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(doc_id, username, day, category)
+            DO UPDATE SET seconds = seconds + excluded.seconds, updated_at = excluded.updated_at
+            """,
+            (doc_id, username, day, category, int(seconds), now)
+        )
+        conn.commit()
+
+
+def db_get_reading_time_stats(username: str, since_days: Optional[int] = None) -> Dict[str, Any]:
+    """사용자의 실측 읽기 시간을 세 가지 형태로 집계해서 반환한다:
+    - total_seconds_by_category: {"reading": n, "chat": n, "compare": n} (시간 분포용)
+    - total_seconds_by_doc: {doc_id: seconds} (Top Papers by Reading Time용, 카테고리 무관 합계)
+    - total_seconds_by_day: {"YYYY-MM-DD": seconds} (일별 총 읽기 시간)
+    since_days가 주어지면 오늘 포함 최근 N일로 제한한다."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        params: List[Any] = [username]
+        day_filter = ""
+        if since_days is not None:
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days - 1)).strftime("%Y-%m-%d")
+            day_filter = " AND day >= ?"
+            params.append(cutoff)
+        cursor.execute(
+            f"SELECT doc_id, day, category, seconds FROM reading_time WHERE username = ?{day_filter}",
+            params,
+        )
+        rows = cursor.fetchall()
+
+    by_category: Dict[str, int] = {}
+    by_doc: Dict[str, int] = {}
+    by_day: Dict[str, int] = {}
+    total_seconds = 0
+    for r in rows:
+        by_category[r["category"]] = by_category.get(r["category"], 0) + r["seconds"]
+        by_doc[r["doc_id"]] = by_doc.get(r["doc_id"], 0) + r["seconds"]
+        by_day[r["day"]] = by_day.get(r["day"], 0) + r["seconds"]
+        total_seconds += r["seconds"]
+
+    return {
+        "total_seconds": total_seconds,
+        "total_seconds_by_category": by_category,
+        "total_seconds_by_doc": by_doc,
+        "total_seconds_by_day": by_day,
+    }

--- a/backend/services/reference_linker.py
+++ b/backend/services/reference_linker.py
@@ -64,6 +64,81 @@ def _pick_url(work: dict) -> Optional[str]:
     return work.get("doi") or None
 
 
+_ARXIV_ID_RE = re.compile(r'arxiv\.org/abs/([0-9]{4}\.[0-9]{4,5}(?:v\d+)?)', re.IGNORECASE)
+
+
+def _extract_arxiv_id(work: dict) -> Optional[str]:
+    for location in work.get("locations") or []:
+        url = location.get("landing_page_url") or ""
+        m = _ARXIV_ID_RE.search(url)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _extract_venue(work: dict) -> Optional[str]:
+    """게재처 이름을 찾는다. primary_location.source.display_name이 정석이지만,
+    실측 결과 상당수 레코드(예: CVPR/ICCV 등 IEEE 학회 논문)가 source를 정식
+    Source 객체로 연결해두지 않고 raw_source_name(원문 그대로의 게재처 문자열)에만
+    담아둔다 - 그 경우도 정직한 실제 값이므로 폴백으로 사용한다."""
+    primary_location = work.get("primary_location") or {}
+    source = primary_location.get("source") or {}
+    if source.get("display_name"):
+        return source["display_name"]
+    if primary_location.get("raw_source_name"):
+        return primary_location["raw_source_name"]
+    for location in work.get("locations") or []:
+        source = location.get("source") or {}
+        name = source.get("display_name") or location.get("raw_source_name")
+        if name and "arxiv" not in name.lower():
+            return name
+    return None
+
+
+async def resolve_paper_metadata(title: str) -> Optional[dict]:
+    """논문 자신의 제목으로 OpenAlex를 검색해 Venue/DOI/ArXiv ID/피인용수를
+    반환합니다(Library 상세 패널의 Quick Info용). resolve_reference()와 달리
+    참고문헌이 아니라 라이브러리에 저장된 논문 그 자체를 찾는 용도라, 인용
+    스타일 텍스트 파싱(따옴표 추출 등) 없이 제목을 그대로 검색어로 쓴다.
+    매칭 실패/네트워크 오류 시 None(호출부가 "찾지 못함"으로 캐시해 재조회를
+    막는다 - db_update_document_metadata 쪽 정책)."""
+    query = (title or "").strip()
+    if not query:
+        return None
+
+    params = {"search": query[:300], "per_page": 1}
+    mailto = get_openalex_mailto()
+    if mailto:
+        params["mailto"] = mailto
+
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            resp = await client.get(_OPENALEX_WORKS_URL, params=params)
+            if resp.status_code != 200:
+                logger.warning(f"OpenAlex 논문 검색 실패: status={resp.status_code}")
+                return None
+
+            data = resp.json()
+            works = data.get("results") or []
+            if not works:
+                return None
+
+            work = works[0]
+            doi = work.get("doi")
+            if doi and doi.startswith("https://doi.org/"):
+                doi = doi[len("https://doi.org/"):]
+
+            return {
+                "venue": _extract_venue(work),
+                "doi": doi,
+                "arxiv_id": _extract_arxiv_id(work),
+                "citation_count": work.get("cited_by_count"),
+            }
+    except Exception as e:
+        logger.warning(f"논문 메타데이터 검색 중 오류: {e}")
+        return None
+
+
 async def resolve_reference(query_text: str) -> Optional[dict]:
     """참고문헌 원문 텍스트로 OpenAlex를 검색해 가장 관련성 높은 논문의
     제목/링크/연도를 반환합니다. 매칭 실패나 네트워크 오류 시 None.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,134 +63,212 @@
 
   <input type="file" id="file-input" accept=".pdf" multiple hidden />
 
-  <!-- 라이브러리 화면 -->
+  <!-- 워크스페이스 화면 (Dashboard / Library / Reading History / AI Chats / Notes / Research Graph) -->
   <div id="library-screen" class="screen">
-    <div class="upload-bg">
-      <div class="orb orb-1"></div>
-      <div class="orb orb-2"></div>
-    </div>
     <div class="library-container">
-      <div class="library-header">
-        <div class="logo">
-          <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg></span>
-          <span class="logo-text">내 라이브러리</span>
-        </div>
-        <div style="display: flex; gap: 10px; align-items: center;">
-          <button id="lib-compare-toggle-btn" class="file-btn-outline" title="여러 논문을 선택해 비교 질문을 할 수 있습니다">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
-            비교하기
+
+      <!-- 좌측 Collapsible Navigation Sidebar -->
+      <aside id="app-sidebar" class="app-sidebar">
+        <div class="app-sidebar-header">
+          <button type="button" id="sidebar-toggle-btn" class="sidebar-toggle-btn" title="사이드바 접기/펼치기">
+            <span class="sidebar-nav-icon" data-icon="panelLeft"></span>
           </button>
-          <button id="lib-upload-btn" class="file-btn">
-            + 새 논문 추가
-          </button>
-        </div>
-      </div>
-
-      <!-- 탭 영역 -->
-      <div class="library-tabs-container">
-        <button id="lib-tab-archive" class="library-tab-btn active" data-tab="archive"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>보관함</button>
-        <button id="lib-tab-history" class="library-tab-btn" data-tab="history"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>히스토리</button>
-        <button id="lib-tab-chat" class="library-tab-btn" data-tab="chat"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>채팅</button>
-        <button id="lib-tab-annotations" class="library-tab-btn" data-tab="annotations"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>주석</button>
-        <button id="lib-tab-graph" class="library-tab-btn" data-tab="graph"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="6" r="3"/><circle cx="12" cy="18" r="3"/><path d="M7.5 7.5 10.5 16"/><path d="M16.5 7.5 13.5 16"/></svg>지식 그래프</button>
-      </div>
-
-      <!-- 독서 통계 위젯 영역 -->
-      <div id="library-stats-container" class="hidden" style="margin-bottom: 16px;"></div>
-
-      <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
-      <div id="library-search-box" style="position: relative; margin-bottom: 14px;">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-        <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
-        <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
-        </button>
-      </div>
-      <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
-
-      <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
-      <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 20px;">
-        <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
-        <div id="library-view-toggle" class="library-view-toggle">
-          <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>
-          <button class="view-toggle-btn" data-view="list" title="리스트 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg></button>
-        </div>
-      </div>
-
-      <div id="library-grid" class="library-grid">
-        <div class="lib-empty" id="lib-empty">
-          <div style="margin-bottom:16px;color:var(--text-muted)"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg></div>
-          <p>저장된 논문이 없습니다</p>
-          <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>
-        </div>
-      </div>
-
-      <!-- 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 채팅 세션 목록) -->
-      <div id="library-chat-section" class="hidden">
-        <div class="chat-session-subtabs">
-          <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트</button>
-          <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교</button>
-        </div>
-        <div id="chat-session-list" class="chat-session-list"></div>
-      </div>
-
-      <!-- 주석 조회 (메모 / 하이라이트 / 언더라인 목록) -->
-      <div id="library-annotations-section" class="hidden">
-        <div class="chat-session-subtabs">
-          <button id="annotation-subtab-memo" class="chat-session-subtab-btn active" data-subtab="memo">메모</button>
-          <button id="annotation-subtab-highlight" class="chat-session-subtab-btn" data-subtab="highlight">하이라이트</button>
-          <button id="annotation-subtab-underline" class="chat-session-subtab-btn" data-subtab="underline">언더라인</button>
-        </div>
-        <div id="annotation-list" class="chat-session-list"></div>
-      </div>
-
-      <!-- 지식 그래프 (논문 + LLM 추출 개념/메모/Figure 노드, 인용/카테고리/유사개념 엣지) -->
-      <div id="library-graph-section" class="hidden">
-        <div style="display: flex; gap: 8px; margin-bottom: 12px;">
-          <button id="library-graph-view-toggle-graph" class="library-tab-btn active" data-view="graph">그래프</button>
-          <button id="library-graph-view-toggle-timeline" class="library-tab-btn" data-view="timeline">타임라인</button>
-          <button id="library-graph-view-toggle-heatmap" class="library-tab-btn" data-view="heatmap">히트맵</button>
-          <button id="library-graph-view-toggle-dashboard" class="library-tab-btn" data-view="dashboard">대시보드</button>
-        </div>
-        <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
-          일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
-        </div>
-        <div id="library-graph-view">
-          <div style="margin-bottom: 12px; padding: 12px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px;">
-            <button id="library-recommendations-btn" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-primary);color:var(--text-primary);font-size:12px;cursor:pointer">다음에 읽을 논문 추천받기</button>
-            <div id="library-recommendations-list" style="margin-top:10px"></div>
+          <div class="sidebar-brand">
+            <span class="logo-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg></span>
+            <span class="sidebar-brand-text">EasyPaper</span>
           </div>
-          <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
-          <div id="library-graph-row" style="display: flex; align-items: stretch;">
-            <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
-            <div id="library-graph-resizer" class="chat-resizer" style="border-radius: 3px;"></div>
-            <div id="library-graph-detail-panel" style="flex: 0 0 auto; width: 260px; max-width: 70%; overflow-y: auto; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
-              <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+        </div>
+
+        <nav class="app-sidebar-nav" id="app-sidebar-nav">
+          <button type="button" class="sidebar-nav-item" data-page="dashboard">
+            <span class="sidebar-nav-icon" data-icon="home"></span>
+            <span class="sidebar-nav-label">Dashboard</span>
+            <span class="sidebar-tooltip">Dashboard</span>
+          </button>
+          <button type="button" class="sidebar-nav-item" data-page="library">
+            <span class="sidebar-nav-icon" data-icon="bookOpen"></span>
+            <span class="sidebar-nav-label">Library</span>
+            <span class="sidebar-tooltip">Library</span>
+          </button>
+          <button type="button" class="sidebar-nav-item" data-page="history">
+            <span class="sidebar-nav-icon" data-icon="clock"></span>
+            <span class="sidebar-nav-label">Reading History</span>
+            <span class="sidebar-tooltip">Reading History</span>
+          </button>
+          <button type="button" class="sidebar-nav-item" data-page="chats">
+            <span class="sidebar-nav-icon" data-icon="messageCircle"></span>
+            <span class="sidebar-nav-label">AI Chats</span>
+            <span class="sidebar-tooltip">AI Chats</span>
+          </button>
+          <button type="button" class="sidebar-nav-item" data-page="notes">
+            <span class="sidebar-nav-icon" data-icon="fileText"></span>
+            <span class="sidebar-nav-label">Notes</span>
+            <span class="sidebar-tooltip">Notes</span>
+          </button>
+          <button type="button" class="sidebar-nav-item" data-page="graph">
+            <span class="sidebar-nav-icon" data-icon="network"></span>
+            <span class="sidebar-nav-label">Research Graph</span>
+            <span class="sidebar-tooltip">Research Graph</span>
+          </button>
+        </nav>
+
+        <div class="app-sidebar-footer">
+          <button type="button" id="sidebar-settings-btn" class="sidebar-nav-item">
+            <span class="sidebar-nav-icon" data-icon="settings"></span>
+            <span class="sidebar-nav-label">Settings</span>
+            <span class="sidebar-tooltip">Settings</span>
+          </button>
+          <button type="button" id="sidebar-logout-btn" class="sidebar-nav-item">
+            <span class="sidebar-nav-icon" data-icon="logOut"></span>
+            <span class="sidebar-nav-label">로그아웃</span>
+            <span class="sidebar-tooltip">로그아웃</span>
+          </button>
+        </div>
+      </aside>
+
+      <!-- 우측 Top Navigation + Page Outlet -->
+      <div class="workspace-main">
+        <header class="workspace-topnav">
+          <h1 id="workspace-page-title" class="workspace-page-title">대시보드</h1>
+          <div class="workspace-topnav-actions">
+            <div class="workspace-search-box">
+              <span class="workspace-search-icon" data-icon="search"></span>
+              <input type="text" id="workspace-search-input" placeholder="논문, 개념, 질문 검색..." />
             </div>
+            <button type="button" id="workspace-avatar-btn" class="workspace-avatar-btn" title="설정">
+              <span data-icon="user"></span>
+            </button>
           </div>
-        </div>
-        <div id="library-timeline-view" class="hidden">
-          <div id="library-timeline-list"></div>
-        </div>
-        <div id="library-heatmap-view" class="hidden">
-          <div id="library-heatmap-list"></div>
-        </div>
-        <div id="library-dashboard-view" class="hidden">
-          <div id="library-dashboard-content"></div>
-        </div>
-      </div>
-    </div>
-    <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
-    <button id="lib-empty-trash-btn" class="file-btn hidden">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
-    </button>
+        </header>
 
-    <!-- 비교하기 선택 모드 하단 플로팅 바 -->
-    <div id="compare-select-bar" class="compare-select-bar hidden">
-      <span id="compare-select-count">0/5개 선택됨</span>
-      <div class="compare-select-bar-actions">
-        <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
-        <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+        <div id="page-outlet" class="page-outlet">
+
+          <!-- Dashboard -->
+          <section id="page-dashboard" class="workspace-page"></section>
+
+          <!-- Library -->
+          <section id="page-library" class="workspace-page">
+            <div class="library-header">
+              <div class="logo">
+                <span class="logo-text">Library</span>
+              </div>
+              <div style="display: flex; gap: 10px; align-items: center;">
+                <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통
+                </button>
+                <button id="lib-compare-toggle-btn" class="file-btn-outline" title="여러 논문을 선택해 비교 질문을 할 수 있습니다">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+                  비교하기
+                </button>
+                <button id="lib-upload-btn" class="file-btn">
+                  + 새 논문 추가
+                </button>
+              </div>
+            </div>
+
+            <!-- 라이브러리 전체 검색 (파일명/제목/카테고리 + 번역된 본문 텍스트) -->
+            <div id="library-search-box" style="position: relative; margin-bottom: 14px;">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+              <input type="text" id="library-search-input" placeholder="논문 제목, 파일명, 번역된 내용 검색..." style="width: 100%; padding: 11px 40px 11px 38px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 13.5px;" />
+              <button type="button" id="library-search-clear-btn" class="hidden" title="검색 지우기" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: flex;">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              </button>
+            </div>
+            <div id="library-search-status" class="hidden" style="font-size: 12.5px; color: var(--text-secondary); margin-bottom: 14px;"></div>
+
+            <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
+            <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 20px;">
+              <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
+              <div id="library-view-toggle" class="library-view-toggle">
+                <button class="view-toggle-btn" data-view="card" title="카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>
+                <button class="view-toggle-btn" data-view="list" title="리스트 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg></button>
+              </div>
+            </div>
+
+            <div id="library-grid" class="library-grid">
+              <div class="lib-empty" id="lib-empty">
+                <div style="margin-bottom:16px;color:var(--text-muted)"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg></div>
+                <p>저장된 논문이 없습니다</p>
+                <p style="font-size:13px;color:var(--text-muted);margin-top:8px">PDF를 업로드하면 자동으로 저장됩니다</p>
+              </div>
+            </div>
+
+            <!-- 우하단 휴지통 비우기 플로팅 버튼 -->
+            <button id="lib-empty-trash-btn" class="file-btn hidden">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
+            </button>
+
+            <!-- 비교하기 선택 모드 하단 플로팅 바 -->
+            <div id="compare-select-bar" class="compare-select-bar hidden">
+              <span id="compare-select-count">0/5개 선택됨</span>
+              <div class="compare-select-bar-actions">
+                <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
+                <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+              </div>
+            </div>
+          </section>
+
+          <!-- Reading History -->
+          <section id="page-history" class="workspace-page"></section>
+
+          <!-- AI Chats -->
+          <section id="page-chats" class="workspace-page">
+            <div id="library-chat-section">
+              <div class="chat-session-subtabs">
+                <button id="chat-subtab-assistant" class="chat-session-subtab-btn active" data-subtab="assistant">AI 어시스턴트</button>
+                <button id="chat-subtab-compare" class="chat-session-subtab-btn" data-subtab="compare">논문 비교</button>
+              </div>
+              <div id="chat-session-list" class="chat-session-list"></div>
+            </div>
+          </section>
+
+          <!-- Notes -->
+          <section id="page-notes" class="workspace-page">
+            <div id="library-annotations-section">
+              <div class="chat-session-subtabs">
+                <button id="annotation-subtab-memo" class="chat-session-subtab-btn active" data-subtab="memo">메모</button>
+                <button id="annotation-subtab-highlight" class="chat-session-subtab-btn" data-subtab="highlight">하이라이트</button>
+                <button id="annotation-subtab-underline" class="chat-session-subtab-btn" data-subtab="underline">언더라인</button>
+              </div>
+              <div id="annotation-list" class="chat-session-list"></div>
+            </div>
+          </section>
+
+          <!-- Research Graph (논문 + LLM 추출 개념/메모/Figure 노드, 인용/카테고리/유사개념 엣지) -->
+          <section id="page-graph" class="workspace-page">
+            <div id="library-graph-section">
+              <div style="display: flex; gap: 8px; margin-bottom: 12px;">
+                <button id="library-graph-view-toggle-graph" class="library-tab-btn active" data-view="graph">그래프</button>
+                <button id="library-graph-view-toggle-timeline" class="library-tab-btn" data-view="timeline">타임라인</button>
+                <button id="library-graph-view-toggle-heatmap" class="library-tab-btn" data-view="heatmap">히트맵</button>
+              </div>
+              <div id="library-graph-pending-banner" class="hidden" style="margin-bottom: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px; font-size: 13px; color: var(--text-secondary);">
+                일부 논문의 그래프 데이터를 준비 중입니다. 잠시 후 자동으로 갱신됩니다...
+              </div>
+              <div id="library-graph-view">
+                <div style="margin-bottom: 12px; padding: 12px 14px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 10px;">
+                  <button id="library-recommendations-btn" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-primary);color:var(--text-primary);font-size:12px;cursor:pointer">다음에 읽을 논문 추천받기</button>
+                  <div id="library-recommendations-list" style="margin-top:10px"></div>
+                </div>
+                <input id="library-graph-search-input" type="text" placeholder="논문/개념/메모/질문 검색" style="width: 100%; margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-elevated); color: var(--text-primary); font-size: 13px;" />
+                <div id="library-graph-row" style="display: flex; align-items: stretch;">
+                  <div id="library-graph-canvas" style="flex: 1 1 auto; min-width: 0; height: 600px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px;"></div>
+                  <div id="library-graph-resizer" class="chat-resizer" style="border-radius: 3px;"></div>
+                  <div id="library-graph-detail-panel" style="flex: 0 0 auto; width: 260px; max-width: 70%; overflow-y: auto; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; padding: 16px; font-size: 13px; color: var(--text-secondary);">
+                    <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+                  </div>
+                </div>
+              </div>
+              <div id="library-timeline-view" class="hidden">
+                <div id="library-timeline-list"></div>
+              </div>
+              <div id="library-heatmap-view" class="hidden">
+                <div id="library-heatmap-list"></div>
+              </div>
+            </div>
+          </section>
+
+        </div>
       </div>
     </div>
   </div>
@@ -432,11 +510,9 @@
   <!-- 토스트 알림 -->
   <div id="toast" class="toast"></div>
 
-  <!-- 공통 테마 토글 버튼 (업로드 & 라이브러리 화면용) -->
+  <!-- 공통 테마 토글/설정/로그아웃 버튼 (로그인 & 비교 화면용 - 라이브러리/워크스페이스 화면은
+       상단 탑네비의 아바타 버튼 및 사이드바 Settings/로그아웃이 같은 핸들러를 대신 호출한다) -->
   <div class="global-theme-toggle" id="global-theme-toggle">
-    <button id="lib-tab-trash" class="file-btn hidden" data-tab="trash" title="휴지통">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-    </button>
     <button id="global-theme-toggle-btn" title="화이트/다크 모드 전환">
       <svg class="sun-icon hidden" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       <svg class="moon-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -45,6 +45,10 @@ const PATHS = {
   underline: '<path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/>',
   lightbulb: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>',
   network: '<rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M12 12H5v4"/><path d="M12 12h7v4"/>',
+  home: '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>',
+  logOut: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" x2="9" y1="12" y2="12"/>',
+  panelLeft: '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/>',
+  user: '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -211,6 +211,31 @@ export async function fetchLibraryDashboard() {
   return res.json()
 }
 
+// 뷰어/비교 화면이 보이고 포커스된 동안 주기적으로 경과 초를 보고한다(main.js의
+// 읽기 시간 하트비트 타이머가 호출). 실패해도 다음 하트비트에서 다시 시도되므로
+// 조용히 무시한다 - 토스트 등으로 사용자에게 알릴 만한 오류가 아니다.
+export async function sendReadingHeartbeat(docId, seconds, category = 'reading') {
+  try {
+    const res = await fetch(`${API_BASE}/library/${docId}/reading-heartbeat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ seconds, category }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+// Reading History 페이지의 총 읽기 시간/카테고리별 시간 분포/논문별 읽기 시간
+// 랭킹에 쓰이는 실측 집계. sinceDays를 주면 최근 N일로 제한한다.
+export async function fetchReadingTimeStats(sinceDays) {
+  const query = sinceDays ? `?since_days=${sinceDays}` : ''
+  const res = await fetch(`${API_BASE}/library/reading-stats${query}`)
+  if (!res.ok) throw new Error('읽기 시간 통계 조회 실패')
+  return res.json()
+}
+
 export async function fetchReadingRecommendations() {
   const res = await fetch(`${API_BASE}/library/graph/recommendations`)
   if (!res.ok) throw new Error('추천 논문 조회 실패')
@@ -248,6 +273,16 @@ export async function deleteLibraryDocPermanently(docId) {
 // 간격으로 재조회한다.
 const PRIMER_POLL_INTERVAL_MS = 3000
 const PRIMER_POLL_MAX_ATTEMPTS = 150 // 최대 약 7.5분 대기
+
+// Library 상세 패널 Quick Info의 Venue/DOI/ArXiv/Citations. 서버가 OpenAlex
+// 제목 검색으로 첫 조회 시 채워서 문서 메타데이터에 캐시해두므로, 여기서는
+// 폴링 없이 단발성 GET이면 된다(생성이 아니라 짧은 검색 1회이기 때문에
+// fetchPrimer처럼 오래 걸리지 않음).
+export async function fetchLibraryBibliography(docId) {
+  const res = await fetch(`${API_BASE}/library/${docId}/bibliography`)
+  if (!res.ok) throw new Error('서지 정보 조회 실패')
+  return res.json()
+}
 
 export async function fetchPrimer(docId, targetLang = '한국어') {
   for (let attempt = 0; attempt < PRIMER_POLL_MAX_ATTEMPTS; attempt++) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,11 +1,18 @@
 import './style.css'
+import './styles/shell.css'
+import './styles/library-page.css'
+import './styles/research-graph.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchLibraryTimeline, fetchReadingRecommendations, fetchLibraryHeatmap, fetchLibraryDashboard } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchLibraryTimeline, fetchReadingRecommendations, fetchLibraryHeatmap, sendReadingHeartbeat } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
+import { renderDashboardPage } from './pages/dashboardPage.js'
+import { renderReadingHistoryPage } from './pages/readingHistoryPage.js'
+import { renderAiChatsPage } from './pages/aiChatsPage.js'
+import { renderNotesPage } from './pages/notesPage.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -25,8 +32,9 @@ window.fetch = async function (...args) {
 
 // ── 상태 ──────────────────────────────────────────
 const state = {
-  currentLibraryTab: 'archive', // 'archive'(보관함) / 'history'(히스토리) / 'trash'(휴지통) / 'chat'(채팅)
+  currentLibraryTab: 'archive', // 'archive'(보관함) / 'trash'(휴지통) - Library 페이지 내부 상태
   previousLibraryTab: 'archive', // 휴지통 진입 전 이전 탭 기억용
+  currentWorkspacePage: 'dashboard', // 'dashboard'/'library'/'history'/'chats'/'notes'/'graph' - 사이드바 최상위 페이지 상태
   currentDocId: null,
   currentDocMetadata: {},
   sessionId: null,
@@ -211,14 +219,8 @@ const librarySearchClearBtn = $('library-search-clear-btn')
 const librarySearchStatus = $('library-search-status')
 const libraryFilterRow  = $('library-filter-row')
 const libraryCountBadge = $('library-count-badge')
-const libTabArchive     = $('lib-tab-archive')
-const libTabHistory     = $('lib-tab-history')
 const libTabTrash       = $('lib-tab-trash')
-const libTabChat        = $('lib-tab-chat')
-const libTabAnnotations = $('lib-tab-annotations')
-const libTabGraph       = $('lib-tab-graph')
 const libEmptyTrashBtn  = $('lib-empty-trash-btn')
-const libraryStatsContainer = $('library-stats-container')
 const librarySearchBox  = $('library-search-box')
 const libraryChatSection = $('library-chat-section')
 const chatSubtabAssistant = $('chat-subtab-assistant')
@@ -239,16 +241,24 @@ const libraryGraphSearchInput   = $('library-graph-search-input')
 const libraryGraphViewToggleGraph     = $('library-graph-view-toggle-graph')
 const libraryGraphViewToggleTimeline  = $('library-graph-view-toggle-timeline')
 const libraryGraphViewToggleHeatmap   = $('library-graph-view-toggle-heatmap')
-const libraryGraphViewToggleDashboard = $('library-graph-view-toggle-dashboard')
 const libraryGraphView         = $('library-graph-view')
 const libraryTimelineView      = $('library-timeline-view')
 const libraryTimelineList      = $('library-timeline-list')
 const libraryHeatmapView       = $('library-heatmap-view')
 const libraryHeatmapList       = $('library-heatmap-list')
-const libraryDashboardView     = $('library-dashboard-view')
-const libraryDashboardContent  = $('library-dashboard-content')
 const libraryRecommendationsBtn  = $('library-recommendations-btn')
 const libraryRecommendationsList = $('library-recommendations-list')
+
+// ── 워크스페이스 셸(사이드바/탑네비/페이지 라우팅) ────────────────
+const appSidebar          = $('app-sidebar')
+const sidebarToggleBtn    = $('sidebar-toggle-btn')
+const sidebarNav          = $('app-sidebar-nav')
+const sidebarSettingsBtn  = $('sidebar-settings-btn')
+const sidebarLogoutBtn    = $('sidebar-logout-btn')
+const workspacePageTitle  = $('workspace-page-title')
+const workspaceSearchInput = $('workspace-search-input')
+const workspaceAvatarBtn  = $('workspace-avatar-btn')
+const pageOutlet          = $('page-outlet')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
 const compareSelectBar      = $('compare-select-bar')
@@ -3545,6 +3555,61 @@ if (settingSkipLoginCheckbox) {
   })
 }
 
+// ── 읽기 시간 하트비트 (Reading History의 "읽은 시간" 실측) ──────────────
+// 뷰어/비교 화면이 화면에 보이고(Page Visibility) 창이 포커스된 동안만 5초
+// 간격으로 "현재 컨텍스트"(문서 id + reading/chat/compare 카테고리)에 초를
+// 적립하고, 20초마다 적립분을 서버로 보낸다. 5초 tick 시점의 컨텍스트를 그때
+// 그때 버킷에 더하므로, 20초 사이에 채팅 사이드바를 열고 닫는 등 컨텍스트가
+// 바뀌어도 각 구간이 올바른 카테고리로 집계된다.
+const READING_HEARTBEAT_TICK_SECONDS = 5
+const READING_HEARTBEAT_FLUSH_MS = 20000
+let readingHeartbeatBuffers = {} // `${docId}|${category}` -> 적립된 초
+
+function isReadingTimeActive() {
+  if (document.visibilityState !== 'visible' || !document.hasFocus()) return false
+  if (viewerScreen && viewerScreen.classList.contains('active') && state.sessionId) return true
+  if (compareScreen && compareScreen.classList.contains('active') && compareChatState.docIds.length > 0) return true
+  return false
+}
+
+function currentReadingContext() {
+  if (viewerScreen && viewerScreen.classList.contains('active') && state.sessionId) {
+    const category = (chatSidebar && !chatSidebar.classList.contains('hidden')) ? 'chat' : 'reading'
+    return { docIds: [state.sessionId], category }
+  }
+  if (compareScreen && compareScreen.classList.contains('active') && compareChatState.docIds.length > 0) {
+    return { docIds: compareChatState.docIds, category: 'compare' }
+  }
+  return null
+}
+
+function tickReadingHeartbeat() {
+  if (!isReadingTimeActive()) return
+  const ctx = currentReadingContext()
+  if (!ctx) return
+  for (const docId of ctx.docIds) {
+    const key = `${docId}|${ctx.category}`
+    readingHeartbeatBuffers[key] = (readingHeartbeatBuffers[key] || 0) + READING_HEARTBEAT_TICK_SECONDS
+  }
+}
+
+async function flushReadingHeartbeat() {
+  const buffers = readingHeartbeatBuffers
+  readingHeartbeatBuffers = {}
+  const entries = Object.entries(buffers).filter(([, s]) => s > 0)
+  if (entries.length === 0) return
+  await Promise.all(entries.map(([key, seconds]) => {
+    const sep = key.lastIndexOf('|')
+    const docId = key.slice(0, sep)
+    const category = key.slice(sep + 1)
+    return sendReadingHeartbeat(docId, seconds, category)
+  }))
+}
+
+setInterval(tickReadingHeartbeat, READING_HEARTBEAT_TICK_SECONDS * 1000)
+setInterval(flushReadingHeartbeat, READING_HEARTBEAT_FLUSH_MS)
+window.addEventListener('beforeunload', () => { flushReadingHeartbeat() })
+
 // ── 초기화 ────────────────────────────────────────
 checkAuthentication()
 checkAIStatus()
@@ -3606,69 +3671,23 @@ async function loadLibraryCount() {
 }
 
 // 탭 클릭 이벤트 리스너 등록
+// Library 페이지 내부 탭(archive: 전체 / trash: 휴지통) 전환. 채팅/주석/그래프/히스토리는
+// 더 이상 Library의 내부 탭이 아니라 사이드바의 독립된 최상위 페이지다 - showWorkspacePage() 참고.
 function updateTabUI(activeTab) {
   state.currentLibraryTab = activeTab
   activeCategoryFilter = 'ALL'
+  activeStatusFilter = 'all'
+  closeLibraryDetailPanel()
 
-  if (libTabArchive) libTabArchive.classList.toggle('active', activeTab === 'archive')
-  if (libTabHistory) libTabHistory.classList.toggle('active', activeTab === 'history')
   if (libTabTrash) libTabTrash.classList.toggle('active', activeTab === 'trash')
-  if (libTabChat) libTabChat.classList.toggle('active', activeTab === 'chat')
-  if (libTabAnnotations) libTabAnnotations.classList.toggle('active', activeTab === 'annotations')
-  if (libTabGraph) libTabGraph.classList.toggle('active', activeTab === 'graph')
-
-  if (libEmptyTrashBtn) {
-    if (activeTab === 'trash') {
-      libEmptyTrashBtn.classList.remove('hidden')
-    } else {
-      libEmptyTrashBtn.classList.add('hidden')
-    }
-  }
-
-  // 휴지통/채팅/주석/그래프 탭인 경우 새 논문 추가/비교하기 플로팅 버튼을 숨깁니다.
-  const isListOnlyTab = activeTab === 'trash' || activeTab === 'chat' || activeTab === 'annotations' || activeTab === 'graph'
-  if (libUploadBtn) {
-    if (isListOnlyTab) {
-      libUploadBtn.classList.add('hidden')
-    } else {
-      libUploadBtn.classList.remove('hidden')
-    }
-  }
-  if (libCompareToggleBtn) {
-    libCompareToggleBtn.classList.toggle('hidden', isListOnlyTab)
-  }
+  if (libEmptyTrashBtn) libEmptyTrashBtn.classList.toggle('hidden', activeTab !== 'trash')
+  if (libUploadBtn) libUploadBtn.classList.toggle('hidden', activeTab === 'trash')
+  if (libCompareToggleBtn) libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash')
   setCompareSelectMode(false)
-
-  // 채팅/주석/그래프 탭은 문서 그리드 대신 목록(또는 그래프)을 보여주므로,
-  // 검색/필터 등 논문 목록 전용 UI는 숨긴다.
-  const isChatTab = activeTab === 'chat'
-  const isAnnotationsTab = activeTab === 'annotations'
-  const isGraphTab = activeTab === 'graph'
-  const hidesGrid = isChatTab || isAnnotationsTab || isGraphTab
-  if (libraryGrid) libraryGrid.classList.toggle('hidden', hidesGrid)
-  if (libraryChatSection) libraryChatSection.classList.toggle('hidden', !isChatTab)
-  if (libraryAnnotationsSection) libraryAnnotationsSection.classList.toggle('hidden', !isAnnotationsTab)
-  if (libraryGraphSection) libraryGraphSection.classList.toggle('hidden', !isGraphTab)
-  if (librarySearchBox) librarySearchBox.classList.toggle('hidden', hidesGrid)
-  if (librarySearchStatus && hidesGrid) librarySearchStatus.classList.add('hidden')
-  if (libraryFilterRow) libraryFilterRow.classList.toggle('hidden', hidesGrid)
-  if (libraryStatsContainer && hidesGrid) libraryStatsContainer.classList.add('hidden')
 
   renderLibrary()
 }
 
-if (libTabArchive) {
-  libTabArchive.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'archive') return
-    updateTabUI('archive')
-  })
-}
-if (libTabHistory) {
-  libTabHistory.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'history') return
-    updateTabUI('history')
-  })
-}
 if (libTabTrash) {
   libTabTrash.addEventListener('click', () => {
     if (state.currentLibraryTab === 'trash') {
@@ -3677,24 +3696,6 @@ if (libTabTrash) {
       state.previousLibraryTab = state.currentLibraryTab
       updateTabUI('trash')
     }
-  })
-}
-if (libTabChat) {
-  libTabChat.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'chat') return
-    updateTabUI('chat')
-  })
-}
-if (libTabAnnotations) {
-  libTabAnnotations.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'annotations') return
-    updateTabUI('annotations')
-  })
-}
-if (libTabGraph) {
-  libTabGraph.addEventListener('click', () => {
-    if (state.currentLibraryTab === 'graph') return
-    updateTabUI('graph')
   })
 }
 
@@ -3716,23 +3717,121 @@ document.querySelectorAll('.view-toggle-btn').forEach(btn => {
 })
 updateViewToggleUI()
 
-async function showLibraryScreen(shouldPushState = true) {
+async function showLibraryScreen(shouldPushState = true, targetPage) {
   hasLibraryStateInHistory = true
-  if (shouldPushState) {
-    history.pushState({ screen: 'library' }, '', '#library')
-  }
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
   libraryScreen.classList.add('active')
-  // 글로벌 테마 토글, 로그아웃, 설정 버튼 표시
+  // 워크스페이스 화면(사이드바+탑네비)에서는 Settings/로그아웃이 이미 사이드바 푸터와
+  // 탑네비 아바타에 있으므로 플로팅 버튼 묶음에서는 숨긴다(안 그러면 페이지 콘텐츠와
+  // 겹침). 테마 토글만 남겨둔다 - 탑네비/사이드바에 별도의 테마 토글이 없기 때문.
   const globalToggle = $('global-theme-toggle')
   if (globalToggle) globalToggle.classList.remove('hidden')
-  globalLogoutBtn.classList.remove('hidden')
-  globalSettingsBtn.classList.remove('hidden')
+  globalLogoutBtn.classList.add('hidden')
+  globalSettingsBtn.classList.add('hidden')
   resetState()
-  await renderLibrary()
+  await showWorkspacePage(targetPage || state.currentWorkspacePage || 'dashboard', { pushState: shouldPushState })
   startLibraryPolling()
+}
+
+// ── 워크스페이스 셸: 사이드바 / 탑네비 / 최상위 페이지 라우팅 ──────────────
+// 6개 페이지(Dashboard/Library/Reading History/AI Chats/Notes/Research Graph)는
+// 각각 #page-<id> 섹션으로 존재하며, 사이드바 클릭이나 해시 변경 시 이 함수 하나로 전환한다.
+const WORKSPACE_PAGES = ['dashboard', 'library', 'history', 'chats', 'notes', 'graph']
+const WORKSPACE_PAGE_TITLES = {
+  dashboard: '대시보드',
+  library: 'Library',
+  history: 'Reading History',
+  chats: 'AI Chats',
+  notes: 'Notes',
+  graph: 'Research Graph',
+}
+
+async function showWorkspacePage(pageId, { pushState = true } = {}) {
+  if (!WORKSPACE_PAGES.includes(pageId)) pageId = 'dashboard'
+  state.currentWorkspacePage = pageId
+
+  if (sidebarNav) {
+    sidebarNav.querySelectorAll('.sidebar-nav-item[data-page]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.page === pageId)
+    })
+  }
+  if (pageOutlet) {
+    pageOutlet.querySelectorAll('.workspace-page').forEach(sec => {
+      sec.classList.toggle('active', sec.id === `page-${pageId}`)
+    })
+  }
+  if (workspacePageTitle) workspacePageTitle.textContent = WORKSPACE_PAGE_TITLES[pageId] || ''
+
+  if (pushState) {
+    history.pushState({ screen: 'library', page: pageId }, '', `#${pageId}`)
+  }
+
+  if (pageId === 'library') {
+    await renderLibrary()
+  } else if (pageId === 'chats') {
+    await renderAiChatsPage()
+  } else if (pageId === 'notes') {
+    await renderNotesPage()
+  } else if (pageId === 'graph') {
+    await renderLibraryGraphTab()
+  } else if (pageId === 'dashboard') {
+    await renderDashboardPage()
+  } else if (pageId === 'history') {
+    await renderReadingHistoryPage()
+  }
+}
+
+// 사이드바 접기/펼치기 - 마지막 상태를 기억해 다음 방문에도 유지
+const SIDEBAR_COLLAPSED_KEY = 'easypaper_sidebar_collapsed'
+function setSidebarCollapsed(collapsed) {
+  if (!appSidebar) return
+  appSidebar.classList.toggle('collapsed', collapsed)
+  localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? 'true' : 'false')
+}
+if (appSidebar) {
+  setSidebarCollapsed(localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true')
+}
+if (sidebarToggleBtn) {
+  sidebarToggleBtn.addEventListener('click', () => {
+    setSidebarCollapsed(!appSidebar.classList.contains('collapsed'))
+  })
+}
+
+// 사이드바 네비게이션 아이콘을 icons.js 아이콘 라이브러리로 채운다 (이모지 사용 금지 원칙).
+document.querySelectorAll('[data-icon]').forEach(el => {
+  el.innerHTML = icon(el.dataset.icon, 18)
+})
+
+if (sidebarNav) {
+  sidebarNav.querySelectorAll('.sidebar-nav-item[data-page]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (state.currentWorkspacePage === btn.dataset.page) return
+      showWorkspacePage(btn.dataset.page)
+    })
+  })
+}
+
+// 사이드바 Settings/로그아웃, 탑네비 아바타는 기존 로직(비밀번호 변경 모달 / 로그아웃)을
+// 그대로 재사용한다 - 새 UI 진입점만 추가하고 동작 자체는 기존 global-settings-btn/
+// global-logout-btn 클릭 핸들러에 위임한다.
+if (sidebarSettingsBtn) sidebarSettingsBtn.addEventListener('click', () => globalSettingsBtn?.click())
+if (sidebarLogoutBtn) sidebarLogoutBtn.addEventListener('click', () => globalLogoutBtn?.click())
+if (workspaceAvatarBtn) workspaceAvatarBtn.addEventListener('click', () => globalSettingsBtn?.click())
+
+// 탑네비 검색창은 새 검색 기능이 아니라 기존 라이브러리 검색으로 그대로 위임한다
+// (Global Search는 기존 검색 기능을 그대로 사용 - 동작 변경 금지 원칙).
+if (workspaceSearchInput) {
+  workspaceSearchInput.addEventListener('input', () => {
+    if (state.currentWorkspacePage !== 'library') {
+      showWorkspacePage('library')
+    }
+    if (librarySearchInput) {
+      librarySearchInput.value = workspaceSearchInput.value
+      librarySearchInput.dispatchEvent(new Event('input'))
+    }
+  })
 }
 
 
@@ -4053,19 +4152,140 @@ if (compareBackBtn) {
   })
 }
 
+// ── Library 재설계: 상태 필터 탭(전체/읽지 않음/읽는 중/완료/즐겨찾기) + 정렬 + 즐겨찾기 ──
+// 즐겨찾기는 documents.metadata에 아직 star/favorite 개념이 없어(백엔드 스키마에
+// 없음) 새 필드를 추가하지 않고 로컬 전용 편의 기능으로만 제공한다 - localStorage에만
+// 저장되며 기기 간 동기화되거나 서버에 반영되지 않는다.
+let activeStatusFilter = 'all' // 'all' | 'unread' | 'reading' | 'finished' | 'favorites'
+let librarySortMode = localStorage.getItem('easypaper_library_sort') || 'recent' // 'recent' | 'title' | 'progress'
+
+const LIBRARY_FAVORITES_KEY = 'easypaper_library_favorites'
+function getFavoriteIds() {
+  try { return new Set(JSON.parse(localStorage.getItem(LIBRARY_FAVORITES_KEY) || '[]')) } catch { return new Set() }
+}
+function isFavoriteDoc(docId) { return getFavoriteIds().has(docId) }
+function toggleFavoriteDoc(docId) {
+  const ids = getFavoriteIds()
+  if (ids.has(docId)) ids.delete(docId); else ids.add(docId)
+  localStorage.setItem(LIBRARY_FAVORITES_KEY, JSON.stringify(Array.from(ids)))
+  return ids.has(docId)
+}
+
+// 번역 진행 상태 기준 분류: Unread=번역 진행 기록이 아예 없음, Reading=일부만
+// 번역됐거나 다 번역됐지만 아직 "읽음" 처리 전, Finished=완독 표시(metadata.read===true)됨.
+function getLibraryDocStatus(doc) {
+  const translated = doc.translated_pages?.length || 0
+  const isRead = doc.metadata?.read === true
+  if (isRead) return 'finished'
+  if (translated <= 0) return 'unread'
+  return 'reading'
+}
+
+const LIBRARY_STATUS_TABS = [
+  { key: 'all', label: '전체' },
+  { key: 'unread', label: '읽지 않음' },
+  { key: 'reading', label: '읽는 중' },
+  { key: 'finished', label: '완료' },
+  { key: 'favorites', label: '즐겨찾기' },
+]
+
+function renderLibraryStatusTabs(docs) {
+  const el = $('library-status-tabs')
+  if (!el) return
+  if (state.currentLibraryTab === 'trash') { el.innerHTML = ''; el.classList.add('hidden'); return }
+  el.classList.remove('hidden')
+
+  const favIds = getFavoriteIds()
+  const counts = { all: docs.length, unread: 0, reading: 0, finished: 0, favorites: 0 }
+  docs.forEach(doc => {
+    counts[getLibraryDocStatus(doc)]++
+    if (favIds.has(doc.id)) counts.favorites++
+  })
+
+  el.innerHTML = LIBRARY_STATUS_TABS.map(t => `
+    <button type="button" class="lib-status-tab ${activeStatusFilter === t.key ? 'active' : ''}" data-status="${t.key}">
+      <span>${t.label}</span><span class="lib-status-tab-count">${counts[t.key]}</span>
+    </button>
+  `).join('')
+  el.querySelectorAll('.lib-status-tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (activeStatusFilter === btn.dataset.status) return
+      activeStatusFilter = btn.dataset.status
+      filterLibraryCards(currentLibraryDocs)
+      renderLibraryStatusTabs(currentLibraryDocs)
+    })
+  })
+}
+
+function sortLibraryDocs(docs) {
+  const sorted = docs.slice()
+  if (librarySortMode === 'title') {
+    sorted.sort((a, b) => {
+      const ta = (a.metadata?.title || a.filename || '').toLowerCase()
+      const tb = (b.metadata?.title || b.filename || '').toLowerCase()
+      return ta.localeCompare(tb)
+    })
+  } else if (librarySortMode === 'progress') {
+    sorted.sort((a, b) => {
+      const pa = (a.translated_pages?.length || 0) / (a.total_pages || 1)
+      const pb = (b.translated_pages?.length || 0) / (b.total_pages || 1)
+      return pb - pa
+    })
+  } else {
+    sorted.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+  }
+  return sorted
+}
+
+// Library 페이지의 새 UI 조각(상태 탭 / 정렬 드롭다운 / 상세 패널)은 index.html을
+// 건드리지 않고 여기서 필요할 때 한 번만 삽입한다. renderLibrary()가 탭 전환/새로고침마다
+// 다시 호출되므로 반드시 멱등이어야 한다(이미 삽입돼 있으면 아무것도 하지 않음).
+let libraryChromeReady = false
+function ensureLibraryChrome() {
+  if (libraryChromeReady) return
+  libraryChromeReady = true
+
+  const headerLogo = document.querySelector('#page-library .library-header .logo')
+  if (headerLogo && !headerLogo.querySelector('.library-header-subtitle')) {
+    headerLogo.insertAdjacentHTML('beforeend', `<p class="library-header-subtitle">보관함에 저장된 모든 논문을 한 곳에서 관리하세요</p>`)
+  }
+
+  if (librarySearchBox && !$('library-status-tabs')) {
+    librarySearchBox.insertAdjacentHTML('beforebegin', `<div id="library-status-tabs" class="lib-status-tabs"></div>`)
+  }
+
+  const viewToggleEl = $('library-view-toggle')
+  if (viewToggleEl && !$('library-sort-select')) {
+    viewToggleEl.insertAdjacentHTML('beforebegin', `
+      <div class="lib-sort-dropdown">
+        <select id="library-sort-select" class="lib-sort-select" title="정렬 기준">
+          <option value="recent">최근 추가순</option>
+          <option value="title">제목순</option>
+          <option value="progress">번역 진행률순</option>
+        </select>
+        <span class="lib-sort-dropdown-icon">${icon('chevronDown', 12)}</span>
+      </div>
+    `)
+    const sortSelect = $('library-sort-select')
+    if (sortSelect) {
+      sortSelect.value = librarySortMode
+      sortSelect.addEventListener('change', () => {
+        librarySortMode = sortSelect.value
+        localStorage.setItem('easypaper_library_sort', librarySortMode)
+        filterLibraryCards(currentLibraryDocs)
+      })
+    }
+  }
+
+  ensureLibraryDetailPanel()
+}
+
 async function renderLibrary() {
-  if (state.currentLibraryTab === 'chat') {
-    await renderChatSessions()
-    return
-  }
-  if (state.currentLibraryTab === 'annotations') {
-    await renderAnnotationsBrowser()
-    return
-  }
-  if (state.currentLibraryTab === 'graph') {
-    await renderLibraryGraphTab()
-    return
-  }
+  // Library 페이지의 새 UI 조각(상태 탭/정렬 드롭다운/상세 패널)이 아직 없으면 삽입한다.
+  ensureLibraryChrome()
+  closeLibraryDetailPanel()
+  // 상세 패널의 "관련 자료" 탭이 쓰는 지식 그래프 캐시도 목록을 새로 불러올 때 함께 무효화한다.
+  libraryGraphCacheForDetail = null
 
   // 탭 전환 등으로 목록을 새로 불러올 때는 검색 상태를 초기화한다 - 검색
   // 결과가 다른 탭의 목록과 뒤섞여 보이는 것을 방지
@@ -4104,47 +4324,15 @@ async function renderLibrary() {
       refreshTrashTabVisibility()
     }
 
-    // 현재 선택된 탭에 따라 논문 목록 필터링
-    const docs = allDocs.filter(doc => {
-      if (state.currentLibraryTab === 'trash') return true
-      const isRead = doc.metadata?.read === true
-      return state.currentLibraryTab === 'history' ? isRead : !isRead
-    })
+    // data는 위에서 이미 currentLibraryTab(archive: 전체 / trash: 휴지통)에 맞춰 조회됨
+    const docs = allDocs
 
-    // 히스토리 탭인 경우 상단에 독서 현황 통계 요약 카드 렌더링
-    if (state.currentLibraryTab === 'history') {
-      const now = new Date()
-      const thisYear = now.getFullYear()
-      const thisMonth = now.getMonth()
-      
-      const readDocs = allDocs.filter(d => d.metadata?.read === true)
-      const thisMonthCount = readDocs.filter(d => {
-        if (!d.metadata?.read_at) return false
-        const rDate = new Date(d.metadata.read_at)
-        return rDate.getFullYear() === thisYear && rDate.getMonth() === thisMonth
-      }).length
-      
-      libraryStatsContainer.innerHTML = `
-        <div class="library-stats-widget">
-          <div class="library-stats-item">
-            <span class="library-stats-label">${icon('calendar', 13, 'style="vertical-align:-2px;margin-right:3px"')}이번 달 읽은 논문</span>
-            <span class="library-stats-value">${thisMonthCount}<span>편</span></span>
-          </div>
-          <div style="width: 1px; height: 28px; background: var(--border-strong);"></div>
-          <div class="library-stats-item">
-            <span class="library-stats-label">${icon('award', 13, 'style="vertical-align:-2px;margin-right:3px"')}누적 완독 논문</span>
-            <span class="library-stats-value">${readDocs.length}<span>편</span></span>
-          </div>
-        </div>
-      `
-      libraryStatsContainer.classList.remove('hidden')
-    } else {
-      libraryStatsContainer.classList.add('hidden')
-      libraryStatsContainer.innerHTML = ''
-    }
+    // 상태 필터 탭(전체/읽지 않음/읽는 중/완료/즐겨찾기)은 카드가 하나도 없어도
+    // 항상 최신 개수로 갱신한다(휴지통 탭에서는 renderLibraryStatusTabs 내부에서 숨김).
+    renderLibraryStatusTabs(docs)
 
     if (docs.length === 0) {
-      libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'history')); return
+      libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'trash' ? 'trash' : 'library')); return
     }
 
     // Extract unique categories
@@ -4190,133 +4378,21 @@ async function renderLibrary() {
   }
 }
 
-// ── 채팅 세션 조회 (AI 어시스턴트 / 논문 비교 대화 목록) ────────────────
-let chatSessionSubtab = 'assistant' // 'assistant' 또는 'compare'
-
-function updateChatSubtabUI() {
-  if (chatSubtabAssistant) chatSubtabAssistant.classList.toggle('active', chatSessionSubtab === 'assistant')
-  if (chatSubtabCompare) chatSubtabCompare.classList.toggle('active', chatSessionSubtab === 'compare')
-}
-
+// AI Chats/Notes 페이지(pages/aiChatsPage.js, pages/notesPage.js)와 Library 상세 패널이
+// 공유해서 쓰는 시간 포맷 헬퍼. 예전에는 이 근처에 라이브러리 탭용 채팅/주석 목록
+// 렌더링 함수들이 있었지만 각 페이지 전용 모듈로 옮겨졌다.
 function formatChatSessionTime(isoString) {
   if (!isoString) return ''
   return new Date(isoString).toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-async function renderChatSessions() {
-  updateChatSubtabUI()
-  if (!chatSessionList) return
-  chatSessionList.innerHTML = `<div class="lib-empty"><p>불러오는 중...</p></div>`
-
-  try {
-    if (chatSessionSubtab === 'assistant') {
-      const data = await getChatSessionsAPI()
-      renderAssistantChatSessions(data.sessions || [])
-    } else {
-      const data = await getCompareChatSessionsAPI()
-      renderCompareChatSessions(data.sessions || [])
-    }
-  } catch (err) {
-    console.error('채팅 세션 목록 로드 실패:', err)
-    chatSessionList.innerHTML = `<div class="lib-empty"><p style="color:var(--error)">채팅 세션을 불러오지 못했습니다</p></div>`
-  }
-}
-
-if (chatSubtabAssistant) {
-  chatSubtabAssistant.addEventListener('click', () => {
-    if (chatSessionSubtab === 'assistant') return
-    chatSessionSubtab = 'assistant'
-    renderChatSessions()
-  })
-}
-if (chatSubtabCompare) {
-  chatSubtabCompare.addEventListener('click', () => {
-    if (chatSessionSubtab === 'compare') return
-    chatSessionSubtab = 'compare'
-    renderChatSessions()
-  })
-}
-
-function renderAssistantChatSessions(sessions) {
-  if (sessions.length === 0) {
-    chatSessionList.innerHTML = `<div class="lib-empty"><p>AI 어시스턴트와 나눈 대화가 없습니다</p></div>`
-    return
-  }
-  chatSessionList.innerHTML = ''
-  sessions.forEach(session => {
-    const item = document.createElement('div')
-    item.className = 'chat-session-item'
-    item.innerHTML = `
-      <div class="chat-session-item-icon">${icon('messageCircle', 17)}</div>
-      <div class="chat-session-item-body">
-        <div class="chat-session-item-title">${escapeHtml(session.title)}</div>
-        <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
-      </div>
-    `
-    item.addEventListener('click', async () => {
-      // location.hash를 바꿔서 라우터(handleRouting)를 거치게 하면, 이 앱에서는
-      // hashchange와 popstate가 함께 발생해 handleRouting이 같은 문서를 두 번
-      // 라우팅하며 문서 조회(fetchLibraryDoc) 요청도 중복으로 나가 체감 로딩이
-      // 늘어진다. 라이브러리 카드의 "열기" 버튼처럼 문서를 직접 한 번만 불러와
-      // 바로 열어서 이 지연을 없앤다.
-      try {
-        const doc = await fetchLibraryDoc(session.doc_id)
-        await openFromLibrary(doc)
-        openChatSidebar()
-      } catch (err) {
-        console.error('채팅 세션에서 논문 열기 실패:', err)
-        showToast('논문을 불러오지 못했습니다.', 'error')
-      }
-    })
-    chatSessionList.appendChild(item)
-  })
-}
-
-function renderCompareChatSessions(sessions) {
-  if (sessions.length === 0) {
-    chatSessionList.innerHTML = `<div class="lib-empty"><p>논문 비교 대화가 없습니다</p></div>`
-    return
-  }
-  chatSessionList.innerHTML = ''
-  sessions.forEach(session => {
-    const item = document.createElement('div')
-    item.className = 'chat-session-item'
-    const titleText = (session.titles || []).join(' · ')
-    item.innerHTML = `
-      <div class="chat-session-item-icon">${icon('compare', 17)}</div>
-      <div class="chat-session-item-body">
-        <div class="chat-session-item-title">${escapeHtml(titleText)}</div>
-        <div class="chat-session-item-meta">${formatChatSessionTime(session.last_message_at)}</div>
-      </div>
-    `
-    item.addEventListener('click', async () => {
-      // 이유는 위 renderAssistantChatSessions와 동일 - 라우터를 거치지 않고
-      // 문서들을 직접 불러와 바로 비교 화면을 연다.
-      try {
-        const docs = await Promise.all(session.doc_ids.map(id => fetchLibraryDoc(id)))
-        if (!docs.every(Boolean)) throw new Error('일부 논문을 찾을 수 없습니다.')
-        await openCompareScreen(docs)
-      } catch (err) {
-        console.error('채팅 세션에서 비교 화면 열기 실패:', err)
-        showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
-      }
-    })
-    chatSessionList.appendChild(item)
-  })
 }
 
 // ── 주석 조회 (메모 / 하이라이트 / 언더라인 목록) ───────────────────────
 // 메모와 하이라이트/언더라인은 서버 DB가 아니라 문서(세션)별 localStorage에만
 // 저장되므로(easypaper_memos_*, easypaper_annotations_*), 라이브러리 전체
 // 문서 목록을 한 번 불러온 뒤 각 문서의 localStorage를 순회해 모아 보여준다.
-let annotationBrowserSubtab = 'memo' // 'memo' | 'highlight' | 'underline'
-
-function updateAnnotationSubtabUI() {
-  if (annotationSubtabMemo) annotationSubtabMemo.classList.toggle('active', annotationBrowserSubtab === 'memo')
-  if (annotationSubtabHighlight) annotationSubtabHighlight.classList.toggle('active', annotationBrowserSubtab === 'highlight')
-  if (annotationSubtabUnderline) annotationSubtabUnderline.classList.toggle('active', annotationBrowserSubtab === 'underline')
-}
-
+// Notes 페이지(pages/notesPage.js)와 Library 상세 패널/Research Graph 노드 상세 패널이
+// 공유해서 쓰는 텍스트 축약 헬퍼. 예전에는 이 근처에 라이브러리 탭용 주석 브라우저
+// 렌더링 함수가 있었지만 Notes 전용 페이지 모듈로 옮겨졌다.
 function truncateForList(text, maxLen) {
   if (!text) return ''
   const trimmed = text.trim()
@@ -4336,7 +4412,6 @@ const GRAPH_SUBVIEWS = {
   graph:     { btn: () => libraryGraphViewToggleGraph,     el: () => libraryGraphView },
   timeline:  { btn: () => libraryGraphViewToggleTimeline,  el: () => libraryTimelineView,  onShow: () => renderLibraryTimelineView() },
   heatmap:   { btn: () => libraryGraphViewToggleHeatmap,   el: () => libraryHeatmapView,   onShow: () => renderLibraryHeatmapView() },
-  dashboard: { btn: () => libraryGraphViewToggleDashboard, el: () => libraryDashboardView, onShow: () => renderLibraryDashboardView() },
 }
 
 function switchGraphSubView(view) {
@@ -4421,7 +4496,7 @@ async function renderLibraryTimelineView() {
   libraryTimelineList.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
   try {
     const { events } = await fetchLibraryTimeline()
-    if (state.currentLibraryTab !== 'graph') return
+    if (state.currentWorkspacePage !== 'graph') return
     if (!events || events.length === 0) {
       libraryTimelineList.innerHTML = '<div class="lib-empty"><p>아직 활동 기록이 없습니다.</p></div>'
       return
@@ -4476,110 +4551,321 @@ async function renderLibraryHeatmapView() {
   libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
   try {
     const { heatmap } = await fetchLibraryHeatmap()
-    if (state.currentLibraryTab !== 'graph') return
+    if (state.currentWorkspacePage !== 'graph') return
     if (!heatmap || heatmap.length === 0) {
       libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>아직 추출된 개념이 없습니다.</p></div>'
       return
     }
     const maxScore = Math.max(...heatmap.map(h => h.score))
-    libraryHeatmapList.innerHTML = `<div class="kg-heatmap-list">${heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}</div>`
+    libraryHeatmapList.innerHTML = `<div class="kg-heatmap-list">${heatmap.map(item => renderHeatCell(item, maxScore)).join('')}</div>`
   } catch (err) {
     console.error('개념 히트맵 로드 실패:', err)
     libraryHeatmapList.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">히트맵을 불러오지 못했습니다</p></div>'
   }
 }
 
-const KG_STAT_ICONS = {
-  papers:   '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>',
-  read:     '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>',
-  pages:    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M6 2h9l5 5v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Z"/><path d="M10 12h4"/><path d="M10 16h4"/></svg>',
-  concepts: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/></svg>',
-  questions:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
-  notes:    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"/></svg>',
-  insight:  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/></svg>',
-  tag:      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42Z"/><circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" stroke="none"/></svg>',
+// ============================================================
+// Research Graph 페이지 재설계 - 노드 타입 메타(범례/상세 패널 공용)
+// 색상은 knowledgeGraph.js의 cytoscape 스타일(off-limits, 직접 수정하지
+// 않음)과 반드시 같은 값을 유지해야 하므로 그쪽 파일이 바뀌면 여기도
+// 맞춰 갱신해야 한다.
+// ============================================================
+const GRAPH_NODE_TYPE_META = {
+  paper:   { label: '논문',          color: '#4f8ef7', icon: 'fileText' },
+  concept: { label: '개념',          color: '#f7b34f', icon: 'lightbulb' },
+  note:    { label: '메모',          color: '#8b5cf6', icon: 'edit3' },
+  figure:  { label: 'Figure/Table',  color: '#10b981', icon: 'image' },
 }
 
-function renderDashboardStats(stats) {
-  const items = [
-    ['papers', '논문', stats.total_papers], ['read', '읽음', stats.read_papers], ['pages', '페이지', stats.total_pages],
-    ['concepts', '개념', stats.total_concepts], ['questions', '질문', stats.total_questions], ['notes', '메모', stats.total_notes],
-  ]
-  return `
-    <div class="kg-stat-grid">
-      ${items.map(([icon, label, value]) => `
-        <div class="kg-stat-card">
-          <div class="kg-stat-icon">${KG_STAT_ICONS[icon]}</div>
-          <div class="kg-stat-value">${value}</div>
-          <div class="kg-stat-label">${label}</div>
-        </div>
-      `).join('')}
-    </div>
-  `
+const RG_ZOOM_IN_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>'
+const RG_ZOOM_OUT_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>'
+const RG_MORE_SVG = '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>'
+
+// 왼쪽 "노드 타입" 범례 + "Graph Overview" 통계 카드. 전부 fetchLibraryGraph()가
+// 이미 내려준 nodes/edges 배열을 클라이언트에서 집계한 값이다 - 별도 API 호출이나
+// 데이터 모델 변경 없음. "Clusters"는 mockup처럼 별도 클러스터링 알고리즘이 있는
+// 게 아니라, 논문끼리 공유 태그로 연결된(category 엣지) 서로 다른 태그 수를
+// 쓴다 - "2편 이상의 논문이 실제로 공유하는 주제"라는 점에서 정직한 근사치.
+// "업데이트"는 서버가 그래프를 마지막으로 재계산한 시각이 아니라(그런 타임스탬프가
+// 없음), 지금 이 화면이 데이터를 마지막으로 불러온 시각이다 - 그렇게 라벨을 붙여
+// 오해가 없게 한다.
+let rgGraphLoadedAt = null
+function relativeTimeShortKo(date) {
+  if (!date) return ''
+  const diffSec = Math.max(0, Math.round((Date.now() - date.getTime()) / 1000))
+  if (diffSec < 60) return '방금 전'
+  const diffMin = Math.round(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}분 전`
+  const diffHour = Math.round(diffMin / 60)
+  if (diffHour < 24) return `${diffHour}시간 전`
+  return `${Math.round(diffHour / 24)}일 전`
 }
 
-function renderDashboardGaps(gaps) {
-  if (!gaps || gaps.length === 0) return ''
-  return `
-    <div class="kg-section">
-      <h4 class="kg-section-title">${KG_STAT_ICONS.insight}인사이트</h4>
-      <ul class="kg-insight-list">
-        ${gaps.map(g => `<li class="kg-insight-item">${KG_STAT_ICONS.insight}<span>${escapeHtml(g.message)}</span></li>`).join('')}
-      </ul>
-    </div>
-  `
-}
-
-function renderDashboardRecentSection(title, items, renderItem) {
-  if (!items || items.length === 0) return ''
-  return `
-    <div class="kg-section">
-      <h4 class="kg-section-title">${title}</h4>
-      <ul class="kg-recent-list">
-        ${items.map(renderItem).join('')}
-      </ul>
-    </div>
-  `
-}
-
-async function renderLibraryDashboardView() {
-  if (!libraryDashboardContent) return
-  libraryDashboardContent.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
-  try {
-    const data = await fetchLibraryDashboard()
-    if (state.currentLibraryTab !== 'graph') return
-
-    const maxScore = data.heatmap.length ? Math.max(...data.heatmap.map(h => h.score)) : 0
-    const hasRecent = data.recent_questions?.length || data.recent_notes?.length || data.recent_papers?.length
-    libraryDashboardContent.innerHTML = `
-      <div class="kg-dashboard">
-        ${renderDashboardStats(data.stats)}
-        ${renderDashboardGaps(data.gaps)}
-        ${data.heatmap.length ? `
-          <div class="kg-section">
-            <h4 class="kg-section-title">${KG_STAT_ICONS.tag}자주 다룬 개념</h4>
-            <div class="kg-heatmap-list">${data.heatmap.map(item => renderHeatmapBar(item, maxScore)).join('')}</div>
-          </div>
-        ` : ''}
-        ${hasRecent ? `
-          <div class="kg-recent-grid">
-            ${renderDashboardRecentSection(`${KG_STAT_ICONS.questions}최근 질문`, data.recent_questions, e => `
-              <li class="kg-recent-item">${escapeHtml(e.summary || '')}<span class="kg-recent-item-doc">${escapeHtml(e.doc_title || '')}</span></li>
-            `)}
-            ${renderDashboardRecentSection(`${KG_STAT_ICONS.notes}최근 메모`, data.recent_notes, e => `
-              <li class="kg-recent-item">${escapeHtml(e.summary || '')}<span class="kg-recent-item-doc">${escapeHtml(e.doc_title || '')}</span></li>
-            `)}
-            ${renderDashboardRecentSection(`${KG_STAT_ICONS.papers}최근 논문`, data.recent_papers, p => `
-              <li class="kg-recent-item">${escapeHtml(p.title || '')}</li>
-            `)}
-          </div>
-        ` : ''}
-      </div>
-    `
-  } catch (err) {
-    console.error('대시보드 로드 실패:', err)
-    libraryDashboardContent.innerHTML = '<div class="lib-empty"><p style="color:var(--error)">대시보드를 불러오지 못했습니다</p></div>'
+function renderGraphLegend(nodes, edges) {
+  const legendEl = $('rg-legend-panel')
+  if (!legendEl) return
+  const counts = { paper: 0, concept: 0, note: 0, figure: 0 }
+  for (const n of nodes || []) {
+    if (counts[n.type] !== undefined) counts[n.type]++
   }
+  const connectionCount = (edges || []).length
+  const clusterTags = new Set()
+  for (const e of edges || []) {
+    if (e.type === 'category' && e.category) clusterTags.add(e.category)
+  }
+
+  legendEl.innerHTML = `
+    <div class="rg-legend-card">
+      <h4 class="rg-legend-title">노드 타입</h4>
+      <ul class="rg-legend-list">
+        ${Object.entries(GRAPH_NODE_TYPE_META).map(([type, meta]) => `
+          <li class="rg-legend-item">
+            <span class="rg-legend-dot" style="background:${meta.color}"></span>
+            <span class="rg-legend-label">${escapeHtml(meta.label)}</span>
+            <span class="rg-legend-count">${counts[type] || 0}</span>
+          </li>
+        `).join('')}
+      </ul>
+    </div>
+    <div class="rg-overview-card">
+      <h4 class="rg-legend-title">Graph Overview</h4>
+      <ul class="rg-overview-list">
+        <li class="rg-overview-row"><span>${icon('fileText', 13)}Papers</span><b>${counts.paper}</b></li>
+        <li class="rg-overview-row"><span>${icon('network', 13)}Connections</span><b>${connectionCount}</b></li>
+        <li class="rg-overview-row"><span>${icon('layers', 13)}Clusters</span><b>${clusterTags.size}</b></li>
+        <li class="rg-overview-row"><span>${icon('clock', 13)}Updated</span><b id="rg-overview-updated">${escapeHtml(relativeTimeShortKo(rgGraphLoadedAt))}</b></li>
+      </ul>
+      <button type="button" id="rg-refresh-btn" class="rg-refresh-btn">${icon('refreshCw', 13)}<span>Refresh Graph</span></button>
+    </div>
+  `
+  const refreshBtn = $('rg-refresh-btn')
+  if (refreshBtn) refreshBtn.addEventListener('click', () => renderLibraryGraphTab())
+}
+
+// 그래프 탭의 DOM 뼈대(범례/툴바/캔버스 래퍼/줌 컨트롤)를 한 번만 구성한다.
+// index.html은 건드리지 않는다는 제약 때문에, 기존 요소(id 보유 - 검색창/
+// 추천 버튼/상세 패널/캔버스 등)는 그대로 재사용하고 위치와 스타일만
+// 재배치한다. library-graph-row는 리사이저(showLibraryScreen 근처 초기화
+// 코드, off-limits)가 rowRect.right 기준으로 상세 패널 폭을 계산하므로
+// display:flex 구조를 그대로 유지해야 한다 - 왼쪽에 범례를 끼워 넣는 것은
+// 그 계산에 영향을 주지 않는다.
+let graphLayoutReady = false
+function ensureGraphLayout() {
+  if (graphLayoutReady) return
+  if (!libraryGraphView || !libraryGraphRow || !libraryGraphCanvas || !libraryGraphDetailPanel || !libraryGraphSearchInput) return
+  graphLayoutReady = true
+
+  // 상단 그래프/타임라인/히트맵 토글에 아이콘을 붙인다.
+  ;[[libraryGraphViewToggleGraph, 'network'], [libraryGraphViewToggleTimeline, 'clock'], [libraryGraphViewToggleHeatmap, 'grid']].forEach(([btn, iconName]) => {
+    if (btn) btn.innerHTML = `${icon(iconName, 13)}<span>${btn.textContent}</span>`
+  })
+  const tabsRow = libraryGraphViewToggleGraph?.parentElement
+  if (tabsRow) tabsRow.classList.add('rg-view-tabs')
+
+  // 기존 추천 박스(안내 문구용 테두리 박스)를 해체하고, 그 안의 버튼/목록
+  // (id 보유, 리스너가 이미 달려 있음)만 새 툴바로 옮긴다.
+  const recoWrapEl = libraryRecommendationsBtn ? libraryRecommendationsBtn.parentElement : null
+
+  // 검색창 자리에 툴바를 만들고 검색창을 그 안으로 옮긴다.
+  const toolbar = document.createElement('div')
+  toolbar.className = 'rg-toolbar'
+  libraryGraphSearchInput.parentElement.insertBefore(toolbar, libraryGraphSearchInput)
+  libraryGraphSearchInput.removeAttribute('style')
+  libraryGraphSearchInput.classList.add('rg-search-input')
+  const searchWrap = document.createElement('div')
+  searchWrap.className = 'rg-search-wrap'
+  searchWrap.innerHTML = icon('search', 15)
+  searchWrap.appendChild(libraryGraphSearchInput)
+  toolbar.appendChild(searchWrap)
+
+  const typeSelect = document.createElement('select')
+  typeSelect.id = 'rg-filter-type'
+  typeSelect.className = 'rg-filter-select'
+  typeSelect.innerHTML = `<option value="all">모든 타입</option>` +
+    Object.entries(GRAPH_NODE_TYPE_META).map(([t, m]) => `<option value="${t}">${escapeHtml(m.label)}</option>`).join('')
+  toolbar.appendChild(typeSelect)
+
+  const tagSelect = document.createElement('select')
+  tagSelect.id = 'rg-filter-tag'
+  tagSelect.className = 'rg-filter-select'
+  tagSelect.innerHTML = `<option value="all">모든 태그</option>`
+  toolbar.appendChild(tagSelect)
+
+  const toolbarRight = document.createElement('div')
+  toolbarRight.className = 'rg-toolbar-right'
+  toolbar.appendChild(toolbarRight)
+  if (libraryRecommendationsBtn) {
+    libraryRecommendationsBtn.removeAttribute('style')
+    libraryRecommendationsBtn.className = 'rg-recommend-btn'
+    libraryRecommendationsBtn.innerHTML = `${icon('zap', 13)}<span>다음에 읽을 논문 추천받기</span>`
+    toolbarRight.appendChild(libraryRecommendationsBtn)
+  }
+
+  const recoPanel = document.createElement('div')
+  recoPanel.className = 'rg-recommend-panel'
+  if (libraryRecommendationsList) {
+    libraryRecommendationsList.removeAttribute('style')
+    recoPanel.appendChild(libraryRecommendationsList)
+  }
+  toolbar.insertAdjacentElement('afterend', recoPanel)
+  if (recoWrapEl && recoWrapEl.parentElement) recoWrapEl.remove()
+
+  typeSelect.addEventListener('change', applyGraphFilters)
+  tagSelect.addEventListener('change', applyGraphFilters)
+
+  // 3열 레이아웃: 범례(신규) / 캔버스 래퍼(신규, 기존 canvas를 감쌈) / 상세
+  // 패널(기존 요소 재사용). library-graph-row의 flex 자식 순서만 바뀐다.
+  const legendPanel = document.createElement('div')
+  legendPanel.id = 'rg-legend-panel'
+  legendPanel.className = 'rg-legend-col'
+  libraryGraphRow.insertBefore(legendPanel, libraryGraphCanvas)
+
+  const canvasWrap = document.createElement('div')
+  canvasWrap.className = 'rg-canvas-wrap'
+  libraryGraphRow.insertBefore(canvasWrap, libraryGraphCanvas)
+  libraryGraphCanvas.removeAttribute('style')
+  libraryGraphCanvas.classList.add('rg-canvas')
+  canvasWrap.appendChild(libraryGraphCanvas)
+
+  const zoomControls = document.createElement('div')
+  zoomControls.className = 'rg-zoom-controls'
+  zoomControls.innerHTML = `
+    <button type="button" id="rg-zoom-in-btn" class="rg-zoom-btn" title="확대">${RG_ZOOM_IN_SVG}</button>
+    <button type="button" id="rg-zoom-out-btn" class="rg-zoom-btn" title="축소">${RG_ZOOM_OUT_SVG}</button>
+    <button type="button" id="rg-zoom-fit-btn" class="rg-zoom-btn" title="화면에 맞추기">${icon('expand', 14)}</button>
+    <button type="button" id="rg-relayout-btn" class="rg-zoom-btn" title="다시 정렬">${icon('refreshCw', 14)}</button>
+  `
+  canvasWrap.appendChild(zoomControls)
+  $('rg-zoom-in-btn').addEventListener('click', () => { if (libraryGraphCyInstance) libraryGraphCyInstance.zoom(libraryGraphCyInstance.zoom() * 1.25) })
+  $('rg-zoom-out-btn').addEventListener('click', () => { if (libraryGraphCyInstance) libraryGraphCyInstance.zoom(libraryGraphCyInstance.zoom() / 1.25) })
+  $('rg-zoom-fit-btn').addEventListener('click', () => { if (libraryGraphCyInstance) libraryGraphCyInstance.fit(undefined, 40) })
+  $('rg-relayout-btn').addEventListener('click', () => {
+    if (libraryGraphCyInstance) libraryGraphCyInstance.layout({ name: 'fcose', quality: 'proof', animate: true }).run()
+  })
+
+  const savedWidth = libraryGraphDetailPanel.style.width
+  libraryGraphDetailPanel.removeAttribute('style')
+  libraryGraphDetailPanel.classList.add('rg-detail-panel')
+  libraryGraphDetailPanel.style.width = savedWidth || '300px'
+
+  // 상세 패널 안에서 열리는 "더보기" 드롭다운은 매 클릭마다 innerHTML로
+  // 새로 그려지므로(showGraphDetailPanel), 여기서는 위임 방식으로 한 번만
+  // 바깥 클릭 시 닫히는 리스너를 건다(lib-detail-more-menu와 동일한 패턴).
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.rg-detail-more-menu').forEach(m => m.classList.add('hidden'))
+  })
+}
+
+// 타입/태그 드롭다운을 조합해 cytoscape 노드의 표시 여부를 결정한다.
+// 노드/엣지 데이터 자체는 건드리지 않고 화면 표시(style('display', ...))만
+// 바꾸므로 "데이터 모델은 그대로" 제약을 지킨다. 태그는 논문 노드의
+// categories 필드에만 있으므로, 논문이 아닌 노드는 태그 필터의 영향을
+// 받지 않는다(타입 필터로만 걸러진다).
+function applyGraphFilters() {
+  if (!libraryGraphCyInstance) return
+  const typeVal = $('rg-filter-type')?.value || 'all'
+  const tagVal = $('rg-filter-tag')?.value || 'all'
+  libraryGraphCyInstance.nodes().forEach(n => {
+    const data = n.data()
+    const typeOk = typeVal === 'all' || data.type === typeVal
+    const tagOk = tagVal === 'all' || data.type !== 'paper' || (data.categories || []).includes(tagVal)
+    n.style('display', (typeOk && tagOk) ? 'element' : 'none')
+  })
+}
+
+function renderGraphDetailEmptyState() {
+  return `
+    <div class="rg-detail-empty-state">
+      ${icon('network', 26)}
+      <p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>
+    </div>
+  `
+}
+
+function renderGraphDetailHeader(nodeData, titleOverride) {
+  const meta = GRAPH_NODE_TYPE_META[nodeData.type] || { label: '노드', color: 'var(--text-tertiary)', icon: 'fileText' }
+  return `
+    <div class="rg-detail-header">
+      <div class="rg-detail-icon" style="background:color-mix(in srgb, ${meta.color} 16%, transparent); color:${meta.color}">${icon(meta.icon, 20)}</div>
+      <div class="rg-detail-header-text">
+        <h4 class="rg-detail-title">${escapeHtml(titleOverride || nodeData.label || '')}</h4>
+        <span class="rg-detail-type-badge" style="color:${meta.color}">${escapeHtml(meta.label)}</span>
+      </div>
+    </div>
+  `
+}
+
+// 1촌 이웃 노드를 타입별로 집계한 "연결 관계" 요약. 실제 엣지 타입(인용/
+// 카테고리/개념 보유 등)은 knowledgeGraph.js의 tap 핸들러가 이웃 "노드"만
+// 넘겨주고 엣지 자체는 넘기지 않아 여기서는 알 수 없다 - 그 파일은 손대지
+// 않기로 했으므로, 대신 이웃 노드의 타입(논문/개념/메모/Figure)별 개수로
+// 보여준다.
+function renderGraphConnectionsSummary(neighborNodes) {
+  const counts = { paper: 0, concept: 0, note: 0, figure: 0 }
+  for (const n of neighborNodes || []) {
+    if (counts[n.type] !== undefined) counts[n.type]++
+  }
+  const rows = Object.entries(GRAPH_NODE_TYPE_META).filter(([type]) => counts[type] > 0)
+  if (rows.length === 0) return `<p class="rg-detail-empty">연결된 노드가 없습니다.</p>`
+  return `
+    <ul class="rg-connections-list">
+      ${rows.map(([type, meta]) => `
+        <li class="rg-connections-item">
+          <span class="rg-connections-dot" style="background:${meta.color}"></span>
+          <span class="rg-connections-label">${escapeHtml(meta.label)}</span>
+          <span class="rg-connections-count">${counts[type]}</span>
+        </li>
+      `).join('')}
+    </ul>
+  `
+}
+
+function renderGraphRelatedNodesList(neighborNodes, emptyText = '관련 노드가 없습니다.', limit = 6) {
+  const list = neighborNodes || []
+  if (list.length === 0) return `<p class="rg-detail-empty">${escapeHtml(emptyText)}</p>`
+  const shown = list.slice(0, limit)
+  return `
+    <ul class="rg-related-list">
+      ${shown.map(n => {
+        const meta = GRAPH_NODE_TYPE_META[n.type] || { label: n.type, color: 'var(--text-tertiary)' }
+        return `
+          <li class="rg-related-item">
+            <span class="rg-related-dot" style="background:${meta.color}"></span>
+            <span class="rg-related-label">${escapeHtml(n.label || '')}</span>
+            <span class="rg-related-type-tag" style="color:${meta.color}">${escapeHtml(meta.label)}</span>
+          </li>
+        `
+      }).join('')}
+    </ul>
+    ${list.length > limit ? `<p class="rg-related-more">외 ${list.length - limit}개</p>` : ''}
+  `
+}
+
+// "내 활동" 미니 통계 - 논문 노드 전용. 서버 API를 새로 호출하지 않고,
+// 이미 뷰어/메모 기능이 쓰고 있는 로컬 캐시(loadMemos/loadAnnotations)를
+// 그대로 읽어 동기적으로 집계한다.
+function renderGraphMyActivityStats(docId) {
+  let noteCount = 0, highlightCount = 0, underlineCount = 0
+  try {
+    const memos = loadMemos(docId) || {}
+    Object.values(memos).forEach(arr => { noteCount += (arr || []).length })
+  } catch { /* 로컬 캐시 파싱 실패는 0건으로 취급 */ }
+  try {
+    const annotations = loadAnnotations(docId) || {}
+    Object.values(annotations).forEach(arr => {
+      (arr || []).forEach(a => {
+        if (a.type === 'highlight') highlightCount++
+        else if (a.type === 'underline') underlineCount++
+      })
+    })
+  } catch { /* 로컬 캐시 파싱 실패는 0건으로 취급 */ }
+  return `
+    <div class="rg-activity-stats">
+      <div class="rg-activity-stat">${icon('edit3', 13)}<span class="rg-activity-stat-value">${noteCount}</span><span class="rg-activity-stat-label">메모</span></div>
+      <div class="rg-activity-stat">${icon('highlighter', 13)}<span class="rg-activity-stat-value">${highlightCount}</span><span class="rg-activity-stat-label">하이라이트</span></div>
+      <div class="rg-activity-stat">${icon('underline', 13)}<span class="rg-activity-stat-value">${underlineCount}</span><span class="rg-activity-stat-label">언더라인</span></div>
+    </div>
+  `
 }
 
 async function renderLibraryGraphTab() {
@@ -4588,16 +4874,21 @@ async function renderLibraryGraphTab() {
     libraryGraphPollTimeout = null
   }
   if (!libraryGraphCanvas) return
+  ensureGraphLayout()
   if (libraryGraphDetailPanel) {
-    libraryGraphDetailPanel.innerHTML = '<p>노드를 클릭하면 상세 정보가 여기에 표시됩니다.</p>'
+    libraryGraphDetailPanel.innerHTML = renderGraphDetailEmptyState()
   }
   if (libraryGraphSearchInput) libraryGraphSearchInput.value = ''
+  const typeFilterEl = $('rg-filter-type')
+  const tagFilterEl = $('rg-filter-tag')
+  if (typeFilterEl) typeFilterEl.value = 'all'
+  if (tagFilterEl) tagFilterEl.value = 'all'
   switchGraphSubView('graph')
 
   try {
     const data = await fetchLibraryGraph()
     // 응답을 기다리는 사이 사용자가 다른 탭으로 이동했다면 그리지 않는다.
-    if (state.currentLibraryTab !== 'graph') return
+    if (state.currentWorkspacePage !== 'graph') return
 
     if (libraryGraphCyInstance) {
       libraryGraphCyInstance.destroy()
@@ -4605,6 +4896,20 @@ async function renderLibraryGraphTab() {
     }
     libraryGraphCanvas.innerHTML = ''
     libraryGraphCyInstance = renderKnowledgeGraph(libraryGraphCanvas, data, { onNodeClick: showGraphDetailPanel })
+
+    rgGraphLoadedAt = new Date()
+    renderGraphLegend(data.nodes, data.edges)
+
+    // 태그 필터 옵션 = 논문 노드들의 categories 값 전체(중복 제거, 가나다순).
+    if (tagFilterEl) {
+      const cats = new Set()
+      for (const n of data.nodes || []) {
+        if (n.type === 'paper') (n.categories || []).forEach(c => c && cats.add(c))
+      }
+      const sorted = [...cats].sort((a, b) => a.localeCompare(b))
+      tagFilterEl.innerHTML = `<option value="all">모든 태그</option>` +
+        sorted.map(c => `<option value="${escapeHtml(c)}">${escapeHtml(c)}</option>`).join('')
+    }
 
     const pending = data.pending_docs || []
     if (libraryGraphPendingBanner) {
@@ -4614,7 +4919,7 @@ async function renderLibraryGraphTab() {
     // 백그라운드 백필 결과가 반영되는지 확인한다(비어질 때까지 반복).
     if (pending.length > 0) {
       libraryGraphPollTimeout = setTimeout(() => {
-        if (state.currentLibraryTab === 'graph') renderLibraryGraphTab()
+        if (state.currentWorkspacePage === 'graph') renderLibraryGraphTab()
       }, 5000)
     }
   } catch (err) {
@@ -4625,80 +4930,150 @@ async function renderLibraryGraphTab() {
 
 function renderRelatedQuestionsList(questions) {
   if (!questions || questions.length === 0) {
-    return '<p style="margin:8px 0 0;color:var(--text-tertiary)">관련 질문이 없습니다.</p>'
+    return `<p class="rg-detail-empty">관련 질문이 없습니다.</p>`
   }
   return `
-    <ul style="margin:8px 0 0;padding-left:16px;max-height:220px;overflow-y:auto">
+    <ul class="rg-questions-list">
       ${questions.map(q => `
-        <li style="margin-bottom:10px">
-          <div>${escapeHtml(q.content || '')}</div>
-          ${q.doc_title ? `<div style="color:var(--text-tertiary);font-size:11px">${escapeHtml(q.doc_title)}</div>` : ''}
+        <li class="rg-questions-item">
+          <div class="rg-questions-item-text">${escapeHtml(q.content || '')}</div>
+          ${q.doc_title ? `<div class="rg-questions-item-doc">${escapeHtml(q.doc_title)}</div>` : ''}
         </li>
       `).join('')}
     </ul>
   `
 }
 
-// 개념의 "관련 논문"/"유사 개념"처럼, 상세 패널에서 보여줄 1촌 이웃 노드
-// 목록을 렌더링한다. neighborNodes는 knowledgeGraph.js의 tap 핸들러가
-// closedNeighborhood()로 이미 계산해 넘겨준 것이라 별도 API 조회가 필요 없다.
-function renderRelatedNodesList(neighborNodes, type, emptyText) {
-  const matches = (neighborNodes || []).filter(n => n.type === type)
-  if (matches.length === 0) {
-    return `<p style="margin:6px 0 0;color:var(--text-tertiary)">${escapeHtml(emptyText)}</p>`
-  }
-  return `
-    <ul style="margin:6px 0 0;padding-left:16px">
-      ${matches.map(n => `<li style="font-size:12px;color:var(--text-secondary);margin-bottom:4px">${escapeHtml(n.label || '')}</li>`).join('')}
-    </ul>
-  `
-}
-
+// 상세 패널: 클릭된 노드 종류(논문/개념/메모/Figure)에 따라 다른 카드를
+// 그린다. neighborNodes는 knowledgeGraph.js의 tap 핸들러가 closedNeighborhood()
+// 로 이미 계산해 넘겨준 1촌 이웃 노드 목록(별도 API 조회 불필요)이다.
 function showGraphDetailPanel(nodeData, neighborNodes = []) {
   if (!libraryGraphDetailPanel) return
   if (nodeData.type === 'paper') {
-    const categories = (nodeData.categories && nodeData.categories.length) ? nodeData.categories.join(', ') : '없음'
+    const categories = nodeData.categories || []
     libraryGraphDetailPanel.innerHTML = `
-      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
-      <p style="margin:0 0 6px"><strong>유형:</strong> 논문</p>
-      <p style="margin:0"><strong>카테고리:</strong> ${escapeHtml(categories)}</p>
-      <button id="kg-related-questions-btn" style="margin-top:10px;padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 보기</button>
-      <div id="kg-related-questions-list"></div>
+      ${renderGraphDetailHeader(nodeData)}
+      ${categories.length ? `<div class="rg-detail-tags">${categories.map(c => `<span class="rg-detail-tag">${escapeHtml(c)}</span>`).join('')}</div>` : ''}
+      <div class="rg-detail-actions">
+        <button id="rg-open-paper-btn" class="rg-detail-open-btn">${icon('externalLink', 14)}<span>논문 열기</span></button>
+        <button id="rg-fav-paper-btn" class="rg-detail-icon-btn" title="즐겨찾기">${icon('star', 15)}</button>
+        <button id="rg-more-paper-btn" class="rg-detail-icon-btn" title="더보기">${RG_MORE_SVG}</button>
+        <div id="rg-more-paper-menu" class="rg-detail-more-menu hidden">
+          <button id="rg-more-paper-library-btn" class="rg-detail-more-item">${icon('bookOpen', 13)}<span>라이브러리에서 자세히 보기</span></button>
+        </div>
+      </div>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">AI 요약</h5>
+        <div id="rg-detail-summary-text" class="rg-detail-summary-text"><p class="rg-detail-loading">불러오는 중...</p></div>
+      </div>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">연결 관계 (${(neighborNodes || []).length})</h5>
+        ${renderGraphConnectionsSummary(neighborNodes)}
+      </div>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">관련 노드</h5>
+        ${renderGraphRelatedNodesList(neighborNodes)}
+      </div>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">내 활동</h5>
+        ${renderGraphMyActivityStats(nodeData.doc_id)}
+      </div>
+      <div class="rg-detail-section">
+        <button id="kg-related-questions-btn" class="rg-detail-question-btn">${icon('messageCircle', 13)}<span>관련 질문 보기</span></button>
+        <div id="kg-related-questions-list"></div>
+      </div>
     `
+    $('rg-fav-paper-btn')?.classList.toggle('active', isFavoriteDoc(nodeData.doc_id))
+    $('rg-fav-paper-btn')?.addEventListener('click', () => {
+      const nowFav = toggleFavoriteDoc(nodeData.doc_id)
+      $('rg-fav-paper-btn')?.classList.toggle('active', nowFav)
+    })
+    $('rg-open-paper-btn')?.addEventListener('click', async () => {
+      try {
+        const doc = await fetchLibraryDoc(nodeData.doc_id)
+        await openFromLibrary(doc)
+      } catch (err) {
+        console.error('논문 열기 실패:', err)
+        showToast('논문을 불러오지 못했습니다.', 'error')
+      }
+    })
+    $('rg-more-paper-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation()
+      $('rg-more-paper-menu')?.classList.toggle('hidden')
+    })
+    $('rg-more-paper-library-btn')?.addEventListener('click', async () => {
+      $('rg-more-paper-menu')?.classList.add('hidden')
+      try {
+        const doc = await fetchLibraryDoc(nodeData.doc_id)
+        openLibraryDetailPanel(doc)
+      } catch (err) {
+        console.error('상세 정보 열기 실패:', err)
+        showToast('상세 정보를 불러오지 못했습니다.', 'error')
+      }
+    })
+    ;(async () => {
+      const summaryEl = $('rg-detail-summary-text')
+      if (!summaryEl) return
+      try {
+        const targetLang = getTranslationOptions().targetLang
+        const primer = await fetchPrimer(nodeData.doc_id, targetLang)
+        const text = primer.hook || primer.feynman || primer.lineage || ''
+        summaryEl.innerHTML = text
+          ? escapeHtml(text).replace(/\n/g, '<br>')
+          : `<p class="rg-detail-loading">아직 생성된 요약이 없습니다.</p>`
+      } catch (err) {
+        console.error('AI 요약 로드 실패:', err)
+        summaryEl.innerHTML = `<p class="rg-detail-error">AI 요약을 불러오지 못했습니다.</p>`
+      }
+    })()
   } else if (nodeData.type === 'concept') {
     const questionCount = nodeData.question_count || 0
     libraryGraphDetailPanel.innerHTML = `
-      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
-      <p style="margin:0 0 6px"><strong>유형:</strong> 개념</p>
-      <p style="margin:0 0 10px"><strong>분류:</strong> ${escapeHtml(nodeData.kind || '미상')}</p>
-      <div style="margin-bottom:10px">
-        <h5 style="margin:0 0 4px;font-size:12px;color:var(--text-primary)">이 개념을 다루는 논문</h5>
-        ${renderRelatedNodesList(neighborNodes, 'paper', '연결된 논문이 없습니다.')}
+      ${renderGraphDetailHeader(nodeData)}
+      <p class="rg-detail-subtitle">분류: ${escapeHtml(nodeData.kind || '미상')}</p>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">연결 관계 (${(neighborNodes || []).length})</h5>
+        ${renderGraphConnectionsSummary(neighborNodes)}
       </div>
-      <div style="margin-bottom:10px">
-        <h5 style="margin:0 0 4px;font-size:12px;color:var(--text-primary)">유사 개념</h5>
-        ${renderRelatedNodesList(neighborNodes, 'concept', '유사한 개념이 없습니다.')}
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">이 개념을 다루는 논문</h5>
+        ${renderGraphRelatedNodesList((neighborNodes || []).filter(n => n.type === 'paper'), '연결된 논문이 없습니다.')}
       </div>
-      <button id="kg-related-questions-btn" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border-strong);background:var(--bg-elevated);color:var(--text-primary);font-size:12px;cursor:pointer">관련 질문 ${questionCount}개 보기</button>
-      <div id="kg-related-questions-list"></div>
+      <div class="rg-detail-section">
+        <h5 class="rg-detail-section-title">유사 개념</h5>
+        ${renderGraphRelatedNodesList((neighborNodes || []).filter(n => n.type === 'concept'), '유사한 개념이 없습니다.')}
+      </div>
+      <div class="rg-detail-section">
+        <button id="kg-related-questions-btn" class="rg-detail-question-btn">${icon('messageCircle', 13)}<span>관련 질문 ${questionCount}개 보기</span></button>
+        <div id="kg-related-questions-list"></div>
+      </div>
     `
   } else if (nodeData.type === 'note') {
     libraryGraphDetailPanel.innerHTML = `
-      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">메모</h4>
-      <p style="margin:0">${escapeHtml(nodeData.label || '')}</p>
+      ${renderGraphDetailHeader(nodeData, '메모')}
+      <p class="rg-detail-note-text">${escapeHtml(nodeData.label || '')}</p>
+      ${nodeData.doc_id ? `<button id="rg-note-open-paper-btn" class="rg-detail-open-btn">${icon('externalLink', 14)}<span>논문에서 보기</span></button>` : ''}
     `
+    $('rg-note-open-paper-btn')?.addEventListener('click', async () => {
+      try {
+        const doc = await fetchLibraryDoc(nodeData.doc_id)
+        await openFromLibrary(doc)
+      } catch (err) {
+        console.error('논문 열기 실패:', err)
+        showToast('논문을 불러오지 못했습니다.', 'error')
+      }
+    })
   } else if (nodeData.type === 'figure') {
     // 캡션은 backend(_spans_to_bold_markdown)가 **볼드**만 마크다운으로 감싸
     // 넘겨준다 - Figure/Table 오버레이 툴팁(renderBoldText 최초 도입 지점)과
     // 동일한 방식으로 렌더링해야 캡션 안의 볼드 서식이 살아난다.
     const captionHtml = nodeData.caption
-      ? `<p style="margin:0 0 10px;color:var(--text-secondary);font-size:12px">${renderBoldText(nodeData.caption)}</p>`
+      ? `<p class="rg-detail-figure-caption">${renderBoldText(nodeData.caption)}</p>`
       : ''
     const hasCrop = nodeData.doc_id != null && nodeData.index != null
     libraryGraphDetailPanel.innerHTML = `
-      <h4 style="margin:0 0 8px;font-size:14px;color:var(--text-primary)">${escapeHtml(nodeData.label || '')}</h4>
-      <p style="margin:0 0 10px"><strong>유형:</strong> Figure/Table</p>
-      ${hasCrop ? `<img id="kg-figure-img" class="primer-figure-img" style="margin-bottom:10px;width:100%;cursor:pointer" alt="${escapeHtml(nodeData.label || '')}" title="클릭하면 논문의 해당 페이지로 이동합니다">` : ''}
+      ${renderGraphDetailHeader(nodeData)}
+      ${hasCrop ? `<img id="kg-figure-img" class="rg-detail-figure-img primer-figure-img" alt="${escapeHtml(nodeData.label || '')}" title="클릭하면 논문의 해당 페이지로 이동합니다">` : ''}
       ${captionHtml}
     `
     const figureImg = $('kg-figure-img')
@@ -4706,7 +5081,7 @@ function showGraphDetailPanel(nodeData, neighborNodes = []) {
       figureImg.addEventListener('error', () => {
         figureImg.replaceWith(Object.assign(document.createElement('p'), {
           textContent: '이미지를 불러올 수 없습니다.',
-          style: 'margin:0 0 10px;color:var(--text-tertiary);font-size:12px',
+          className: 'rg-detail-empty',
         }))
       })
       figureImg.src = `/api/library/${encodeURIComponent(nodeData.doc_id)}/figure-image/${encodeURIComponent(nodeData.index)}`
@@ -4719,7 +5094,7 @@ function showGraphDetailPanel(nodeData, neighborNodes = []) {
       }
     }
   } else {
-    libraryGraphDetailPanel.innerHTML = '<p>알 수 없는 노드입니다.</p>'
+    libraryGraphDetailPanel.innerHTML = `<p class="rg-detail-empty">알 수 없는 노드입니다.</p>`
   }
 
   const questionsBtn = $('kg-related-questions-btn')
@@ -4727,12 +5102,12 @@ function showGraphDetailPanel(nodeData, neighborNodes = []) {
     questionsBtn.addEventListener('click', async () => {
       const listEl = $('kg-related-questions-list')
       if (!listEl) return
-      listEl.innerHTML = '<p style="margin:8px 0 0;color:var(--text-tertiary)">불러오는 중...</p>'
+      listEl.innerHTML = `<p class="rg-detail-loading">불러오는 중...</p>`
       try {
         const { questions } = await fetchGraphNodeQuestions(nodeData.id)
         listEl.innerHTML = renderRelatedQuestionsList(questions)
       } catch (err) {
-        listEl.innerHTML = '<p style="margin:8px 0 0;color:var(--error)">질문을 불러오지 못했습니다.</p>'
+        listEl.innerHTML = `<p class="rg-detail-error">질문을 불러오지 못했습니다.</p>`
       }
     })
   }
@@ -4770,97 +5145,30 @@ if (libraryRecommendationsBtn) {
   libraryRecommendationsBtn.addEventListener('click', async () => {
     if (!libraryRecommendationsList) return
     libraryRecommendationsBtn.disabled = true
-    libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--text-tertiary);font-size:12px">추천 논문을 찾는 중... (시간이 걸릴 수 있습니다)</p>'
+    libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">추천 논문을 찾는 중... (시간이 걸릴 수 있습니다)</p>`
     try {
       const { recommendations } = await fetchReadingRecommendations()
       if (!recommendations || recommendations.length === 0) {
-        libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--text-tertiary);font-size:12px">추천할 만한 논문을 찾지 못했습니다.</p>'
+        libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">추천할 만한 논문을 찾지 못했습니다.</p>`
       } else {
         libraryRecommendationsList.innerHTML = recommendations.map(r => `
-          <div style="padding:8px 0;border-top:1px solid var(--border-strong)">
-            <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" style="font-size:13px;font-weight:600;color:var(--text-primary)">${escapeHtml(r.title || '')}</a>
-            ${r.reason ? `<div style="font-size:12px;color:var(--text-secondary);margin-top:4px">${escapeHtml(r.reason)}</div>` : ''}
+          <div class="rg-recommend-item">
+            <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" class="rg-recommend-item-title">${escapeHtml(r.title || '')}</a>
+            ${r.reason ? `<div class="rg-recommend-item-reason">${escapeHtml(r.reason)}</div>` : ''}
           </div>
         `).join('')
       }
     } catch (err) {
       console.error('추천 논문 조회 실패:', err)
-      libraryRecommendationsList.innerHTML = '<p style="margin:0;color:var(--error);font-size:12px">추천 논문을 불러오지 못했습니다.</p>'
+      libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status rg-recommend-error">추천 논문을 불러오지 못했습니다.</p>`
     } finally {
       libraryRecommendationsBtn.disabled = false
     }
   })
 }
 
-async function renderAnnotationsBrowser() {
-  updateAnnotationSubtabUI()
-  if (!annotationList) return
-  annotationList.innerHTML = `<div class="lib-empty"><p>불러오는 중...</p></div>`
-
-  try {
-    const data = await fetchLibrary(getTranslationOptions())
-    const docs = data.documents || []
-    const items = []
-
-    docs.forEach(doc => {
-      const docTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
-
-      if (annotationBrowserSubtab === 'memo') {
-        const memosByPage = loadMemos(doc.id)
-        Object.keys(memosByPage).forEach(pageKey => {
-          const pageNum = parseInt(pageKey.replace('page_', ''), 10)
-          if (isNaN(pageNum)) return
-          memosByPage[pageKey].forEach(memo => items.push({ doc, docTitle, pageNum, memo }))
-        })
-      } else {
-        const annotationsByPage = loadAnnotations(doc.id)
-        Object.keys(annotationsByPage).forEach(pageKey => {
-          const pageNum = parseInt(pageKey.replace('page_', ''), 10)
-          if (isNaN(pageNum)) return
-          annotationsByPage[pageKey].forEach(ann => {
-            if (ann.type === annotationBrowserSubtab) items.push({ doc, docTitle, pageNum, annotation: ann })
-          })
-        })
-      }
-    })
-
-    if (annotationBrowserSubtab === 'memo') {
-      // 메모 id에 생성 시각(Date.now())이 들어있어 최근 순으로 정렬 가능
-      items.sort((a, b) => String(b.memo.id).localeCompare(String(a.memo.id)))
-    } else {
-      items.sort((a, b) => a.docTitle.localeCompare(b.docTitle) || a.pageNum - b.pageNum)
-    }
-
-    renderAnnotationItems(items)
-  } catch (err) {
-    console.error('주석 목록 로드 실패:', err)
-    annotationList.innerHTML = `<div class="lib-empty"><p style="color:var(--error)">주석 목록을 불러오지 못했습니다</p></div>`
-  }
-}
-
-if (annotationSubtabMemo) {
-  annotationSubtabMemo.addEventListener('click', () => {
-    if (annotationBrowserSubtab === 'memo') return
-    annotationBrowserSubtab = 'memo'
-    renderAnnotationsBrowser()
-  })
-}
-if (annotationSubtabHighlight) {
-  annotationSubtabHighlight.addEventListener('click', () => {
-    if (annotationBrowserSubtab === 'highlight') return
-    annotationBrowserSubtab = 'highlight'
-    renderAnnotationsBrowser()
-  })
-}
-if (annotationSubtabUnderline) {
-  annotationSubtabUnderline.addEventListener('click', () => {
-    if (annotationBrowserSubtab === 'underline') return
-    annotationBrowserSubtab = 'underline'
-    renderAnnotationsBrowser()
-  })
-}
-
 // 메모/하이라이트/언더라인 항목을 클릭하면 해당 논문을 열고 해당 페이지로 이동한다.
+// Notes 페이지(pages/notesPage.js)와 Library 상세 패널에서 공유해서 쓴다.
 async function openAnnotationTarget(doc, pageNum) {
   try {
     const freshDoc = await fetchLibraryDoc(doc.id)
@@ -4870,67 +5178,6 @@ async function openAnnotationTarget(doc, pageNum) {
     console.error('주석에서 논문 열기 실패:', err)
     showToast('논문을 불러오지 못했습니다.', 'error')
   }
-}
-
-function renderAnnotationItems(items) {
-  const emptyMessages = {
-    memo: 'AI 논문에 남긴 메모가 없습니다',
-    highlight: '하이라이트한 내용이 없습니다',
-    underline: '밑줄 친 내용이 없습니다',
-  }
-
-  if (items.length === 0) {
-    annotationList.innerHTML = `<div class="lib-empty"><p>${emptyMessages[annotationBrowserSubtab]}</p></div>`
-    return
-  }
-
-  annotationList.innerHTML = ''
-  items.forEach(entry => {
-    const { doc, docTitle, pageNum } = entry
-    const item = document.createElement('div')
-    item.className = 'chat-session-item'
-
-    let iconHtml, fullText, iconBg
-    if (entry.memo) {
-      iconHtml = icon('messageCircle', 17)
-      fullText = (entry.memo.content && entry.memo.content.trim()) || entry.memo.sentenceText || '(내용 없음)'
-      iconBg = ''
-    } else {
-      const isHighlight = annotationBrowserSubtab === 'highlight'
-      iconHtml = icon(isHighlight ? 'highlighter' : 'underline', 17)
-      fullText = entry.annotation.text || '(내용 없음)'
-      iconBg = entry.annotation.color ? `background:${hexToRgba(entry.annotation.color, 0.22)};color:${entry.annotation.color}` : ''
-    }
-
-    const shortText = truncateForList(fullText, 70)
-    const canExpand = fullText.trim().length > shortText.replace(/\.\.\.$/, '').length
-
-    item.innerHTML = `
-      <div class="chat-session-item-icon" style="${iconBg}">${iconHtml}</div>
-      <div class="chat-session-item-body">
-        <div class="chat-session-item-title">${escapeHtml(docTitle)} · ${pageNum}페이지</div>
-        <div class="chat-session-item-meta annotation-item-meta">${escapeHtml(shortText)}</div>
-      </div>
-      ${canExpand ? `<button class="annotation-expand-btn" title="전체 내용 보기">${icon('chevronDown', 12)}</button>` : ''}
-    `
-    item.addEventListener('click', () => openAnnotationTarget(doc, pageNum))
-
-    if (canExpand) {
-      const expandBtn = item.querySelector('.annotation-expand-btn')
-      const metaEl = item.querySelector('.annotation-item-meta')
-      let expanded = false
-      expandBtn.addEventListener('click', (e) => {
-        e.stopPropagation()
-        expanded = !expanded
-        metaEl.textContent = expanded ? fullText : shortText
-        metaEl.classList.toggle('expanded', expanded)
-        expandBtn.innerHTML = icon(expanded ? 'chevronUp' : 'chevronDown', 12)
-        expandBtn.title = expanded ? '접기' : '전체 내용 보기'
-      })
-    }
-
-    annotationList.appendChild(item)
-  })
 }
 
 let currentLibraryDocs = []
@@ -5005,13 +5252,26 @@ function filterLibraryCards(docs) {
     btn.classList.toggle('active', btn.dataset.category === activeCategoryFilter)
   })
 
-  // Filter docs
-  const filteredDocs = activeCategoryFilter === 'ALL'
+  // Filter docs by category tag
+  let filteredDocs = activeCategoryFilter === 'ALL'
     ? docs
     : docs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
 
+  // 상태 필터(전체/읽지 않음/읽는 중/완료/즐겨찾기) 적용 - 휴지통 탭에는 없는 개념이라 건너뛴다.
+  if (state.currentLibraryTab !== 'trash' && activeStatusFilter !== 'all') {
+    const favIds = getFavoriteIds()
+    filteredDocs = filteredDocs.filter(doc => (
+      activeStatusFilter === 'favorites' ? favIds.has(doc.id) : getLibraryDocStatus(doc) === activeStatusFilter
+    ))
+  }
+
+  filteredDocs = sortLibraryDocs(filteredDocs)
+
   if (filteredDocs.length === 0) {
-    libraryGrid.appendChild(createEmptyState(state.currentLibraryTab === 'history')); return
+    const variant = state.currentLibraryTab === 'trash'
+      ? 'trash'
+      : (activeStatusFilter !== 'all' ? activeStatusFilter : (docs.length > 0 ? 'filtered' : 'library'))
+    libraryGrid.appendChild(createEmptyState(variant)); return
   }
 
   const createItem = libraryViewMode === 'list' ? createDocListRow : createDocCard
@@ -5093,18 +5353,28 @@ if (librarySearchClearBtn) {
   })
 }
 
-function createEmptyState(isHistory = false) {
+// variant: 'library'(보관함 전체가 비어 있음) | 'trash'(휴지통이 비어 있음) |
+// 'unread' | 'reading' | 'finished' | 'favorites'(해당 상태 탭에 걸리는 문서가 없음) |
+// 'filtered'(태그 필터 결과가 없음). 과거 boolean(isHistory) 시그니처와의 호환을 위해
+// true도 'finished'로 취급한다.
+const LIBRARY_EMPTY_STATE_VARIANTS = {
+  trash:     { iconName: 'trash2',   title: '휴지통이 비어 있습니다', desc: '삭제한 논문이 여기에 표시됩니다' },
+  unread:    { iconName: 'bookOpen', title: '읽지 않은 논문이 없습니다', desc: '모든 논문을 확인했네요' },
+  reading:   { iconName: 'bookOpen', title: '읽는 중인 논문이 없습니다', desc: '번역이 진행 중인 논문이 여기에 표시됩니다' },
+  finished:  { iconName: 'bookOpen', title: '읽은 논문이 없습니다', desc: '보관함에서 논문의 체크 아이콘을 눌러 읽음 처리해 보세요' },
+  favorites: { iconName: 'star',     title: '즐겨찾기한 논문이 없습니다', desc: '카드의 별표 아이콘을 눌러 즐겨찾기에 추가해 보세요' },
+  filtered:  { iconName: 'tag',      title: '조건에 맞는 논문이 없습니다', desc: '다른 필터를 선택해 보세요' },
+  library:   { iconName: 'book',     title: '보관함에 저장된 논문이 없습니다', desc: '새 논문을 추가하거나 PDF를 업로드해 보세요' },
+}
+function createEmptyState(variant = 'library') {
+  if (variant === true) variant = 'finished'
+  if (variant === false) variant = 'library'
   const el = document.createElement('div')
   el.className = 'lib-empty'
-  if (isHistory) {
-    el.innerHTML = `<div style="margin-bottom:16px;color:var(--text-muted)">${icon('bookOpen', 48)}</div>
-      <p>읽은 논문이 없습니다</p>
-      <p style="font-size:13px;color:var(--text-muted);margin-top:8px">보관함에서 논문의 체크 아이콘을 눌러 읽음 처리해 보세요</p>`
-  } else {
-    el.innerHTML = `<div style="margin-bottom:16px;color:var(--text-muted)">${icon('book', 48)}</div>
-      <p>보관함에 저장된 논문이 없습니다</p>
-      <p style="font-size:13px;color:var(--text-muted);margin-top:8px">새 논문을 추가하거나 PDF를 업로드해 보세요</p>`
-  }
+  const c = LIBRARY_EMPTY_STATE_VARIANTS[variant] || LIBRARY_EMPTY_STATE_VARIANTS.library
+  el.innerHTML = `<div style="margin-bottom:16px;color:var(--text-muted)">${icon(c.iconName, 48)}</div>
+    <p>${c.title}</p>
+    <p style="font-size:13px;color:var(--text-muted);margin-top:8px">${c.desc}</p>`
   return el
 }
 
@@ -5376,6 +5646,26 @@ function wireDocItemEvents(container, doc, displayTitle) {
 
 function createDocCard(doc) {
   const d = prepareDocItemHtml(doc)
+  const isFav = isFavoriteDoc(doc.id)
+
+  // 카드 뷰는 리스트 뷰의 압축 진행률(d.progressHtml)과는 별도로, 전체 너비 바 +
+  // 퍼센트를 보여주는 새 레이아웃을 쓴다(리스트 뷰는 손대지 않는다 - createDocListRow는
+  // 편집 허용 범위 밖).
+  let cardProgressHtml = ''
+  if (!d.isDone) {
+    cardProgressHtml = `
+      <div class="lib-card-progress">
+        <div class="lib-card-progress-bar-wrap"><div class="lib-card-progress-bar" style="width:${d.pct}%"></div></div>
+        <span class="lib-card-progress-pct">${d.pct}%</span>
+      </div>
+    `
+  }
+
+  // 즐겨찾기는 휴지통 문서에는 의미가 없어(체크/미리보기 버튼과 동일하게) 숨긴다.
+  const favBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
+    <button class="doc-card-fav-btn ${isFav ? 'active' : ''}" data-id="${escapeHtml(doc.id)}" title="즐겨찾기">${icon('star', 11)}</button>
+  `
+
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.dataset.id = doc.id
@@ -5386,18 +5676,56 @@ function createDocCard(doc) {
         ${d.expandBtnHtml}
         ${d.checkBtnHtml}
       </div>
-      <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
+      <div class="lib-card-top">
+        <div class="lib-card-thumb">
+          <img src="/api/library/${encodeURIComponent(doc.id)}/cover" alt="" loading="lazy" />
+          <div class="lib-card-thumb-fallback">${icon('fileText', 18)}</div>
+          ${favBtnHtml}
+        </div>
+        <div class="lib-card-top-body">
+          <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
+        </div>
+      </div>
       ${d.tagsHtml}
       <div class="doc-card-meta">
         ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${d.total}p</span>
       </div>
-      ${d.progressHtml}
+      ${cardProgressHtml}
     </div>
     <div class="doc-card-footer">
       ${d.ctaBtnFullHtml}
       <div class="doc-icon-actions">${d.iconActionsHtml}</div>
     </div>`
+
+  const thumbImg = card.querySelector('.lib-card-thumb img')
+  if (thumbImg) {
+    thumbImg.addEventListener('error', () => {
+      thumbImg.closest('.lib-card-thumb')?.classList.add('cover-fallback')
+    })
+  }
+
+  // 카드 빈 영역 클릭 시 상세 패널을 연다. wireDocItemEvents()가 곧이어 등록할
+  // "카드 전체 클릭 = 뷰어 즉시 열기" 리스너보다 먼저 걸어 stopImmediatePropagation으로
+  // 가로챈다 - 같은 엘리먼트에 등록된 리스너는 등록 순서대로 실행되므로, 여기서
+  // 먼저 등록한 뒤 막으면 이후 리스너는 아예 실행되지 않는다. 비교 선택 모드/휴지통
+  // 안내 동작은 기존과 동일하게 여기서도 복제해 그대로 유지한다.
+  card.addEventListener('click', (e) => {
+    if (compareSelectMode) {
+      toggleDocCompareSelection(card, doc)
+      e.stopImmediatePropagation()
+      return
+    }
+    if (state.currentLibraryTab === 'trash') {
+      showToast('휴지통에 있는 논문입니다. 복원 후 열 수 있습니다.', 'warning')
+      e.stopImmediatePropagation()
+      return
+    }
+    openLibraryDetailPanel(doc)
+    e.stopImmediatePropagation()
+  })
+
   wireDocItemEvents(card, doc, d.displayTitle)
+
   const expandBtn = card.querySelector('.doc-card-expand-btn')
   if (expandBtn) {
     expandBtn.addEventListener('click', (e) => {
@@ -5405,7 +5733,472 @@ function createDocCard(doc) {
       showDocPreview(doc)
     })
   }
+
+  const favBtn = card.querySelector('.doc-card-fav-btn')
+  if (favBtn) {
+    favBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      const nowFav = toggleFavoriteDoc(doc.id)
+      favBtn.classList.toggle('active', nowFav)
+      renderLibraryStatusTabs(currentLibraryDocs)
+    })
+  }
+
   return card
+}
+
+// ============================================================
+// 라이브러리 카드 상세 패널 (우측 드로어)
+// 카드를 클릭하면 열리며, 표지/제목 + "논문 열기" 버튼 + 개요(AI 요약/기본 정보/태그)·
+// 메모·AI 대화·관련 자료 탭을 보여준다. index.html은 건드리지 않고 이 함수들이
+// 처음 필요할 때(ensureLibraryDetailPanel) 마크업을 직접 삽입한다.
+// ============================================================
+let libraryDetailDoc = null
+let libraryDetailLoadedTabs = new Set()
+let libraryDetailSummaryReqToken = 0
+let libraryDetailBiblioReqToken = 0
+let libraryGraphCacheForDetail = null // fetchLibraryGraph() 결과 캐시 - 패널을 열 때마다 다시 조회하지 않도록. renderLibrary()가 무효화한다.
+const LIBRARY_DETAIL_TABS = ['overview', 'notes', 'questions', 'related']
+
+function ensureLibraryDetailPanel() {
+  if ($('lib-detail-panel')) return
+
+  const openIconSvg = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>'
+  const closeIconSvg = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>'
+  const moreIconSvg = '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>'
+
+  document.body.insertAdjacentHTML('beforeend', `
+    <div id="lib-detail-overlay" class="lib-detail-overlay"></div>
+    <aside id="lib-detail-panel" class="lib-detail-panel" aria-hidden="true">
+      <button id="lib-detail-close-btn" class="lib-detail-close-btn" title="닫기">${closeIconSvg}</button>
+      <div class="lib-detail-hero">
+        <div class="lib-detail-cover" id="lib-detail-cover">
+          <img id="lib-detail-cover-img" alt="" />
+          <div class="lib-detail-cover-fallback">${icon('fileText', 26)}</div>
+        </div>
+        <div class="lib-detail-title-block">
+          <h2 id="lib-detail-title" class="lib-detail-title"></h2>
+          <p id="lib-detail-subtitle" class="lib-detail-subtitle"></p>
+        </div>
+      </div>
+      <div class="lib-detail-actions">
+        <button id="lib-detail-open-btn" class="lib-detail-open-btn">${openIconSvg}<span>논문 열기</span></button>
+        <button id="lib-detail-fav-btn" class="lib-detail-icon-btn" title="즐겨찾기">${icon('star', 15)}</button>
+        <button id="lib-detail-edit-btn" class="lib-detail-icon-btn" title="제목 수정">${icon('edit3', 14)}</button>
+        <button id="lib-detail-more-btn" class="lib-detail-icon-btn" title="더보기">${moreIconSvg}</button>
+        <div id="lib-detail-more-menu" class="lib-detail-more-menu hidden">
+          <button id="lib-detail-delete-btn" class="lib-detail-more-item danger">${icon('trash2', 13)}<span>삭제 (휴지통으로 이동)</span></button>
+        </div>
+      </div>
+      <div class="lib-detail-tabs">
+        <button type="button" class="lib-detail-tab active" data-tab="overview">개요</button>
+        <button type="button" class="lib-detail-tab" data-tab="notes">메모<span id="lib-detail-tab-count-notes" class="lib-detail-tab-count hidden"></span></button>
+        <button type="button" class="lib-detail-tab" data-tab="questions">AI 대화<span id="lib-detail-tab-count-questions" class="lib-detail-tab-count hidden"></span></button>
+        <button type="button" class="lib-detail-tab" data-tab="related">관련 자료<span id="lib-detail-tab-count-related" class="lib-detail-tab-count hidden"></span></button>
+      </div>
+      <div class="lib-detail-body">
+        <section id="lib-detail-panel-overview" class="lib-detail-panel-section">
+          <div class="lib-detail-summary-block">
+            <h3>AI 요약</h3>
+            <div id="lib-detail-summary-text" class="lib-detail-summary-text"></div>
+          </div>
+          <div class="lib-detail-quickinfo-block">
+            <h3>기본 정보</h3>
+            <dl id="lib-detail-quickinfo" class="lib-detail-quickinfo"></dl>
+          </div>
+          <div class="lib-detail-tags-block">
+            <h3>태그</h3>
+            <div id="lib-detail-tags" class="lib-detail-tags"></div>
+          </div>
+        </section>
+        <section id="lib-detail-panel-notes" class="lib-detail-panel-section hidden"></section>
+        <section id="lib-detail-panel-questions" class="lib-detail-panel-section hidden"></section>
+        <section id="lib-detail-panel-related" class="lib-detail-panel-section hidden"></section>
+      </div>
+    </aside>
+  `)
+
+  $('lib-detail-overlay')?.addEventListener('click', closeLibraryDetailPanel)
+  $('lib-detail-close-btn')?.addEventListener('click', closeLibraryDetailPanel)
+
+  document.querySelectorAll('#lib-detail-panel .lib-detail-tab').forEach(btn => {
+    btn.addEventListener('click', () => switchLibraryDetailTab(btn.dataset.tab))
+  })
+
+  $('lib-detail-open-btn')?.addEventListener('click', () => {
+    if (!libraryDetailDoc) return
+    const doc = libraryDetailDoc
+    closeLibraryDetailPanel()
+    openFromLibrary(doc)
+  })
+
+  $('lib-detail-fav-btn')?.addEventListener('click', () => {
+    if (!libraryDetailDoc) return
+    const nowFav = toggleFavoriteDoc(libraryDetailDoc.id)
+    $('lib-detail-fav-btn')?.classList.toggle('active', nowFav)
+    const cardFavBtn = libraryGrid.querySelector(`.doc-card-fav-btn[data-id="${CSS.escape(libraryDetailDoc.id)}"]`)
+    if (cardFavBtn) cardFavBtn.classList.toggle('active', nowFav)
+    renderLibraryStatusTabs(currentLibraryDocs)
+  })
+
+  $('lib-detail-edit-btn')?.addEventListener('click', () => {
+    if (libraryDetailDoc) startLibraryDetailTitleEdit(libraryDetailDoc)
+  })
+
+  const moreBtn = $('lib-detail-more-btn')
+  const moreMenu = $('lib-detail-more-menu')
+  if (moreBtn && moreMenu) {
+    moreBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      moreMenu.classList.toggle('hidden')
+    })
+    document.addEventListener('click', () => moreMenu.classList.add('hidden'))
+  }
+
+  $('lib-detail-delete-btn')?.addEventListener('click', async () => {
+    if (!libraryDetailDoc) return
+    const doc = libraryDetailDoc
+    const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+    moreMenu?.classList.add('hidden')
+    const ok = await showCustomConfirm(`"${displayTitle}"을 삭제할까요? (휴지통으로 이동합니다)`, { title: '논문 삭제', confirmText: '삭제', danger: true })
+    if (!ok) return
+    try {
+      await deleteLibraryDoc(doc.id)
+      showToast('휴지통으로 이동되었습니다.', 'success')
+      closeLibraryDetailPanel()
+      await renderLibrary()
+    } catch {
+      showToast('삭제 실패', 'error')
+    }
+  })
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && $('lib-detail-panel')?.classList.contains('open')) closeLibraryDetailPanel()
+  })
+}
+
+function openLibraryDetailPanel(doc) {
+  ensureLibraryDetailPanel()
+  libraryDetailDoc = doc
+  libraryDetailLoadedTabs = new Set(['overview'])
+
+  const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  const titleEl = $('lib-detail-title')
+  if (titleEl) titleEl.textContent = displayTitle
+  const subtitleEl = $('lib-detail-subtitle')
+  if (subtitleEl) {
+    const date = new Date(doc.created_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
+    subtitleEl.textContent = `등록 ${date} · ${doc.total_pages || 1}페이지`
+  }
+
+  const coverWrap = $('lib-detail-cover')
+  const coverImg = $('lib-detail-cover-img')
+  if (coverWrap && coverImg) {
+    coverWrap.classList.remove('cover-fallback')
+    coverImg.onerror = () => coverWrap.classList.add('cover-fallback')
+    coverImg.src = `/api/library/${encodeURIComponent(doc.id)}/cover`
+  }
+
+  $('lib-detail-fav-btn')?.classList.toggle('active', isFavoriteDoc(doc.id))
+  ;['notes', 'questions', 'related'].forEach(t => {
+    const c = $(`lib-detail-tab-count-${t}`)
+    if (c) { c.textContent = ''; c.classList.add('hidden') }
+  })
+
+  switchLibraryDetailTab('overview')
+  loadLibraryDetailOverview(doc)
+
+  $('lib-detail-overlay')?.classList.add('open')
+  const panel = $('lib-detail-panel')
+  if (panel) { panel.classList.add('open'); panel.setAttribute('aria-hidden', 'false') }
+}
+
+function closeLibraryDetailPanel() {
+  if (!libraryDetailDoc) return
+  libraryDetailDoc = null
+  libraryDetailSummaryReqToken++ // 진행 중이던 AI 요약 요청의 응답이 늦게 와도 화면에 반영되지 않도록 무효화
+  libraryDetailBiblioReqToken++ // 진행 중이던 서지 정보 요청도 동일하게 무효화
+  $('lib-detail-overlay')?.classList.remove('open')
+  const panel = $('lib-detail-panel')
+  if (panel) { panel.classList.remove('open'); panel.setAttribute('aria-hidden', 'true') }
+  $('lib-detail-more-menu')?.classList.add('hidden')
+}
+
+function switchLibraryDetailTab(tab) {
+  document.querySelectorAll('#lib-detail-panel .lib-detail-tab').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tab)
+  })
+  LIBRARY_DETAIL_TABS.forEach(t => {
+    $(`lib-detail-panel-${t}`)?.classList.toggle('hidden', t !== tab)
+  })
+  if (!libraryDetailDoc) return
+  if (!libraryDetailLoadedTabs.has(tab)) {
+    libraryDetailLoadedTabs.add(tab)
+    if (tab === 'notes') loadLibraryDetailNotes(libraryDetailDoc)
+    else if (tab === 'questions') loadLibraryDetailQuestions(libraryDetailDoc)
+    else if (tab === 'related') loadLibraryDetailRelated(libraryDetailDoc)
+  }
+}
+
+// 카드의 제목 인라인 수정(wireDocItemEvents의 .doc-edit-btn 핸들러)과 동일한 방식으로,
+// 패널 안에서도 제목을 바로 고칠 수 있게 한다.
+function startLibraryDetailTitleEdit(doc) {
+  const titleEl = $('lib-detail-title')
+  if (!titleEl) return
+  const oldTitle = titleEl.textContent
+
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.className = 'lib-detail-title-input'
+  input.value = oldTitle
+  titleEl.replaceWith(input)
+  input.focus()
+  input.select()
+
+  let isSaving = false
+  async function save() {
+    if (isSaving) return
+    isSaving = true
+    const newTitle = input.value.trim()
+    if (newTitle && newTitle !== oldTitle) {
+      try {
+        await updateLibraryDocMetadata(doc.id, { title: newTitle })
+        showToast('제목이 변경되었습니다.', 'success')
+        titleEl.textContent = newTitle
+        await renderLibrary()
+      } catch (err) {
+        showToast('제목 변경 실패: ' + err.message, 'error')
+        titleEl.textContent = oldTitle
+      }
+    } else {
+      titleEl.textContent = oldTitle
+    }
+    input.replaceWith(titleEl)
+  }
+  input.addEventListener('keydown', async (ev) => {
+    if (ev.key === 'Enter') { ev.preventDefault(); await save() }
+    else if (ev.key === 'Escape') {
+      ev.preventDefault()
+      isSaving = true
+      titleEl.textContent = oldTitle
+      input.replaceWith(titleEl)
+    }
+  })
+  input.addEventListener('blur', () => { if (!isSaving) save() })
+}
+
+// 개요 탭: Quick Info/태그는 이미 갖고 있는 문서 데이터로 즉시 렌더링하고, AI 요약은
+// 읽기 전 브리핑(primer)의 hook 텍스트를 재사용한다(백엔드에 별도 "요약" 필드는 없음).
+// 아직 캐시가 없으면 생성에 시간이 걸릴 수 있어(fetchPrimer가 내부적으로 폴링), 패널을
+// 닫거나 다른 논문으로 바꾼 뒤 응답이 와도 화면에 반영되지 않도록 요청 토큰으로 막는다.
+async function loadLibraryDetailOverview(doc) {
+  const total = doc.total_pages || 1
+  const translated = doc.translated_pages?.length || 0
+  const pct = Math.round((translated / total) * 100)
+  const status = getLibraryDocStatus(doc)
+  const statusLabel = { unread: '읽지 않음', reading: '읽는 중', finished: '완료' }[status] || status
+  const addedDate = new Date(doc.created_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
+
+  const quickInfoEl = $('lib-detail-quickinfo')
+  if (quickInfoEl) {
+    quickInfoEl.innerHTML = `
+      <dt>Venue</dt><dd id="lib-detail-qi-venue">불러오는 중...</dd>
+      <dt>등록일</dt><dd>${escapeHtml(addedDate)}</dd>
+      <dt>페이지</dt><dd>${total}p</dd>
+      <dt>DOI</dt><dd id="lib-detail-qi-doi">불러오는 중...</dd>
+      <dt>ArXiv</dt><dd id="lib-detail-qi-arxiv">불러오는 중...</dd>
+      <dt>Citations</dt><dd id="lib-detail-qi-citations">불러오는 중...</dd>
+      <dt>번역 진행률</dt><dd>${pct}%</dd>
+      <dt>상태</dt><dd>${escapeHtml(statusLabel)}</dd>
+    `
+  }
+  // Venue/DOI/ArXiv/Citations는 문서 자체에 저장된 필드가 없어 OpenAlex 제목
+  // 검색으로 채운다(서버가 첫 조회 때만 검색하고 이후엔 캐시 반환 - services/
+  // reference_linker.py resolve_paper_metadata). 못 찾은 필드는 "—"로 표시하고
+  // 지어내지 않는다.
+  const myBiblioToken = ++libraryDetailBiblioReqToken
+  fetchLibraryBibliography(doc.id).then(biblio => {
+    if (myBiblioToken !== libraryDetailBiblioReqToken) return
+    const venueEl = $('lib-detail-qi-venue')
+    const doiEl = $('lib-detail-qi-doi')
+    const arxivEl = $('lib-detail-qi-arxiv')
+    const citationsEl = $('lib-detail-qi-citations')
+    if (venueEl) venueEl.textContent = biblio.venue || '—'
+    if (doiEl) doiEl.textContent = biblio.doi || '—'
+    if (arxivEl) arxivEl.textContent = biblio.arxiv_id || '—'
+    if (citationsEl) citationsEl.textContent = biblio.citation_count != null ? biblio.citation_count.toLocaleString('ko-KR') : '—'
+  }).catch(err => {
+    if (myBiblioToken !== libraryDetailBiblioReqToken) return
+    console.error('서지 정보 로드 실패:', err)
+    ;['lib-detail-qi-venue', 'lib-detail-qi-doi', 'lib-detail-qi-arxiv', 'lib-detail-qi-citations'].forEach(id => {
+      const el = $(id)
+      if (el) el.textContent = '—'
+    })
+  })
+
+  const tagsEl = $('lib-detail-tags')
+  if (tagsEl) {
+    const categories = doc.metadata?.categories || []
+    tagsEl.innerHTML = categories.length
+      ? categories.map(c => `<span class="lib-detail-tag">${escapeHtml(c)}</span>`).join('')
+      : `<p class="lib-detail-empty" style="padding:0">지정된 태그가 없습니다.</p>`
+  }
+
+  const myToken = ++libraryDetailSummaryReqToken
+  const summaryEl = $('lib-detail-summary-text')
+  if (summaryEl) summaryEl.innerHTML = `<p class="lib-detail-summary-loading">AI 요약을 불러오는 중...</p>`
+  try {
+    const targetLang = getTranslationOptions().targetLang
+    const data = await fetchPrimer(doc.id, targetLang)
+    if (myToken !== libraryDetailSummaryReqToken) return
+    const text = data.hook || data.feynman || data.lineage || ''
+    if (summaryEl) {
+      summaryEl.innerHTML = text
+        ? escapeHtml(text).replace(/\n/g, '<br>')
+        : `<p class="lib-detail-summary-loading">아직 생성된 요약이 없습니다.</p>`
+    }
+  } catch (err) {
+    if (myToken !== libraryDetailSummaryReqToken) return
+    console.error('AI 요약 로드 실패:', err)
+    if (summaryEl) summaryEl.innerHTML = `<p class="lib-detail-summary-error">AI 요약을 불러오지 못했습니다.</p>`
+  }
+}
+
+// 메모 탭: 서버 API가 아니라 문서별 localStorage(easypaper_memos_*)에서 바로 읽는다
+// (loadMemos는 이미 메모/하이라이트 목록 화면(renderAnnotationsBrowser)이 쓰는 함수).
+function loadLibraryDetailNotes(doc) {
+  const section = $('lib-detail-panel-notes')
+  const countEl = $('lib-detail-tab-count-notes')
+  if (!section) return
+
+  const memosByPage = loadMemos(doc.id)
+  const items = []
+  Object.keys(memosByPage).forEach(pageKey => {
+    const pageNum = parseInt(pageKey.replace('page_', ''), 10)
+    if (isNaN(pageNum)) return
+    memosByPage[pageKey].forEach(memo => items.push({ pageNum, memo }))
+  })
+  items.sort((a, b) => String(b.memo.id).localeCompare(String(a.memo.id)))
+
+  if (countEl) { countEl.textContent = String(items.length); countEl.classList.toggle('hidden', items.length === 0) }
+
+  if (items.length === 0) {
+    section.innerHTML = `<p class="lib-detail-empty">이 논문에 남긴 메모가 없습니다.</p>`
+    return
+  }
+  section.innerHTML = items.map((entry, i) => {
+    const text = (entry.memo.content && entry.memo.content.trim()) || entry.memo.sentenceText || '(내용 없음)'
+    return `
+      <div class="lib-detail-list-item" data-idx="${i}">
+        <div class="lib-detail-list-item-meta">${entry.pageNum}페이지</div>
+        <div class="lib-detail-list-item-text">${escapeHtml(truncateForList(text, 90))}</div>
+      </div>
+    `
+  }).join('')
+  section.querySelectorAll('.lib-detail-list-item').forEach((item, i) => {
+    item.addEventListener('click', () => {
+      const entry = items[i]
+      closeLibraryDetailPanel()
+      openAnnotationTarget(doc, entry.pageNum)
+    })
+  })
+}
+
+// "질문" 탭: 문서별 질문 개수를 직접 세는 API/필드가 없어(메시지 단위 카운트는
+// 제공되지 않음), 이 문서에 대해 실제로 나눈 AI 어시스턴트 대화 세션 수/목록으로
+// 대체한다 - getChatSessionsAPI()는 이미 AI Chats 페이지가 쓰는 기존 엔드포인트다.
+async function loadLibraryDetailQuestions(doc) {
+  const section = $('lib-detail-panel-questions')
+  const countEl = $('lib-detail-tab-count-questions')
+  if (!section) return
+  section.innerHTML = `<p class="lib-detail-empty">불러오는 중...</p>`
+  try {
+    const data = await getChatSessionsAPI()
+    const sessions = (data.sessions || []).filter(s => s.doc_id === doc.id)
+    if (countEl) { countEl.textContent = String(sessions.length); countEl.classList.toggle('hidden', sessions.length === 0) }
+    if (sessions.length === 0) {
+      section.innerHTML = `<p class="lib-detail-empty">이 논문에 대해 나눈 AI 대화가 없습니다.</p>`
+      return
+    }
+    section.innerHTML = sessions.map((s, i) => `
+      <div class="lib-detail-list-item" data-idx="${i}">
+        <div class="lib-detail-list-item-meta">${escapeHtml(formatChatSessionTime(s.last_message_at))}</div>
+        <div class="lib-detail-list-item-text">${escapeHtml(s.title || '')}</div>
+      </div>
+    `).join('')
+    section.querySelectorAll('.lib-detail-list-item').forEach(item => {
+      item.addEventListener('click', async () => {
+        try {
+          closeLibraryDetailPanel()
+          await openFromLibrary(doc)
+          openChatSidebar()
+        } catch {
+          showToast('대화를 열 수 없습니다.', 'error')
+        }
+      })
+    })
+  } catch (err) {
+    console.error('AI 대화 목록 로드 실패:', err)
+    section.innerHTML = `<p class="lib-detail-empty" style="color:var(--error)">대화 목록을 불러오지 못했습니다.</p>`
+  }
+}
+
+// "관련 자료" 탭: 지식 그래프에서 이 논문(paper:{id}) 노드와 직접 연결된 이웃(인용/카테고리/
+// 개념/메모/Figure)을 보여준다. 전체 그래프를 한 번만 불러와 캐시하고(renderLibrary가 무효화),
+// 문서 하나마다 새 API를 만들지 않는다.
+async function getLibraryGraphForDetail() {
+  if (!libraryGraphCacheForDetail) {
+    libraryGraphCacheForDetail = await fetchLibraryGraph()
+  }
+  return libraryGraphCacheForDetail
+}
+
+async function loadLibraryDetailRelated(doc) {
+  const section = $('lib-detail-panel-related')
+  const countEl = $('lib-detail-tab-count-related')
+  if (!section) return
+  section.innerHTML = `<p class="lib-detail-empty">불러오는 중...</p>`
+  try {
+    const graph = await getLibraryGraphForDetail()
+    const nodeId = `paper:${doc.id}`
+    const nodesById = new Map((graph.nodes || []).map(n => [n.id, n]))
+    const neighborIds = new Set()
+    ;(graph.edges || []).forEach(e => {
+      if (e.source === nodeId) neighborIds.add(e.target)
+      else if (e.target === nodeId) neighborIds.add(e.source)
+    })
+    const neighbors = Array.from(neighborIds).map(id => nodesById.get(id)).filter(Boolean)
+
+    if (countEl) { countEl.textContent = String(neighbors.length); countEl.classList.toggle('hidden', neighbors.length === 0) }
+
+    if (neighbors.length === 0) {
+      section.innerHTML = `<p class="lib-detail-empty">아직 연결된 논문/개념이 없습니다.</p>`
+      return
+    }
+    const typeLabel = { paper: '논문', concept: '개념', note: '메모', figure: 'Figure' }
+    section.innerHTML = neighbors.map((n, i) => `
+      <div class="lib-detail-list-item" data-idx="${i}">
+        <div class="lib-detail-list-item-meta">${escapeHtml(typeLabel[n.type] || n.type || '')}</div>
+        <div class="lib-detail-list-item-text">${escapeHtml(n.label || '')}</div>
+      </div>
+    `).join('')
+    section.querySelectorAll('.lib-detail-list-item').forEach((item, i) => {
+      item.addEventListener('click', async () => {
+        const n = neighbors[i]
+        if (n.type !== 'paper') return
+        try {
+          const targetDoc = await fetchLibraryDoc(n.id.replace('paper:', ''))
+          closeLibraryDetailPanel()
+          openLibraryDetailPanel(targetDoc)
+        } catch {
+          showToast('논문 정보를 불러오지 못했습니다.', 'error')
+        }
+      })
+    })
+  } catch (err) {
+    console.error('관련 자료 로드 실패:', err)
+    section.innerHTML = `<p class="lib-detail-empty" style="color:var(--error)">관련 정보를 불러오지 못했습니다.</p>`
+  }
 }
 
 function createDocListRow(doc) {
@@ -12345,9 +13138,12 @@ async function handleRouting() {
       showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
       location.hash = 'library'
     } else {
-      console.log("[Router] Routing to Library screen. Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))
+      const pageId = hash.replace('#', '') || 'dashboard'
+      console.log("[Router] Routing to workspace page:", pageId, "Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))
       if (viewerScreen.classList.contains('active') || !libraryScreen.classList.contains('active')) {
-        await showLibraryScreen(false)
+        await showLibraryScreen(false, WORKSPACE_PAGES.includes(pageId) ? pageId : 'dashboard')
+      } else if (WORKSPACE_PAGES.includes(pageId) && state.currentWorkspacePage !== pageId) {
+        await showWorkspacePage(pageId, { pushState: false })
       }
     }
   } catch (err) {

--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -1,0 +1,448 @@
+// AI Chats 워크스페이스 페이지 — 논문별(단일 논문) AI 어시스턴트 채팅 세션 목록
+// 검색 / 탭 필터 / 정렬 / 표·카드 보기 전환 / 페이지네이션을 지원한다.
+// 데이터 원본: getChatSessionsAPI() → { sessions: [{ doc_id, title, last_message_at }] }
+// "최근 메시지" 미리보기는 세션 목록 API에 없으므로, 세션별로 getChatHistoryAPI(doc_id)를
+// (동시 실행 개수를 제한하며) 추가로 불러와 마지막 메시지 내용을 채운다.
+
+import '../styles/ai-chats.css'
+import { icon } from '../icons.js'
+import { getChatSessionsAPI, getChatHistoryAPI } from '../api.js'
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')
+}
+
+const PAGE_SIZE = 8
+const RECENT_MS = 24 * 60 * 60 * 1000       // "최근 대화" 기준: 24시간 이내
+const ACTIVE_MS = 7 * 24 * 60 * 60 * 1000   // "활성" 기준: 7일 이내
+const PREVIEW_CONCURRENCY = 6
+
+function formatRelativeTime(isoString) {
+  if (!isoString) return '-'
+  const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) return '-'
+  const diffMs = Date.now() - date.getTime()
+  const min = Math.floor(diffMs / 60000)
+  if (min < 1) return '방금 전'
+  if (min < 60) return `${min}분 전`
+  const hour = Math.floor(min / 60)
+  if (hour < 24) return `${hour}시간 전`
+  const day = Math.floor(hour / 24)
+  if (day === 1) return '어제'
+  if (day < 7) return `${day}일 전`
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatFullTime(isoString) {
+  if (!isoString) return ''
+  const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function truncate(text, max) {
+  if (!text) return ''
+  const trimmed = text.replace(/\s+/g, ' ').trim()
+  return trimmed.length > max ? trimmed.slice(0, max) + '…' : trimmed
+}
+
+// items를 limit개씩 동시 실행하며 fn(item)을 적용한다 (세션이 많을 때 서버에 한 번에
+// 수십~수백 개 요청이 몰리는 것을 막기 위함).
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length)
+  let cursor = 0
+  async function worker() {
+    while (cursor < items.length) {
+      const idx = cursor++
+      try {
+        results[idx] = await fn(items[idx], idx)
+      } catch {
+        results[idx] = null
+      }
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker)
+  await Promise.all(workers)
+  return results
+}
+
+export async function renderAiChatsPage() {
+  const container = document.getElementById('page-chats')
+  if (!container) return
+
+  container.innerHTML = `
+    <div class="aic-page">
+      <div class="aic-header">
+        <div class="aic-header-text">
+          <h2 class="aic-title">AI Chats</h2>
+          <p class="aic-subtitle">논문별 AI 채팅 세션을 관리하고 이어서 대화하세요.</p>
+        </div>
+        <div class="aic-search-box">
+          <span class="aic-search-icon">${icon('search', 15)}</span>
+          <input type="text" id="aic-search-input" placeholder="논문 제목으로 검색..." autocomplete="off" />
+        </div>
+      </div>
+
+      <div class="aic-controls">
+        <div class="aic-tabs" id="aic-tabs"></div>
+        <div class="aic-controls-right">
+          <div class="aic-sort-wrap">
+            <button type="button" id="aic-sort-btn" class="aic-sort-btn">
+              <span id="aic-sort-label">최근 업데이트순</span>
+              ${icon('chevronDown', 14)}
+            </button>
+            <div id="aic-sort-menu" class="aic-sort-menu hidden">
+              <button type="button" class="aic-sort-option active" data-sort="updated">최근 업데이트순</button>
+              <button type="button" class="aic-sort-option" data-sort="title">제목순 (가나다)</button>
+            </div>
+          </div>
+          <div class="aic-view-toggle" id="aic-view-toggle">
+            <button type="button" class="aic-view-btn active" data-view="table" title="표로 보기">${icon('list', 15)}</button>
+            <button type="button" class="aic-view-btn" data-view="card" title="카드로 보기">${icon('grid', 15)}</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="aic-body" class="aic-body"></div>
+      <div id="aic-pagination" class="aic-pagination"></div>
+    </div>
+  `
+
+  const searchInput = container.querySelector('#aic-search-input')
+  const tabsEl = container.querySelector('#aic-tabs')
+  const bodyEl = container.querySelector('#aic-body')
+  const paginationEl = container.querySelector('#aic-pagination')
+  const sortBtn = container.querySelector('#aic-sort-btn')
+  const sortLabel = container.querySelector('#aic-sort-label')
+  const sortMenu = container.querySelector('#aic-sort-menu')
+  const viewToggle = container.querySelector('#aic-view-toggle')
+
+  // ── 페이지 인스턴스 로컬 상태 (재방문 시 renderAiChatsPage()가 다시 호출되어
+  //    이 클로저 전체가 새로 만들어지므로, 별도 초기화 로직 없이 항상 초기값으로 시작한다) ──
+  const state = {
+    sessions: [],
+    previews: new Map(), // doc_id -> { text, error }
+    searchQuery: '',
+    activeTab: 'all',
+    sortMode: 'updated',
+    viewMode: 'table',
+    currentPage: 1,
+    loading: true,
+    loadError: null,
+  }
+
+  const TABS = [
+    { id: 'all', label: '전체' },
+    { id: 'active', label: '활성' },
+    { id: 'recent', label: '최근 대화' },
+  ]
+
+  function tabMatches(tabId, session) {
+    if (tabId === 'all') return true
+    const t = session.last_message_at ? new Date(session.last_message_at).getTime() : 0
+    const diff = Date.now() - t
+    if (tabId === 'recent') return diff <= RECENT_MS
+    if (tabId === 'active') return diff <= ACTIVE_MS
+    return true
+  }
+
+  function getFilteredSorted() {
+    const q = state.searchQuery.trim().toLowerCase()
+    let list = state.sessions.filter(s => tabMatches(state.activeTab, s))
+    if (q) list = list.filter(s => (s.title || '').toLowerCase().includes(q))
+    list = list.slice()
+    if (state.sortMode === 'title') {
+      list.sort((a, b) => (a.title || '').localeCompare(b.title || '', 'ko'))
+    } else {
+      list.sort((a, b) => new Date(b.last_message_at || 0) - new Date(a.last_message_at || 0))
+    }
+    return list
+  }
+
+  function renderTabs() {
+    tabsEl.innerHTML = TABS.map(tab => {
+      const count = state.sessions.filter(s => tabMatches(tab.id, s)).length
+      const active = state.activeTab === tab.id ? ' active' : ''
+      return `<button type="button" class="aic-tab-btn${active}" data-tab="${tab.id}">${tab.label} <span class="aic-tab-count">${count}</span></button>`
+    }).join('')
+    tabsEl.querySelectorAll('.aic-tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.activeTab = btn.dataset.tab
+        state.currentPage = 1
+        renderTabs()
+        renderBody()
+        renderPagination()
+      })
+    })
+  }
+
+  function previewCellHtml(session) {
+    const p = state.previews.get(session.doc_id)
+    if (!p) return `<span class="aic-preview-loading">불러오는 중...</span>`
+    if (p.error || !p.text) return `<span class="aic-preview-empty">-</span>`
+    return escapeHtml(truncate(p.text, 72))
+  }
+
+  function actionsHtml(session) {
+    return `
+      <button type="button" class="aic-action-btn aic-action-primary" data-action="chat" data-doc="${escapeHtml(session.doc_id)}">
+        ${icon('messageCircle', 14)} 대화 열기
+      </button>
+      <button type="button" class="aic-action-btn" data-action="viewer" data-doc="${escapeHtml(session.doc_id)}">
+        ${icon('bookOpen', 14)} 뷰어 열기
+      </button>
+    `
+  }
+
+  function bindActionButtons(root) {
+    root.querySelectorAll('[data-action="chat"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.doc
+        location.hash = 'viewer?id=' + encodeURIComponent(id) + '&chat=1'
+      })
+    })
+    root.querySelectorAll('[data-action="viewer"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.doc
+        location.hash = 'viewer?id=' + encodeURIComponent(id)
+      })
+    })
+  }
+
+  function renderTable(items) {
+    return `
+      <div class="aic-table-wrap">
+        <table class="aic-table">
+          <thead>
+            <tr>
+              <th class="aic-col-paper">논문</th>
+              <th class="aic-col-message">최근 메시지</th>
+              <th class="aic-col-updated">마지막 대화</th>
+              <th class="aic-col-actions">작업</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map(session => `
+              <tr>
+                <td class="aic-col-paper">
+                  <div class="aic-paper-cell">
+                    <div class="aic-paper-icon">${icon('fileText', 17)}</div>
+                    <div class="aic-paper-title" title="${escapeHtml(session.title)}">${escapeHtml(session.title)}</div>
+                  </div>
+                </td>
+                <td class="aic-col-message"><span class="aic-preview" data-preview-doc="${escapeHtml(session.doc_id)}">${previewCellHtml(session)}</span></td>
+                <td class="aic-col-updated" title="${escapeHtml(formatFullTime(session.last_message_at))}">${formatRelativeTime(session.last_message_at)}</td>
+                <td class="aic-col-actions"><div class="aic-actions">${actionsHtml(session)}</div></td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    `
+  }
+
+  function renderCards(items) {
+    return `
+      <div class="aic-card-grid">
+        ${items.map(session => `
+          <div class="aic-card">
+            <div class="aic-card-top">
+              <div class="aic-paper-icon">${icon('fileText', 17)}</div>
+              <span class="aic-card-updated" title="${escapeHtml(formatFullTime(session.last_message_at))}">${formatRelativeTime(session.last_message_at)}</span>
+            </div>
+            <div class="aic-card-title" title="${escapeHtml(session.title)}">${escapeHtml(session.title)}</div>
+            <div class="aic-card-preview" data-preview-doc="${escapeHtml(session.doc_id)}">${previewCellHtml(session)}</div>
+            <div class="aic-actions aic-card-actions">${actionsHtml(session)}</div>
+          </div>
+        `).join('')}
+      </div>
+    `
+  }
+
+  function renderBody() {
+    if (state.loading) {
+      bodyEl.innerHTML = `<div class="aic-state"><div class="aic-spinner"></div><p>채팅 세션을 불러오는 중...</p></div>`
+      return
+    }
+    if (state.loadError) {
+      bodyEl.innerHTML = `
+        <div class="aic-state aic-state-error">
+          <div class="aic-state-icon">${icon('alertTriangle', 32)}</div>
+          <p>채팅 세션을 불러오지 못했습니다</p>
+          <button type="button" class="aic-retry-btn" id="aic-retry-btn">다시 시도</button>
+        </div>
+      `
+      const retryBtn = bodyEl.querySelector('#aic-retry-btn')
+      if (retryBtn) retryBtn.addEventListener('click', () => load())
+      return
+    }
+
+    const filteredSorted = getFilteredSorted()
+    if (state.sessions.length === 0) {
+      bodyEl.innerHTML = `
+        <div class="aic-state">
+          <div class="aic-state-icon">${icon('messageCircle', 32)}</div>
+          <p>AI와 나눈 대화가 없습니다</p>
+          <p class="aic-state-sub">논문 뷰어에서 AI 어시스턴트에게 질문을 시작해 보세요</p>
+        </div>
+      `
+      return
+    }
+    if (filteredSorted.length === 0) {
+      bodyEl.innerHTML = `
+        <div class="aic-state">
+          <div class="aic-state-icon">${icon('search', 32)}</div>
+          <p>조건에 맞는 채팅 세션이 없습니다</p>
+        </div>
+      `
+      return
+    }
+
+    const totalPages = Math.max(1, Math.ceil(filteredSorted.length / PAGE_SIZE))
+    if (state.currentPage > totalPages) state.currentPage = totalPages
+    const start = (state.currentPage - 1) * PAGE_SIZE
+    const pageItems = filteredSorted.slice(start, start + PAGE_SIZE)
+
+    bodyEl.innerHTML = state.viewMode === 'table' ? renderTable(pageItems) : renderCards(pageItems)
+    bindActionButtons(bodyEl)
+  }
+
+  function renderPagination() {
+    if (state.loading || state.loadError || state.sessions.length === 0) {
+      paginationEl.innerHTML = ''
+      return
+    }
+    const filteredSorted = getFilteredSorted()
+    const totalPages = Math.max(1, Math.ceil(filteredSorted.length / PAGE_SIZE))
+    if (totalPages <= 1) {
+      paginationEl.innerHTML = ''
+      return
+    }
+    const cur = state.currentPage
+    const pages = []
+    const addPage = n => { if (!pages.includes(n) && n >= 1 && n <= totalPages) pages.push(n) }
+    addPage(1)
+    addPage(cur - 1); addPage(cur); addPage(cur + 1)
+    addPage(totalPages)
+    pages.sort((a, b) => a - b)
+
+    let html = `<button type="button" class="aic-page-btn aic-page-nav" id="aic-page-prev" ${cur === 1 ? 'disabled' : ''} aria-label="이전 페이지">‹</button>`
+    let prev = 0
+    for (const p of pages) {
+      if (prev && p - prev > 1) html += `<span class="aic-page-ellipsis">…</span>`
+      html += `<button type="button" class="aic-page-btn${p === cur ? ' active' : ''}" data-page="${p}">${p}</button>`
+      prev = p
+    }
+    html += `<button type="button" class="aic-page-btn aic-page-nav" id="aic-page-next" ${cur === totalPages ? 'disabled' : ''} aria-label="다음 페이지">›</button>`
+
+    paginationEl.innerHTML = html
+    paginationEl.querySelectorAll('[data-page]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.currentPage = Number(btn.dataset.page)
+        renderBody()
+        renderPagination()
+      })
+    })
+    const prevBtn = paginationEl.querySelector('#aic-page-prev')
+    const nextBtn = paginationEl.querySelector('#aic-page-next')
+    if (prevBtn) prevBtn.addEventListener('click', () => {
+      if (state.currentPage > 1) { state.currentPage--; renderBody(); renderPagination() }
+    })
+    if (nextBtn) nextBtn.addEventListener('click', () => {
+      if (state.currentPage < totalPages) { state.currentPage++; renderBody(); renderPagination() }
+    })
+  }
+
+  function updatePreviewInDom(docId) {
+    container.querySelectorAll(`[data-preview-doc="${CSS.escape(docId)}"]`).forEach(el => {
+      el.innerHTML = previewCellHtml({ doc_id: docId })
+    })
+  }
+
+  async function loadPreviews(sessions) {
+    await mapWithConcurrency(sessions, PREVIEW_CONCURRENCY, async (session) => {
+      try {
+        const data = await getChatHistoryAPI(session.doc_id)
+        const history = data.history || []
+        const last = history.length ? history[history.length - 1] : null
+        state.previews.set(session.doc_id, { text: last ? last.content : '', error: false })
+      } catch {
+        state.previews.set(session.doc_id, { text: '', error: true })
+      }
+      updatePreviewInDom(session.doc_id)
+    })
+  }
+
+  async function load() {
+    state.loading = true
+    state.loadError = null
+    renderBody()
+    renderPagination()
+    try {
+      const data = await getChatSessionsAPI()
+      state.sessions = data.sessions || []
+      state.loading = false
+      renderTabs()
+      renderBody()
+      renderPagination()
+      // 목록 API에는 마지막 메시지 내용이 없으므로, 세션별 히스토리를 추가로 불러와
+      // 표시된 행의 미리보기 텍스트만 점진적으로 채워 넣는다.
+      loadPreviews(state.sessions)
+    } catch (err) {
+      console.error('AI 채팅 세션 목록 로드 실패:', err)
+      state.loading = false
+      state.loadError = err
+      renderTabs()
+      renderBody()
+      renderPagination()
+    }
+  }
+
+  // ── 정적 컨트롤 이벤트 바인딩 ──
+  searchInput.addEventListener('input', () => {
+    state.searchQuery = searchInput.value
+    state.currentPage = 1
+    renderBody()
+    renderPagination()
+  })
+
+  sortBtn.addEventListener('click', (e) => {
+    e.stopPropagation()
+    sortMenu.classList.toggle('hidden')
+  })
+  sortMenu.querySelectorAll('.aic-sort-option').forEach(opt => {
+    opt.addEventListener('click', () => {
+      state.sortMode = opt.dataset.sort
+      sortLabel.textContent = opt.textContent
+      sortMenu.querySelectorAll('.aic-sort-option').forEach(o => o.classList.toggle('active', o === opt))
+      sortMenu.classList.add('hidden')
+      renderBody()
+      renderPagination()
+    })
+  })
+  // 페이지를 재방문할 때마다 renderAiChatsPage()가 새로 호출되며 이전 DOM은
+  // container.innerHTML 교체로 사라지지만, document 리스너는 자동으로 제거되지
+  // 않으므로 매번 쌓이지 않도록 sortBtn이 더는 문서에 붙어있지 않으면 스스로 해제한다.
+  function handleOutsideClick(e) {
+    if (!sortBtn.isConnected) {
+      document.removeEventListener('click', handleOutsideClick)
+      return
+    }
+    if (!sortMenu.contains(e.target) && e.target !== sortBtn && !sortBtn.contains(e.target)) {
+      sortMenu.classList.add('hidden')
+    }
+  }
+  document.addEventListener('click', handleOutsideClick)
+
+  viewToggle.querySelectorAll('.aic-view-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.viewMode = btn.dataset.view
+      viewToggle.querySelectorAll('.aic-view-btn').forEach(b => b.classList.toggle('active', b === btn))
+      renderBody()
+    })
+  })
+
+  renderTabs()
+  await load()
+}

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -1,0 +1,599 @@
+// 대시보드 페이지 — 워크스페이스 셸의 #page-dashboard 컨테이너를 전담 렌더링한다.
+// 모든 위젯은 실제 백엔드 데이터(/api/library/dashboard, /timeline, /library,
+// /graph, /graph/recommendations, /library/reading-stats)에서 가져오거나 그
+// 위에서 클라이언트단으로 정직하게 계산한 값만 사용한다 - 뒷받침할 데이터가
+// 없는 지표(연구 점수 등)는 만들어내지 않고 통째로 생략했다(자세한 내용은
+// 각 렌더 함수 주석 참고). 읽기 시간은 main.js의 읽기 시간 하트비트
+// (뷰어/비교 화면이 보이고 포커스된 동안 적립 → 서버 전송)가 쌓은 실측치를
+// fetchReadingTimeStats()로 가져온 것이다.
+import './../styles/dashboard.css'
+import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
+import { icon } from '../icons.js'
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+function emptyNote(text) {
+  return `<p class="dash-empty-note">${escapeHtml(text)}</p>`
+}
+
+function formatNumber(n) {
+  return (n || 0).toLocaleString('ko-KR')
+}
+
+function formatDuration(seconds) {
+  const s = Math.max(0, Math.round(seconds || 0))
+  const h = Math.floor(s / 3600)
+  const m = Math.round((s % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m`
+  return s > 0 ? `${s}s` : '0m'
+}
+
+function sumSecondsInDays(byDay, days) {
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000
+  let total = 0
+  for (const [day, seconds] of Object.entries(byDay || {})) {
+    const t = new Date(`${day}T00:00:00`).getTime()
+    if (!Number.isNaN(t) && t >= cutoff) total += seconds
+  }
+  return total
+}
+
+// ── 시간 계산 헬퍼 ── 전부 백엔드가 이미 내려주는 ISO 타임스탬프(timeline
+// events, metadata.read_at)를 그대로 재사용한다. 새 저장소나 서버 집계가
+// 필요 없다.
+function isWithinDays(iso, days) {
+  if (!iso) return false
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return false
+  return t >= Date.now() - days * 24 * 60 * 60 * 1000
+}
+
+function relativeTimeKo(iso) {
+  if (!iso) return ''
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return ''
+  const diffMs = Date.now() - t
+  if (diffMs < 60000) return '방금 전'
+  const min = Math.floor(diffMs / 60000)
+  if (min < 60) return `${min}분 전`
+  const hour = Math.floor(min / 60)
+  if (hour < 24) return `${hour}시간 전`
+  const day = Math.floor(hour / 24)
+  if (day === 1) return '어제'
+  if (day < 7) return `${day}일 전`
+  const week = Math.floor(day / 7)
+  if (week < 5) return `${week}주 전`
+  return new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function dateKey(iso) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+
+// 활동(업로드/읽음/질문/메모) 타임스탬프가 찍힌 날짜들을 모아 오늘(또는
+// 어제, 아직 오늘 활동을 안 했을 수 있으니)부터 거슬러 며칠 연속으로
+// 활동이 있었는지 센다 - 순수하게 실제 이벤트 날짜만으로 계산.
+function computeStreakDays(events) {
+  const dates = new Set()
+  events.forEach(e => { const k = dateKey(e.timestamp); if (k) dates.add(k) })
+  if (dates.size === 0) return 0
+  const today = new Date()
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  let cursor = null
+  if (dates.has(dateKey(today))) cursor = today
+  else if (dates.has(dateKey(yesterday))) cursor = yesterday
+  else return 0
+  const c = new Date(cursor)
+  let streak = 0
+  while (dates.has(dateKey(c))) {
+    streak++
+    c.setDate(c.getDate() - 1)
+  }
+  return streak
+}
+
+function countEventsInDays(events, type, days) {
+  return events.filter(e => e.type === type && isWithinDays(e.timestamp, days)).length
+}
+
+// "이번 주 읽은 페이지"는 서버에 별도 집계가 없어, 이번 주 안에 읽음
+// 처리(read_at)된 논문들의 total_pages 합으로 근사한다 - 실존하는 필드만
+// 조합한 값이라 근거가 있는 근사치다.
+function pagesReadInDays(docs, days) {
+  return docs.reduce((sum, d) => {
+    const meta = d.metadata || {}
+    if (meta.read && meta.read_at && isWithinDays(meta.read_at, days)) return sum + (d.total_pages || 0)
+    return sum
+  }, 0)
+}
+
+function truncateLabel(s, n) {
+  if (!s) return ''
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s
+}
+
+// ── 통계 카드 ──────────────────────────────────────────────────────────
+const STAT_DEFS = [
+  { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (events) => countEventsInDays(events, 'uploaded', 7) },
+  { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (events) => countEventsInDays(events, 'read', 7) },
+  { key: 'total_pages', label: '페이지', iconName: 'fileText', tint: 3, weekly: (events, docs) => pagesReadInDays(docs, 7) },
+  // 개념은 생성 시각이 저장되지 않아 "이번 주 신규 개념 수"를 계산할 근거가
+  // 없다 - 지어내지 않고 주간 델타 자체를 생략한다.
+  { key: 'total_concepts', label: '개념', iconName: 'layers', tint: 4, weekly: null },
+  { key: 'total_questions', label: '질문', iconName: 'messageCircle', tint: 5, weekly: (events) => countEventsInDays(events, 'question', 7) },
+  { key: 'total_notes', label: '메모', iconName: 'edit3', tint: 6, weekly: (events) => countEventsInDays(events, 'note', 7) },
+]
+
+function renderStatCard(def, value, events, docs) {
+  const delta = def.weekly ? def.weekly(events, docs) : null
+  const deltaHtml = delta === null ? '' : `
+    <div class="dash-stat-delta ${delta > 0 ? 'is-up' : ''}">
+      ${delta > 0 ? icon('chevronUp', 11) : ''}
+      <span>${delta > 0 ? `+${formatNumber(delta)}` : '0'} 이번 주</span>
+    </div>
+  `
+  return `
+    <div class="dash-stat-card">
+      <div class="dash-stat-top">
+        <div class="dash-stat-icon dash-tint-${def.tint}">${icon(def.iconName, 18)}</div>
+        <div class="dash-stat-textwrap">
+          <div class="dash-stat-label">${escapeHtml(def.label)}</div>
+          <div class="dash-stat-value">${formatNumber(value)}</div>
+        </div>
+      </div>
+      ${deltaHtml}
+    </div>
+  `
+}
+
+function renderStatGrid(stats, events, docs) {
+  return `
+    <div class="dash-stat-grid">
+      ${STAT_DEFS.map(def => renderStatCard(def, stats[def.key], events, docs)).join('')}
+    </div>
+  `
+}
+
+// ── AI 인사이트 ── 지식 격차 감지(services/knowledge_graph.get_knowledge_gaps)
+// 결과를 그대로 인사이트 문구로 노출한다 - 규칙 기반이라 매번 근거가 있다.
+function renderInsightsCard(gaps) {
+  const items = (gaps || []).slice(0, 4)
+  return `
+    <div class="dash-card dash-card-insights">
+      <div class="dash-card-head"><h3>${icon('lightbulb', 15)}AI 인사이트</h3></div>
+      ${items.length === 0
+        ? emptyNote('아직 표시할 인사이트가 없습니다. 논문을 더 읽고 질문/메모를 남기면 여기에 제안이 쌓입니다.')
+        : `<ul class="dash-insight-list">${items.map(g => `
+            <li class="dash-insight-item">
+              <span class="dash-insight-icon">${icon(g.type === 'no_notes_paper' ? 'edit3' : 'messageCircle', 14)}</span>
+              <span>${escapeHtml(g.message)}</span>
+            </li>`).join('')}</ul>`
+      }
+    </div>
+  `
+}
+
+// ── 이번 주 활동 ── 목표(target)를 알 수 없어 mockup처럼 "goal" 대비
+// 진행률을 표시하는 대신, 실제 라이브러리 전체 규모 대비 이번 주 활동
+// 비중으로 바를 채운다(둘 다 실존 값).
+function renderWeeklyActivityCard(events, stats, docs, readingStats) {
+  const weeklySeconds = sumSecondsInDays(readingStats?.total_seconds_by_day, 7)
+  const totalSeconds = readingStats?.total_seconds || 0
+  const rows = [
+    { iconName: 'bookOpen', label: '읽은 논문', value: countEventsInDays(events, 'read', 7), total: stats.total_papers || 0, kind: 'count' },
+    { iconName: 'fileText', label: '읽은 페이지', value: pagesReadInDays(docs, 7), total: stats.total_pages || 0, kind: 'count' },
+    { iconName: 'messageCircle', label: '질문', value: countEventsInDays(events, 'question', 7), total: stats.total_questions || 0, kind: 'count' },
+    { iconName: 'clock', label: '읽은 시간', value: weeklySeconds, total: totalSeconds, kind: 'duration' },
+  ]
+  return `
+    <div class="dash-card">
+      <div class="dash-card-head">
+        <h3>${icon('zap', 15)}이번 주 활동</h3>
+        <span class="dash-card-tag">최근 7일</span>
+      </div>
+      <div class="dash-activity-list">
+        ${rows.map(r => {
+          const pct = r.total > 0 ? Math.min(100, Math.round((r.value / r.total) * 100)) : 0
+          const valueText = r.kind === 'duration' ? `${formatDuration(r.value)} / ${formatDuration(r.total)}` : `${formatNumber(r.value)} / ${formatNumber(r.total)}`
+          return `
+            <div class="dash-activity-row">
+              <div class="dash-activity-top">
+                <span class="dash-activity-label">${icon(r.iconName, 13)}${escapeHtml(r.label)}</span>
+                <span class="dash-activity-value">${valueText}</span>
+              </div>
+              <div class="dash-activity-track"><div class="dash-activity-fill" style="width:${pct}%"></div></div>
+            </div>
+          `
+        }).join('')}
+      </div>
+    </div>
+  `
+}
+
+// ── 연구 진행 요약 ── mockup의 "연구 점수"(0~100 + 스파크라인)는 뒷받침할
+// 시계열 데이터가 전혀 없어 생략했다(임의 가중치로 점수를 지어내는 건
+// 지시사항 위반). 대신 실제 타임스탬프/읽기 시간 하트비트에서 계산 가능한
+// 세 지표(연구 연속일, 주간 읽기 시간, 집중 주제)를 보여준다.
+function renderProgressSummaryCard(events, heatmap, readingStats) {
+  const streak = computeStreakDays(events)
+  const weeklySeconds = sumSecondsInDays(readingStats?.total_seconds_by_day, 7)
+  const focusTopic = heatmap[0]
+  return `
+    <div class="dash-card">
+      <div class="dash-card-head">
+        <h3>${icon('award', 15)}연구 진행 요약</h3>
+        <a href="#" class="dash-link" data-nav="graph">자세히 보기 ›</a>
+      </div>
+      <div class="dash-summary-grid">
+        <div class="dash-summary-box">
+          <div class="dash-summary-value">${formatNumber(streak)}<span class="dash-summary-unit">일</span></div>
+          <div class="dash-summary-label">연구 연속일</div>
+        </div>
+        <div class="dash-summary-box">
+          <div class="dash-summary-value dash-summary-value-text">${formatDuration(weeklySeconds)}</div>
+          <div class="dash-summary-label">주간 읽기 시간</div>
+        </div>
+        <div class="dash-summary-box">
+          <div class="dash-summary-value dash-summary-value-text">${focusTopic ? escapeHtml(truncateLabel(focusTopic.name, 12)) : '—'}</div>
+          <div class="dash-summary-label">집중 주제</div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+// ── 최근 읽은 논문 ── dashboard.recent_papers는 실제로는 "최근 업로드"라
+// 라벨과 맞지 않는다. 대신 fetchLibrary()의 문서 목록에서 metadata.read가
+// true인 것만 read_at 내림차순으로 골라 쓴다. 진행률(%)은 페이지별
+// "읽음" 추적이 없어, translated_pages/total_pages(실제 번역된 페이지
+// 비율)로 근사했다 - 읽으면서 페이지가 번역되는 흐름이라 합리적인 대리
+// 지표지만 엄밀히는 "읽은 비율"이 아니라 "번역 진행률"이다.
+function renderRecentPapersCard(docs) {
+  const read = docs
+    .filter(d => d.metadata && d.metadata.read)
+    .sort((a, b) => new Date(b.metadata.read_at || b.created_at).getTime() - new Date(a.metadata.read_at || a.created_at).getTime())
+    .slice(0, 5)
+
+  return `
+    <div class="dash-card dash-card-list">
+      <div class="dash-card-head">
+        <h3>${icon('bookOpen', 15)}최근 읽은 논문</h3>
+        <a href="#" class="dash-link" data-nav="library">전체보기 ›</a>
+      </div>
+      ${read.length === 0 ? emptyNote('아직 읽음으로 표시한 논문이 없습니다.') : `
+      <ul class="dash-paper-list">
+        ${read.map(d => {
+          const title = (d.metadata && d.metadata.title) || d.filename
+          const total = d.total_pages || 0
+          const translated = (d.translated_pages && d.translated_pages.length) || 0
+          const pct = total > 0 ? Math.min(100, Math.round((translated / total) * 100)) : 0
+          const cats = ((d.metadata && d.metadata.categories) || []).slice(0, 2)
+          return `
+            <li class="dash-paper-item" data-doc-id="${escapeHtml(d.id)}">
+              <img class="dash-paper-cover" src="/api/library/${encodeURIComponent(d.id)}/cover" alt="" loading="lazy" onerror="this.style.visibility='hidden'" />
+              <div class="dash-paper-info">
+                <div class="dash-paper-title">${escapeHtml(title)}</div>
+                <div class="dash-paper-meta">
+                  <span>${cats.length ? escapeHtml(cats.join(' · ')) : ''}</span>
+                  <span class="dash-paper-time">${relativeTimeKo(d.metadata.read_at || d.created_at)}</span>
+                </div>
+                <div class="dash-paper-progress-row">
+                  <div class="dash-activity-track small"><div class="dash-activity-fill" style="width:${pct}%"></div></div>
+                  <span class="dash-paper-pct">${pct}%</span>
+                </div>
+              </div>
+            </li>
+          `
+        }).join('')}
+      </ul>`}
+    </div>
+  `
+}
+
+// ── 최근 질문 ── dashboard.recent_questions를 그대로 사용(이미 timeline에서
+// type==='question'만 골라 최신순으로 내려준다).
+function renderRecentQuestionsCard(list) {
+  const items = (list || []).slice(0, 5)
+  return `
+    <div class="dash-card dash-card-list">
+      <div class="dash-card-head">
+        <h3>${icon('messageCircle', 15)}최근 질문</h3>
+        <a href="#" class="dash-link" data-nav="chats">전체보기 ›</a>
+      </div>
+      ${items.length === 0 ? emptyNote('최근 질문이 없습니다.') : `
+      <ul class="dash-question-list">
+        ${items.map(q => `
+          <li class="dash-question-item" data-nav="chats">
+            <span class="dash-question-icon">${icon('messageCircle', 13)}</span>
+            <div class="dash-question-body">
+              <div class="dash-question-text">${escapeHtml(q.summary || '')}</div>
+              <div class="dash-question-meta">${escapeHtml(q.doc_title || '')}<span class="dash-dot">·</span>${relativeTimeKo(q.timestamp)}</div>
+            </div>
+          </li>
+        `).join('')}
+      </ul>`}
+    </div>
+  `
+}
+
+// ── AI 추천 논문 ── /library/graph/recommendations는 LLM+OpenAlex를 여러 번
+// 호출하는 무거운 엔드포인트라, 백엔드 주석과 기존 그래프 탭 구현이 그러듯
+// 대시보드 진입 시 자동 호출하지 않고 사용자가 버튼을 눌렀을 때만 지연
+// 로드한다(불필요한 지연/비용을 방지).
+function renderRecommendationsCard() {
+  return `
+    <div class="dash-card dash-card-list dash-card-recs">
+      <div class="dash-card-head">
+        <h3>${icon('star', 15)}AI 추천 논문</h3>
+        <a href="#" class="dash-link" data-nav="library">더 보기 ›</a>
+      </div>
+      <div class="dash-recs-body" data-recs-body>
+        ${emptyNote('읽은 논문들을 바탕으로 다음에 읽으면 좋을 논문을 추천받아 보세요.')}
+        <button type="button" class="dash-recs-btn" data-recs-btn>${icon('zap', 13)}추천 받기</button>
+      </div>
+    </div>
+  `
+}
+
+// ── 개념 히트맵 ── dashboard.heatmap(paper_count+question_count 합인 score
+// 기준 정렬)을 그대로 타일로 표시하고, 색 진하기는 이 목록 안에서의
+// 상대적 score로 정규화한다.
+function renderHeatmapCard(heatmap) {
+  const maxScore = heatmap.length ? Math.max(...heatmap.map(h => h.score || 0)) : 0
+  return `
+    <div class="dash-card dash-card-heatmap">
+      <div class="dash-card-head">
+        <h3>${icon('tag', 15)}개념 히트맵</h3>
+        <a href="#" class="dash-link" data-nav="graph">전체보기 ›</a>
+      </div>
+      ${heatmap.length === 0 ? emptyNote('아직 추출된 개념이 없습니다.') : `
+      <div class="dash-heat-grid">
+        ${heatmap.slice(0, 8).map(h => {
+          const pct = maxScore > 0 ? Math.max(6, Math.round(((h.score || 0) / maxScore) * 100)) : 6
+          return `
+            <div class="dash-heat-cell" title="논문 ${h.paper_count}편 · 질문 ${h.question_count}개">
+              <div class="dash-heat-swatch" style="--heat-pct:${pct}%"></div>
+              <div class="dash-heat-label">${escapeHtml(h.name)}</div>
+              <div class="dash-heat-count">${formatNumber(h.score)}</div>
+            </div>
+          `
+        }).join('')}
+      </div>
+      <div class="dash-heat-legend"><span>낮음</span><div class="dash-heat-legend-bar"></div><span>높음</span></div>
+      `}
+    </div>
+  `
+}
+
+// ── 연구 타임라인(최근 7일) ── /library/timeline 이벤트를 그대로 시간순
+// 미니 리스트로 보여준다.
+const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
+
+function renderTimelineCard(events) {
+  const recent = events.filter(e => isWithinDays(e.timestamp, 7)).slice(0, 7)
+  return `
+    <div class="dash-card">
+      <div class="dash-card-head">
+        <h3>${icon('clock', 15)}연구 타임라인</h3>
+        <a href="#" class="dash-link" data-nav="history">전체보기 ›</a>
+      </div>
+      <div class="dash-card-tag dash-card-tag-inline">최근 7일</div>
+      ${recent.length === 0 ? emptyNote('최근 7일간 활동이 없습니다.') : `
+      <ul class="dash-timeline-list">
+        ${recent.map(e => `
+          <li class="dash-timeline-item dash-timeline-${escapeHtml(e.type)}">
+            <span class="dash-timeline-dot"></span>
+            <div class="dash-timeline-body">
+              <div class="dash-timeline-top">
+                <span class="dash-timeline-type">${escapeHtml(TIMELINE_TYPE_LABEL[e.type] || e.type)}</span>
+                <span class="dash-timeline-time">${relativeTimeKo(e.timestamp)}</span>
+              </div>
+              <div class="dash-timeline-title">${escapeHtml(e.doc_title || '')}</div>
+              ${e.summary ? `<div class="dash-timeline-summary">${escapeHtml(e.summary)}</div>` : ''}
+            </div>
+          </li>
+        `).join('')}
+      </ul>`}
+    </div>
+  `
+}
+
+// ── 연구 그래프 미리보기 ── /library/graph의 실제 노드/엣지에서, 개념
+// 히트맵 1위 개념을 중심으로 직접 연결된 이웃(해당 개념을 가진 논문 =
+// has_concept 엣지, 유사 개념 = similar_to 엣지)만 뽑아 작은 방사형
+// SVG로 그린다. "추천 논문"은 아직 라이브러리에 없는 논문이라 그래프
+// 노드 자체가 없으므로 범례에서 제외했다(실데이터 없는 항목은 만들지
+// 않는다는 원칙).
+function buildGraphPreview(graphData, heatmap) {
+  if (!graphData || !graphData.nodes || !heatmap.length) return null
+  const nodeById = new Map(graphData.nodes.map(n => [n.id, n]))
+  const top = heatmap.find(h => nodeById.has(`concept:${h.concept_id}`))
+  if (!top) return null
+  const centerId = `concept:${top.concept_id}`
+  const center = nodeById.get(centerId)
+
+  const seen = new Set()
+  const neighbors = []
+  for (const e of graphData.edges) {
+    if (e.source !== centerId && e.target !== centerId) continue
+    const otherId = e.source === centerId ? e.target : e.source
+    if (seen.has(otherId)) continue
+    const node = nodeById.get(otherId)
+    if (!node || (node.type !== 'paper' && node.type !== 'concept')) continue
+    seen.add(otherId)
+    neighbors.push(node)
+    if (neighbors.length >= 7) break
+  }
+  if (neighbors.length === 0) return null
+  return { center, neighbors }
+}
+
+function renderMiniGraphSvg({ center, neighbors }) {
+  const W = 280, H = 176
+  const cx = W / 2, cy = H / 2 + 6
+  const r = 66
+  const n = neighbors.length
+  const points = neighbors.map((node, i) => {
+    const angle = (Math.PI * 2 * i) / n - Math.PI / 2
+    return { node, x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) }
+  })
+
+  const lines = points.map(p => `<line x1="${cx.toFixed(1)}" y1="${cy.toFixed(1)}" x2="${p.x.toFixed(1)}" y2="${p.y.toFixed(1)}" class="dash-graph-edge" />`).join('')
+  const nodesHtml = points.map(p => {
+    const isPaper = p.node.type === 'paper'
+    const labelY = p.y > cy ? p.y + 16 : p.y - 11
+    return `
+      <g class="dash-graph-node ${isPaper ? 'is-paper' : 'is-concept'}">
+        <title>${escapeHtml(p.node.label || '')}</title>
+        <circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${isPaper ? 8 : 6.5}" />
+        <text x="${p.x.toFixed(1)}" y="${labelY.toFixed(1)}" text-anchor="middle">${escapeHtml(truncateLabel(p.node.label, 13))}</text>
+      </g>
+    `
+  }).join('')
+
+  return `
+    <svg class="dash-graph-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet">
+      ${lines}
+      ${nodesHtml}
+      <g class="dash-graph-node is-center">
+        <title>${escapeHtml(center.label || '')}</title>
+        <circle cx="${cx}" cy="${cy}" r="13" />
+        <text x="${cx}" y="${cy + 26}" text-anchor="middle" class="dash-graph-center-label">${escapeHtml(truncateLabel(center.label, 12))}</text>
+      </g>
+    </svg>
+    <div class="dash-graph-legend">
+      <span><i class="dash-legend-dot is-center"></i>현재 개념</span>
+      <span><i class="dash-legend-dot is-paper"></i>연결된 논문</span>
+      <span><i class="dash-legend-dot is-concept"></i>관련 개념</span>
+    </div>
+  `
+}
+
+function renderGraphPreviewCard(graphData, heatmap) {
+  const preview = buildGraphPreview(graphData, heatmap)
+  return `
+    <div class="dash-card dash-card-graph">
+      <div class="dash-card-head">
+        <h3>${icon('network', 15)}연구 그래프 미리보기</h3>
+        <a href="#" class="dash-link" data-nav="graph">그래프 보기 ›</a>
+      </div>
+      ${!preview ? emptyNote('아직 미리 볼 만큼 연결된 그래프 데이터가 없습니다.') : renderMiniGraphSvg(preview)}
+    </div>
+  `
+}
+
+// ── 이벤트 바인딩 ──────────────────────────────────────────────────────
+function attachHandlers(root) {
+  root.querySelectorAll('[data-nav]').forEach(elm => {
+    elm.addEventListener('click', (ev) => {
+      ev.preventDefault()
+      const page = elm.dataset.nav
+      if (page) location.hash = page
+    })
+  })
+
+  root.querySelectorAll('.dash-paper-item[data-doc-id]').forEach(elm => {
+    elm.addEventListener('click', () => {
+      const id = elm.dataset.docId
+      if (id) location.hash = `viewer?id=${encodeURIComponent(id)}`
+    })
+  })
+
+  const recsBtn = root.querySelector('[data-recs-btn]')
+  if (recsBtn) {
+    recsBtn.addEventListener('click', async () => {
+      const body = root.querySelector('[data-recs-body]')
+      if (!body) return
+      recsBtn.disabled = true
+      body.innerHTML = emptyNote('추천 논문을 찾는 중입니다... (다소 시간이 걸릴 수 있어요)')
+      try {
+        const { recommendations } = await fetchReadingRecommendations()
+        if (!recommendations || recommendations.length === 0) {
+          body.innerHTML = emptyNote('추천할 만한 논문을 찾지 못했습니다.')
+          return
+        }
+        body.innerHTML = `
+          <ul class="dash-rec-list">
+            ${recommendations.slice(0, 5).map(r => `
+              <li class="dash-rec-item">
+                <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" class="dash-rec-title">${escapeHtml(r.title || '')}</a>
+                ${r.year ? `<span class="dash-rec-year">${escapeHtml(String(r.year))}</span>` : ''}
+                ${r.reason ? `<div class="dash-rec-reason">${escapeHtml(r.reason)}</div>` : ''}
+              </li>
+            `).join('')}
+          </ul>
+        `
+      } catch (err) {
+        console.error('추천 논문 조회 실패:', err)
+        body.innerHTML = `<p class="dash-empty-note dash-error-note">추천 논문을 불러오지 못했습니다.</p>`
+      } finally {
+        if (root.contains(recsBtn)) recsBtn.disabled = false
+      }
+    })
+  }
+}
+
+// ── 진입점 ──────────────────────────────────────────────────────────
+export async function renderDashboardPage() {
+  const el = document.getElementById('page-dashboard')
+  if (!el) return
+
+  el.innerHTML = `<div class="dash-loading">${icon('refreshCw', 20)}<span>대시보드를 불러오는 중...</span></div>`
+
+  let dashboard, timelineData, libraryData, graphData, readingStats
+  try {
+    const results = await Promise.all([
+      fetchLibraryDashboard(),
+      fetchLibraryTimeline(),
+      fetchLibrary(),
+      fetchLibraryGraph().catch(() => null),
+      fetchReadingTimeStats().catch(() => null),
+    ])
+    dashboard = results[0]
+    timelineData = results[1]
+    libraryData = results[2]
+    graphData = results[3]
+    readingStats = results[4]
+  } catch (err) {
+    console.error('대시보드 데이터 로드 실패:', err)
+    el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
+    return
+  }
+
+  const events = (timelineData && timelineData.events) || []
+  const docs = (libraryData && libraryData.documents) || []
+  const stats = dashboard.stats || {}
+  const heatmap = dashboard.heatmap || []
+  const gaps = dashboard.gaps || []
+  const recentQuestions = dashboard.recent_questions || []
+
+  el.innerHTML = `
+    <div class="dash-root">
+      ${renderStatGrid(stats, events, docs)}
+      <div class="dash-row dash-row-3">
+        ${renderInsightsCard(gaps)}
+        ${renderWeeklyActivityCard(events, stats, docs, readingStats)}
+        ${renderProgressSummaryCard(events, heatmap, readingStats)}
+      </div>
+      <div class="dash-row dash-row-recent">
+        ${renderRecentPapersCard(docs)}
+        ${renderRecentQuestionsCard(recentQuestions)}
+        ${renderRecommendationsCard()}
+      </div>
+      <div class="dash-row dash-row-bottom">
+        ${renderHeatmapCard(heatmap)}
+        ${renderTimelineCard(events)}
+        ${renderGraphPreviewCard(graphData, heatmap)}
+      </div>
+    </div>
+  `
+
+  attachHandlers(el)
+}

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -1,0 +1,537 @@
+// ── Notes 페이지 ──────────────────────────────────────────────────────
+// 뷰어에서 남긴 메모/하이라이트/언더라인을 논문별로 모아 "읽기 전용"으로
+// 보여준다. 이 페이지에서는 주석을 새로 만들거나 편집할 수 없다 - 오직
+// 뷰어에서 이미 만든 것을 조회하고, 클릭하면 해당 논문 뷰어로 이동한다.
+//
+// 데이터 출처: 메모/하이라이트/언더라인은 서버 DB가 아니라 문서(세션)별
+// localStorage(`easypaper_annotations_<id>`, `easypaper_memos_<id>`)에만
+// 저장된다(main.js의 loadAnnotations/loadMemos/saveAnnotations/saveMemos와
+// 동일한 키·형태를 그대로 읽는다 - import는 하지 않고 패턴만 따라한다).
+// 로컬이 비어있는 문서에 한해서만 서버 미러(fetchLibraryAnnotations/
+// fetchLibraryMemos)로 폴백한다("로컬이 있으면 항상 로컬 우선, 병합 없음"
+// - main.js의 hydrateAnnotationsAndMemosFromServer와 동일한 정책이지만,
+// 여기서는 표시 전용이라 로컬에 다시 써넣지는 않는다).
+
+import '../styles/notes.css'
+import { fetchLibrary, fetchLibraryAnnotations, fetchLibraryMemos, fetchPrimer } from '../library.js'
+import { icon } from '../icons.js'
+
+// 즐겨찾기는 서버에 저장되는 필드가 아니라 Library 페이지가 이미 쓰고 있는
+// 로컬 전용 상태다(백엔드에 star/favorite 필드가 없음 - Library 리스킨 때 같은
+// 이유로 로컬로 구현됨). 같은 localStorage 키를 그대로 읽고 써서 Library와
+// Notes 양쪽에서 즐겨찾기 상태가 항상 동일하게 보이도록 한다.
+const FAVORITES_KEY = 'easypaper_library_favorites'
+function getFavoriteIds() {
+  try { return new Set(JSON.parse(localStorage.getItem(FAVORITES_KEY) || '[]')) } catch { return new Set() }
+}
+function isFavoriteDoc(docId) { return getFavoriteIds().has(docId) }
+function toggleFavoriteDoc(docId) {
+  const ids = getFavoriteIds()
+  if (ids.has(docId)) ids.delete(docId); else ids.add(docId)
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(ids)))
+  return ids.has(docId)
+}
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+function truncate(text, maxLen) {
+  if (!text) return ''
+  const trimmed = text.trim()
+  return trimmed.length > maxLen ? trimmed.substring(0, maxLen) + '...' : trimmed
+}
+
+// ── 모듈 상태 (페이지를 재방문해도 마지막 선택/탭/검색어를 기억한다) ──
+let allPapers = []          // PaperEntry[] - renderNotesPage()마다 새로 집계
+let filterMode = 'all'      // 'all' | 'hasNotes' | 'favorites'
+let searchQuery = ''
+let selectedDocId = null
+let activeSubtab = 'summary' // 'summary' | 'memo' | 'highlight' | 'underline' | 'all'
+
+// 요약(primer.hook)은 문서당 LLM 호출 비용이 있으므로 탭을 실제로 열었을 때만
+// 가져오고, 한 번 가져오면 페이지 재방문 동안 재사용한다.
+// docId -> { status: 'loading'|'ready'|'error', text?: string }
+const summaryCache = new Map()
+
+// ── localStorage 읽기 (main.js loadAnnotations/loadMemos와 동일한 키/형태) ──
+function readLocalAnnotations(docId) {
+  try {
+    const raw = localStorage.getItem(`easypaper_annotations_${docId}`)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function readLocalMemos(docId) {
+  try {
+    const raw = localStorage.getItem(`easypaper_memos_${docId}`)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+async function getDocAnnotationsAndMemos(docId) {
+  let annotationsByPage = readLocalAnnotations(docId)
+  let memosByPage = readLocalMemos(docId)
+
+  if (Object.keys(annotationsByPage).length === 0) {
+    try {
+      const server = await fetchLibraryAnnotations(docId)
+      if (server && server.data && Object.keys(server.data).length) annotationsByPage = server.data
+    } catch {
+      // best-effort - 조회 실패해도 목록 표시는 계속 진행
+    }
+  }
+  if (Object.keys(memosByPage).length === 0) {
+    try {
+      const server = await fetchLibraryMemos(docId)
+      if (server && server.data && Object.keys(server.data).length) memosByPage = server.data
+    } catch {
+      // best-effort
+    }
+  }
+  return { annotationsByPage, memosByPage }
+}
+
+// 메모 객체에는 별도 createdAt 필드가 없고, id가 `memo_${Date.now()}` 형태로
+// 생성 시각을 담고 있다(main.js createFloatingMemoForSentence 참고) - 이게
+// 유일한 시각 정보라 여기서 역산한다. 하이라이트/언더라인 객체는 애초에
+// 시각 필드 자체가 저장되지 않으므로(타입/텍스트/오프셋/색만 저장) 카드에
+// 시간을 표시할 수 없다 - 페이지 배지만 노출한다.
+function memoTimestamp(memo) {
+  const m = /^memo_(\d+)/.exec(String((memo && memo.id) || ''))
+  if (!m) return null
+  const d = new Date(Number(m[1]))
+  return isNaN(d.getTime()) ? null : d
+}
+
+function formatTs(d) {
+  if (!d) return ''
+  const pad = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// 논문 하나에 대한 메모/하이라이트/언더라인을 모두 모아 화면에서 바로 쓸 수
+// 있는 형태로 집계한다.
+async function buildPaperEntry(doc) {
+  const { annotationsByPage, memosByPage } = await getDocAnnotationsAndMemos(doc.id)
+
+  const memoItems = []
+  const highlightItems = []
+  const underlineItems = []
+
+  Object.keys(memosByPage).forEach(pageKey => {
+    const pageNum = parseInt(pageKey.replace('page_', ''), 10)
+    if (isNaN(pageNum)) return
+    ;(memosByPage[pageKey] || []).forEach(memo => {
+      const ts = memoTimestamp(memo)
+      const text = (memo.content && memo.content.trim()) || memo.sentenceText || '(내용 없음)'
+      memoItems.push({ kind: 'memo', docId: doc.id, page: pageNum, ts, text, color: null })
+    })
+  })
+
+  Object.keys(annotationsByPage).forEach(pageKey => {
+    const pageNum = parseInt(pageKey.replace('page_', ''), 10)
+    if (isNaN(pageNum)) return
+    ;(annotationsByPage[pageKey] || []).forEach(ann => {
+      const item = { kind: ann.type, docId: doc.id, page: pageNum, ts: null, text: ann.text || '(내용 없음)', color: ann.color || null }
+      if (ann.type === 'highlight') highlightItems.push(item)
+      else if (ann.type === 'underline') underlineItems.push(item)
+    })
+  })
+
+  memoItems.sort((a, b) => (b.ts ? b.ts.getTime() : 0) - (a.ts ? a.ts.getTime() : 0))
+  highlightItems.sort((a, b) => a.page - b.page)
+  underlineItems.sort((a, b) => a.page - b.page)
+  const allItems = [...memoItems, ...highlightItems, ...underlineItems].sort((a, b) => a.page - b.page)
+
+  const meta = doc.metadata || {}
+  const title = meta.title || doc.filename
+  const author = meta.author || ''
+  const categories = meta.categories || []
+  const read = meta.read === true
+
+  return {
+    doc,
+    title,
+    author,
+    categories,
+    read,
+    favorite: isFavoriteDoc(doc.id),
+    counts: { memo: memoItems.length, highlight: highlightItems.length, underline: underlineItems.length },
+    items: { memo: memoItems, highlight: highlightItems, underline: underlineItems, all: allItems },
+  }
+}
+
+function totalCount(entry) {
+  return entry.counts.memo + entry.counts.highlight + entry.counts.underline
+}
+
+// ── 좌측 논문 목록 ────────────────────────────────────────────────────
+function getFilteredPapers() {
+  const q = searchQuery.trim().toLowerCase()
+  return allPapers.filter(entry => {
+    if (filterMode === 'hasNotes' && totalCount(entry) === 0) return false
+    if (filterMode === 'favorites' && !entry.favorite) return false
+    if (!q) return true
+    return entry.title.toLowerCase().includes(q) || (entry.author || '').toLowerCase().includes(q)
+  })
+}
+
+function renderThumb(docId, sizePx) {
+  return `
+    <div class="notes-thumb" style="--notes-thumb-size:${sizePx}px">
+      <span class="notes-thumb-fallback">${icon('fileText', Math.round(sizePx * 0.42))}</span>
+      <img class="notes-thumb-img" data-doc-id="${escapeHtml(docId)}" src="/api/library/${encodeURIComponent(docId)}/cover" alt="" loading="lazy" />
+    </div>
+  `
+}
+
+function renderPaperRow(entry) {
+  const { doc, title, author, categories, counts, favorite } = entry
+  const selected = doc.id === selectedDocId
+  const metaLine = [author, categories[0]].filter(Boolean).join(' · ')
+  return `
+    <div class="notes-paper-row ${selected ? 'selected' : ''}" data-doc-id="${escapeHtml(doc.id)}">
+      ${renderThumb(doc.id, 40)}
+      <div class="notes-paper-row-body">
+        <div class="notes-paper-row-title">${escapeHtml(title)}</div>
+        ${metaLine ? `<div class="notes-paper-row-meta">${escapeHtml(metaLine)}</div>` : ''}
+        <div class="notes-paper-row-counts">
+          <span class="notes-count-chip" title="하이라이트">${icon('highlighter', 12)}${counts.highlight}</span>
+          <span class="notes-count-chip" title="언더라인">${icon('underline', 12)}${counts.underline}</span>
+          <span class="notes-count-chip" title="메모">${icon('edit3', 12)}${counts.memo}</span>
+        </div>
+      </div>
+      <button type="button" class="notes-fav-btn ${favorite ? 'active' : ''}" data-fav-doc-id="${escapeHtml(doc.id)}" title="${favorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}">
+        ${icon('star', 15)}
+      </button>
+    </div>
+  `
+}
+
+function renderPaperList(root) {
+  const listEl = root.querySelector('.notes-paper-list-items')
+  const countAllEl = root.querySelector('.notes-filter-count-all')
+  const countHasNotesEl = root.querySelector('.notes-filter-count-hasnotes')
+  const countFavEl = root.querySelector('.notes-filter-count-fav')
+  if (countAllEl) countAllEl.textContent = String(allPapers.length)
+  if (countHasNotesEl) countHasNotesEl.textContent = String(allPapers.filter(e => totalCount(e) > 0).length)
+  if (countFavEl) countFavEl.textContent = String(allPapers.filter(e => e.favorite).length)
+
+  const filtered = getFilteredPapers()
+  if (!listEl) return
+
+  if (filtered.length === 0) {
+    listEl.innerHTML = `<div class="notes-empty"><p>${allPapers.length === 0 ? '저장된 논문이 없습니다' : '조건에 맞는 논문이 없습니다'}</p></div>`
+    return
+  }
+  listEl.innerHTML = filtered.map(renderPaperRow).join('')
+  bindThumbFallback(listEl)
+}
+
+function bindThumbFallback(container) {
+  container.querySelectorAll('.notes-thumb-img').forEach(img => {
+    img.addEventListener('error', () => { img.style.display = 'none' }, { once: true })
+  })
+}
+
+// ── 우측 상세 패널 ────────────────────────────────────────────────────
+const SUBTABS = [
+  { key: 'summary', label: '요약', icon: 'lightbulb' },
+  { key: 'memo', label: '메모', icon: 'edit3' },
+  { key: 'highlight', label: '하이라이트', icon: 'highlighter' },
+  { key: 'underline', label: '언더라인', icon: 'underline' },
+  { key: 'all', label: '모든 주석', icon: 'layers' },
+]
+
+const EMPTY_MESSAGES = {
+  memo: '이 논문에 남긴 메모가 없습니다.',
+  highlight: '하이라이트한 내용이 없습니다.',
+  underline: '밑줄 친 내용이 없습니다.',
+  all: '아직 저장된 주석이 없습니다.',
+}
+
+// 요약 탭: primer(읽기 전 브리핑)의 hook을 재사용한다 - Library 상세 패널의
+// AI 요약과 동일한 데이터 소스/우선순위(hook → feynman → lineage, main.js
+// showGraphDetailPanel/openLibraryDetailPanel과 동일한 관례)라 새 백엔드가
+// 필요 없다. LLM 호출 비용이 있어 탭을 열 때만 fetchPrimer()를 호출하고
+// summaryCache에 담아 재방문 시 재사용한다.
+function renderSummaryTabContent(docId) {
+  const cached = summaryCache.get(docId)
+  if (!cached || cached.status === 'loading') {
+    return `<div class="notes-summary-loading">${icon('refreshCw', 15)}<span>AI 요약을 불러오는 중...</span></div>`
+  }
+  if (cached.status === 'error') {
+    return `<div class="notes-empty"><p style="color:var(--error)">요약을 불러오지 못했습니다.</p></div>`
+  }
+  if (!cached.text) {
+    return `<div class="notes-empty"><p>이 논문에는 아직 생성된 요약이 없습니다.</p></div>`
+  }
+  return `<div class="notes-summary-text">${escapeHtml(cached.text)}</div>`
+}
+
+function ensureSummaryLoaded(root, docId) {
+  const cached = summaryCache.get(docId)
+  if (cached && (cached.status === 'ready' || cached.status === 'error')) return
+  if (cached && cached.status === 'loading') return
+  summaryCache.set(docId, { status: 'loading' })
+  fetchPrimer(docId).then(data => {
+    const text = data.hook || data.feynman || data.lineage || ''
+    summaryCache.set(docId, { status: 'ready', text })
+  }).catch(err => {
+    console.error('Notes 요약 로드 실패:', err)
+    summaryCache.set(docId, { status: 'error' })
+  }).finally(() => {
+    // 로드되는 동안 사용자가 다른 논문/탭으로 이동했을 수 있으니, 여전히
+    // 같은 문서의 요약 탭을 보고 있을 때만 다시 그린다.
+    if (selectedDocId === docId && activeSubtab === 'summary') {
+      const contentEl = root.querySelector('.notes-tab-content')
+      if (contentEl) contentEl.innerHTML = renderSummaryTabContent(docId)
+    }
+  })
+}
+
+function renderAnnotationCard(item) {
+  const iconName = item.kind === 'memo' ? 'edit3' : item.kind === 'highlight' ? 'highlighter' : 'underline'
+  const shortText = truncate(item.text, 220)
+  const canExpand = item.text.trim().length > shortText.replace(/\.\.\.$/, '').length
+  const tsHtml = item.ts ? `<span class="notes-card-ts">${escapeHtml(formatTs(item.ts))}</span>` : ''
+  const style = item.color ? ` style="--notes-item-accent:${escapeHtml(item.color)}"` : ''
+  return `
+    <div class="notes-annotation-card notes-card-${item.kind}"${style} data-doc-id="${escapeHtml(item.docId)}">
+      <div class="notes-card-top">
+        <span class="notes-card-badge">${icon(iconName, 12)}p. ${item.page}</span>
+        ${tsHtml}
+      </div>
+      <p class="notes-card-text" data-full="${escapeHtml(item.text)}" data-short="${escapeHtml(shortText)}">${escapeHtml(shortText)}</p>
+      ${canExpand ? `<button type="button" class="notes-card-expand-btn">${icon('chevronDown', 12)}<span>더보기</span></button>` : ''}
+    </div>
+  `
+}
+
+function renderTabContent(entry) {
+  if (activeSubtab === 'summary') return renderSummaryTabContent(entry.doc.id)
+  const items = entry.items[activeSubtab] || []
+  if (items.length === 0) {
+    return `<div class="notes-empty"><p>${EMPTY_MESSAGES[activeSubtab]}</p></div>`
+  }
+  return `<div class="notes-card-list">${items.map(renderAnnotationCard).join('')}</div>`
+}
+
+function renderDetail(root) {
+  const detailEl = root.querySelector('.notes-detail')
+  if (!detailEl) return
+
+  const entry = allPapers.find(e => e.doc.id === selectedDocId)
+  if (!entry) {
+    detailEl.innerHTML = `
+      <div class="notes-detail-empty">
+        ${icon('fileText', 40)}
+        <p>왼쪽 목록에서 논문을 선택하면<br/>메모와 하이라이트를 확인할 수 있습니다.</p>
+      </div>
+    `
+    return
+  }
+
+  const metaLine = [entry.author, entry.categories.join(', ')].filter(Boolean).join(' · ')
+
+  detailEl.innerHTML = `
+    <div class="notes-paper-header">
+      ${renderThumb(entry.doc.id, 56)}
+      <div class="notes-paper-header-info">
+        <h2 class="notes-paper-header-title">${escapeHtml(entry.title)}</h2>
+        ${metaLine ? `<div class="notes-paper-header-meta">${escapeHtml(metaLine)}</div>` : ''}
+      </div>
+      <div class="notes-paper-header-actions">
+        ${entry.read ? `<span class="notes-read-badge">${icon('checkCircle', 13)}읽음</span>` : ''}
+        <button type="button" class="notes-fav-btn notes-fav-btn-lg ${entry.favorite ? 'active' : ''}" data-fav-doc-id="${escapeHtml(entry.doc.id)}" title="${entry.favorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}">
+          ${icon('star', 15)}
+        </button>
+        <button type="button" class="notes-open-viewer-btn" data-doc-id="${escapeHtml(entry.doc.id)}">
+          ${icon('externalLink', 13)}<span>뷰어에서 열기</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="notes-tabs">
+      ${SUBTABS.map(t => `
+        <button type="button" class="notes-tab-btn ${activeSubtab === t.key ? 'active' : ''}" data-subtab="${t.key}">
+          ${icon(t.icon, 13)}<span>${t.label}</span>
+          ${t.key === 'summary' ? '' : `<span class="notes-tab-count">${t.key === 'all' ? totalCount(entry) : entry.counts[t.key]}</span>`}
+        </button>
+      `).join('')}
+    </div>
+
+    <div class="notes-tab-content">${renderTabContent(entry)}</div>
+  `
+  bindThumbFallback(detailEl)
+
+  if (activeSubtab === 'summary') ensureSummaryLoaded(root, entry.doc.id)
+}
+
+// ── 이벤트 위임 (root는 renderNotesPage()마다 새로 생기지만, root 자체에
+// 한 번만 걸어두면 내부 재렌더링(검색/필터/탭 전환)에도 계속 살아있다) ──
+function attachListeners(root) {
+  const searchInput = root.querySelector('.notes-search-input')
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      searchQuery = searchInput.value
+      renderPaperList(root)
+    })
+  }
+
+  root.querySelectorAll('.notes-filter-tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const mode = btn.dataset.filter
+      if (mode === filterMode) return
+      filterMode = mode
+      root.querySelectorAll('.notes-filter-tab-btn').forEach(b => b.classList.toggle('active', b === btn))
+      renderPaperList(root)
+    })
+  })
+
+  root.addEventListener('click', (e) => {
+    // 즐겨찾기 별 토글 (목록 행/상세 헤더 공용) - 논문 선택보다 먼저 처리해서
+    // 별을 눌러도 그 논문이 함께 선택되지 않도록 한다.
+    const favBtn = e.target.closest('.notes-fav-btn')
+    if (favBtn) {
+      const docId = favBtn.dataset.favDocId
+      if (docId) {
+        const nowFav = toggleFavoriteDoc(docId)
+        const entry = allPapers.find(en => en.doc.id === docId)
+        if (entry) entry.favorite = nowFav
+        renderPaperList(root)
+        if (selectedDocId === docId) renderDetail(root)
+      }
+      return
+    }
+
+    // 좌측 목록에서 논문 선택
+    const row = e.target.closest('.notes-paper-row')
+    if (row) {
+      const docId = row.dataset.docId
+      if (docId && docId !== selectedDocId) {
+        selectedDocId = docId
+        renderPaperList(root)
+        renderDetail(root)
+      }
+      return
+    }
+
+    // 우측 상세: 서브탭 전환
+    const tabBtn = e.target.closest('.notes-tab-btn')
+    if (tabBtn) {
+      const key = tabBtn.dataset.subtab
+      if (key && key !== activeSubtab) {
+        activeSubtab = key
+        renderDetail(root)
+      }
+      return
+    }
+
+    // 카드 "더보기/접기" 토글 (뷰어 이동으로 전파되지 않도록 별도 처리)
+    const expandBtn = e.target.closest('.notes-card-expand-btn')
+    if (expandBtn) {
+      const card = expandBtn.closest('.notes-annotation-card')
+      const textEl = card && card.querySelector('.notes-card-text')
+      if (!card || !textEl) return
+      const expanded = card.classList.toggle('expanded')
+      textEl.textContent = expanded ? textEl.dataset.full : textEl.dataset.short
+      expandBtn.innerHTML = `${icon(expanded ? 'chevronUp' : 'chevronDown', 12)}<span>${expanded ? '접기' : '더보기'}</span>`
+      return
+    }
+
+    // 주석 카드 클릭 → 뷰어에서 해당 논문 열기(뷰어 라우터는 정확한 페이지
+    // 이동을 위한 쿼리 파라미터를 지원하지 않아 문서까지만 이동한다)
+    const card = e.target.closest('.notes-annotation-card')
+    if (card && card.dataset.docId) {
+      location.hash = 'viewer?id=' + encodeURIComponent(card.dataset.docId)
+      return
+    }
+
+    // "뷰어에서 열기" 버튼
+    const openBtn = e.target.closest('.notes-open-viewer-btn')
+    if (openBtn && openBtn.dataset.docId) {
+      location.hash = 'viewer?id=' + encodeURIComponent(openBtn.dataset.docId)
+    }
+  })
+}
+
+function shellHtml() {
+  return `
+    <div class="notes-page-inner">
+      <p class="notes-page-subtitle">논문별 메모, 하이라이트, 언더라인을 확인하세요.</p>
+      <div class="notes-layout">
+        <aside class="notes-sidebar">
+          <div class="notes-sidebar-header">
+            <h3>논문 목록</h3>
+          </div>
+          <div class="notes-search-box">
+            ${icon('search', 14)}
+            <input type="text" class="notes-search-input" placeholder="논문 검색..." />
+          </div>
+          <div class="notes-filter-tabs">
+            <button type="button" class="notes-filter-tab-btn active" data-filter="all">전체 <span class="notes-filter-count-all">0</span></button>
+            <button type="button" class="notes-filter-tab-btn" data-filter="hasNotes">메모 있음 <span class="notes-filter-count-hasnotes">0</span></button>
+            <button type="button" class="notes-filter-tab-btn" data-filter="favorites">${icon('star', 12)} 즐겨찾기 <span class="notes-filter-count-fav">0</span></button>
+          </div>
+          <div class="notes-paper-list-items">
+            <div class="notes-empty"><p>불러오는 중...</p></div>
+          </div>
+        </aside>
+        <section class="notes-detail">
+          <div class="notes-detail-empty">
+            ${icon('fileText', 40)}
+            <p>불러오는 중...</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  `
+}
+
+export async function renderNotesPage() {
+  const root = document.getElementById('page-notes')
+  if (!root) return
+
+  root.innerHTML = shellHtml()
+  attachListeners(root)
+
+  let docs = []
+  try {
+    const data = await fetchLibrary()
+    docs = data.documents || []
+  } catch (err) {
+    console.error('Notes 페이지: 라이브러리 조회 실패:', err)
+    const listEl = root.querySelector('.notes-paper-list-items')
+    if (listEl) listEl.innerHTML = `<div class="notes-empty"><p style="color:var(--error)">논문 목록을 불러오지 못했습니다</p></div>`
+    return
+  }
+
+  if (docs.length === 0) {
+    allPapers = []
+    selectedDocId = null
+    renderPaperList(root)
+    renderDetail(root)
+    return
+  }
+
+  allPapers = await Promise.all(docs.map(buildPaperEntry))
+
+  if (!selectedDocId || !allPapers.some(e => e.doc.id === selectedDocId)) {
+    selectedDocId = allPapers[0].doc.id
+  }
+
+  // 필터 탭 활성 상태를 모듈 상태와 동기화(재방문 시 이전 필터 유지)
+  root.querySelectorAll('.notes-filter-tab-btn').forEach(b => b.classList.toggle('active', b.dataset.filter === filterMode))
+  const searchInput = root.querySelector('.notes-search-input')
+  if (searchInput) searchInput.value = searchQuery
+
+  renderPaperList(root)
+  renderDetail(root)
+}

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -1,0 +1,593 @@
+// Reading History 페이지
+//
+// "읽은 시간"은 main.js의 읽기 시간 하트비트(뷰어/비교 화면이 보이고 포커스된
+// 동안 5초 tick으로 현재 문서+카테고리에 적립 → 20초마다 서버로 flush,
+// POST /library/{doc_id}/reading-heartbeat)가 쌓은 실측치를
+// fetchReadingTimeStats()로 집계해서 쓴다. 카테고리는 실제로 구분 가능한 화면
+// 상태 3가지뿐이다: reading(뷰어 기본) / chat(채팅 사이드바 열림) /
+// compare(논문 비교 채팅). 이 기능을 도입하기 전에 만든 페이지라 이 시점
+// 이전의 활동에는 시간 데이터가 없을 수 있다 - 그런 경우 위젯은 "아직 기록된
+// 읽기 시간이 없습니다"로 정직하게 표시한다.
+
+import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats } from '../library.js'
+import { icon } from '../icons.js'
+import '../styles/reading-history.css'
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+const TYPE_LABEL = { uploaded: 'Uploaded', read: 'Read', question: 'Question', note: 'Note' }
+const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', question: 'messageCircle', note: 'edit3' }
+// 활동 구성 막대(part-to-whole)의 분류 색 - dataviz 팔레트의 앞 4개 슬롯을
+// 고정 순서(blue→orange→aqua→yellow)로만 사용해 색맹 인접성 검증을 그대로 유지한다.
+const TYPE_COLOR_VAR = { read: '--rh-c1', question: '--rh-c2', note: '--rh-c3', uploaded: '--rh-c4' }
+const TYPE_ORDER = ['read', 'question', 'note', 'uploaded']
+
+const DAY_MS = 86400000
+const WEEKDAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', 'Sun']
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+// ── 날짜 키 유틸: 로컬 자정 기준 "YYYY-MM-DD". 이벤트 timestamp는
+// 백엔드가 UTC ISO 문자열로 내려주므로 .slice(0,10) 자체가 이미 날짜 키다 -
+// main.js의 groupTimelineEventsByDate와 동일한 관례를 그대로 따른다. ──
+function localDateToKey(d) {
+  const y = d.getFullYear(), m = String(d.getMonth() + 1).padStart(2, '0'), day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+function keyToLocalDate(key) {
+  return new Date(`${key}T00:00:00`)
+}
+function addDaysKey(key, delta) {
+  const d = keyToLocalDate(key)
+  d.setDate(d.getDate() + delta)
+  return localDateToKey(d)
+}
+function todayKey() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return localDateToKey(d)
+}
+function eventKey(e) {
+  return (e.timestamp || '').slice(0, 10)
+}
+
+function formatDayLabel(dateKey) {
+  const day = keyToLocalDate(dateKey)
+  if (isNaN(day.getTime())) return { primary: dateKey, secondary: '' }
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffDays = Math.round((today - day) / DAY_MS)
+  const primary = diffDays === 0 ? 'Today' : diffDays === 1 ? 'Yesterday'
+    : day.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
+  return { primary, secondary: day.toLocaleDateString('en-US', { weekday: 'long' }) }
+}
+function formatTime(timestamp) {
+  const d = new Date(timestamp)
+  return isNaN(d.getTime()) ? '' : d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+}
+function formatShortDate(dateKey) {
+  const d = keyToLocalDate(dateKey)
+  if (isNaN(d.getTime())) return dateKey
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+// ── 집계 헬퍼 ──────────────────────────────────────────────
+function countByDay(events) {
+  const map = new Map()
+  for (const e of events) {
+    const k = eventKey(e)
+    if (!k) continue
+    map.set(k, (map.get(k) || 0) + 1)
+  }
+  return map
+}
+
+// 실제 연속일 스트릭(현재/최장)을 날짜 집합에서 그대로 계산한다 - 절대 임의의
+// 숫자를 넣지 않는다.
+function computeStreaks(activeDayKeys) {
+  const sorted = Array.from(activeDayKeys).sort()
+  let longest = 0, longestEnd = null
+  let run = 0, prevKey = null
+  for (const k of sorted) {
+    if (prevKey && addDaysKey(prevKey, 1) === k) {
+      run += 1
+    } else {
+      run = 1
+    }
+    if (run > longest) { longest = run; longestEnd = k }
+    prevKey = k
+  }
+  const longestStart = longestEnd ? addDaysKey(longestEnd, -(longest - 1)) : null
+
+  // 현재 스트릭: 오늘부터, 오늘 기록이 아직 없으면 어제부터 거슬러 올라가며 연속일 수를 센다.
+  const today = todayKey()
+  let cursor = activeDayKeys.has(today) ? today : addDaysKey(today, -1)
+  let current = 0
+  while (activeDayKeys.has(cursor)) {
+    current += 1
+    cursor = addDaysKey(cursor, -1)
+  }
+  return { current, longest, longestStart, longestEnd }
+}
+
+function periodStats(events, docsById, startKey, endKeyExclusive) {
+  const inPeriod = events.filter(e => {
+    const k = eventKey(e)
+    return k && k >= startKey && k < endKeyExclusive
+  })
+  const activeDays = new Set(inPeriod.map(eventKey)).size
+  const readDocIds = new Set(inPeriod.filter(e => e.type === 'read').map(e => e.doc_id))
+  const pagesRead = Array.from(readDocIds).reduce((sum, id) => sum + (docsById.get(id)?.total_pages || 0), 0)
+  const questions = inPeriod.filter(e => e.type === 'question').length
+  const notes = inPeriod.filter(e => e.type === 'note').length
+  return { activeDays, papersRead: readDocIds.size, pagesRead, questions, notes }
+}
+
+function deltaHtml(curr, prev, unit = '') {
+  const diff = curr - prev
+  if (diff === 0) return `<span class="rh-stat-delta">±0${unit ? ' ' + unit : ''} vs prior 30 days</span>`
+  const cls = diff > 0 ? 'up' : 'down'
+  const arrow = diff > 0 ? '↑' : '↓'
+  return `<span class="rh-stat-delta ${cls}">${arrow} ${Math.abs(diff).toLocaleString()}${unit ? ' ' + unit : ''} vs prior 30 days</span>`
+}
+
+// ── 읽기 시간 포맷/집계 헬퍼 ──────────────────────────────────
+function formatDuration(seconds) {
+  const s = Math.max(0, Math.round(seconds || 0))
+  const h = Math.floor(s / 3600)
+  const m = Math.round((s % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m`
+  return s > 0 ? `${s}s` : '0m'
+}
+function deltaDurationHtml(currSeconds, prevSeconds) {
+  const diff = Math.round(currSeconds - prevSeconds)
+  if (diff === 0) return `<span class="rh-stat-delta">±0m vs prior 30 days</span>`
+  const cls = diff > 0 ? 'up' : 'down'
+  const arrow = diff > 0 ? '↑' : '↓'
+  return `<span class="rh-stat-delta ${cls}">${arrow} ${formatDuration(Math.abs(diff))} vs prior 30 days</span>`
+}
+function sumSecondsByDayRange(byDay, startKey, endKeyExclusive) {
+  let total = 0
+  for (const [day, seconds] of Object.entries(byDay || {})) {
+    if (day >= startKey && day < endKeyExclusive) total += seconds
+  }
+  return total
+}
+
+// ── 렌더 ───────────────────────────────────────────────────
+export async function renderReadingHistoryPage() {
+  const el = document.getElementById('page-history')
+  if (!el) return
+
+  el.innerHTML = '<div class="rh-page"><div class="rh-empty">Loading reading history...</div></div>'
+
+  let events = []
+  let dashboard = null
+  let libraryDocs = []
+  let readingStats = null
+  try {
+    const [timelineRes, dashboardRes, libraryRes, readingStatsRes] = await Promise.all([
+      fetchLibraryTimeline(),
+      fetchLibraryDashboard().catch(() => null),
+      fetchLibrary().catch(() => ({ documents: [] })),
+      fetchReadingTimeStats().catch(() => null),
+    ])
+    events = timelineRes?.events || []
+    dashboard = dashboardRes
+    libraryDocs = libraryRes?.documents || []
+    readingStats = readingStatsRes
+  } catch (err) {
+    console.error('Reading History 로드 실패:', err)
+    el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">Failed to load reading history.</div></div>'
+    return
+  }
+
+  if (document.getElementById('page-history') !== el) return // 페이지 전환됨
+
+  const docsById = new Map(libraryDocs.map(d => [d.id, d]))
+  const docTitle = (docId, fallback) => {
+    const d = docsById.get(docId)
+    return (d?.metadata?.title) || d?.filename || fallback || 'Untitled'
+  }
+
+  if (events.length === 0) {
+    el.innerHTML = `
+      <div class="rh-page">
+        <div class="rh-header">
+          <div>
+            <p class="rh-header-subtitle">Track your reading activities and research journey.</p>
+          </div>
+        </div>
+        <div class="rh-card"><div class="rh-empty">No activity yet. Upload and read a paper to start building your history.</div></div>
+      </div>`
+    return
+  }
+
+  // ── 스탯 카드: 최근 30일 vs 그 이전 30일 ──
+  const tKey = todayKey()
+  const currStart = addDaysKey(tKey, -29)
+  const currEnd = addDaysKey(tKey, 1)
+  const prevStart = addDaysKey(tKey, -59)
+  const prevEnd = currStart
+  const curr = periodStats(events, docsById, currStart, currEnd)
+  const prev = periodStats(events, docsById, prevStart, prevEnd)
+  const activeDaysPct = Math.round((curr.activeDays / 30) * 100)
+
+  const totalQuestions = dashboard?.stats?.total_questions ?? events.filter(e => e.type === 'question').length
+  const totalNotes = dashboard?.stats?.total_notes ?? events.filter(e => e.type === 'note').length
+
+  const byDay = readingStats?.total_seconds_by_day || {}
+  const currReadingSeconds = sumSecondsByDayRange(byDay, currStart, currEnd)
+  const prevReadingSeconds = sumSecondsByDayRange(byDay, prevStart, prevEnd)
+
+  const statCards = [
+    {
+      icon: 'calendar', color: 'var(--rh-c1)', label: 'Days Active',
+      value: `${curr.activeDays} / 30`,
+      sub: `<span class="rh-stat-delta">${activeDaysPct}% of last 30 days</span>`,
+    },
+    {
+      icon: 'clock', color: 'var(--rh-c3)', label: 'Reading Time',
+      value: formatDuration(currReadingSeconds),
+      sub: deltaDurationHtml(currReadingSeconds, prevReadingSeconds),
+    },
+    {
+      icon: 'layers', color: 'var(--rh-c6)', label: 'Pages Read',
+      value: curr.pagesRead.toLocaleString(),
+      sub: deltaHtml(curr.pagesRead, prev.pagesRead),
+    },
+    {
+      icon: 'messageCircle', color: 'var(--rh-c5)', label: 'Questions Asked',
+      value: curr.questions.toLocaleString(),
+      sub: deltaHtml(curr.questions, prev.questions),
+    },
+    {
+      icon: 'edit3', color: 'var(--rh-c2)', label: 'Notes Created',
+      value: curr.notes.toLocaleString(),
+      sub: deltaHtml(curr.notes, prev.notes),
+    },
+  ]
+
+  // ── 캘린더 히트맵: 최근 12주(84일), 월~일 ──
+  const WEEKS = 12
+  const gridEnd = tKey
+  const gridEndDate = keyToLocalDate(gridEnd)
+  const endDow = (gridEndDate.getDay() + 6) % 7 // 0=Mon..6=Sun
+  const gridStart = addDaysKey(gridEnd, -(endDow) - (WEEKS - 1) * 7)
+  const dayCounts = countByDay(events)
+  const allActiveKeys = new Set(dayCounts.keys())
+
+  const weeks = []
+  let cursorKey = gridStart
+  let maxCountInGrid = 0
+  for (let w = 0; w < WEEKS; w++) {
+    const week = []
+    for (let d = 0; d < 7; d++) {
+      const count = dayCounts.get(cursorKey) || 0
+      const isFuture = cursorKey > gridEnd
+      if (!isFuture) maxCountInGrid = Math.max(maxCountInGrid, count)
+      week.push({ key: cursorKey, count, isFuture })
+      cursorKey = addDaysKey(cursorKey, 1)
+    }
+    weeks.push(week)
+  }
+  const bucketOf = (count) => count === 0 ? 0 : Math.min(4, Math.ceil((count / Math.max(1, maxCountInGrid)) * 4))
+
+  const monthMarkers = []
+  weeks.forEach((week, wi) => {
+    const firstOfMonthDay = week.find(d => keyToLocalDate(d.key).getDate() <= 7)
+    if (firstOfMonthDay) {
+      const label = MONTH_LABELS[keyToLocalDate(firstOfMonthDay.key).getMonth()]
+      if (!monthMarkers.length || monthMarkers[monthMarkers.length - 1].label !== label) {
+        monthMarkers.push({ col: wi + 1, label })
+      }
+    }
+  })
+
+  const calGridHtml = weeks.map(week => week.map(cell => {
+    if (cell.isFuture) return '<div class="rh-cal-cell rh-future"></div>'
+    const bucket = bucketOf(cell.count)
+    const title = `${formatShortDate(cell.key)}: ${cell.count} ${cell.count === 1 ? 'activity' : 'activities'}`
+    return `<div class="rh-cal-cell rh-heat-${bucket}" title="${escapeHtml(title)}"></div>`
+  }).join('')).join('')
+
+  const monthsHtml = (() => {
+    // 각 마커부터 다음 마커 전까지 grid-column span으로 라벨을 배치
+    let out = ''
+    for (let i = 0; i < monthMarkers.length; i++) {
+      const start = monthMarkers[i].col
+      const end = i + 1 < monthMarkers.length ? monthMarkers[i + 1].col : WEEKS + 1
+      out += `<span class="rh-cal-month-label" style="grid-column:${start} / ${end}">${escapeHtml(monthMarkers[i].label)}</span>`
+    }
+    return out
+  })()
+
+  const streaks = computeStreaks(allActiveKeys)
+  let bestDayKey = null, bestDayCount = 0
+  for (const [k, c] of dayCounts) { if (c > bestDayCount) { bestDayCount = c; bestDayKey = k } }
+
+  // ── Reading Time Distribution (part-to-whole, 전체 기간 실측치) ──
+  // 카테고리는 main.js 하트비트가 실제로 구분하는 화면 상태 3가지뿐이다:
+  // reading(뷰어에서 읽는 중) / chat(채팅 사이드바 사용 중) / compare(논문 비교).
+  const CATEGORY_LABEL = { reading: 'Paper Reading', chat: 'AI Chat', compare: 'Comparing Papers' }
+  const CATEGORY_COLOR_VAR = { reading: '--rh-c1', chat: '--rh-c2', compare: '--rh-c5' }
+  const CATEGORY_ORDER = ['reading', 'chat', 'compare']
+  const byCategory = readingStats?.total_seconds_by_category || {}
+  const mixTotalSeconds = CATEGORY_ORDER.reduce((s, c) => s + (byCategory[c] || 0), 0)
+
+  const mixBarHtml = CATEGORY_ORDER.map(c => {
+    const seconds = byCategory[c] || 0
+    const pct = mixTotalSeconds ? (seconds / mixTotalSeconds) * 100 : 0
+    if (pct <= 0) return ''
+    return `<div class="rh-mix-seg" style="width:${pct}%;background:var(${CATEGORY_COLOR_VAR[c]})" title="${escapeHtml(CATEGORY_LABEL[c])}: ${formatDuration(seconds)}"></div>`
+  }).join('')
+
+  const mixLegendHtml = CATEGORY_ORDER.map(c => {
+    const seconds = byCategory[c] || 0
+    const pct = mixTotalSeconds ? Math.round((seconds / mixTotalSeconds) * 100) : 0
+    return `
+      <div class="rh-mix-row">
+        <span class="rh-mix-dot" style="background:var(${CATEGORY_COLOR_VAR[c]})"></span>
+        <span class="rh-mix-label">${escapeHtml(CATEGORY_LABEL[c])}</span>
+        <span class="rh-mix-count">${formatDuration(seconds)}</span>
+        <span class="rh-mix-pct">${pct}%</span>
+      </div>`
+  }).join('')
+
+  // ── Top Papers by Reading Time (전체 기간 실측 초 합계 기준) ──
+  const byDoc = readingStats?.total_seconds_by_doc || {}
+  const topPapers = Object.entries(byDoc)
+    .map(([docId, seconds]) => ({ doc_id: docId, seconds }))
+    .sort((a, b) => b.seconds - a.seconds)
+    .slice(0, 5)
+  const topMaxSeconds = topPapers.length ? topPapers[0].seconds : 1
+
+  const topPapersHtml = topPapers.length ? topPapers.map((p, i) => {
+    const title = docTitle(p.doc_id)
+    const widthPct = Math.max(6, Math.round((p.seconds / topMaxSeconds) * 100))
+    return `
+      <div class="rh-top-row" data-doc-id="${escapeHtml(p.doc_id || '')}">
+        <span class="rh-top-rank">${i + 1}</span>
+        <div class="rh-top-body">
+          <div class="rh-top-title">${escapeHtml(title)}</div>
+          <div class="rh-top-track"><div class="rh-top-fill" style="width:${widthPct}%"></div></div>
+        </div>
+        <span class="rh-top-value">${formatDuration(p.seconds)}</span>
+      </div>`
+  }).join('') : '<div class="rh-empty">아직 기록된 읽기 시간이 없습니다. 뷰어에서 논문을 열어 읽으면 자동으로 쌓입니다.</div>'
+
+  // ── Reading Streak 위젯: 이번 주(월~일) ──
+  const weekStartOffset = (keyToLocalDate(tKey).getDay() + 6) % 7
+  const weekStartKey = addDaysKey(tKey, -weekStartOffset)
+  const weekDayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+  const streakWeekHtml = weekDayLabels.map((label, i) => {
+    const k = addDaysKey(weekStartKey, i)
+    const isFuture = k > tKey
+    const isToday = k === tKey
+    const isActive = allActiveKeys.has(k)
+    const cls = ['rh-streak-day']
+    if (isActive) cls.push('active')
+    if (isFuture) cls.push('future')
+    if (isToday) cls.push('today')
+    return `<span class="${cls.join(' ')}" title="${escapeHtml(formatShortDate(k))}">${label}</span>`
+  }).join('')
+
+  // ── HTML 조립 ──
+  el.innerHTML = `
+    <div class="rh-page">
+      <div class="rh-header">
+        <div>
+          <p class="rh-header-subtitle">Track your reading activities and research journey.</p>
+        </div>
+        <span class="rh-header-period">${icon('calendar', 13)} Last 30 days</span>
+      </div>
+
+      <div class="rh-stat-grid">
+        ${statCards.map(c => `
+          <div class="rh-stat-card">
+            <div class="rh-stat-icon" style="--rh-stat-color:${c.color}">${icon(c.icon, 17)}</div>
+            <div class="rh-stat-body">
+              <div class="rh-stat-label">${escapeHtml(c.label)}</div>
+              <div class="rh-stat-value">${c.value}</div>
+              <div>${c.sub}</div>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+
+      <div class="rh-columns">
+        <div class="rh-col">
+          <div class="rh-card">
+            <div class="rh-card-head">
+              <span class="rh-card-title">${icon('calendar', 15)} Reading Activity</span>
+              <div class="rh-cal-legend">
+                Less
+                <span class="rh-cal-legend-swatch rh-heat-0" style="background:color-mix(in srgb, var(--accent-mid) 6%, var(--bg-elevated))"></span>
+                <span class="rh-cal-legend-swatch rh-heat-1" style="background:color-mix(in srgb, var(--accent-mid) 28%, var(--bg-elevated))"></span>
+                <span class="rh-cal-legend-swatch rh-heat-2" style="background:color-mix(in srgb, var(--accent-mid) 50%, var(--bg-elevated))"></span>
+                <span class="rh-cal-legend-swatch rh-heat-3" style="background:color-mix(in srgb, var(--accent-mid) 72%, var(--bg-elevated))"></span>
+                <span class="rh-cal-legend-swatch rh-heat-4" style="background:var(--accent-mid)"></span>
+                More
+              </div>
+            </div>
+            <div class="rh-cal-scroll">
+              <div class="rh-cal">
+                <div class="rh-cal-months">${monthsHtml}</div>
+                <div class="rh-cal-body">
+                  <div class="rh-cal-weekday-labels">${WEEKDAY_LABELS.map(l => `<span>${l}</span>`).join('')}</div>
+                  <div class="rh-cal-grid">${calGridHtml}</div>
+                </div>
+              </div>
+            </div>
+            <div class="rh-cal-footer">
+              <span>${formatShortDate(gridStart)} &ndash; ${formatShortDate(gridEnd)}</span>
+              <span>Total <b>${allActiveKeys.size}</b> active days &bull; Longest streak <b>${streaks.longest}</b> days</span>
+            </div>
+          </div>
+
+          <div class="rh-card">
+            <div class="rh-card-head">
+              <span class="rh-card-title">${icon('list', 15)} All Activities</span>
+            </div>
+            <div class="rh-tabs" id="rh-filter-tabs">
+              <button type="button" class="rh-tab-btn active" data-type="all">All Activities</button>
+              ${TYPE_ORDER.map(t => `<button type="button" class="rh-tab-btn" data-type="${t}">${escapeHtml(TYPE_LABEL[t])}</button>`).join('')}
+            </div>
+            <div id="rh-timeline-list"></div>
+            <button type="button" class="rh-more-btn hidden" id="rh-more-btn">${icon('chevronDown', 14)} Show more activities</button>
+          </div>
+        </div>
+
+        <div class="rh-col">
+          <div class="rh-card">
+            <div class="rh-card-head">
+              <span class="rh-card-title">${icon('grid', 15)} Reading Time Distribution</span>
+              <span class="rh-card-sub">뷰어/비교 화면 실측 시간</span>
+            </div>
+            ${mixTotalSeconds > 0 ? `
+              <div class="rh-mix-total">All-time total: <b>${formatDuration(mixTotalSeconds)}</b></div>
+              <div class="rh-mix-bar">${mixBarHtml}</div>
+              <div class="rh-mix-legend">${mixLegendHtml}</div>
+            ` : `<div class="rh-empty">아직 기록된 읽기 시간이 없습니다.</div>`}
+          </div>
+
+          <div class="rh-card">
+            <div class="rh-card-head">
+              <span class="rh-card-title">${icon('award', 15)} Top Papers by Reading Time</span>
+            </div>
+            <div class="rh-top-list">${topPapersHtml}</div>
+          </div>
+
+          <div class="rh-card">
+            <div class="rh-card-head">
+              <span class="rh-card-title">${icon('zap', 15)} Reading Streak</span>
+            </div>
+            <div class="rh-streak-value">
+              <span class="rh-streak-num">${streaks.current}</span>
+              <span class="rh-streak-unit">day${streaks.current === 1 ? '' : 's'}</span>
+            </div>
+            <div class="rh-streak-week">${streakWeekHtml}</div>
+            <div class="rh-streak-msg">${streaks.current > 0 ? 'Keep it up!' : 'Read a paper today to start a streak.'}</div>
+          </div>
+
+          <div class="rh-callout-row">
+            <div class="rh-callout">
+              <div class="rh-callout-icon" style="--rh-callout-color:var(--rh-c4)">${icon('award', 16)}</div>
+              <div class="rh-callout-body">
+                <div class="rh-callout-label">Most Active Day</div>
+                <div class="rh-callout-value">${bestDayCount ? `${bestDayCount} activities` : '&mdash;'}</div>
+                <div class="rh-callout-sub">${bestDayKey ? formatShortDate(bestDayKey) : 'No activity yet'}</div>
+              </div>
+            </div>
+            <div class="rh-callout">
+              <div class="rh-callout-icon" style="--rh-callout-color:var(--success)">${icon('checkCircle', 16)}</div>
+              <div class="rh-callout-body">
+                <div class="rh-callout-label">Longest Streak</div>
+                <div class="rh-callout-value">${streaks.longest} day${streaks.longest === 1 ? '' : 's'}</div>
+                <div class="rh-callout-sub">${streaks.longestStart ? `${formatShortDate(streaks.longestStart)} &ndash; ${formatShortDate(streaks.longestEnd)}` : 'No activity yet'}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+
+  // ── All Activities: 필터 + 더보기 상태 ──
+  const sortedEvents = events.slice().sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
+  const groupByDay = (list) => {
+    const groups = new Map()
+    for (const e of list) {
+      const k = eventKey(e)
+      if (!groups.has(k)) groups.set(k, [])
+      groups.get(k).push(e)
+    }
+    return Array.from(groups.entries()).sort((a, b) => b[0].localeCompare(a[0]))
+  }
+
+  const INITIAL_GROUPS = 4
+  let activeType = 'all'
+  let visibleGroups = INITIAL_GROUPS
+
+  const timelineListEl = el.querySelector('#rh-timeline-list')
+  const moreBtn = el.querySelector('#rh-more-btn')
+
+  function renderTimeline() {
+    const filtered = activeType === 'all' ? sortedEvents : sortedEvents.filter(e => e.type === activeType)
+    if (filtered.length === 0) {
+      timelineListEl.innerHTML = '<div class="rh-empty">No activities of this type yet.</div>'
+      moreBtn.classList.add('hidden')
+      return
+    }
+    const dayGroups = groupByDay(filtered)
+    const shown = dayGroups.slice(0, visibleGroups)
+    timelineListEl.innerHTML = `<div class="rh-timeline">${shown.map(([dateKey, dayEvents]) => {
+      const { primary, secondary } = formatDayLabel(dateKey)
+      return `
+        <div class="rh-timeline-day">
+          <div class="rh-timeline-day-header">
+            <span class="rh-timeline-day-date">${escapeHtml(primary)}</span>
+            <span class="rh-timeline-day-weekday">${escapeHtml(secondary)}</span>
+          </div>
+          <div class="rh-timeline-track">
+            ${dayEvents.map(e => {
+              const title = docTitle(e.doc_id, e.doc_title)
+              const pages = e.type === 'read' ? docsById.get(e.doc_id)?.total_pages : null
+              return `
+                <div class="rh-timeline-entry" data-doc-id="${escapeHtml(e.doc_id || '')}" data-type="${escapeHtml(e.type)}" title="Open this paper">
+                  <div class="rh-timeline-dot">${icon(TYPE_ICON[e.type] || 'clock', 13)}</div>
+                  <div class="rh-timeline-row">
+                    <span class="rh-timeline-time">${escapeHtml(formatTime(e.timestamp))}</span>
+                    <span class="rh-timeline-type">${escapeHtml(TYPE_LABEL[e.type] || e.type)}</span>
+                    <div class="rh-timeline-main">
+                      <div class="rh-timeline-title">${escapeHtml(title)}</div>
+                      ${e.summary ? `<div class="rh-timeline-summary">${escapeHtml(e.summary)}</div>` : ''}
+                    </div>
+                    ${pages ? `<span class="rh-timeline-meta">${pages} pages</span>` : ''}
+                  </div>
+                </div>`
+            }).join('')}
+          </div>
+        </div>`
+    }).join('')}</div>`
+
+    moreBtn.classList.toggle('hidden', shown.length >= dayGroups.length)
+  }
+
+  const tabsEl = el.querySelector('#rh-filter-tabs')
+  tabsEl.addEventListener('click', (event) => {
+    const btn = event.target.closest('.rh-tab-btn')
+    if (!btn) return
+    tabsEl.querySelectorAll('.rh-tab-btn').forEach(b => b.classList.toggle('active', b === btn))
+    activeType = btn.dataset.type
+    visibleGroups = INITIAL_GROUPS
+    renderTimeline()
+  })
+
+  moreBtn.addEventListener('click', () => {
+    visibleGroups += 6
+    renderTimeline()
+  })
+
+  const openDoc = (docId, type) => {
+    if (!docId) return
+    location.hash = 'viewer?id=' + encodeURIComponent(docId) + (type === 'question' ? '&chat=1' : '')
+  }
+
+  timelineListEl.addEventListener('click', (event) => {
+    const entry = event.target.closest('.rh-timeline-entry')
+    if (!entry) return
+    openDoc(entry.dataset.docId, entry.dataset.type)
+  })
+
+  el.querySelector('.rh-top-list')?.addEventListener('click', (event) => {
+    const row = event.target.closest('.rh-top-row')
+    if (!row) return
+    openDoc(row.dataset.docId)
+  })
+
+  renderTimeline()
+}

--- a/frontend/src/styles/ai-chats.css
+++ b/frontend/src/styles/ai-chats.css
@@ -1,0 +1,429 @@
+/* ============================================================
+   AI Chats 페이지 — 논문별 AI 채팅 세션 목록
+   기존 디자인 토큰(--bg-*, --accent-*, --border-*, --radius-*, --shadow-*, --text-*)만
+   사용하며 색상을 하드코딩하지 않는다 (라이트/다크 테마 자동 대응).
+   ============================================================ */
+
+.aic-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── 헤더 ── */
+.aic-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.aic-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+}
+.aic-subtitle {
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+.aic-search-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.aic-search-icon {
+  position: absolute;
+  left: 12px;
+  color: var(--text-muted);
+  display: flex;
+  pointer-events: none;
+}
+.aic-search-box input {
+  width: 280px;
+  max-width: 100%;
+  padding: 9px 12px 9px 34px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.aic-search-box input:focus {
+  border-color: var(--control-accent);
+  box-shadow: 0 0 0 3px var(--control-accent-soft);
+}
+.aic-search-box input::placeholder { color: var(--text-muted); }
+
+/* ── 컨트롤 바 (탭 필터 + 정렬 + 보기 전환) ── */
+.aic-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.aic-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.aic-tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+.aic-tab-btn:hover { color: var(--text-primary); }
+.aic-tab-btn.active {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.aic-tab-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+.aic-tab-btn.active .aic-tab-count { color: var(--control-accent-text); opacity: 0.85; }
+
+.aic-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.aic-sort-wrap { position: relative; }
+.aic-sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+.aic-sort-btn:hover { color: var(--text-primary); border-color: var(--control-accent); }
+.aic-sort-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 170px;
+  padding: 6px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+}
+.aic-sort-menu.hidden { display: none; }
+.aic-sort-option {
+  display: block;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.aic-sort-option:hover { background: var(--bg-hover); color: var(--text-primary); }
+.aic-sort-option.active { color: var(--control-accent-text); font-weight: 600; background: var(--control-accent-soft); }
+
+.aic-view-toggle {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+.aic-view-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.aic-view-btn + .aic-view-btn { border-left: 1px solid var(--border-strong); }
+.aic-view-btn:hover { color: var(--text-primary); }
+.aic-view-btn.active { background: var(--control-accent-soft); color: var(--control-accent-text); }
+
+/* ── 본문 영역 ── */
+.aic-body { min-height: 240px; }
+
+/* 표 보기 */
+.aic-table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+.aic-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.aic-table thead th {
+  text-align: left;
+  padding: 12px 20px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  white-space: nowrap;
+}
+.aic-table tbody tr {
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s ease;
+}
+.aic-table tbody tr:last-child { border-bottom: none; }
+.aic-table tbody tr:hover { background: var(--bg-hover); }
+.aic-table td {
+  padding: 14px 20px;
+  vertical-align: middle;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.aic-col-paper { width: 34%; }
+.aic-col-message { width: 32%; color: var(--text-secondary); }
+.aic-col-updated { width: 14%; white-space: nowrap; color: var(--text-tertiary); }
+.aic-col-actions { width: 20%; }
+
+.aic-paper-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.aic-paper-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-sm);
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.aic-paper-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.aic-preview {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aic-preview-loading { color: var(--text-muted); font-style: italic; }
+.aic-preview-empty { color: var(--text-muted); }
+
+.aic-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.aic-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.aic-action-btn:hover { color: var(--text-primary); border-color: var(--control-accent); }
+.aic-action-btn.aic-action-primary {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  border-color: transparent;
+}
+.aic-action-btn.aic-action-primary:hover { box-shadow: 0 0 0 3px var(--control-accent-soft); }
+
+/* 카드 보기 */
+.aic-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+.aic-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.aic-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+.aic-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.aic-card-updated { font-size: 11.5px; color: var(--text-muted); white-space: nowrap; }
+.aic-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.35;
+  min-height: 2.7em;
+}
+.aic-card-preview {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aic-card-actions { margin-top: 4px; }
+.aic-card-actions .aic-action-btn { flex: 1 1 auto; justify-content: center; }
+
+/* ── 상태 (로딩 / 에러 / 빈 목록) ── */
+.aic-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 70px 20px;
+  text-align: center;
+  color: var(--text-secondary);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+}
+.aic-state p { margin: 0; font-size: 13.5px; }
+.aic-state-sub { color: var(--text-muted); font-size: 12.5px !important; }
+.aic-state-icon { color: var(--text-muted); display: flex; margin-bottom: 4px; }
+.aic-state-error p { color: var(--error); }
+.aic-retry-btn {
+  margin-top: 6px;
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+.aic-retry-btn:hover { border-color: var(--control-accent); }
+
+.aic-spinner {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2.5px solid var(--border-strong);
+  border-top-color: var(--control-accent);
+  animation: aic-spin 0.7s linear infinite;
+  margin-bottom: 6px;
+}
+@keyframes aic-spin { to { transform: rotate(360deg); } }
+
+/* ── 페이지네이션 ── */
+.aic-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.aic-page-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.aic-page-btn:hover:not(:disabled) { color: var(--text-primary); border-color: var(--control-accent); }
+.aic-page-btn.active {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  border-color: transparent;
+}
+.aic-page-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.aic-page-nav { font-size: 15px; }
+.aic-page-ellipsis {
+  color: var(--text-muted);
+  padding: 0 4px;
+  font-size: 12.5px;
+}
+
+/* ── 반응형 ── */
+@media (max-width: 860px) {
+  .aic-search-box input { width: 100%; }
+  .aic-controls { flex-direction: column; align-items: stretch; }
+  .aic-controls-right { justify-content: space-between; }
+  .aic-table thead { display: none; }
+  .aic-table, .aic-table tbody, .aic-table tr, .aic-table td { display: block; width: 100% !important; }
+  .aic-table tr { padding: 14px 16px; }
+  .aic-table td { padding: 4px 0; border: none; }
+  .aic-col-actions { margin-top: 8px; }
+}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1,0 +1,417 @@
+/* ── 대시보드 페이지 (Research Workspace) ──────────────────────────────
+   Apple HIG / Linear / Vercel / Notion 느낌의 여백 있고 절제된 카드형
+   레이아웃. 모든 색상은 기존 style.css의 디자인 토큰(var(--...))만
+   사용해 라이트/다크 테마 전환에 자동으로 대응한다. */
+
+.dash-root {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.dash-loading,
+.dash-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 96px 20px;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.dash-error svg { color: var(--error); }
+.dash-loading svg { animation: dash-spin 1s linear infinite; }
+@keyframes dash-spin { to { transform: rotate(360deg); } }
+
+/* ── 통계 카드 그리드 ── */
+.dash-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.dash-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 18px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.2s ease;
+}
+.dash-stat-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-glow, var(--border-strong));
+}
+
+.dash-stat-top { display: flex; align-items: center; gap: 12px; }
+
+.dash-stat-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.dash-tint-1 { background: color-mix(in srgb, var(--accent-mid) 16%, transparent); color: var(--accent-mid); }
+.dash-tint-2 { background: color-mix(in srgb, var(--success) 16%, transparent); color: var(--success); }
+.dash-tint-3 { background: color-mix(in srgb, var(--control-accent) 18%, transparent); color: var(--control-accent-text); }
+.dash-tint-4 { background: color-mix(in srgb, var(--warning) 16%, transparent); color: var(--warning); }
+.dash-tint-5 { background: color-mix(in srgb, var(--error) 14%, transparent); color: var(--error); }
+.dash-tint-6 { background: color-mix(in srgb, var(--accent-to) 20%, transparent); color: var(--accent-to); }
+
+.dash-stat-textwrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.dash-stat-label { font-size: 12.5px; font-weight: 600; color: var(--text-tertiary); }
+.dash-stat-value {
+  font-family: var(--font-mono);
+  font-size: 23px;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.dash-stat-delta {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.dash-stat-delta.is-up { color: var(--success); }
+
+/* ── 공용 카드 ── */
+.dash-row { display: grid; gap: 16px; }
+.dash-row-3 { grid-template-columns: 1.15fr 1fr 1fr; }
+.dash-row-recent { grid-template-columns: 1.2fr 1fr 0.95fr; }
+.dash-row-bottom { grid-template-columns: 1.3fr 1fr 1fr; }
+
+@media (max-width: 1180px) {
+  .dash-row-3, .dash-row-recent, .dash-row-bottom { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 760px) {
+  .dash-row-3, .dash-row-recent, .dash-row-bottom { grid-template-columns: 1fr; }
+  .dash-stat-grid { grid-template-columns: repeat(auto-fit, minmax(135px, 1fr)); }
+}
+
+.dash-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 18px 18px 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.dash-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.dash-card-head h3 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.dash-card-head h3 svg { color: var(--control-accent-text); flex-shrink: 0; }
+
+.dash-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--control-accent-text);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.dash-link:hover { text-decoration: underline; }
+
+.dash-card-tag {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  padding: 3px 9px;
+  border-radius: 100px;
+}
+.dash-card-tag-inline { align-self: flex-start; margin: -6px 0 12px; }
+
+.dash-empty-note { margin: 0; font-size: 12px; color: var(--text-tertiary); line-height: 1.55; }
+.dash-error-note { color: var(--error); }
+
+/* ── AI 인사이트 ── */
+.dash-insight-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.dash-insight-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 10px 12px;
+  background: var(--control-accent-soft);
+  border-radius: var(--radius-md);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.dash-insight-icon { color: var(--control-accent-text); flex-shrink: 0; margin-top: 1px; display: flex; }
+
+/* ── 이번 주 활동 / 진행률 바 (여기 트랙은 최근 읽은 논문 카드와도 공유) ── */
+.dash-activity-list { display: flex; flex-direction: column; gap: 15px; }
+.dash-activity-row { display: flex; flex-direction: column; gap: 7px; }
+.dash-activity-top { display: flex; align-items: center; justify-content: space-between; }
+.dash-activity-label { display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--text-secondary); }
+.dash-activity-value { font-family: var(--font-mono); font-size: 11.5px; font-weight: 700; color: var(--text-primary); }
+
+.dash-activity-track { flex: 1 1 auto; height: 7px; border-radius: 5px; background: var(--border-strong); overflow: hidden; }
+.dash-activity-track.small { height: 5px; }
+.dash-activity-fill {
+  height: 100%;
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── 연구 진행 요약 ── */
+.dash-summary-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.dash-summary-box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 13px 8px;
+  text-align: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.dash-summary-value { font-family: var(--font-mono); font-size: 19px; font-weight: 800; color: var(--text-primary); }
+.dash-summary-value-text { font-family: var(--font-body); font-size: 13.5px; word-break: keep-all; }
+.dash-summary-unit { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-left: 2px; }
+.dash-summary-label { font-size: 10.5px; font-weight: 600; color: var(--text-tertiary); }
+
+/* ── 최근 읽은 논문 ── */
+.dash-paper-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.dash-paper-item {
+  display: flex;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+.dash-paper-item:last-child { border-bottom: none; padding-bottom: 0; }
+.dash-paper-item:hover { transform: translateX(2px); }
+.dash-paper-cover {
+  width: 38px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+.dash-paper-info { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 7px; }
+.dash-paper-title {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.dash-paper-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.dash-paper-time { flex-shrink: 0; }
+.dash-paper-progress-row { display: flex; align-items: center; gap: 8px; }
+.dash-paper-pct { flex-shrink: 0; font-size: 10.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+/* ── 최근 질문 ── */
+.dash-question-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.dash-question-item { display: flex; gap: 10px; cursor: pointer; }
+.dash-question-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.dash-question-body { flex: 1 1 auto; min-width: 0; }
+.dash-question-text {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.dash-question-meta { margin-top: 4px; font-size: 11px; color: var(--text-tertiary); }
+.dash-dot { margin: 0 5px; }
+
+/* ── AI 추천 논문 ── */
+.dash-recs-body { display: flex; flex-direction: column; }
+.dash-recs-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.dash-recs-btn:hover { background: var(--bg-hover); }
+.dash-recs-btn:disabled { opacity: 0.6; cursor: default; }
+
+.dash-rec-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.dash-rec-item { padding-bottom: 12px; border-bottom: 1px solid var(--border); }
+.dash-rec-item:last-child { border-bottom: none; padding-bottom: 0; }
+.dash-rec-title { font-size: 12.5px; font-weight: 700; color: var(--text-primary); text-decoration: none; line-height: 1.4; }
+.dash-rec-title:hover { color: var(--control-accent-text); }
+.dash-rec-year { margin-left: 6px; font-size: 11px; color: var(--text-muted); }
+.dash-rec-reason { margin-top: 4px; font-size: 11.5px; color: var(--text-secondary); line-height: 1.45; }
+
+/* ── 개념 히트맵 ── */
+.dash-heat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.dash-heat-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 10px 9px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.dash-heat-cell:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.dash-heat-swatch {
+  height: 8px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent-mid) var(--heat-pct, 6%), var(--bg-elevated));
+}
+.dash-heat-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dash-heat-count { font-family: var(--font-mono); font-size: 14.5px; font-weight: 700; color: var(--text-secondary); }
+
+.dash-heat-legend { display: flex; align-items: center; gap: 8px; font-size: 11px; color: var(--text-muted); }
+.dash-heat-legend-bar {
+  width: 100px;
+  height: 7px;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--accent-mid) 6%, var(--bg-elevated)),
+    var(--accent-mid));
+}
+
+/* ── 연구 타임라인 ── */
+.dash-timeline-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+.dash-timeline-item { position: relative; display: flex; gap: 10px; padding-bottom: 14px; }
+.dash-timeline-item:last-child { padding-bottom: 0; }
+.dash-timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 13px;
+  bottom: -2px;
+  width: 1px;
+  background: var(--border);
+}
+.dash-timeline-item:last-child::before { display: none; }
+.dash-timeline-dot {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  width: 9px;
+  height: 9px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: var(--control-accent);
+}
+.dash-timeline-uploaded .dash-timeline-dot { background: var(--accent-mid); }
+.dash-timeline-read .dash-timeline-dot { background: var(--success); }
+.dash-timeline-question .dash-timeline-dot { background: var(--warning); }
+.dash-timeline-note .dash-timeline-dot { background: var(--control-accent-text); }
+.dash-timeline-body { flex: 1 1 auto; min-width: 0; }
+.dash-timeline-top { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+.dash-timeline-type { font-size: 10.5px; font-weight: 700; color: var(--text-tertiary); letter-spacing: 0.02em; }
+.dash-timeline-time { margin-left: auto; font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.dash-timeline-title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); line-height: 1.4; }
+.dash-timeline-summary { margin-top: 2px; font-size: 11.5px; color: var(--text-secondary); line-height: 1.4; }
+
+/* ── 연구 그래프 미리보기 ── */
+.dash-card-graph { align-items: stretch; }
+.dash-graph-svg { width: 100%; height: 168px; }
+.dash-graph-edge { stroke: var(--border-strong); stroke-width: 1.2; }
+.dash-graph-node circle {
+  fill: var(--bg-panel);
+  stroke: var(--border-strong);
+  stroke-width: 1.5;
+}
+.dash-graph-node.is-center circle { fill: var(--accent-mid); stroke: var(--accent-to); stroke-width: 2; }
+.dash-graph-node.is-paper circle { fill: color-mix(in srgb, var(--success) 32%, var(--bg-panel)); stroke: var(--success); }
+.dash-graph-node.is-concept circle { fill: color-mix(in srgb, var(--control-accent) 38%, var(--bg-panel)); stroke: var(--control-accent-text); }
+.dash-graph-node text { font-size: 8.5px; fill: var(--text-tertiary); }
+.dash-graph-center-label { font-size: 9.5px; font-weight: 700; fill: var(--text-primary); }
+
+.dash-graph-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.dash-legend-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: 5px;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+.dash-legend-dot.is-center { background: var(--accent-mid); }
+.dash-legend-dot.is-paper { background: var(--success); }
+.dash-legend-dot.is-concept { background: var(--control-accent-text); }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -1,0 +1,512 @@
+/* ============================================================
+   Library Page — 재설계된 라이브러리 화면 전용 스타일
+   (상태 필터 탭 / 정렬 드롭다운 / 카드 커버 썸네일+즐겨찾기 / 우측 상세 패널)
+
+   기존 style.css의 .doc-card* 클래스(다른 화면과 공유)는 건드리지 않고, 여기서는
+   이 파일에서만 쓰는 새 클래스로 덧붙여 확장한다. 색상은 전부 기존 디자인 토큰
+   (var(--...))만 사용해 라이트/다크 테마를 자동으로 따라간다.
+   ============================================================ */
+
+/* ── 라이브러리 헤더 부제목 ── */
+.library-header-subtitle {
+  margin: 3px 0 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+/* ── 상태 필터 탭 (전체 / 읽지 않음 / 읽는 중 / 완료 / 즐겨찾기) ── */
+.lib-status-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: fit-content;
+  flex-wrap: wrap;
+}
+.lib-status-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+.lib-status-tab:hover { color: var(--text-primary); background: var(--bg-hover); }
+.lib-status-tab.active {
+  background: var(--bg-surface);
+  color: var(--control-accent-text);
+  box-shadow: var(--shadow-sm);
+}
+.lib-status-tab-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  border-radius: 100px;
+  padding: 1px 6px;
+  min-width: 18px;
+  text-align: center;
+}
+.lib-status-tab.active .lib-status-tab-count {
+  color: var(--control-accent-text);
+  background: var(--control-accent-soft);
+}
+
+/* ── 정렬 드롭다운 ── */
+.lib-sort-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.lib-sort-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 7px 28px 7px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.lib-sort-select:hover, .lib-sort-select:focus { border-color: var(--control-accent); }
+.lib-sort-dropdown-icon {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--text-muted);
+  display: flex;
+}
+
+/* ── 카드: 커버 썸네일 + 제목 2열 배치 ── */
+.lib-card-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.lib-card-thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: 52px;
+  height: 68px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+}
+.lib-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.lib-card-thumb-fallback {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  background: linear-gradient(160deg, var(--bg-elevated), var(--bg-hover));
+}
+.lib-card-thumb.cover-fallback img { display: none; }
+.lib-card-thumb.cover-fallback .lib-card-thumb-fallback { display: flex; }
+
+.lib-card-top-body {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+.lib-card-top-body .doc-card-title { padding-right: 28px; }
+
+/* 즐겨찾기 배지 - 카드 썸네일 오른쪽 위 모서리에 겹쳐 배치해 기존
+   읽음 체크/미리보기 아이콘(카드 우상단, .doc-card-zone-actions)과
+   시각적으로 겹치지 않게 한다. */
+.doc-card-fav-btn {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  z-index: 3;
+  padding: 0;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.doc-card-fav-btn:hover { color: var(--warning); border-color: var(--warning); transform: scale(1.08); }
+.doc-card-fav-btn.active { color: var(--warning); border-color: var(--warning); }
+.doc-card-fav-btn.active svg { fill: var(--warning); }
+
+/* ── 카드: 전체 너비 진행률 바 (기존 .doc-card-progress-row는 리스트 뷰의
+   압축된 형태로 그대로 남겨두고, 카드 뷰는 이 새 클래스로 별도 렌더링한다) ── */
+.lib-card-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.lib-card-progress-bar-wrap {
+  flex: 1;
+  height: 5px;
+  border-radius: 4px;
+  background: var(--border);
+  overflow: hidden;
+}
+.lib-card-progress-bar {
+  height: 100%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.lib-card-progress-pct {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-mid);
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   상세 패널 (우측 드로어) — 카드를 클릭하면 열리며, 표지/제목/저자,
+   "논문 열기" 버튼, 개요(AI 요약+기본 정보+태그)/메모/AI 대화/관련 자료 탭을 보여준다.
+   ============================================================ */
+.lib-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.32);
+  z-index: 45;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.lib-detail-overlay.open { opacity: 1; pointer-events: auto; }
+
+.lib-detail-panel {
+  position: fixed;
+  top: var(--topbar-h);
+  right: 0;
+  bottom: 0;
+  width: 420px;
+  max-width: 94vw;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  z-index: 46;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.lib-detail-panel.open { transform: translateX(0); }
+
+.lib-detail-close-btn {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: all 0.15s ease;
+}
+.lib-detail-close-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+.lib-detail-hero {
+  display: flex;
+  gap: 14px;
+  padding: 26px 50px 18px 24px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+}
+.lib-detail-cover {
+  position: relative;
+  flex-shrink: 0;
+  width: 72px;
+  height: 96px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+}
+.lib-detail-cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.lib-detail-cover-fallback {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  background: linear-gradient(160deg, var(--bg-elevated), var(--bg-hover));
+}
+.lib-detail-cover.cover-fallback img { display: none; }
+.lib-detail-cover.cover-fallback .lib-detail-cover-fallback { display: flex; }
+
+.lib-detail-title-block {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 2px;
+}
+.lib-detail-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-primary);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.lib-detail-title-input {
+  width: 100%;
+  font-size: 15px;
+  font-weight: 700;
+  padding: 5px 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--control-accent);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  outline: none;
+  font-family: var(--font-body);
+}
+.lib-detail-subtitle {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+
+.lib-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  position: relative;
+}
+.lib-detail-open-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--control-accent);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+.lib-detail-open-btn:hover { filter: brightness(1.08); }
+.lib-detail-open-btn:active { transform: scale(0.98); }
+
+.lib-detail-icon-btn {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.lib-detail-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.lib-detail-icon-btn.active { color: var(--warning); border-color: var(--warning); }
+.lib-detail-icon-btn.active svg { fill: var(--warning); }
+
+.lib-detail-more-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 24px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 6px;
+  min-width: 200px;
+  z-index: 5;
+}
+.lib-detail-more-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.lib-detail-more-item:hover { background: var(--bg-hover); }
+.lib-detail-more-item.danger { color: var(--error); }
+.lib-detail-more-item.danger:hover { background: color-mix(in srgb, var(--error) 12%, transparent); }
+
+.lib-detail-tabs {
+  display: flex;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  overflow-x: auto;
+}
+.lib-detail-tab {
+  padding: 12px 4px;
+  margin-right: 18px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  transition: color 0.15s ease;
+}
+.lib-detail-tab:hover { color: var(--text-primary); }
+.lib-detail-tab.active { color: var(--control-accent-text); border-bottom-color: var(--control-accent); }
+.lib-detail-tab-count {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  border-radius: 100px;
+  padding: 1px 6px;
+}
+.lib-detail-tab.active .lib-detail-tab-count { color: var(--control-accent-text); background: var(--control-accent-soft); }
+
+.lib-detail-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px 24px 32px;
+}
+.lib-detail-panel-section h3 {
+  margin: 0 0 8px;
+  font-size: 11.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.lib-detail-summary-block,
+.lib-detail-quickinfo-block,
+.lib-detail-tags-block { margin-bottom: 24px; }
+
+.lib-detail-summary-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-height: 132px;
+  overflow: hidden;
+  position: relative;
+}
+.lib-detail-summary-text.expanded { max-height: none; }
+.lib-detail-summary-loading,
+.lib-detail-summary-error { margin: 0; font-size: 12.5px; color: var(--text-tertiary); }
+.lib-detail-summary-error { color: var(--error); }
+.lib-detail-summary-more-btn {
+  margin-top: 8px;
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--control-accent-text);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.lib-detail-quickinfo {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 9px 12px;
+  margin: 0;
+}
+.lib-detail-quickinfo dt { font-size: 12px; color: var(--text-tertiary); font-weight: 600; }
+.lib-detail-quickinfo dd { margin: 0; font-size: 12.5px; color: var(--text-primary); font-weight: 600; }
+
+.lib-detail-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.lib-detail-tag {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 100px;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+
+.lib-detail-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.lib-detail-list-item:hover { background: var(--bg-hover); border-color: var(--border-strong); }
+.lib-detail-list-item-meta { font-size: 11px; color: var(--text-tertiary); font-weight: 600; }
+.lib-detail-list-item-text { font-size: 12.5px; color: var(--text-primary); line-height: 1.4; }
+.lib-detail-empty { font-size: 12.5px; color: var(--text-tertiary); padding: 4px 0; }
+
+@media (max-width: 640px) {
+  .lib-detail-panel { width: 100vw; max-width: 100vw; }
+}

--- a/frontend/src/styles/notes.css
+++ b/frontend/src/styles/notes.css
@@ -1,0 +1,427 @@
+/* ============================================================
+   Notes 페이지 — 논문별 메모 / 하이라이트 / 언더라인 읽기 전용 뷰어
+   좌: 논문 목록, 우: 선택한 논문의 주석 목록(서브탭). 색/간격/모서리는
+   전부 앱 전역 디자인 토큰(--bg-*, --text-*, --border*, --radius-*,
+   --control-accent* 등)을 그대로 재사용해 라이트/다크 테마에 자동 대응한다.
+   ============================================================ */
+
+.notes-page-inner {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+}
+
+.notes-page-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+.notes-layout {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  gap: 20px;
+}
+
+/* ── 좌측: 논문 목록 ── */
+.notes-sidebar {
+  flex: 0 0 320px;
+  width: 320px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.notes-sidebar-header {
+  flex-shrink: 0;
+  padding: 16px 16px 4px;
+}
+.notes-sidebar-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.notes-search-box {
+  flex-shrink: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 12px 16px;
+  color: var(--text-muted);
+}
+.notes-search-box svg { position: absolute; left: 10px; pointer-events: none; }
+.notes-search-input {
+  width: 100%;
+  padding: 8px 10px 8px 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.notes-search-input:focus { border-color: var(--control-accent); }
+.notes-search-input::placeholder { color: var(--text-muted); }
+
+.notes-filter-tabs {
+  flex-shrink: 0;
+  display: flex;
+  gap: 6px;
+  padding: 0 16px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.notes-filter-tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.notes-filter-tab-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.notes-filter-tab-btn.active { background: var(--control-accent-soft); color: var(--control-accent-text); }
+.notes-filter-tab-btn span {
+  font-size: 11px;
+  font-weight: 700;
+  color: inherit;
+  opacity: 0.8;
+}
+
+.notes-paper-list-items {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.notes-paper-row {
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  border: 1px solid transparent;
+}
+.notes-paper-row:hover { background: var(--bg-hover); }
+.notes-paper-row.selected {
+  background: var(--control-accent-soft);
+  border-color: var(--control-accent);
+}
+.notes-paper-row-body { min-width: 0; flex: 1 1 auto; }
+.notes-paper-row-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.notes-paper-row-meta {
+  margin-top: 3px;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.notes-paper-row-counts {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.notes-count-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+.notes-count-chip svg { flex-shrink: 0; }
+
+/* ── 공용: 논문 커버 썸네일 ── */
+.notes-thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: var(--notes-thumb-size, 40px);
+  height: var(--notes-thumb-size, 40px);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+.notes-thumb-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── 우측: 상세 패널 ── */
+.notes-detail {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.notes-detail-empty {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 40px;
+}
+.notes-detail-empty p { margin: 0; font-size: 13px; line-height: 1.6; }
+
+.notes-paper-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 22px;
+  border-bottom: 1px solid var(--border);
+}
+.notes-paper-header-info { min-width: 0; flex: 1 1 auto; }
+.notes-paper-header-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+.notes-paper-header-meta {
+  margin-top: 4px;
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+}
+.notes-paper-header-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.notes-read-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--success);
+}
+.notes-open-viewer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.notes-open-viewer-btn:hover { border-color: var(--control-accent); color: var(--control-accent-text); }
+
+.notes-tabs {
+  flex-shrink: 0;
+  display: flex;
+  gap: 4px;
+  padding: 10px 22px 0;
+  border-bottom: 1px solid var(--border);
+}
+.notes-tab-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.notes-tab-btn:hover { color: var(--text-primary); }
+.notes-tab-btn.active { color: var(--control-accent-text); border-bottom-color: var(--control-accent); }
+.notes-tab-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+.notes-tab-btn.active .notes-tab-count { color: var(--control-accent-text); }
+
+.notes-tab-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 22px 26px;
+}
+
+.notes-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.notes-annotation-card {
+  --notes-item-accent: var(--control-accent);
+  position: relative;
+  padding: 12px 14px 12px 16px;
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--notes-item-accent);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.notes-annotation-card:hover { background: var(--bg-hover); }
+.notes-card-memo { --notes-item-accent: var(--control-accent); }
+.notes-card-highlight { --notes-item-accent: #eab308; }
+.notes-card-underline { --notes-item-accent: #22c55e; }
+
+.notes-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.notes-card-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--notes-item-accent);
+}
+.notes-card-ts {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.notes-card-text {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.notes-card-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--control-accent-text);
+  font-family: var(--font-body);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.notes-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* ── 좁은 화면: 좌우 2열 대신 위/아래 스택 ── */
+@media (max-width: 900px) {
+  .notes-layout { flex-direction: column; }
+  .notes-sidebar { width: 100%; flex: 0 0 auto; max-height: 260px; }
+}
+
+/* ── 즐겨찾기 별 토글 (목록 행 / 상세 헤더 공용) ── */
+.notes-fav-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  align-self: flex-start;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.notes-fav-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
+.notes-fav-btn.active { color: #f59e0b; }
+.notes-fav-btn.active svg { fill: #f59e0b; }
+.notes-fav-btn-lg {
+  width: 32px;
+  height: 32px;
+  align-self: center;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+/* ── 요약 탭 ── */
+.notes-summary-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 24px 4px;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.notes-summary-loading svg { animation: notes-spin 1s linear infinite; }
+@keyframes notes-spin { to { transform: rotate(360deg); } }
+.notes-summary-text {
+  padding: 4px;
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}

--- a/frontend/src/styles/reading-history.css
+++ b/frontend/src/styles/reading-history.css
@@ -1,0 +1,524 @@
+/* ============================================================
+   Reading History 페이지 전용 스타일
+   ============================================================
+   디자인 토큰(var(--*))은 전부 style.css에 이미 정의된 것을 재사용해
+   라이트/다크 테마·사용자 지정 accent 색에 자동으로 맞춰진다.
+   카테고리컬 색이 필요한 두 곳(활동 구성 막대, 통계 카드 아이콘)만
+   dataviz 팔레트에서 가져온 고정 hue를 --rh-c1..c6 로 로컬 정의한다
+   (분류 축은 fixed order로 색을 배정하고 절대 순환시키지 않는다). */
+
+:root {
+  --rh-c1: #3987e5; /* blue    */
+  --rh-c2: #d95926; /* orange  */
+  --rh-c3: #199e70; /* aqua    */
+  --rh-c4: #c98500; /* yellow  */
+  --rh-c5: #d55181; /* magenta */
+  --rh-c6: #9085e9; /* violet  */
+}
+body.light-theme {
+  --rh-c1: #2a78d6;
+  --rh-c2: #eb6834;
+  --rh-c3: #1baf7a;
+  --rh-c4: #eda100;
+  --rh-c5: #e87ba4;
+  --rh-c6: #4a3aa7;
+}
+
+.rh-page {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding-bottom: 40px;
+}
+
+/* ── 헤더 ── */
+.rh-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.rh-header-subtitle {
+  margin: 4px 0 0;
+  font-size: 13.5px;
+  color: var(--text-secondary);
+}
+.rh-header-period {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  padding: 6px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+/* ── 공통 카드 ── */
+.rh-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px 20px;
+}
+.rh-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.rh-card-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.rh-card-title svg { color: var(--control-accent-text); flex-shrink: 0; }
+.rh-card-sub {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.rh-empty {
+  padding: 28px 12px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* ── 통계 카드 ── */
+.rh-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+.rh-stat-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 16px 15px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.2s ease;
+}
+.rh-stat-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-glow);
+}
+.rh-stat-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--rh-stat-color, var(--accent-mid)) 18%, transparent);
+  color: var(--rh-stat-color, var(--accent-mid));
+}
+.rh-stat-body { min-width: 0; flex: 1; }
+.rh-stat-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.rh-stat-value {
+  font-family: var(--font-mono);
+  font-size: 21px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+.rh-stat-delta {
+  margin-top: 5px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+.rh-stat-delta.up { color: var(--success); }
+.rh-stat-delta.down { color: var(--error); }
+
+/* ── 2열 레이아웃 ── */
+.rh-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+.rh-col { display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+@media (max-width: 980px) {
+  .rh-columns { grid-template-columns: 1fr; }
+}
+
+/* ── Reading Activity 캘린더 히트맵 ── */
+.rh-cal-legend {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.rh-cal-legend-swatch {
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  border: 1px solid var(--border-strong);
+}
+.rh-cal-scroll { overflow-x: auto; padding-bottom: 4px; }
+.rh-cal {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: max-content;
+}
+.rh-cal-months {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 3px;
+  padding-left: 30px;
+}
+.rh-cal-month-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.rh-cal-body { display: flex; gap: 6px; }
+.rh-cal-weekday-labels {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  gap: 3px;
+  width: 24px;
+  flex-shrink: 0;
+}
+.rh-cal-weekday-labels span {
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  line-height: 12px;
+}
+.rh-cal-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 12px);
+  gap: 3px;
+}
+.rh-cal-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent-mid) 6%, var(--bg-elevated));
+  border: 1px solid var(--border);
+  cursor: default;
+}
+.rh-cal-cell.rh-heat-1 { background: color-mix(in srgb, var(--accent-mid) 28%, var(--bg-elevated)); }
+.rh-cal-cell.rh-heat-2 { background: color-mix(in srgb, var(--accent-mid) 50%, var(--bg-elevated)); }
+.rh-cal-cell.rh-heat-3 { background: color-mix(in srgb, var(--accent-mid) 72%, var(--bg-elevated)); }
+.rh-cal-cell.rh-heat-4 { background: var(--accent-mid); border-color: var(--accent-mid); }
+.rh-cal-cell.rh-future { background: transparent; border-color: transparent; }
+
+.rh-cal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.rh-cal-footer b { color: var(--text-primary); font-weight: 700; }
+
+/* ── Activity Mix (stacked bar, part-to-whole) ── */
+.rh-mix-total {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 10px;
+}
+.rh-mix-total b { color: var(--text-primary); font-weight: 700; }
+.rh-mix-bar {
+  display: flex;
+  gap: 2px;
+  height: 14px;
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--bg-panel);
+  margin-bottom: 16px;
+}
+.rh-mix-seg { flex: 0 0 auto; min-width: 3px; }
+.rh-mix-legend { display: flex; flex-direction: column; gap: 10px; }
+.rh-mix-row { display: flex; align-items: center; gap: 9px; }
+.rh-mix-dot { width: 9px; height: 9px; border-radius: 3px; flex-shrink: 0; }
+.rh-mix-label { flex: 1; font-size: 12.5px; color: var(--text-primary); font-weight: 600; }
+.rh-mix-count { font-size: 12px; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
+.rh-mix-pct { font-size: 11.5px; color: var(--text-muted); min-width: 34px; text-align: right; font-variant-numeric: tabular-nums; }
+
+/* ── All Activities: 필터 탭 ── */
+.rh-tabs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.rh-tab-btn {
+  padding: 6px 13px;
+  border-radius: 100px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.rh-tab-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.rh-tab-btn.active {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  border-color: transparent;
+}
+
+/* ── 세로 타임라인 (dot + 연결선) ── */
+.rh-timeline { display: flex; flex-direction: column; gap: 26px; }
+.rh-timeline-day-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.rh-timeline-day-date { font-size: 13px; font-weight: 700; color: var(--text-primary); }
+.rh-timeline-day-weekday { font-size: 11.5px; font-weight: 600; color: var(--text-muted); }
+
+.rh-timeline-track { position: relative; padding-left: 34px; }
+.rh-timeline-track::before {
+  content: '';
+  position: absolute;
+  left: 12px;
+  top: 2px;
+  bottom: 2px;
+  width: 2px;
+  background: var(--border-strong);
+}
+.rh-timeline-entry { position: relative; cursor: pointer; }
+.rh-timeline-entry + .rh-timeline-entry { margin-top: 10px; }
+.rh-timeline-dot {
+  position: absolute;
+  left: -34px;
+  top: 1px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  color: var(--control-accent-text);
+  box-sizing: border-box;
+}
+.rh-timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.rh-timeline-entry:hover .rh-timeline-row {
+  transform: translateX(3px);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+.rh-timeline-time {
+  flex-shrink: 0;
+  width: 58px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.rh-timeline-type {
+  flex-shrink: 0;
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 3px 9px;
+  border-radius: 100px;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  white-space: nowrap;
+}
+.rh-timeline-main { flex: 1; min-width: 0; }
+.rh-timeline-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rh-timeline-summary {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rh-timeline-meta {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.rh-more-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 16px;
+  padding: 10px;
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.rh-more-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* ── Top Papers by Activity ── */
+.rh-top-list { display: flex; flex-direction: column; gap: 14px; }
+.rh-top-row { display: flex; align-items: center; gap: 11px; cursor: pointer; }
+.rh-top-rank {
+  flex-shrink: 0;
+  width: 20px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-align: center;
+}
+.rh-top-body { flex: 1; min-width: 0; }
+.rh-top-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 6px;
+}
+.rh-top-track {
+  height: 6px;
+  border-radius: 4px;
+  background: var(--border-strong);
+  overflow: hidden;
+}
+.rh-top-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.rh-top-value {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.rh-top-row:hover .rh-top-title { color: var(--control-accent-text); }
+
+/* ── Reading Streak / Best Day / Longest Streak ── */
+.rh-streak-value {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.rh-streak-num {
+  font-family: var(--font-mono);
+  font-size: 32px;
+  font-weight: 800;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.rh-streak-unit { font-size: 13px; font-weight: 600; color: var(--text-secondary); }
+.rh-streak-week {
+  display: flex;
+  gap: 7px;
+  margin-bottom: 12px;
+}
+.rh-streak-day {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-panel);
+}
+.rh-streak-day.active { background: var(--accent-mid); border-color: var(--accent-mid); color: #fff; }
+.rh-streak-day.future { opacity: 0.4; border-style: dashed; }
+.rh-streak-day.today { border-color: var(--control-accent-text); }
+.rh-streak-msg { font-size: 12px; color: var(--text-tertiary); }
+
+.rh-callout-row { display: flex; gap: 14px; }
+.rh-callout {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  min-width: 0;
+}
+.rh-callout-icon {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--rh-callout-color, var(--accent-mid)) 18%, transparent);
+  color: var(--rh-callout-color, var(--accent-mid));
+}
+.rh-callout-body { min-width: 0; }
+.rh-callout-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-bottom: 3px; }
+.rh-callout-value { font-size: 15px; font-weight: 700; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rh-callout-sub { margin-top: 2px; font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+@media (max-width: 560px) {
+  .rh-callout-row { flex-direction: column; }
+}

--- a/frontend/src/styles/research-graph.css
+++ b/frontend/src/styles/research-graph.css
@@ -1,0 +1,433 @@
+/* ============================================================
+   Research Graph 페이지 — 3열 레이아웃(범례 / 캔버스 / 상세 패널) 재설계
+   (노드 클릭 → 상세 패널, 검색, 타입/태그 필터, 그래프-타임라인-히트맵
+   서브뷰 전환은 main.js가 그대로 담당한다 — 여기는 시각 스타일만.)
+
+   요소 대부분은 index.html에 이미 있던 id 보유 노드를 main.js가 런타임에
+   재배치/재사용한 것이다(ensureGraphLayout). 기존 style.css의 .doc-card*,
+   .kg-timeline*, .kg-heatmap* 클래스는 건드리지 않고, 여기서는 이 파일
+   전용의 새 클래스(rg- 접두사)만 사용한다. 색상은 전부 디자인 토큰
+   (var(--...))만 사용해 라이트/다크 테마를 자동으로 따라간다.
+   ============================================================ */
+
+#library-graph-section { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+#library-graph-view { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+
+/* ── 상단 그래프/타임라인/히트맵 토글 ── */
+.rg-view-tabs { display: inline-flex; }
+.rg-view-tabs .library-tab-btn { display: inline-flex; align-items: center; gap: 6px; }
+
+/* ── 검색 + 필터 툴바 ── */
+.rg-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.rg-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1 1 260px;
+  min-width: 200px;
+  gap: 8px;
+  padding: 0 12px;
+  height: 38px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  transition: border-color 0.15s ease;
+}
+.rg-search-wrap:focus-within { border-color: var(--control-accent); color: var(--text-secondary); }
+.rg-search-input {
+  flex: 1;
+  border: none;
+  background: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+}
+.rg-search-input::placeholder { color: var(--text-muted); }
+
+.rg-filter-select {
+  appearance: none;
+  -webkit-appearance: none;
+  height: 38px;
+  padding: 0 28px 0 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="%2386868f" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>') no-repeat right 10px center;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.rg-filter-select:hover, .rg-filter-select:focus { border-color: var(--control-accent); }
+
+.rg-toolbar-right { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+.rg-recommend-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: var(--shadow-sm);
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+.rg-recommend-btn:hover:not(:disabled) { filter: brightness(1.08); }
+.rg-recommend-btn:active:not(:disabled) { transform: scale(0.98); }
+.rg-recommend-btn:disabled { opacity: 0.65; cursor: default; }
+
+/* library-recommendations-list는 클릭 전엔 완전히 비어 있는 <div>라
+   :empty로 걸러내면 카드 테두리가 미리 나타나지 않는다. */
+#library-recommendations-list:not(:empty) {
+  margin-bottom: 12px;
+  padding: 4px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.rg-recommend-status { margin: 0; padding: 10px 0; font-size: 12.5px; color: var(--text-tertiary); }
+.rg-recommend-status.rg-recommend-error { color: var(--error); }
+.rg-recommend-item { padding: 10px 0; border-top: 1px solid var(--border); }
+.rg-recommend-item:first-child { border-top: none; }
+.rg-recommend-item-title { display: block; font-size: 13px; font-weight: 700; color: var(--text-primary); text-decoration: none; }
+.rg-recommend-item-title:hover { color: var(--control-accent-text); }
+.rg-recommend-item-reason { margin-top: 4px; font-size: 12px; color: var(--text-secondary); line-height: 1.5; }
+
+/* ── 3열 레이아웃(범례 / 캔버스 / 상세 패널) ──
+   library-graph-row는 기존 상세 패널 리사이저 로직이 flex 구조에 의존하므로
+   display:flex는 index.html의 인라인 스타일 그대로 유지된다. */
+.rg-legend-col {
+  flex: 0 0 208px;
+  width: 208px;
+  margin-right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-self: flex-start;
+}
+.rg-legend-card,
+.rg-overview-card {
+  padding: 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+}
+.rg-legend-title {
+  margin: 0 0 12px;
+  font-size: 11.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.rg-legend-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.rg-legend-item { display: flex; align-items: center; gap: 9px; }
+.rg-legend-dot { flex-shrink: 0; width: 9px; height: 9px; border-radius: 50%; }
+.rg-legend-label { flex: 1; min-width: 0; font-size: 12.5px; font-weight: 600; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rg-legend-count { flex-shrink: 0; font-size: 11px; font-weight: 700; color: var(--text-tertiary); background: var(--bg-hover); border-radius: 100px; padding: 1px 7px; min-width: 20px; text-align: center; }
+
+/* ── Graph Overview 통계 카드 ── */
+.rg-overview-list { list-style: none; margin: 0 0 12px; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.rg-overview-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12.5px;
+}
+.rg-overview-row span { display: inline-flex; align-items: center; gap: 7px; color: var(--text-secondary); font-weight: 600; }
+.rg-overview-row span svg { flex-shrink: 0; color: var(--text-tertiary); }
+.rg-overview-row b { color: var(--text-primary); font-weight: 700; }
+.rg-refresh-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.rg-refresh-btn:hover { border-color: var(--control-accent); color: var(--control-accent-text); }
+
+.rg-canvas-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  /* cytoscape는 컨테이너의 실제 픽셀 높이가 필요하다 - flex stretch나
+     퍼센트 높이에 기대면 조상 체인에 따라 0이 될 수 있어(원래 코드도
+     동일한 이유로 인라인 height:600px를 썼다) 여기서도 고정값을 준다. */
+  height: 600px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+}
+.rg-canvas { width: 100% !important; height: 100% !important; background: none; border: none; border-radius: 0; }
+
+.rg-zoom-controls {
+  position: absolute;
+  left: 14px;
+  bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  z-index: 5;
+}
+.rg-zoom-btn {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.rg-zoom-btn + .rg-zoom-btn { border-top: 1px solid var(--border); }
+.rg-zoom-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* ── 우측 상세 패널 (기존 library-graph-detail-panel 재사용) ── */
+.rg-detail-panel {
+  flex: 0 0 auto;
+  max-width: 70%;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.rg-detail-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100%;
+  min-height: 220px;
+  text-align: center;
+  color: var(--text-tertiary);
+}
+.rg-detail-empty-state svg { opacity: 0.5; }
+.rg-detail-empty-state p { margin: 0; font-size: 12.5px; max-width: 20ch; line-height: 1.5; }
+
+.rg-detail-header { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
+.rg-detail-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.rg-detail-header-text { min-width: 0; display: flex; flex-direction: column; gap: 4px; padding-top: 1px; }
+.rg-detail-title {
+  margin: 0;
+  font-size: 14.5px;
+  font-weight: 800;
+  color: var(--text-primary);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.rg-detail-type-badge { font-size: 11px; font-weight: 700; }
+.rg-detail-subtitle { margin: -4px 0 14px; font-size: 12px; color: var(--text-tertiary); font-weight: 600; }
+
+.rg-detail-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 14px; }
+.rg-detail-tag {
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 3px 9px;
+  border-radius: 100px;
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+
+.rg-detail-actions { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; position: relative; }
+.rg-detail-open-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 12px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--control-accent);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+.rg-detail-open-btn:hover { filter: brightness(1.08); }
+.rg-detail-icon-btn {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.rg-detail-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.rg-detail-icon-btn.active { color: var(--warning); border-color: var(--warning); }
+.rg-detail-icon-btn.active svg { fill: var(--warning); }
+
+.rg-detail-more-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 6px;
+  min-width: 210px;
+  z-index: 6;
+}
+.rg-detail-more-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.rg-detail-more-item:hover { background: var(--bg-hover); }
+
+.rg-detail-section { margin-bottom: 18px; }
+.rg-detail-section:last-child { margin-bottom: 0; }
+.rg-detail-section-title {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.rg-detail-empty, .rg-detail-loading { margin: 0; font-size: 12.5px; color: var(--text-tertiary); }
+.rg-detail-error { margin: 0; font-size: 12.5px; color: var(--error); }
+.rg-detail-summary-text { font-size: 12.5px; line-height: 1.65; color: var(--text-secondary); }
+.rg-detail-note-text { font-size: 13px; line-height: 1.6; color: var(--text-secondary); margin: 0 0 14px; white-space: pre-wrap; }
+
+.rg-connections-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.rg-connections-item { display: flex; align-items: center; gap: 8px; }
+.rg-connections-dot { flex-shrink: 0; width: 8px; height: 8px; border-radius: 2px; }
+.rg-connections-label { flex: 1; font-size: 12.5px; color: var(--text-secondary); font-weight: 600; }
+.rg-connections-count { font-size: 11px; font-weight: 700; color: var(--text-tertiary); background: var(--bg-hover); border-radius: 100px; padding: 1px 7px; min-width: 18px; text-align: center; }
+
+.rg-related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.rg-related-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+}
+.rg-related-dot { flex-shrink: 0; width: 7px; height: 7px; border-radius: 50%; }
+.rg-related-label { flex: 1; min-width: 0; font-size: 12px; color: var(--text-primary); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rg-related-type-tag { flex-shrink: 0; font-size: 10px; font-weight: 700; }
+.rg-related-more { margin: 6px 0 0; font-size: 11.5px; color: var(--text-tertiary); }
+
+.rg-activity-stats { display: flex; gap: 8px; }
+.rg-activity-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 6px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+}
+.rg-activity-stat-value { font-size: 14px; font-weight: 800; color: var(--text-primary); }
+.rg-activity-stat-label { font-size: 10.5px; font-weight: 600; color: var(--text-tertiary); }
+
+.rg-detail-question-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  justify-content: center;
+  padding: 9px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.rg-detail-question-btn:hover { background: var(--bg-hover); }
+
+.rg-questions-list { list-style: none; margin: 10px 0 0; padding: 0; max-height: 240px; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; }
+.rg-questions-item { padding: 8px 10px; border-radius: var(--radius-sm); background: var(--bg-panel); border: 1px solid var(--border); }
+.rg-questions-item-text { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; }
+.rg-questions-item-doc { margin-top: 4px; font-size: 11px; color: var(--text-tertiary); }
+
+.rg-detail-figure-img { display: block; width: 100%; border-radius: var(--radius-md); margin-bottom: 10px; cursor: pointer; }
+.rg-detail-figure-caption { margin: 0; font-size: 12px; color: var(--text-secondary); line-height: 1.5; }
+
+@media (max-width: 960px) {
+  .rg-legend-col { display: none; }
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -1,0 +1,265 @@
+/* ============================================================
+   Workspace Shell — Collapsible Sidebar + Top Navigation + Page Outlet
+   (Dashboard / Library / Reading History / AI Chats / Notes / Research Graph)
+   기존 디자인 토큰(--bg-*, --accent-*, --border-*, --radius-*, --shadow-*, --text-*)을
+   그대로 재사용하며, 셸 전용 토큰만 여기서 추가로 정의한다.
+   ============================================================ */
+
+:root {
+  --sidebar-w: 236px;
+  --sidebar-w-collapsed: 68px;
+  --sidebar-transition: width 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* .library-container를 사이드바+메인 2열 레이아웃으로 재정의 (기존: 세로 패딩 컨테이너) */
+.library-container {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  height: 100%;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* ── 좌측 Collapsible Navigation Sidebar ── */
+.app-sidebar {
+  flex: 0 0 var(--sidebar-w);
+  width: var(--sidebar-w);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  padding: 16px 12px;
+  gap: 4px;
+  transition: var(--sidebar-transition);
+  overflow: hidden;
+}
+.app-sidebar.collapsed {
+  flex-basis: var(--sidebar-w-collapsed);
+  width: var(--sidebar-w-collapsed);
+}
+
+.app-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 6px 16px;
+  flex-shrink: 0;
+}
+.sidebar-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.sidebar-toggle-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+.sidebar-brand .logo-icon { color: var(--control-accent); flex-shrink: 0; display: flex; }
+.sidebar-brand-text {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+.app-sidebar.collapsed .sidebar-brand-text { display: none; }
+
+.app-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.app-sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.sidebar-nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 9px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.sidebar-nav-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+.sidebar-nav-item.active {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+}
+.sidebar-nav-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+.sidebar-nav-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.app-sidebar.collapsed .sidebar-nav-item { justify-content: center; padding: 9px; }
+.app-sidebar.collapsed .sidebar-nav-label { display: none; }
+
+/* Hover 시 Tooltip - 접힌 상태에서만 노출 */
+.sidebar-tooltip {
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 40;
+}
+.app-sidebar.collapsed .sidebar-nav-item:hover .sidebar-tooltip {
+  opacity: 1;
+}
+.app-sidebar:not(.collapsed) .sidebar-tooltip { display: none; }
+
+/* ── 우측 Top Navigation + Page Outlet ── */
+.workspace-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.workspace-topnav {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--topbar-h);
+  padding: 0 28px;
+  border-bottom: 1px solid var(--border);
+}
+.workspace-page-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.workspace-topnav-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  /* 로그인/비교 화면과 공유하는 플로팅 테마/설정/로그아웃 버튼(우상단 고정)과
+     겹치지 않도록 여유 공간을 둔다 */
+  margin-right: 78px;
+}
+.workspace-search-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.workspace-search-icon {
+  position: absolute;
+  left: 12px;
+  color: var(--text-muted);
+  display: flex;
+  pointer-events: none;
+}
+.workspace-search-box input {
+  width: 260px;
+  padding: 8px 12px 8px 34px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s ease, width 0.15s ease;
+}
+.workspace-search-box input:focus {
+  border-color: var(--control-accent);
+  width: 300px;
+}
+.workspace-avatar-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.workspace-avatar-btn:hover { color: var(--text-primary); border-color: var(--control-accent); }
+
+.page-outlet {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 28px 32px 40px;
+}
+
+.workspace-page { display: none; }
+.workspace-page.active { display: block; height: 100%; }
+
+/* Library 페이지는 자체적으로 세로 flex 레이아웃(헤더/검색/그리드)을 유지한다 */
+#page-library.active {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Tablet 대응 - 사이드바를 기본 축소 폭으로 */
+@media (max-width: 1100px) {
+  .app-sidebar:not(.collapsed) { flex-basis: var(--sidebar-w-collapsed); width: var(--sidebar-w-collapsed); }
+  .app-sidebar:not(.collapsed) .sidebar-brand-text,
+  .app-sidebar:not(.collapsed) .sidebar-nav-label { display: none; }
+  .app-sidebar:not(.collapsed) .sidebar-nav-item { justify-content: center; padding: 9px; }
+  .app-sidebar:not(.collapsed) .sidebar-tooltip { display: block; }
+  .app-sidebar:not(.collapsed) .sidebar-nav-item:hover .sidebar-tooltip { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- 목업(ask/UI)에 맞춰 Dashboard/Library/Reading History/AI Chats/Notes/Research Graph 6개 페이지 + collapsible 사이드바/탑네비 셸을 신규 구축
- 552KB 단일 main.js/index.html을 페이지별 모듈(`frontend/src/pages/*.js` + `frontend/src/styles/*.css`)로 분리
- 읽기 시간 실측 추적 신규 구현(하트비트 API + `reading_time` 테이블), Dashboard/Reading History에 반영
- Library Quick Info(Venue/DOI/ArXiv/Citations) — 기존 OpenAlex 연동 확장으로 실제 값 채움
- Research Graph 사이드바에 Graph Overview 통계 블록 추가
- Notes에 요약(Primer 재사용)/즐겨찾기(Library와 공유하는 로컬 상태) 탭 추가
- 기존 기능(뷰어, 검색, 인증, 번역, 채팅, 지식 그래프 데이터 모델) 변경 없음 — 디자인/레이아웃 재구성과 위에 명시한 신규 API만 추가

## Test plan
- [x] `npx vite build` 클린 통과
- [x] 백엔드 `python -c "import ast; ..."` 문법 확인 + 실제 서버 기동 확인
- [x] 실제 로그인 후 6개 페이지 전부 브라우저에서 시각 확인, 콘솔 에러 없음
- [x] `db_add_reading_time`/`db_get_reading_time_stats` 직접 함수 테스트로 집계 로직 검증
- [x] OpenAlex 논문 검색(`resolve_paper_metadata`)을 실제 논문 3편으로 테스트해 Venue/DOI/ArXiv/Citations 정상 확인
- [ ] 실제 논문을 업로드해 Dashboard/Reading History 위젯에 데이터가 채워지는 모습 확인 (사용자 확인 필요)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>