### PR TITLE
워크스페이스 UI 후속 피드백 반영

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,14 @@
         </nav>
 
         <div class="app-sidebar-footer">
+          <button type="button" id="sidebar-theme-toggle-btn" class="sidebar-nav-item" title="화이트/다크 모드 전환">
+            <span class="sidebar-nav-icon">
+              <svg class="sun-icon hidden" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+              <svg class="moon-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </span>
+            <span class="sidebar-nav-label">테마 전환</span>
+            <span class="sidebar-tooltip">테마 전환</span>
+          </button>
           <button type="button" id="sidebar-settings-btn" class="sidebar-nav-item">
             <span class="sidebar-nav-icon" data-icon="settings"></span>
             <span class="sidebar-nav-label">Settings</span>
@@ -135,9 +143,6 @@
               <span class="workspace-search-icon" data-icon="search"></span>
               <input type="text" id="workspace-search-input" placeholder="논문, 개념, 질문 검색..." />
             </div>
-            <button type="button" id="workspace-avatar-btn" class="workspace-avatar-btn" title="설정">
-              <span data-icon="user"></span>
-            </button>
           </div>
         </header>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -257,7 +257,6 @@ const sidebarSettingsBtn  = $('sidebar-settings-btn')
 const sidebarLogoutBtn    = $('sidebar-logout-btn')
 const workspacePageTitle  = $('workspace-page-title')
 const workspaceSearchInput = $('workspace-search-input')
-const workspaceAvatarBtn  = $('workspace-avatar-btn')
 const pageOutlet          = $('page-outlet')
 
 const libCompareToggleBtn   = $('lib-compare-toggle-btn')
@@ -3723,11 +3722,11 @@ async function showLibraryScreen(shouldPushState = true, targetPage) {
   viewerScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
   libraryScreen.classList.add('active')
-  // 워크스페이스 화면(사이드바+탑네비)에서는 Settings/로그아웃이 이미 사이드바 푸터와
-  // 탑네비 아바타에 있으므로 플로팅 버튼 묶음에서는 숨긴다(안 그러면 페이지 콘텐츠와
-  // 겹침). 테마 토글만 남겨둔다 - 탑네비/사이드바에 별도의 테마 토글이 없기 때문.
+  // 워크스페이스 화면(사이드바+탑네비)에서는 테마 토글/Settings/로그아웃이 전부
+  // 사이드바 푸터에 있으므로, 로그인/비교 화면 전용인 플로팅 버튼 묶음은 통째로 숨긴다
+  // (안 그러면 우측 상단에 뜬금없이 떠서 페이지 콘텐츠와 겹친다).
   const globalToggle = $('global-theme-toggle')
-  if (globalToggle) globalToggle.classList.remove('hidden')
+  if (globalToggle) globalToggle.classList.add('hidden')
   globalLogoutBtn.classList.add('hidden')
   globalSettingsBtn.classList.add('hidden')
   resetState()
@@ -3813,12 +3812,11 @@ if (sidebarNav) {
   })
 }
 
-// 사이드바 Settings/로그아웃, 탑네비 아바타는 기존 로직(비밀번호 변경 모달 / 로그아웃)을
-// 그대로 재사용한다 - 새 UI 진입점만 추가하고 동작 자체는 기존 global-settings-btn/
+// 사이드바 Settings/로그아웃은 기존 로직(비밀번호 변경 모달 / 로그아웃)을 그대로
+// 재사용한다 - 새 UI 진입점만 추가하고 동작 자체는 기존 global-settings-btn/
 // global-logout-btn 클릭 핸들러에 위임한다.
 if (sidebarSettingsBtn) sidebarSettingsBtn.addEventListener('click', () => globalSettingsBtn?.click())
 if (sidebarLogoutBtn) sidebarLogoutBtn.addEventListener('click', () => globalLogoutBtn?.click())
-if (workspaceAvatarBtn) workspaceAvatarBtn.addEventListener('click', () => globalSettingsBtn?.click())
 
 // 탑네비 검색창은 새 검색 기능이 아니라 기존 라이브러리 검색으로 그대로 위임한다
 // (Global Search는 기존 검색 기능을 그대로 사용 - 동작 변경 금지 원칙).
@@ -4171,13 +4169,24 @@ function toggleFavoriteDoc(docId) {
   return ids.has(docId)
 }
 
-// 번역 진행 상태 기준 분류: Unread=번역 진행 기록이 아예 없음, Reading=일부만
-// 번역됐거나 다 번역됐지만 아직 "읽음" 처리 전, Finished=완독 표시(metadata.read===true)됨.
+// 읽은 페이지(뷰어가 스크롤 위치를 저장하는 metadata.last_page - 책갈피 기능과
+// 동일한 필드) 기준 진행률. 번역 진행률(translated_pages)은 "얼마나 번역했는지"일
+// 뿐 "얼마나 읽었는지"가 아니라서 카드/대시보드의 기본 퍼센트로는 쓰지 않는다
+// (번역 진행률은 뷰어 안의 번역 진행 표시에서만 쓴다).
+function getLibraryReadProgress(doc) {
+  if (doc.metadata?.read === true) return 100
+  const lastPage = doc.metadata?.last_page
+  const total = doc.total_pages || 1
+  if (!Number.isInteger(lastPage) || lastPage <= 0) return 0
+  return Math.min(100, Math.round((lastPage / total) * 100))
+}
+
+// 읽기 진행 상태 기준 분류: Unread=읽은 기록이 아예 없음, Reading=일부 페이지까지
+// 읽었지만 아직 "읽음" 처리 전, Finished=완독 표시(metadata.read===true)됨.
 function getLibraryDocStatus(doc) {
-  const translated = doc.translated_pages?.length || 0
   const isRead = doc.metadata?.read === true
   if (isRead) return 'finished'
-  if (translated <= 0) return 'unread'
+  if (getLibraryReadProgress(doc) <= 0) return 'unread'
   return 'reading'
 }
 
@@ -4217,7 +4226,7 @@ function renderLibraryStatusTabs(docs) {
   })
 }
 
-function sortLibraryDocs(docs) {
+function sortDocsByMode(docs) {
   const sorted = docs.slice()
   if (librarySortMode === 'title') {
     sorted.sort((a, b) => {
@@ -4226,15 +4235,24 @@ function sortLibraryDocs(docs) {
       return ta.localeCompare(tb)
     })
   } else if (librarySortMode === 'progress') {
-    sorted.sort((a, b) => {
-      const pa = (a.translated_pages?.length || 0) / (a.total_pages || 1)
-      const pb = (b.translated_pages?.length || 0) / (b.total_pages || 1)
-      return pb - pa
-    })
+    sorted.sort((a, b) => getLibraryReadProgress(b) - getLibraryReadProgress(a))
   } else {
     sorted.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
   }
   return sorted
+}
+
+// 전체 탭(activeStatusFilter === 'all')에서는 완료(읽음 표시) 논문을 정렬 기준과
+// 무관하게 항상 맨 뒤로 보낸다 - "다 읽은 논문"이 최신순/진행률순 목록 사이에
+// 섞여 새로 봐야 할 논문을 찾기 번거롭다는 피드백에 따른 것. 완료 탭을 직접 볼
+// 때(activeStatusFilter === 'finished')는 원래 정렬 순서를 그대로 유지한다.
+function sortLibraryDocs(docs) {
+  if (state.currentLibraryTab === 'trash' || activeStatusFilter !== 'all') {
+    return sortDocsByMode(docs)
+  }
+  const unfinished = docs.filter(d => getLibraryDocStatus(d) !== 'finished')
+  const finished = docs.filter(d => getLibraryDocStatus(d) === 'finished')
+  return [...sortDocsByMode(unfinished), ...sortDocsByMode(finished)]
 }
 
 // Library 페이지의 새 UI 조각(상태 탭 / 정렬 드롭다운 / 상세 패널)은 index.html을
@@ -5381,10 +5399,8 @@ function createEmptyState(variant = 'library') {
 
 // 카드/리스트 뷰 공용: 문서 데이터로부터 두 뷰가 함께 쓰는 마크업 조각을 미리 계산한다.
 function prepareDocItemHtml(doc) {
-  const translated = doc.translated_pages?.length || 0
-  const total = doc.total_pages || 1
-  const pct = Math.round((translated / total) * 100)
-  const isDone = translated >= total
+  const pct = getLibraryReadProgress(doc)
+  const isDone = doc.metadata?.read === true || pct >= 100
   const date = new Date(doc.created_at).toLocaleDateString('ko-KR', { year:'numeric', month:'short', day:'numeric' })
 
   const categories = doc.metadata?.categories || []
@@ -5652,7 +5668,13 @@ function createDocCard(doc) {
   // 퍼센트를 보여주는 새 레이아웃을 쓴다(리스트 뷰는 손대지 않는다 - createDocListRow는
   // 편집 허용 범위 밖).
   let cardProgressHtml = ''
-  if (!d.isDone) {
+  if (d.isDone) {
+    cardProgressHtml = `
+      <div class="lib-card-progress lib-card-progress-done">
+        <span class="doc-meta-chip done">${icon('checkCircle', 11)}완료</span>
+      </div>
+    `
+  } else {
     cardProgressHtml = `
       <div class="lib-card-progress">
         <div class="lib-card-progress-bar-wrap"><div class="lib-card-progress-bar" style="width:${d.pct}%"></div></div>
@@ -6912,12 +6934,16 @@ function updateThemeIcons(isLight) {
 
 const themeToggleBtn = $('theme-toggle-btn')
 const globalThemeToggleBtn = $('global-theme-toggle-btn')
+const sidebarThemeToggleBtn = $('sidebar-theme-toggle-btn')
 
 if (themeToggleBtn) {
   themeToggleBtn.addEventListener('click', toggleTheme)
 }
 if (globalThemeToggleBtn) {
   globalThemeToggleBtn.addEventListener('click', toggleTheme)
+}
+if (sidebarThemeToggleBtn) {
+  sidebarThemeToggleBtn.addEventListener('click', toggleTheme)
 }
 
 // 초기 테마 적용

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4918,6 +4918,24 @@ async function renderLibraryGraphTab() {
     rgGraphLoadedAt = new Date()
     renderGraphLegend(data.nodes, data.edges)
 
+    // Dashboard(개념 히트맵/연구 그래프 미리보기)에서 특정 노드를 보려고 넘어온
+    // 경우, sessionStorage로 넘겨받은 노드 id를 실제 클릭과 동일하게 처리한다
+    // (cy.trigger('tap')이 renderKnowledgeGraph의 tap 핸들러를 그대로 태워
+    // 하이라이트/상세 패널 표시까지 한 번에 재사용한다). fcose 레이아웃
+    // 애니메이션이 자리를 잡을 시간을 잠깐 준 뒤 실행한다.
+    const focusNodeId = sessionStorage.getItem('easypaper_graph_focus_node')
+    if (focusNodeId) {
+      sessionStorage.removeItem('easypaper_graph_focus_node')
+      setTimeout(() => {
+        if (!libraryGraphCyInstance) return
+        const node = libraryGraphCyInstance.getElementById(focusNodeId)
+        if (node && node.length) {
+          node.trigger('tap')
+          libraryGraphCyInstance.animate({ center: { eles: node }, zoom: 1.3 }, { duration: 400 })
+        }
+      }, 450)
+    }
+
     // 태그 필터 옵션 = 논문 노드들의 categories 값 전체(중복 제거, 가나다순).
     if (tagFilterEl) {
       const cats = new Set()
@@ -5438,10 +5456,12 @@ function prepareDocItemHtml(doc) {
 
   let progressHtml = ''
   if (!isDone) {
+    const lastPage = Number.isInteger(doc.metadata?.last_page) ? doc.metadata.last_page : 0
+    const totalPages = doc.total_pages || 0
     progressHtml = `
       <div class="doc-card-progress-row">
         <div class="doc-progress-bar-wrap"><div class="doc-progress-bar" style="width:${pct}%"></div></div>
-        <span>${translated}/${total} · ${pct}%</span>
+        <span>${lastPage}/${totalPages}p · ${pct}%</span>
       </div>
     `
   }
@@ -5480,7 +5500,7 @@ function prepareDocItemHtml(doc) {
     ctaBtnFullHtml = `<button class="doc-open-btn" data-id="${doc.id}"><span>열기</span>${openIcon}</button>`
   }
 
-  return { translated, total, pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, compareCheckHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, ctaBtnFullHtml }
+  return { pct, isDone, categories, tagsHtml, displayTitle, isRead, dateHtml, checkBtnHtml, compareCheckHtml, expandBtnHtml, progressHtml, iconActionsHtml, ctaBtnHtml, ctaBtnFullHtml }
 }
 
 // 카드/리스트 뷰 공용: 위임 없이 각 아이템 컨테이너에 직접 붙는 이벤트 리스너를 등록한다.
@@ -5710,7 +5730,7 @@ function createDocCard(doc) {
       </div>
       ${d.tagsHtml}
       <div class="doc-card-meta">
-        ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${d.total}p</span>
+        ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${doc.total_pages || 0}p</span>
       </div>
       ${cardProgressHtml}
     </div>
@@ -6247,7 +6267,7 @@ function createDocListRow(doc) {
     <div class="doc-list-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
     ${listTagsHtml}
     <div class="doc-card-meta">
-      ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${d.total}p</span>
+      ${d.dateHtml}<span class="meta-dot"></span><span class="doc-meta-chip">${doc.total_pages || 0}p</span>
     </div>
     <div class="doc-list-progress-slot">${d.progressHtml}</div>
     <div class="doc-card-cta">

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -249,15 +249,14 @@ function renderProgressSummaryCard(events, heatmap, readingStats) {
   `
 }
 
-// ── 최근 읽은 논문 ── dashboard.recent_papers는 실제로는 "최근 업로드"라
-// 라벨과 맞지 않는다. 대신 fetchLibrary()의 문서 목록에서 metadata.read가
-// true인 것만 read_at 내림차순으로 골라 쓴다. 진행률(%)은 페이지별
-// "읽음" 추적이 없어, translated_pages/total_pages(실제 번역된 페이지
-// 비율)로 근사했다 - 읽으면서 페이지가 번역되는 흐름이라 합리적인 대리
-// 지표지만 엄밀히는 "읽은 비율"이 아니라 "번역 진행률"이다.
+// ── 최근 읽은 논문 ── 완독 표시(metadata.read)된 논문뿐 아니라 읽던 중인
+// 논문(metadata.last_page - 뷰어의 책갈피 기능이 저장하는 마지막 읽은 페이지)도
+// 함께 보여준다("최근 읽은" = 최근에 펼쳐본 논문). 퍼센트는 번역 진행률이 아니라
+// last_page/total_pages로 계산한 실제 읽은 진행률이고, 완독 표시된 논문은
+// 퍼센트 대신 "완료" 칩을 보여준다.
 function renderRecentPapersCard(docs) {
   const read = docs
-    .filter(d => d.metadata && d.metadata.read)
+    .filter(d => (d.metadata && d.metadata.read) || Number.isInteger(d.metadata?.last_page))
     .sort((a, b) => new Date(b.metadata.read_at || b.created_at).getTime() - new Date(a.metadata.read_at || a.created_at).getTime())
     .slice(0, 5)
 
@@ -271,10 +270,17 @@ function renderRecentPapersCard(docs) {
       <ul class="dash-paper-list">
         ${read.map(d => {
           const title = (d.metadata && d.metadata.title) || d.filename
-          const total = d.total_pages || 0
-          const translated = (d.translated_pages && d.translated_pages.length) || 0
-          const pct = total > 0 ? Math.min(100, Math.round((translated / total) * 100)) : 0
+          const isDone = d.metadata?.read === true
+          const total = d.total_pages || 1
+          const lastPage = d.metadata?.last_page
+          const pct = isDone ? 100 : (Number.isInteger(lastPage) ? Math.min(100, Math.round((lastPage / total) * 100)) : 0)
           const cats = ((d.metadata && d.metadata.categories) || []).slice(0, 2)
+          const progressHtml = isDone
+            ? `<span class="dash-paper-done-chip">${icon('checkCircle', 12)}완료</span>`
+            : `
+              <div class="dash-activity-track small"><div class="dash-activity-fill" style="width:${pct}%"></div></div>
+              <span class="dash-paper-pct">${pct}%</span>
+            `
           return `
             <li class="dash-paper-item" data-doc-id="${escapeHtml(d.id)}">
               <img class="dash-paper-cover" src="/api/library/${encodeURIComponent(d.id)}/cover" alt="" loading="lazy" onerror="this.style.visibility='hidden'" />
@@ -285,8 +291,7 @@ function renderRecentPapersCard(docs) {
                   <span class="dash-paper-time">${relativeTimeKo(d.metadata.read_at || d.created_at)}</span>
                 </div>
                 <div class="dash-paper-progress-row">
-                  <div class="dash-activity-track small"><div class="dash-activity-fill" style="width:${pct}%"></div></div>
-                  <span class="dash-paper-pct">${pct}%</span>
+                  ${progressHtml}
                 </div>
               </div>
             </li>

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -315,7 +315,7 @@ function renderRecentQuestionsCard(list) {
       ${items.length === 0 ? emptyNote('최근 질문이 없습니다.') : `
       <ul class="dash-question-list">
         ${items.map(q => `
-          <li class="dash-question-item" data-nav="chats">
+          <li class="dash-question-item" data-doc-id="${escapeHtml(q.doc_id || '')}" title="이 논문의 채팅으로 이동">
             <span class="dash-question-icon">${icon('messageCircle', 13)}</span>
             <div class="dash-question-body">
               <div class="dash-question-text">${escapeHtml(q.summary || '')}</div>
@@ -363,7 +363,7 @@ function renderHeatmapCard(heatmap) {
         ${heatmap.slice(0, 8).map(h => {
           const pct = maxScore > 0 ? Math.max(6, Math.round(((h.score || 0) / maxScore) * 100)) : 6
           return `
-            <div class="dash-heat-cell" title="논문 ${h.paper_count}편 · 질문 ${h.question_count}개">
+            <div class="dash-heat-cell" data-node-id="concept:${escapeHtml(String(h.concept_id))}" title="${escapeHtml(h.name)} · 논문 ${h.paper_count}편 · 질문 ${h.question_count}개 · 클릭하면 연구 그래프에서 보기">
               <div class="dash-heat-swatch" style="--heat-pct:${pct}%"></div>
               <div class="dash-heat-label">${escapeHtml(h.name)}</div>
               <div class="dash-heat-count">${formatNumber(h.score)}</div>
@@ -393,7 +393,7 @@ function renderTimelineCard(events) {
       ${recent.length === 0 ? emptyNote('최근 7일간 활동이 없습니다.') : `
       <ul class="dash-timeline-list">
         ${recent.map(e => `
-          <li class="dash-timeline-item dash-timeline-${escapeHtml(e.type)}">
+          <li class="dash-timeline-item dash-timeline-${escapeHtml(e.type)}" data-doc-id="${escapeHtml(e.doc_id || '')}" data-type="${escapeHtml(e.type)}" title="이 논문 열기">
             <span class="dash-timeline-dot"></span>
             <div class="dash-timeline-body">
               <div class="dash-timeline-top">
@@ -455,8 +455,8 @@ function renderMiniGraphSvg({ center, neighbors }) {
     const isPaper = p.node.type === 'paper'
     const labelY = p.y > cy ? p.y + 16 : p.y - 11
     return `
-      <g class="dash-graph-node ${isPaper ? 'is-paper' : 'is-concept'}">
-        <title>${escapeHtml(p.node.label || '')}</title>
+      <g class="dash-graph-node ${isPaper ? 'is-paper' : 'is-concept'}" data-node-id="${escapeHtml(p.node.id || '')}">
+        <title>${escapeHtml(p.node.label || '')} (클릭하면 연구 그래프에서 보기)</title>
         <circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${isPaper ? 8 : 6.5}" />
         <text x="${p.x.toFixed(1)}" y="${labelY.toFixed(1)}" text-anchor="middle">${escapeHtml(truncateLabel(p.node.label, 13))}</text>
       </g>
@@ -467,8 +467,8 @@ function renderMiniGraphSvg({ center, neighbors }) {
     <svg class="dash-graph-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet">
       ${lines}
       ${nodesHtml}
-      <g class="dash-graph-node is-center">
-        <title>${escapeHtml(center.label || '')}</title>
+      <g class="dash-graph-node is-center" data-node-id="${escapeHtml(center.id || '')}">
+        <title>${escapeHtml(center.label || '')} (클릭하면 연구 그래프에서 보기)</title>
         <circle cx="${cx}" cy="${cy}" r="13" />
         <text x="${cx}" y="${cy + 26}" text-anchor="middle" class="dash-graph-center-label">${escapeHtml(truncateLabel(center.label, 12))}</text>
       </g>
@@ -494,6 +494,17 @@ function renderGraphPreviewCard(graphData, heatmap) {
   `
 }
 
+// Research Graph 페이지(main.js의 renderLibraryGraphTab)가 로드된 뒤 이 키를
+// 확인해서, 있으면 그 노드를 실제로 클릭한 것과 동일하게 선택하고(showGraphDetailPanel
+// 호출 + 하이라이트) 지운다. main.js를 거치지 않고 URL만으로 넘기면 해시 라우터가
+// 페이지 이름만 정확히 매칭하는 방식과 충돌하므로, 세션 스토리지로 핸드오프한다.
+const GRAPH_FOCUS_NODE_KEY = 'easypaper_graph_focus_node'
+function goToGraphNode(nodeId) {
+  if (!nodeId) return
+  sessionStorage.setItem(GRAPH_FOCUS_NODE_KEY, nodeId)
+  location.hash = 'graph'
+}
+
 // ── 이벤트 바인딩 ──────────────────────────────────────────────────────
 function attachHandlers(root) {
   root.querySelectorAll('[data-nav]').forEach(elm => {
@@ -509,6 +520,34 @@ function attachHandlers(root) {
       const id = elm.dataset.docId
       if (id) location.hash = `viewer?id=${encodeURIComponent(id)}`
     })
+  })
+
+  // 최근 질문 → 해당 논문을 채팅 사이드바가 열린 채로 연다.
+  root.querySelectorAll('.dash-question-item[data-doc-id]').forEach(elm => {
+    elm.addEventListener('click', () => {
+      const id = elm.dataset.docId
+      if (id) location.hash = `viewer?id=${encodeURIComponent(id)}&chat=1`
+    })
+  })
+
+  // 연구 타임라인 항목 → 해당 논문 열기(질문 이벤트는 채팅까지 함께 열기).
+  root.querySelectorAll('.dash-timeline-item[data-doc-id]').forEach(elm => {
+    elm.addEventListener('click', () => {
+      const id = elm.dataset.docId
+      if (!id) return
+      const wantChat = elm.dataset.type === 'question'
+      location.hash = `viewer?id=${encodeURIComponent(id)}${wantChat ? '&chat=1' : ''}`
+    })
+  })
+
+  // 개념 히트맵 타일 → 연구 그래프에서 해당 개념 노드를 선택된 상태로 연다.
+  root.querySelectorAll('.dash-heat-cell[data-node-id]').forEach(elm => {
+    elm.addEventListener('click', () => goToGraphNode(elm.dataset.nodeId))
+  })
+
+  // 연구 그래프 미리보기의 노드(중심 개념/이웃 논문·개념) → 연구 그래프에서 이어서 보기.
+  root.querySelectorAll('.dash-graph-node[data-node-id]').forEach(elm => {
+    elm.addEventListener('click', () => goToGraphNode(elm.dataset.nodeId))
   })
 
   const recsBtn = root.querySelector('[data-recs-btn]')

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -18,7 +18,7 @@ function escapeHtml(str) {
   return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
 
-const TYPE_LABEL = { uploaded: 'Uploaded', read: 'Read', question: 'Question', note: 'Note' }
+const TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
 const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', question: 'messageCircle', note: 'edit3' }
 // 활동 구성 막대(part-to-whole)의 분류 색 - dataviz 팔레트의 앞 4개 슬롯을
 // 고정 순서(blue→orange→aqua→yellow)로만 사용해 색맹 인접성 검증을 그대로 유지한다.
@@ -26,8 +26,7 @@ const TYPE_COLOR_VAR = { read: '--rh-c1', question: '--rh-c2', note: '--rh-c3', 
 const TYPE_ORDER = ['read', 'question', 'note', 'uploaded']
 
 const DAY_MS = 86400000
-const WEEKDAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', 'Sun']
-const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const WEEKDAY_LABELS = ['월', '', '수', '', '금', '', '일']
 
 // ── 날짜 키 유틸: 로컬 자정 기준 "YYYY-MM-DD". 이벤트 timestamp는
 // 백엔드가 UTC ISO 문자열로 내려주므로 .slice(0,10) 자체가 이미 날짜 키다 -
@@ -59,18 +58,18 @@ function formatDayLabel(dateKey) {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
   const diffDays = Math.round((today - day) / DAY_MS)
-  const primary = diffDays === 0 ? 'Today' : diffDays === 1 ? 'Yesterday'
-    : day.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
-  return { primary, secondary: day.toLocaleDateString('en-US', { weekday: 'long' }) }
+  const primary = diffDays === 0 ? '오늘' : diffDays === 1 ? '어제'
+    : day.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })
+  return { primary, secondary: day.toLocaleDateString('ko-KR', { weekday: 'long' }) }
 }
 function formatTime(timestamp) {
   const d = new Date(timestamp)
-  return isNaN(d.getTime()) ? '' : d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  return isNaN(d.getTime()) ? '' : d.toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit' })
 }
 function formatShortDate(dateKey) {
   const d = keyToLocalDate(dateKey)
   if (isNaN(d.getTime())) return dateKey
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  return d.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 // ── 집계 헬퍼 ──────────────────────────────────────────────
@@ -127,10 +126,10 @@ function periodStats(events, docsById, startKey, endKeyExclusive) {
 
 function deltaHtml(curr, prev, unit = '') {
   const diff = curr - prev
-  if (diff === 0) return `<span class="rh-stat-delta">±0${unit ? ' ' + unit : ''} vs prior 30 days</span>`
+  if (diff === 0) return `<span class="rh-stat-delta">±0${unit ? ' ' + unit : ''} 이전 30일 대비</span>`
   const cls = diff > 0 ? 'up' : 'down'
   const arrow = diff > 0 ? '↑' : '↓'
-  return `<span class="rh-stat-delta ${cls}">${arrow} ${Math.abs(diff).toLocaleString()}${unit ? ' ' + unit : ''} vs prior 30 days</span>`
+  return `<span class="rh-stat-delta ${cls}">${arrow} ${Math.abs(diff).toLocaleString()}${unit ? ' ' + unit : ''} 이전 30일 대비</span>`
 }
 
 // ── 읽기 시간 포맷/집계 헬퍼 ──────────────────────────────────
@@ -144,10 +143,10 @@ function formatDuration(seconds) {
 }
 function deltaDurationHtml(currSeconds, prevSeconds) {
   const diff = Math.round(currSeconds - prevSeconds)
-  if (diff === 0) return `<span class="rh-stat-delta">±0m vs prior 30 days</span>`
+  if (diff === 0) return `<span class="rh-stat-delta">±0m 이전 30일 대비</span>`
   const cls = diff > 0 ? 'up' : 'down'
   const arrow = diff > 0 ? '↑' : '↓'
-  return `<span class="rh-stat-delta ${cls}">${arrow} ${formatDuration(Math.abs(diff))} vs prior 30 days</span>`
+  return `<span class="rh-stat-delta ${cls}">${arrow} ${formatDuration(Math.abs(diff))} 이전 30일 대비</span>`
 }
 function sumSecondsByDayRange(byDay, startKey, endKeyExclusive) {
   let total = 0
@@ -162,7 +161,7 @@ export async function renderReadingHistoryPage() {
   const el = document.getElementById('page-history')
   if (!el) return
 
-  el.innerHTML = '<div class="rh-page"><div class="rh-empty">Loading reading history...</div></div>'
+  el.innerHTML = '<div class="rh-page"><div class="rh-empty">읽기 기록을 불러오는 중...</div></div>'
 
   let events = []
   let dashboard = null
@@ -181,7 +180,7 @@ export async function renderReadingHistoryPage() {
     readingStats = readingStatsRes
   } catch (err) {
     console.error('Reading History 로드 실패:', err)
-    el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">Failed to load reading history.</div></div>'
+    el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">읽기 기록을 불러오지 못했습니다.</div></div>'
     return
   }
 
@@ -190,7 +189,7 @@ export async function renderReadingHistoryPage() {
   const docsById = new Map(libraryDocs.map(d => [d.id, d]))
   const docTitle = (docId, fallback) => {
     const d = docsById.get(docId)
-    return (d?.metadata?.title) || d?.filename || fallback || 'Untitled'
+    return (d?.metadata?.title) || d?.filename || fallback || '제목 없음'
   }
 
   if (events.length === 0) {
@@ -198,10 +197,10 @@ export async function renderReadingHistoryPage() {
       <div class="rh-page">
         <div class="rh-header">
           <div>
-            <p class="rh-header-subtitle">Track your reading activities and research journey.</p>
+            <p class="rh-header-subtitle">읽기 활동과 연구 여정을 확인하세요.</p>
           </div>
         </div>
-        <div class="rh-card"><div class="rh-empty">No activity yet. Upload and read a paper to start building your history.</div></div>
+        <div class="rh-card"><div class="rh-empty">아직 활동 기록이 없습니다. 논문을 업로드하고 읽으면 기록이 쌓입니다.</div></div>
       </div>`
     return
   }
@@ -225,27 +224,27 @@ export async function renderReadingHistoryPage() {
 
   const statCards = [
     {
-      icon: 'calendar', color: 'var(--rh-c1)', label: 'Days Active',
+      icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
       value: `${curr.activeDays} / 30`,
-      sub: `<span class="rh-stat-delta">${activeDaysPct}% of last 30 days</span>`,
+      sub: `<span class="rh-stat-delta">최근 30일 중 ${activeDaysPct}%</span>`,
     },
     {
-      icon: 'clock', color: 'var(--rh-c3)', label: 'Reading Time',
+      icon: 'clock', color: 'var(--rh-c3)', label: '읽은 시간',
       value: formatDuration(currReadingSeconds),
       sub: deltaDurationHtml(currReadingSeconds, prevReadingSeconds),
     },
     {
-      icon: 'layers', color: 'var(--rh-c6)', label: 'Pages Read',
+      icon: 'layers', color: 'var(--rh-c6)', label: '읽은 페이지',
       value: curr.pagesRead.toLocaleString(),
       sub: deltaHtml(curr.pagesRead, prev.pagesRead),
     },
     {
-      icon: 'messageCircle', color: 'var(--rh-c5)', label: 'Questions Asked',
+      icon: 'messageCircle', color: 'var(--rh-c5)', label: '질문 수',
       value: curr.questions.toLocaleString(),
       sub: deltaHtml(curr.questions, prev.questions),
     },
     {
-      icon: 'edit3', color: 'var(--rh-c2)', label: 'Notes Created',
+      icon: 'edit3', color: 'var(--rh-c2)', label: '작성한 메모',
       value: curr.notes.toLocaleString(),
       sub: deltaHtml(curr.notes, prev.notes),
     },
@@ -280,7 +279,7 @@ export async function renderReadingHistoryPage() {
   weeks.forEach((week, wi) => {
     const firstOfMonthDay = week.find(d => keyToLocalDate(d.key).getDate() <= 7)
     if (firstOfMonthDay) {
-      const label = MONTH_LABELS[keyToLocalDate(firstOfMonthDay.key).getMonth()]
+      const label = `${keyToLocalDate(firstOfMonthDay.key).getMonth() + 1}월`
       if (!monthMarkers.length || monthMarkers[monthMarkers.length - 1].label !== label) {
         monthMarkers.push({ col: wi + 1, label })
       }
@@ -290,7 +289,7 @@ export async function renderReadingHistoryPage() {
   const calGridHtml = weeks.map(week => week.map(cell => {
     if (cell.isFuture) return '<div class="rh-cal-cell rh-future"></div>'
     const bucket = bucketOf(cell.count)
-    const title = `${formatShortDate(cell.key)}: ${cell.count} ${cell.count === 1 ? 'activity' : 'activities'}`
+    const title = `${formatShortDate(cell.key)}: 활동 ${cell.count}건`
     return `<div class="rh-cal-cell rh-heat-${bucket}" title="${escapeHtml(title)}"></div>`
   }).join('')).join('')
 
@@ -312,7 +311,7 @@ export async function renderReadingHistoryPage() {
   // ── Reading Time Distribution (part-to-whole, 전체 기간 실측치) ──
   // 카테고리는 main.js 하트비트가 실제로 구분하는 화면 상태 3가지뿐이다:
   // reading(뷰어에서 읽는 중) / chat(채팅 사이드바 사용 중) / compare(논문 비교).
-  const CATEGORY_LABEL = { reading: 'Paper Reading', chat: 'AI Chat', compare: 'Comparing Papers' }
+  const CATEGORY_LABEL = { reading: '논문 읽기', chat: 'AI 채팅', compare: '논문 비교' }
   const CATEGORY_COLOR_VAR = { reading: '--rh-c1', chat: '--rh-c2', compare: '--rh-c5' }
   const CATEGORY_ORDER = ['reading', 'chat', 'compare']
   const byCategory = readingStats?.total_seconds_by_category || {}
@@ -380,9 +379,9 @@ export async function renderReadingHistoryPage() {
     <div class="rh-page">
       <div class="rh-header">
         <div>
-          <p class="rh-header-subtitle">Track your reading activities and research journey.</p>
+          <p class="rh-header-subtitle">읽기 활동과 연구 여정을 확인하세요.</p>
         </div>
-        <span class="rh-header-period">${icon('calendar', 13)} Last 30 days</span>
+        <span class="rh-header-period">${icon('calendar', 13)} 최근 30일</span>
       </div>
 
       <div class="rh-stat-grid">
@@ -402,15 +401,15 @@ export async function renderReadingHistoryPage() {
         <div class="rh-col">
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('calendar', 15)} Reading Activity</span>
+              <span class="rh-card-title">${icon('calendar', 15)} 읽기 활동</span>
               <div class="rh-cal-legend">
-                Less
+                적음
                 <span class="rh-cal-legend-swatch rh-heat-0" style="background:color-mix(in srgb, var(--accent-mid) 6%, var(--bg-elevated))"></span>
                 <span class="rh-cal-legend-swatch rh-heat-1" style="background:color-mix(in srgb, var(--accent-mid) 28%, var(--bg-elevated))"></span>
                 <span class="rh-cal-legend-swatch rh-heat-2" style="background:color-mix(in srgb, var(--accent-mid) 50%, var(--bg-elevated))"></span>
                 <span class="rh-cal-legend-swatch rh-heat-3" style="background:color-mix(in srgb, var(--accent-mid) 72%, var(--bg-elevated))"></span>
                 <span class="rh-cal-legend-swatch rh-heat-4" style="background:var(--accent-mid)"></span>
-                More
+                많음
               </div>
             </div>
             <div class="rh-cal-scroll">
@@ -424,31 +423,31 @@ export async function renderReadingHistoryPage() {
             </div>
             <div class="rh-cal-footer">
               <span>${formatShortDate(gridStart)} &ndash; ${formatShortDate(gridEnd)}</span>
-              <span>Total <b>${allActiveKeys.size}</b> active days &bull; Longest streak <b>${streaks.longest}</b> days</span>
+              <span>총 <b>${allActiveKeys.size}</b>일 활동 &bull; 최장 연속 <b>${streaks.longest}</b>일</span>
             </div>
           </div>
 
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('list', 15)} All Activities</span>
+              <span class="rh-card-title">${icon('list', 15)} 전체 활동</span>
             </div>
             <div class="rh-tabs" id="rh-filter-tabs">
-              <button type="button" class="rh-tab-btn active" data-type="all">All Activities</button>
+              <button type="button" class="rh-tab-btn active" data-type="all">전체</button>
               ${TYPE_ORDER.map(t => `<button type="button" class="rh-tab-btn" data-type="${t}">${escapeHtml(TYPE_LABEL[t])}</button>`).join('')}
             </div>
             <div id="rh-timeline-list"></div>
-            <button type="button" class="rh-more-btn hidden" id="rh-more-btn">${icon('chevronDown', 14)} Show more activities</button>
+            <button type="button" class="rh-more-btn hidden" id="rh-more-btn">${icon('chevronDown', 14)} 활동 더 보기</button>
           </div>
         </div>
 
         <div class="rh-col">
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('grid', 15)} Reading Time Distribution</span>
+              <span class="rh-card-title">${icon('grid', 15)} 읽기 시간 분포</span>
               <span class="rh-card-sub">뷰어/비교 화면 실측 시간</span>
             </div>
             ${mixTotalSeconds > 0 ? `
-              <div class="rh-mix-total">All-time total: <b>${formatDuration(mixTotalSeconds)}</b></div>
+              <div class="rh-mix-total">전체 누적: <b>${formatDuration(mixTotalSeconds)}</b></div>
               <div class="rh-mix-bar">${mixBarHtml}</div>
               <div class="rh-mix-legend">${mixLegendHtml}</div>
             ` : `<div class="rh-empty">아직 기록된 읽기 시간이 없습니다.</div>`}
@@ -456,38 +455,38 @@ export async function renderReadingHistoryPage() {
 
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('award', 15)} Top Papers by Reading Time</span>
+              <span class="rh-card-title">${icon('award', 15)} 읽기 시간 상위 논문</span>
             </div>
             <div class="rh-top-list">${topPapersHtml}</div>
           </div>
 
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('zap', 15)} Reading Streak</span>
+              <span class="rh-card-title">${icon('zap', 15)} 연속 읽기</span>
             </div>
             <div class="rh-streak-value">
               <span class="rh-streak-num">${streaks.current}</span>
-              <span class="rh-streak-unit">day${streaks.current === 1 ? '' : 's'}</span>
+              <span class="rh-streak-unit">일</span>
             </div>
             <div class="rh-streak-week">${streakWeekHtml}</div>
-            <div class="rh-streak-msg">${streaks.current > 0 ? 'Keep it up!' : 'Read a paper today to start a streak.'}</div>
+            <div class="rh-streak-msg">${streaks.current > 0 ? '계속 이어가세요!' : '오늘 논문을 읽고 연속 기록을 시작해보세요.'}</div>
           </div>
 
           <div class="rh-callout-row">
             <div class="rh-callout">
               <div class="rh-callout-icon" style="--rh-callout-color:var(--rh-c4)">${icon('award', 16)}</div>
               <div class="rh-callout-body">
-                <div class="rh-callout-label">Most Active Day</div>
-                <div class="rh-callout-value">${bestDayCount ? `${bestDayCount} activities` : '&mdash;'}</div>
-                <div class="rh-callout-sub">${bestDayKey ? formatShortDate(bestDayKey) : 'No activity yet'}</div>
+                <div class="rh-callout-label">가장 활발했던 날</div>
+                <div class="rh-callout-value">${bestDayCount ? `${bestDayCount}건의 활동` : '&mdash;'}</div>
+                <div class="rh-callout-sub">${bestDayKey ? formatShortDate(bestDayKey) : '아직 활동 없음'}</div>
               </div>
             </div>
             <div class="rh-callout">
               <div class="rh-callout-icon" style="--rh-callout-color:var(--success)">${icon('checkCircle', 16)}</div>
               <div class="rh-callout-body">
-                <div class="rh-callout-label">Longest Streak</div>
-                <div class="rh-callout-value">${streaks.longest} day${streaks.longest === 1 ? '' : 's'}</div>
-                <div class="rh-callout-sub">${streaks.longestStart ? `${formatShortDate(streaks.longestStart)} &ndash; ${formatShortDate(streaks.longestEnd)}` : 'No activity yet'}</div>
+                <div class="rh-callout-label">최장 연속 기록</div>
+                <div class="rh-callout-value">${streaks.longest}일</div>
+                <div class="rh-callout-sub">${streaks.longestStart ? `${formatShortDate(streaks.longestStart)} &ndash; ${formatShortDate(streaks.longestEnd)}` : '아직 활동 없음'}</div>
               </div>
             </div>
           </div>
@@ -518,7 +517,7 @@ export async function renderReadingHistoryPage() {
   function renderTimeline() {
     const filtered = activeType === 'all' ? sortedEvents : sortedEvents.filter(e => e.type === activeType)
     if (filtered.length === 0) {
-      timelineListEl.innerHTML = '<div class="rh-empty">No activities of this type yet.</div>'
+      timelineListEl.innerHTML = '<div class="rh-empty">이 유형의 활동이 아직 없습니다.</div>'
       moreBtn.classList.add('hidden')
       return
     }
@@ -537,7 +536,7 @@ export async function renderReadingHistoryPage() {
               const title = docTitle(e.doc_id, e.doc_title)
               const pages = e.type === 'read' ? docsById.get(e.doc_id)?.total_pages : null
               return `
-                <div class="rh-timeline-entry" data-doc-id="${escapeHtml(e.doc_id || '')}" data-type="${escapeHtml(e.type)}" title="Open this paper">
+                <div class="rh-timeline-entry" data-doc-id="${escapeHtml(e.doc_id || '')}" data-type="${escapeHtml(e.type)}" title="이 논문 열기">
                   <div class="rh-timeline-dot">${icon(TYPE_ICON[e.type] || 'clock', 13)}</div>
                   <div class="rh-timeline-row">
                     <span class="rh-timeline-time">${escapeHtml(formatTime(e.timestamp))}</span>
@@ -546,7 +545,7 @@ export async function renderReadingHistoryPage() {
                       <div class="rh-timeline-title">${escapeHtml(title)}</div>
                       ${e.summary ? `<div class="rh-timeline-summary">${escapeHtml(e.summary)}</div>` : ''}
                     </div>
-                    ${pages ? `<span class="rh-timeline-meta">${pages} pages</span>` : ''}
+                    ${pages ? `<span class="rh-timeline-meta">${pages}페이지</span>` : ''}
                   </div>
                 </div>`
             }).join('')}

--- a/frontend/src/styles/ai-chats.css
+++ b/frontend/src/styles/ai-chats.css
@@ -193,10 +193,14 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-surface);
-  overflow: hidden;
+  /* Action 컬럼(대화 열기/뷰어 열기 버튼 2개)이 좁은 화면에서 잘리던 문제 -
+     min-width로 표가 너무 좁아지지 않게 바닥을 깔아두고, 그래도 컨테이너보다
+     넓어지면 잘리는 대신 가로 스크롤이 되게 한다. */
+  overflow-x: auto;
 }
 .aic-table {
   width: 100%;
+  min-width: 720px;
   border-collapse: collapse;
 }
 .aic-table thead th {
@@ -221,10 +225,10 @@
   font-size: 13px;
   color: var(--text-secondary);
 }
-.aic-col-paper { width: 34%; }
-.aic-col-message { width: 32%; color: var(--text-secondary); }
-.aic-col-updated { width: 14%; white-space: nowrap; color: var(--text-tertiary); }
-.aic-col-actions { width: 20%; }
+.aic-col-paper { width: 32%; }
+.aic-col-message { width: 26%; color: var(--text-secondary); }
+.aic-col-updated { width: 12%; white-space: nowrap; color: var(--text-tertiary); }
+.aic-col-actions { width: 30%; }
 
 .aic-paper-cell {
   display: flex;
@@ -261,18 +265,18 @@
 .aic-preview-loading { color: var(--text-muted); font-style: italic; }
 .aic-preview-empty { color: var(--text-muted); }
 
-.aic-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.aic-actions { display: flex; align-items: center; gap: 6px; flex-wrap: nowrap; }
 .aic-action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 7px 11px;
+  gap: 5px;
+  padding: 6px 9px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-strong);
   background: var(--bg-elevated);
   color: var(--text-secondary);
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -325,9 +325,10 @@
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--bg-surface);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
-.dash-heat-cell:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.dash-heat-cell:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); border-color: var(--control-accent); }
 .dash-heat-swatch {
   height: 8px;
   border-radius: 4px;
@@ -356,7 +357,8 @@
 
 /* ── 연구 타임라인 ── */
 .dash-timeline-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
-.dash-timeline-item { position: relative; display: flex; gap: 10px; padding-bottom: 14px; }
+.dash-timeline-item { position: relative; display: flex; gap: 10px; padding-bottom: 14px; cursor: pointer; border-radius: var(--radius-sm); transition: background 0.15s ease; }
+.dash-timeline-item:hover { background: var(--bg-hover); }
 .dash-timeline-item:last-child { padding-bottom: 0; }
 .dash-timeline-item::before {
   content: '';
@@ -393,11 +395,14 @@
 .dash-card-graph { align-items: stretch; }
 .dash-graph-svg { width: 100%; height: 168px; }
 .dash-graph-edge { stroke: var(--border-strong); stroke-width: 1.2; }
+.dash-graph-node { cursor: pointer; }
 .dash-graph-node circle {
   fill: var(--bg-panel);
   stroke: var(--border-strong);
   stroke-width: 1.5;
+  transition: stroke-width 0.15s ease;
 }
+.dash-graph-node:hover circle { stroke-width: 3; }
 .dash-graph-node.is-center circle { fill: var(--accent-mid); stroke: var(--accent-to); stroke-width: 2; }
 .dash-graph-node.is-paper circle { fill: color-mix(in srgb, var(--success) 32%, var(--bg-panel)); stroke: var(--success); }
 .dash-graph-node.is-concept circle { fill: color-mix(in srgb, var(--control-accent) 38%, var(--bg-panel)); stroke: var(--control-accent-text); }

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -243,6 +243,14 @@
 .dash-paper-time { flex-shrink: 0; }
 .dash-paper-progress-row { display: flex; align-items: center; gap: 8px; }
 .dash-paper-pct { flex-shrink: 0; font-size: 10.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.dash-paper-done-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--success);
+}
 
 /* ── 최근 질문 ── */
 .dash-question-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -191,6 +191,13 @@
   color: var(--accent-mid);
   flex-shrink: 0;
 }
+.lib-card-progress-done { min-height: 5px; }
+.lib-card-progress-done .doc-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11.5px;
+}
 
 /* ============================================================
    상세 패널 (우측 드로어) — 카드를 클릭하면 열리며, 표지/제목/저자,

--- a/frontend/src/styles/reading-history.css
+++ b/frontend/src/styles/reading-history.css
@@ -363,6 +363,17 @@ body.light-theme {
   color: var(--control-accent-text);
   white-space: nowrap;
 }
+/* 활동 타입(읽음/질문/메모/업로드)별로 서로 다른 색을 준다 - Reading Time
+   Distribution 등 다른 위젯에서 이미 쓰는 --rh-c1..c4 dataviz 팔레트와 동일한
+   타입→색 매핑(TYPE_COLOR_VAR)을 그대로 재사용해 페이지 안에서 일관되게 한다. */
+.rh-timeline-entry[data-type="read"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c1) 18%, transparent); color: var(--rh-c1); }
+.rh-timeline-entry[data-type="question"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c2) 18%, transparent); color: var(--rh-c2); }
+.rh-timeline-entry[data-type="note"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c3) 18%, transparent); color: var(--rh-c3); }
+.rh-timeline-entry[data-type="uploaded"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c4) 18%, transparent); color: var(--rh-c4); }
+.rh-timeline-entry[data-type="read"] .rh-timeline-dot { color: var(--rh-c1); border-color: color-mix(in srgb, var(--rh-c1) 40%, var(--border-strong)); }
+.rh-timeline-entry[data-type="question"] .rh-timeline-dot { color: var(--rh-c2); border-color: color-mix(in srgb, var(--rh-c2) 40%, var(--border-strong)); }
+.rh-timeline-entry[data-type="note"] .rh-timeline-dot { color: var(--rh-c3); border-color: color-mix(in srgb, var(--rh-c3) 40%, var(--border-strong)); }
+.rh-timeline-entry[data-type="uploaded"] .rh-timeline-dot { color: var(--rh-c4); border-color: color-mix(in srgb, var(--rh-c4) 40%, var(--border-strong)); }
 .rh-timeline-main { flex: 1; min-width: 0; }
 .rh-timeline-title {
   font-size: 13px;

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -190,9 +190,6 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  /* 로그인/비교 화면과 공유하는 플로팅 테마/설정/로그아웃 버튼(우상단 고정)과
-     겹치지 않도록 여유 공간을 둔다 */
-  margin-right: 78px;
 }
 .workspace-search-box {
   position: relative;
@@ -221,21 +218,6 @@
   border-color: var(--control-accent);
   width: 300px;
 }
-.workspace-avatar-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  flex-shrink: 0;
-  border-radius: 50%;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-.workspace-avatar-btn:hover { color: var(--text-primary); border-color: var(--control-accent); }
 
 .page-outlet {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- 우측 상단 플로팅 테마 토글/아바타 버튼 제거 → 사이드바 푸터(Settings 위)로 이동
- Dashboard/Library 카드 진행률: 번역률 → 실제 읽은 페이지 기준으로 변경, 완독 논문 완료 칩 추가
- Library 전체 탭: 완독 논문을 항상 맨 뒤로 정렬
- Reading History 페이지 전체 한글화
- Reading History 활동 타입 칩(읽음/질문/메모/업로드) 색상 구분
- AI Chats 표 컬럼 잘림 수정(폭 재배분 + 가로 스크롤 폴백)

## Test plan
- [x] `npx vite build` 클린 통과
- [x] 실제 로그인 후 6개 페이지 전부 스크린샷으로 시각 확인, 콘솔 에러 없음
- [x] 사이드바 테마 토글 클릭 시 정상 전환 확인, 플로팅 버튼 미노출 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>