### PR TITLE
AI Chats 표 컬럼 잘림/가로 스크롤 근본 수정

### DIFF
--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -186,11 +186,11 @@ export async function renderAiChatsPage() {
 
   function actionsHtml(session) {
     return `
-      <button type="button" class="aic-action-btn aic-action-primary" data-action="chat" data-doc="${escapeHtml(session.doc_id)}">
-        ${icon('messageCircle', 14)} 대화 열기
+      <button type="button" class="aic-action-btn aic-action-primary" data-action="chat" data-doc="${escapeHtml(session.doc_id)}" title="대화 열기">
+        ${icon('messageCircle', 14)} 대화
       </button>
-      <button type="button" class="aic-action-btn" data-action="viewer" data-doc="${escapeHtml(session.doc_id)}">
-        ${icon('bookOpen', 14)} 뷰어 열기
+      <button type="button" class="aic-action-btn" data-action="viewer" data-doc="${escapeHtml(session.doc_id)}" title="뷰어 열기">
+        ${icon('bookOpen', 14)} 뷰어
       </button>
     `
   }

--- a/frontend/src/styles/ai-chats.css
+++ b/frontend/src/styles/ai-chats.css
@@ -193,19 +193,24 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-surface);
-  /* Action 컬럼(대화 열기/뷰어 열기 버튼 2개)이 좁은 화면에서 잘리던 문제 -
-     min-width로 표가 너무 좁아지지 않게 바닥을 깔아두고, 그래도 컨테이너보다
-     넓어지면 잘리는 대신 가로 스크롤이 되게 한다. */
+  /* 아주 좁은 창(1024px 미만 등)에 대한 최후의 안전판일 뿐, 일반적인 데스크톱
+     너비에서는 아래 table-layout:fixed + 컬럼 폭 조정만으로 스크롤 없이 다 보인다. */
   overflow-x: auto;
 }
 .aic-table {
   width: 100%;
-  min-width: 720px;
+  min-width: 620px;
+  /* 잘림의 실제 원인 - table-layout이 기본값(auto)이면 브라우저가 셀
+     내용(특히 줄바꿈 없는 논문 제목)의 "선호 폭"을 기준으로 컬럼 폭을
+     재배분해서, 아래 %가 있어도 Action 컬럼이 밀려 잘렸다. fixed로
+     고정해 %가 항상 그대로 지켜지게 하고, 넘치는 텍스트는 ellipsis로
+     줄인다(논문 제목/미리보기 모두 이미 text-overflow:ellipsis 적용됨). */
+  table-layout: fixed;
   border-collapse: collapse;
 }
 .aic-table thead th {
   text-align: left;
-  padding: 12px 20px;
+  padding: 12px 16px;
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
@@ -220,15 +225,15 @@
 .aic-table tbody tr:last-child { border-bottom: none; }
 .aic-table tbody tr:hover { background: var(--bg-hover); }
 .aic-table td {
-  padding: 14px 20px;
+  padding: 12px 16px;
   vertical-align: middle;
   font-size: 13px;
   color: var(--text-secondary);
 }
-.aic-col-paper { width: 32%; }
-.aic-col-message { width: 26%; color: var(--text-secondary); }
-.aic-col-updated { width: 12%; white-space: nowrap; color: var(--text-tertiary); }
-.aic-col-actions { width: 30%; }
+.aic-col-paper { width: 28%; }
+.aic-col-message { width: 24%; color: var(--text-secondary); }
+.aic-col-updated { width: 12%; white-space: nowrap; color: var(--text-tertiary); overflow: hidden; text-overflow: ellipsis; }
+.aic-col-actions { width: 36%; }
 
 .aic-paper-cell {
   display: flex;


### PR DESCRIPTION
## Summary
지난 PR(#290)에서 `overflow-x:auto`로 스크롤 폴백만 추가했었는데, 근본 원인(table-layout이 기본값 auto라 컬럼 % 폭이 무시되던 것)을 찾아 `table-layout: fixed`로 수정. 컬럼 비율 재조정 + 액션 버튼 라벨 축소로 여유 확보.

## Test plan
- [x] `npx vite build` 클린 통과
- [x] 실제 채팅 세션 데이터(매우 긴 논문 제목 포함)로 1024/1200/1366/1680px 전 구간에서 가로 스크롤 불필요 확인 (`scrollWidth === clientWidth`)
- [x] 버튼/텍스트 잘림 없이 정상 표시 스크린샷 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>