### PR TITLE
AI Chats 독립 대화 화면 추가 + Notes 요약 탭에 읽기 전 브리핑 전체 반영

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -310,6 +310,40 @@
     </div>
   </div>
 
+  <!-- 단일 논문 대화 화면 (뷰어 없이 채팅 메시지 + 입력창만) -->
+  <div id="chat-screen" class="screen">
+    <header class="compare-topbar">
+      <button id="chat-screen-back-btn" class="icon-btn" title="AI Chats로 돌아가기">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
+      </button>
+      <div class="compare-topbar-title">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>
+        <span id="chat-screen-title">AI 대화</span>
+      </div>
+      <button type="button" id="chat-screen-viewer-btn" class="file-btn-outline compact" title="뷰어에서 열기">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>뷰어에서 열기
+      </button>
+    </header>
+
+    <div class="compare-chat-body">
+      <div class="chat-messages" id="chat-screen-messages"></div>
+      <div class="chat-input-area compare-chat-input-area">
+        <div class="chat-input-box">
+          <textarea id="chat-screen-input" class="chat-input-textarea" placeholder="이 논문에 대해 질문해보세요..." rows="1"></textarea>
+          <div class="chat-input-footer">
+            <span class="compare-chat-hint">Enter로 전송 · Shift+Enter로 줄바꿈</span>
+            <button id="chat-screen-send-btn" class="chat-send-btn" title="전송">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="22" y1="2" x2="11" y2="13"/>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- 뷰어 화면 -->
   <div id="viewer-screen" class="screen">
 

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -49,6 +49,11 @@ const PATHS = {
   logOut: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" x2="9" y1="12" y2="12"/>',
   panelLeft: '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/>',
   user: '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
+  helpCircle: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>',
+  listChecks: '<path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/>',
+  activity: '<path d="M3 12h4l3 8 4-16 3 8h4"/>',
+  smile: '<circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/>',
+  flaskConical: '<path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/>',
 }
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -13,6 +13,7 @@ import { renderDashboardPage } from './pages/dashboardPage.js'
 import { renderReadingHistoryPage } from './pages/readingHistoryPage.js'
 import { renderAiChatsPage } from './pages/aiChatsPage.js'
 import { renderNotesPage } from './pages/notesPage.js'
+import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -272,6 +273,15 @@ const compareChatMessages  = $('compare-chat-messages')
 const compareChatInput     = $('compare-chat-input')
 const compareChatSendBtn   = $('compare-chat-send-btn')
 
+// ── 단일 논문 대화 화면 (뷰어 없이 채팅만) ──
+const chatScreenEl         = $('chat-screen')
+const chatScreenBackBtn    = $('chat-screen-back-btn')
+const chatScreenTitle      = $('chat-screen-title')
+const chatScreenViewerBtn  = $('chat-screen-viewer-btn')
+const chatScreenMessages   = $('chat-screen-messages')
+const chatScreenInput      = $('chat-screen-input')
+const chatScreenSendBtn    = $('chat-screen-send-btn')
+
 const docPreviewOverlay  = $('doc-preview-overlay')
 const docPreviewClose    = $('doc-preview-close')
 const docPreviewCoverImg = $('doc-preview-cover-img')
@@ -418,6 +428,7 @@ function showLogin() {
   viewerScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
+  if (chatScreenEl) chatScreenEl.classList.remove('active')
   loginScreen.classList.add('active')
   // 글로벌 테마 토글 표시, 로그아웃 및 설정 버튼 숨김
   const globalToggle = $('global-theme-toggle')
@@ -430,6 +441,7 @@ function showViewer() {
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
+  if (chatScreenEl) chatScreenEl.classList.remove('active')
   viewerScreen.classList.add('active')
   // 글로벌 테마 토글 숨김 (뷰어 상단바 테마 버튼 사용)
   const globalToggle = $('global-theme-toggle')
@@ -441,9 +453,24 @@ function showCompareScreen() {
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
+  if (chatScreenEl) chatScreenEl.classList.remove('active')
   if (compareScreen) compareScreen.classList.add('active')
   // 라이브러리 화면과 동일하게 글로벌 테마/로그아웃/설정 버튼을 표시한다
   // (비교 화면 자체에는 별도의 테마 버튼이 없음)
+  const globalToggle = $('global-theme-toggle')
+  if (globalToggle) globalToggle.classList.remove('hidden')
+  globalLogoutBtn.classList.remove('hidden')
+  globalSettingsBtn.classList.remove('hidden')
+}
+
+function showChatScreen() {
+  stopLibraryPolling()
+  loginScreen.classList.remove('active')
+  libraryScreen.classList.remove('active')
+  viewerScreen.classList.remove('active')
+  if (compareScreen) compareScreen.classList.remove('active')
+  chatScreenEl.classList.add('active')
+  // compare 화면과 동일하게 글로벌 테마/로그아웃/설정 버튼을 표시한다
   const globalToggle = $('global-theme-toggle')
   if (globalToggle) globalToggle.classList.remove('hidden')
   globalLogoutBtn.classList.remove('hidden')
@@ -961,132 +988,6 @@ function replaceBoldOutsideCode(text) {
     return processedSubBlocks.join('')
   })
   return processedBlocks.join('')
-}
-
-// PDF 원문에서 첫 줄 들여쓰기가 감지된 문단의 맨 앞에 backend(pdf_parser.py의
-// _INDENT_SENTINEL)가 붙여두는 표시 - 같은 문자를 여기서도 그대로 사용해야
-// chunker.py가 [S{n}:I] 태그 자리에 남겨준 표시를 인식할 수 있다.
-const INDENT_MARK = String.fromCharCode(0xE000)
-
-// ── 번역 텍스트 포맷팅 (LaTeX & HTML 처리) ─────────
-function formatTranslationHtml(text) {
-  if (!text) return ''
-
-  // 문장 정렬용 태그([S0], [S1], [S0:I] 등)가 번역창에 출력되지 않도록 제거
-  let t = text.replace(/\[[sS]\d+(?::[A-Za-z]+)?\]/g, '')
-
-  const mathBlocks = []
-
-  // 1. 블록 수식: $$...$$
-  t = t.replace(/\$\$([\s\S]*?)\$\$/g, (_, f) => {
-    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: true })
-    return `::MATH_FLT_PLACEHOLDER_${id}::`
-  })
-  // 2. 블록 수식: \[...\]
-  t = t.replace(/\\\[([\s\S]*?)\\\]/g, (_, f) => {
-    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: true })
-    return `::MATH_FLT_PLACEHOLDER_${id}::`
-  })
-  // 3. 인라인: $...$
-  t = t.replace(/(?<!\$)\$([^\$\n]+?)\$(?!\$)/g, (_, f) => {
-    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: false })
-    return `::MATH_FLT_PLACEHOLDER_${id}::`
-  })
-  // 4. 인라인: \(...\)
-  t = t.replace(/\\\(([\s\S]*?)\\\)/g, (_, f) => {
-    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: false })
-    return `::MATH_FLT_PLACEHOLDER_${id}::`
-  })
-
-  // 4.5. 이스케이프된 볼드체 복원 및 공백 트리밍 (** 마커의 HTML 변환은 아래
-  // escapeHtml 이후 6번 단계에서 수행한다 - 여기서 <strong>으로 먼저 바꿔버리면
-  // 5번의 escapeHtml이 그 태그까지 다시 이스케이프해서 화면에 "&lt;strong&gt;"처럼
-  // 그대로 노출되는 문제가 있었다)
-  t = t.replace(/\\+\*\*/g, '**')
-  t = t.replace(/\*\*\s*([^*]+?)\s*\*\*/g, '**$1**')
-
-  // 5. 마크다운 헤더 & 이스케이프 처리 (+ 원문 들여쓰기 표시가 붙은 줄은 인라인
-  // 들여쓰기 스타일 적용 후 표시 문자 자체는 제거)
-  const lines = t.split('\n')
-  const htmlParts = lines.map(line => {
-    let workingLine = line
-    let isIndented = false
-    const leadingWs = workingLine.match(/^\s*/)[0]
-    if (workingLine.slice(leadingWs.length).startsWith(INDENT_MARK)) {
-      isIndented = true
-      workingLine = leadingWs + workingLine.slice(leadingWs.length + INDENT_MARK.length).replace(/^\s+/, '')
-    }
-    const tr = workingLine.trim()
-    let rendered
-    if (tr.startsWith('### ')) rendered = `<h4 class="md-h4">${escapeHtml(tr.slice(4))}</h4>`
-    else if (tr.startsWith('## '))  rendered = `<h3 class="md-h3">${escapeHtml(tr.slice(3))}</h3>`
-    else if (tr.startsWith('# '))   rendered = `<h2 class="md-h2">${escapeHtml(tr.slice(2))}</h2>`
-    else rendered = escapeHtml(workingLine)
-    return isIndented ? `<span class="trans-indent">${rendered}</span>` : rendered
-  })
-  let html = htmlParts.join('\n')
-    .replace(/\n\n/g, '<br><br>').replace(/\n/g, '<br>')
-
-  // 6. 볼드: **...**
-  html = html.replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
-
-  // 7. 수식 플레이스홀더 복원
-  html = html.replace(/::MATH_FLT_PLACEHOLDER_(\d+)::/g, (_, idStr) => {
-    const item = mathBlocks[parseInt(idStr)]
-    if (!item) return _
-    if (window.katex) {
-      try {
-        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'htmlAndMathml' })
-        if (item.display) {
-          return `<div class="katex-display-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="true">${r}</div>`
-        } else {
-          return `<span class="katex-inline-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="false">${r}</span>`
-        }
-      } catch (e) {
-        return `<code class="math-error" data-formula="${encodeURIComponent(item.formula)}" data-display="${item.display}">${escapeHtml(item.formula)}</code>`
-      }
-    }
-    // KaTeX 미로드 시 pending 마킹 → 나중에 applyKatexToElement()로 재처리
-    const delim = item.display ? '$$' : '$'
-    return `<code class="math-pending" data-formula="${encodeURIComponent(item.formula)}" data-display="${item.display}">${escapeHtml(delim + item.formula + delim)}</code>`
-  })
-
-  return html
-}
-
-/** KaTeX 로드 후 .math-pending 코드를 실제 수식으로 교체 */
-function applyKatexToElement(el) {
-  if (!el || !window.katex) return
-  el.querySelectorAll('code.math-pending').forEach(code => {
-    try {
-      const formula = decodeURIComponent(code.dataset.formula || '')
-      const display = code.dataset.display === 'true'
-      const r = window.katex.renderToString(formula, { displayMode: display, throwOnError: false, output: 'htmlAndMathml' })
-      const wrapper = display
-        ? Object.assign(document.createElement('div'), { className: 'katex-display-wrap', innerHTML: r })
-        : Object.assign(document.createElement('span'), { className: 'katex-inline-wrap', innerHTML: r })
-      wrapper.dataset.formula = encodeURIComponent(formula)
-      wrapper.dataset.display = display.toString()
-      
-      // 세그멘테이션 데이터 및 마킹 속성 보존
-      if (code.classList.contains('trans-sentence')) {
-        wrapper.classList.add('trans-sentence');
-      }
-      if (code.dataset.page) {
-        wrapper.dataset.page = code.dataset.page;
-      }
-      if (code.dataset.sentenceIdx) {
-        wrapper.dataset.sentenceIdx = code.dataset.sentenceIdx;
-      }
-      if (code.style.cursor) {
-        wrapper.style.cursor = code.style.cursor;
-      }
-
-      code.replaceWith(wrapper)
-    } catch (e) {
-      code.classList.remove('math-pending')
-    }
-  })
 }
 
 function renderTransContent(pageNum, text, cached = false) {
@@ -3721,6 +3622,7 @@ async function showLibraryScreen(shouldPushState = true, targetPage) {
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
+  if (chatScreenEl) chatScreenEl.classList.remove('active')
   libraryScreen.classList.add('active')
   // 워크스페이스 화면(사이드바+탑네비)에서는 테마 토글/Settings/로그아웃이 전부
   // 사이드바 푸터에 있으므로, 로그인/비교 화면 전용인 플로팅 버튼 묶음은 통째로 숨긴다
@@ -4147,6 +4049,253 @@ if (compareBackBtn) {
   compareBackBtn.addEventListener('click', () => {
     if (compareChatState.activeStream) { compareChatState.activeStream(); compareChatState.activeStream = null }
     showLibraryScreen()
+  })
+}
+
+// ── 단일 논문 대화 화면 (뷰어 없이 채팅 메시지 + 입력창만) ──────────────
+// AI Chats 페이지의 "대화 열기"는 기존에 뷰어를 열고 채팅 사이드바를 함께
+// 펼치는 방식(#viewer?id=...&chat=1)이었는데, PDF 없이 대화만 보고 싶다는
+// 요청에 따라 이 화면으로 대신 연다. 백엔드는 그대로 재사용한다 - streamChatAPI/
+// getChatHistoryAPI는 이미 뷰어를 실제로 "연" 적이 없어도 동작한다
+// (require_session_owner → ensure_session이 세션이 메모리에 없으면 DB 문서로부터
+// 알아서 복구한다, backend/routers/upload.py). 화면 구조/상태 관리는 바로 위
+// compareChatState/openCompareScreen 패턴을 논문 1편짜리로 그대로 옮긴 것이다.
+let soloChatState = { docId: null, doc: null, history: [], activeStream: null, currentText: '' }
+
+function renderSoloChatMessage(role, content, isHtml = false) {
+  const msgEl = document.createElement('div')
+  msgEl.className = `chat-message ${role}`
+
+  const bubbleEl = document.createElement('div')
+  bubbleEl.className = 'message-bubble'
+  if (isHtml) bubbleEl.innerHTML = content
+  else bubbleEl.textContent = content
+  msgEl.appendChild(bubbleEl)
+
+  if (content) appendSoloActionButtons(msgEl, role, content)
+
+  chatScreenMessages.appendChild(msgEl)
+  chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+  return msgEl
+}
+
+function appendSoloActionButtons(msgEl, role, content) {
+  if (!content || content.includes('chat-error-text')) return
+  const actionsEl = document.createElement('div')
+  actionsEl.className = 'message-actions'
+  actionsEl.style.display = 'flex'
+  actionsEl.style.gap = '8px'
+  actionsEl.style.marginTop = '4px'
+  actionsEl.style.alignSelf = role === 'user' ? 'flex-end' : 'flex-start'
+
+  const copyBtn = document.createElement('button')
+  copyBtn.className = 'msg-action-btn'
+  copyBtn.innerHTML = `${icon('clipboard', 12, 'style="vertical-align:-2px;margin-right:3px"')}복사`
+  copyBtn.style.background = 'none'
+  copyBtn.style.border = 'none'
+  copyBtn.style.color = 'var(--text-muted)'
+  copyBtn.style.fontSize = '11px'
+  copyBtn.style.cursor = 'pointer'
+  copyBtn.title = '텍스트 복사'
+  copyBtn.addEventListener('click', () => {
+    const text = msgEl.querySelector('.message-bubble').textContent
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(() => {
+        showToast('텍스트가 복사되었습니다.', 'success')
+      }).catch(() => showToast('복사 실패', 'error'))
+    }
+  })
+  actionsEl.appendChild(copyBtn)
+  msgEl.appendChild(actionsEl)
+}
+
+function appendSoloTypingIndicator() {
+  const msgEl = document.createElement('div')
+  msgEl.className = 'chat-message assistant temp-typing'
+  const bubbleEl = document.createElement('div')
+  bubbleEl.className = 'message-bubble'
+  bubbleEl.innerHTML = `<div class="typing-container" style="display: flex; align-items: center; gap: 8px;"><span class="typing-text" style="font-size: 12px; color: var(--text-secondary);">AI가 답변을 준비하고 있습니다</span><div class="typing-indicator" style="display: flex; gap: 3px; align-items: center;"><span></span><span></span><span></span></div></div>`
+  msgEl.appendChild(bubbleEl)
+  chatScreenMessages.appendChild(msgEl)
+  chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+  return msgEl
+}
+
+function removeSoloTypingIndicator() {
+  chatScreenMessages.querySelectorAll('.temp-typing').forEach(el => el.remove())
+}
+
+function updateSoloChatSendBtnIcon(isGenerating) {
+  if (!chatScreenSendBtn) return
+  if (isGenerating) {
+    chatScreenSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2" /></svg>`
+    chatScreenSendBtn.title = '답변 생성 중단'
+  } else {
+    chatScreenSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`
+    chatScreenSendBtn.title = '전송'
+  }
+}
+
+function renderSoloGreeting(doc) {
+  const title = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  renderSoloChatMessage('assistant',
+    `<strong>${escapeHtml(title)}</strong>에 대해 무엇이든 물어보세요.<br><br>` +
+    `<strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong>` +
+    `<ul><li>이 논문의 핵심 기여는 무엇인가요?</li><li>실험 설정을 요약해줄 수 있나요?</li><li>이 방법론의 한계점은 뭔가요?</li></ul>`,
+    true)
+}
+
+// location.hash 대입은 popstate/hashchange를 둘 다 발생시킬 수 있어(openCompareScreen과
+// 동일한 이유), 같은 문서에 대한 재진입 호출을 걸러낸다.
+let soloChatOpeningDocId = null
+
+async function openSoloChatScreen(doc, shouldPushState = true) {
+  if (soloChatOpeningDocId === doc.id) return
+  if (chatScreenEl.classList.contains('active') && soloChatState.docId === doc.id) return
+  soloChatOpeningDocId = doc.id
+
+  if (soloChatState.activeStream) { soloChatState.activeStream(); soloChatState.activeStream = null }
+  soloChatState = { docId: doc.id, doc, history: [], activeStream: null, currentText: '' }
+
+  if (shouldPushState) {
+    history.pushState({ screen: 'chat', id: doc.id }, '', `#chat?id=${encodeURIComponent(doc.id)}`)
+  }
+
+  const title = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+  if (chatScreenTitle) chatScreenTitle.textContent = title
+
+  if (chatScreenMessages) chatScreenMessages.innerHTML = ''
+  showChatScreen()
+
+  try {
+    const res = await getChatHistoryAPI(doc.id)
+    const savedHistory = res.history || []
+    if (savedHistory.length === 0) {
+      renderSoloGreeting(doc)
+    } else {
+      savedHistory.forEach(msg => {
+        renderSoloChatMessage(msg.role, msg.role === 'assistant' ? formatChatHtml(msg.content) : msg.content, msg.role === 'assistant')
+        soloChatState.history.push({ role: msg.role, content: msg.content })
+      })
+    }
+  } catch (err) {
+    console.warn('논문 채팅 기록 로드 실패:', err)
+    renderSoloGreeting(doc)
+  } finally {
+    if (soloChatOpeningDocId === doc.id) soloChatOpeningDocId = null
+  }
+}
+
+async function sendSoloChatMessage() {
+  if (!soloChatState.docId) return
+  if (soloChatState.activeStream) return
+
+  const text = chatScreenInput.value.trim()
+  if (!text) return
+
+  chatScreenInput.value = ''
+  chatScreenInput.style.height = 'auto'
+
+  renderSoloChatMessage('user', text)
+  soloChatState.history.push({ role: 'user', content: text })
+
+  appendSoloTypingIndicator()
+  chatScreenInput.disabled = true
+  updateSoloChatSendBtnIcon(true)
+
+  let accumulatedText = ''
+  let replyBubble = null
+  let firstToken = true
+  soloChatState.currentText = ''
+
+  soloChatState.activeStream = streamChatAPI(
+    soloChatState.docId,
+    soloChatState.history,
+    // onToken
+    (token) => {
+      if (firstToken) {
+        if (!token.trim()) return
+        removeSoloTypingIndicator()
+        replyBubble = renderSoloChatMessage('assistant', '', true).querySelector('.message-bubble')
+        firstToken = false
+      }
+      accumulatedText += token
+      soloChatState.currentText = accumulatedText
+      replyBubble.innerHTML = formatChatHtml(accumulatedText)
+      chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+    },
+    // onDone
+    () => {
+      soloChatState.activeStream = null
+      soloChatState.history.push({ role: 'assistant', content: accumulatedText })
+      if (replyBubble) {
+        replyBubble.innerHTML = formatChatHtml(accumulatedText)
+        if (replyBubble.parentElement) appendSoloActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+      }
+      chatScreenInput.disabled = false
+      updateSoloChatSendBtnIcon(false)
+      chatScreenInput.focus()
+    },
+    // onError
+    (err) => {
+      removeSoloTypingIndicator()
+      soloChatState.activeStream = null
+      if (firstToken) {
+        renderSoloChatMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
+      } else if (replyBubble) {
+        replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${err.message}]</span>`
+      }
+      chatScreenInput.disabled = false
+      updateSoloChatSendBtnIcon(false)
+      chatScreenInput.focus()
+    }
+  )
+}
+
+if (chatScreenSendBtn) {
+  chatScreenSendBtn.addEventListener('click', () => {
+    if (soloChatState.activeStream) {
+      soloChatState.activeStream()
+      soloChatState.activeStream = null
+      removeSoloTypingIndicator()
+      if (soloChatState.currentText) {
+        soloChatState.history.push({ role: 'assistant', content: soloChatState.currentText })
+      } else {
+        soloChatState.history.pop()
+      }
+      showToast('답변 생성이 중단되었습니다.', 'info')
+      chatScreenInput.disabled = false
+      updateSoloChatSendBtnIcon(false)
+      chatScreenInput.focus()
+    } else {
+      sendSoloChatMessage()
+    }
+  })
+}
+
+if (chatScreenInput) {
+  chatScreenInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendSoloChatMessage()
+    }
+  })
+  chatScreenInput.addEventListener('input', () => {
+    chatScreenInput.style.height = 'auto'
+    chatScreenInput.style.height = `${chatScreenInput.scrollHeight}px`
+  })
+}
+
+if (chatScreenBackBtn) {
+  chatScreenBackBtn.addEventListener('click', () => {
+    if (soloChatState.activeStream) { soloChatState.activeStream(); soloChatState.activeStream = null }
+    location.hash = 'chats'
+  })
+}
+
+if (chatScreenViewerBtn) {
+  chatScreenViewerBtn.addEventListener('click', () => {
+    if (soloChatState.docId) location.hash = `viewer?id=${encodeURIComponent(soloChatState.docId)}`
   })
 }
 
@@ -13183,6 +13332,25 @@ async function handleRouting() {
       }
       showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
       location.hash = 'library'
+    } else if (hash.startsWith('#chat?id=')) {
+      const params = new URLSearchParams(hash.slice('#chat?'.length))
+      const docId = params.get('id')
+      if (docId) {
+        if (soloChatState.docId === docId && chatScreenEl.classList.contains('active')) {
+          return
+        }
+        try {
+          const doc = await fetchLibraryDoc(docId)
+          if (doc) {
+            await openSoloChatScreen(doc, false)
+            return
+          }
+        } catch (err) {
+          console.warn('[Router] 논문 채팅 문서 로드 실패:', err)
+        }
+      }
+      showToast('대화할 논문 정보를 불러올 수 없습니다.', 'error')
+      location.hash = 'chats'
     } else {
       const pageId = hash.replace('#', '') || 'dashboard'
       console.log("[Router] Routing to workspace page:", pageId, "Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))

--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -199,7 +199,7 @@ export async function renderAiChatsPage() {
     root.querySelectorAll('[data-action="chat"]').forEach(btn => {
       btn.addEventListener('click', () => {
         const id = btn.dataset.doc
-        location.hash = 'viewer?id=' + encodeURIComponent(id) + '&chat=1'
+        location.hash = 'chat?id=' + encodeURIComponent(id)
       })
     })
     root.querySelectorAll('[data-action="viewer"]').forEach(btn => {

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -15,6 +15,7 @@
 import '../styles/notes.css'
 import { fetchLibrary, fetchLibraryAnnotations, fetchLibraryMemos, fetchPrimer } from '../library.js'
 import { icon } from '../icons.js'
+import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
 // 즐겨찾기는 서버에 저장되는 필드가 아니라 Library 페이지가 이미 쓰고 있는
 // 로컬 전용 상태다(백엔드에 star/favorite 필드가 없음 - Library 리스킨 때 같은
@@ -50,9 +51,9 @@ let searchQuery = ''
 let selectedDocId = null
 let activeSubtab = 'summary' // 'summary' | 'memo' | 'highlight' | 'underline' | 'all'
 
-// 요약(primer.hook)은 문서당 LLM 호출 비용이 있으므로 탭을 실제로 열었을 때만
+// 요약(primer)은 문서당 LLM 호출 비용이 있으므로 탭을 실제로 열었을 때만
 // 가져오고, 한 번 가져오면 페이지 재방문 동안 재사용한다.
-// docId -> { status: 'loading'|'ready'|'error', text?: string }
+// docId -> { status: 'loading'|'ready'|'error', data?: object(primer 전체) }
 const summaryCache = new Map()
 
 // ── localStorage 읽기 (main.js loadAnnotations/loadMemos와 동일한 키/형태) ──
@@ -256,23 +257,116 @@ const EMPTY_MESSAGES = {
   all: '아직 저장된 주석이 없습니다.',
 }
 
-// 요약 탭: primer(읽기 전 브리핑)의 hook을 재사용한다 - Library 상세 패널의
-// AI 요약과 동일한 데이터 소스/우선순위(hook → feynman → lineage, main.js
-// showGraphDetailPanel/openLibraryDetailPanel과 동일한 관례)라 새 백엔드가
-// 필요 없다. LLM 호출 비용이 있어 탭을 열 때만 fetchPrimer()를 호출하고
-// summaryCache에 담아 재방문 시 재사용한다.
+// 요약 탭: primer(읽기 전 브리핑)를 그대로 가져와 뷰어의 브리핑 모달과 같은
+// 내용(핵심 한 줄, 스스로 답해볼 질문, 대표 Figure, 체크리스트, 연구 계보,
+// 파인만 설명, 실험 흐름, 용어집)을 한 화면에 쭉 이어서 보여준다(Notes는
+// 탭 하나짜리 읽기 전용 뷰라 모달처럼 소탭으로 나누지 않고 전부 스택한다).
+// 관련 논문 그래프(citation_graph)는 클릭 시 다른 논문 뷰어로 이동하는
+// 상호작용용 기능이라 "읽기 전용 열람"이라는 이 페이지 성격과 맞지 않아
+// 제외한다. LLM 호출 비용이 있어 탭을 열 때만 fetchPrimer()를 호출하고
+// summaryCache에 원본 데이터를 담아 재방문 시 재사용한다.
+function primerHasAnyContent(data) {
+  return !!(
+    data.hook || data.lineage || data.feynman || data.figure ||
+    (data.questions && data.questions.length) ||
+    (data.checklist && data.checklist.length) ||
+    (data.experiment_flow && data.experiment_flow.length) ||
+    (data.glossary && data.glossary.length)
+  )
+}
+
+function renderPrimerSection(labelIcon, labelText, innerHtml) {
+  return `
+    <div class="notes-primer-section">
+      <div class="primer-label">
+        <span class="primer-label-icon">${icon(labelIcon, 13)}</span>
+        <span>${labelText}</span>
+      </div>
+      ${innerHtml}
+    </div>
+  `
+}
+
 function renderSummaryTabContent(docId) {
   const cached = summaryCache.get(docId)
   if (!cached || cached.status === 'loading') {
-    return `<div class="notes-summary-loading">${icon('refreshCw', 15)}<span>AI 요약을 불러오는 중...</span></div>`
+    return `<div class="notes-summary-loading">${icon('refreshCw', 15)}<span>읽기 전 브리핑을 불러오는 중...</span></div>`
   }
   if (cached.status === 'error') {
-    return `<div class="notes-empty"><p style="color:var(--error)">요약을 불러오지 못했습니다.</p></div>`
+    return `<div class="notes-empty"><p style="color:var(--error)">브리핑을 불러오지 못했습니다.</p></div>`
   }
-  if (!cached.text) {
-    return `<div class="notes-empty"><p>이 논문에는 아직 생성된 요약이 없습니다.</p></div>`
+  const data = cached.data || {}
+  if (!primerHasAnyContent(data)) {
+    return `<div class="notes-empty"><p>이 논문에는 아직 생성된 브리핑이 없습니다.<br/>뷰어에서 논문을 열면 자동으로 생성됩니다.</p></div>`
   }
-  return `<div class="notes-summary-text">${escapeHtml(cached.text)}</div>`
+
+  const parts = []
+
+  if (data.hook) {
+    parts.push(`
+      <div class="primer-hook-section">
+        <span class="primer-hook-quote">&ldquo;</span>
+        <p class="primer-hook-text">${formatTranslationHtml(data.hook)}</p>
+      </div>
+    `)
+  }
+
+  const questions = data.questions || []
+  if (questions.length) {
+    parts.push(renderPrimerSection('helpCircle', '읽기 전에 스스로 답해보기',
+      `<ol class="primer-list">${questions.map(q => `<li>${formatTranslationHtml(q)}</li>`).join('')}</ol>`))
+  }
+
+  if (data.figure) {
+    parts.push(renderPrimerSection('image', '핵심 그림 먼저 보기',
+      `<img class="primer-figure-img" src="/api/library/${encodeURIComponent(docId)}/primer-figure?ts=${Date.now()}" alt="대표 Figure" />`))
+  }
+
+  const checklist = data.checklist || []
+  if (checklist.length) {
+    parts.push(renderPrimerSection('listChecks', '읽으면서 확인할 것',
+      `<ul class="primer-checklist">${checklist.map(c => `<li>${formatTranslationHtml(c)}</li>`).join('')}</ul>`))
+  }
+
+  if (data.lineage) {
+    parts.push(renderPrimerSection('activity', '이 논문의 연구 계보',
+      `<p class="primer-lineage-text">${formatTranslationHtml(data.lineage)}</p>`))
+  }
+
+  if (data.feynman) {
+    parts.push(renderPrimerSection('smile', '파인만 기법으로 쉽게 이해하기',
+      `<p class="primer-feynman-text">${formatTranslationHtml(data.feynman)}</p>`))
+  }
+
+  const flow = data.experiment_flow || []
+  if (flow.length) {
+    const stepsHtml = flow.map((step, i) => `
+      <li class="primer-experiment-step">
+        <div class="primer-experiment-step-num">${i + 1}</div>
+        <div class="primer-experiment-step-body">
+          <div class="primer-experiment-row"><span class="primer-experiment-tag">가설</span><span>${formatTranslationHtml(step.hypothesis)}</span></div>
+          <div class="primer-experiment-row"><span class="primer-experiment-tag">방법</span><span>${formatTranslationHtml(step.method)}</span></div>
+          <div class="primer-experiment-row"><span class="primer-experiment-tag">결과</span><span>${formatTranslationHtml(step.result)}</span></div>
+        </div>
+      </li>
+    `).join('')
+    parts.push(renderPrimerSection('flaskConical', '가설 → 실험 → 결과 흐름',
+      `<ol class="primer-experiment-flow">${stepsHtml}</ol>`))
+  }
+
+  const glossary = data.glossary || []
+  if (glossary.length) {
+    const itemsHtml = glossary.map(g => `
+      <details class="primer-glossary-item">
+        <summary class="primer-glossary-term">${formatTranslationHtml(g.term)}</summary>
+        <p class="primer-glossary-def">${formatTranslationHtml(g.definition)}</p>
+      </details>
+    `).join('')
+    parts.push(renderPrimerSection('book', '이 논문이 새로 정의한 용어',
+      `<div class="primer-glossary">${itemsHtml}</div>`))
+  }
+
+  return `<div class="notes-primer-content">${parts.join('')}</div>`
 }
 
 function ensureSummaryLoaded(root, docId) {
@@ -281,8 +375,7 @@ function ensureSummaryLoaded(root, docId) {
   if (cached && cached.status === 'loading') return
   summaryCache.set(docId, { status: 'loading' })
   fetchPrimer(docId).then(data => {
-    const text = data.hook || data.feynman || data.lineage || ''
-    summaryCache.set(docId, { status: 'ready', text })
+    summaryCache.set(docId, { status: 'ready', data })
   }).catch(err => {
     console.error('Notes 요약 로드 실패:', err)
     summaryCache.set(docId, { status: 'error' })
@@ -291,7 +384,10 @@ function ensureSummaryLoaded(root, docId) {
     // 같은 문서의 요약 탭을 보고 있을 때만 다시 그린다.
     if (selectedDocId === docId && activeSubtab === 'summary') {
       const contentEl = root.querySelector('.notes-tab-content')
-      if (contentEl) contentEl.innerHTML = renderSummaryTabContent(docId)
+      if (contentEl) {
+        contentEl.innerHTML = renderSummaryTabContent(docId)
+        applyKatexToElement(contentEl)
+      }
     }
   })
 }

--- a/frontend/src/styles/notes.css
+++ b/frontend/src/styles/notes.css
@@ -425,3 +425,14 @@
   color: var(--text-primary);
   white-space: pre-wrap;
 }
+
+/* 읽기 전 브리핑(primer) 전체 내용 - 뷰어의 브리핑 모달과 같은 .primer-*
+   컴포넌트를 그대로 재사용하되, 탭으로 나누지 않고 섹션을 세로로 쭉 이어
+   붙인다(Notes는 탭 하나짜리 읽기 전용 뷰라 모달의 소탭 구조가 필요 없음). */
+.notes-primer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  padding: 4px;
+}
+.notes-primer-section:empty { display: none; }

--- a/frontend/src/textFormat.js
+++ b/frontend/src/textFormat.js
@@ -1,0 +1,126 @@
+// ── 리치 텍스트 포맷터 (마크다운 헤더/볼드 + LaTeX 수식) ──────────────
+// 번역창(main.js)의 formatTranslationHtml/applyKatexToElement를 그대로
+// 옮겨온 것이다. 원래는 main.js 안에 있었는데, 읽기 전 브리핑(primer)
+// 텍스트도 같은 서식(LLM이 **볼드**나 $...$ 수식을 섞어 반환)을 쓰는
+// Notes 요약 탭에서도 그대로 재사용하려고 별도 모듈로 뺐다.
+const INDENT_MARK = String.fromCharCode(0xE000)
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return ''
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export function formatTranslationHtml(text) {
+  if (!text) return ''
+
+  // 문장 정렬용 태그([S0], [S1], [S0:I] 등)가 렌더링에 노출되지 않도록 제거
+  let t = text.replace(/\[[sS]\d+(?::[A-Za-z]+)?\]/g, '')
+
+  const mathBlocks = []
+
+  // 1. 블록 수식: $$...$$
+  t = t.replace(/\$\$([\s\S]*?)\$\$/g, (_, f) => {
+    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: true })
+    return `::MATH_FLT_PLACEHOLDER_${id}::`
+  })
+  // 2. 블록 수식: \[...\]
+  t = t.replace(/\\\[([\s\S]*?)\\\]/g, (_, f) => {
+    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: true })
+    return `::MATH_FLT_PLACEHOLDER_${id}::`
+  })
+  // 3. 인라인: $...$
+  t = t.replace(/(?<!\$)\$([^\$\n]+?)\$(?!\$)/g, (_, f) => {
+    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: false })
+    return `::MATH_FLT_PLACEHOLDER_${id}::`
+  })
+  // 4. 인라인: \(...\)
+  t = t.replace(/\\\(([\s\S]*?)\\\)/g, (_, f) => {
+    const id = mathBlocks.length; mathBlocks.push({ formula: f.trim(), display: false })
+    return `::MATH_FLT_PLACEHOLDER_${id}::`
+  })
+
+  // 4.5. 이스케이프된 볼드체 복원 및 공백 트리밍
+  t = t.replace(/\\+\*\*/g, '**')
+  t = t.replace(/\*\*\s*([^*]+?)\s*\*\*/g, '**$1**')
+
+  // 5. 마크다운 헤더 & 이스케이프 처리
+  const lines = t.split('\n')
+  const htmlParts = lines.map(line => {
+    let workingLine = line
+    let isIndented = false
+    const leadingWs = workingLine.match(/^\s*/)[0]
+    if (workingLine.slice(leadingWs.length).startsWith(INDENT_MARK)) {
+      isIndented = true
+      workingLine = leadingWs + workingLine.slice(leadingWs.length + INDENT_MARK.length).replace(/^\s+/, '')
+    }
+    const tr = workingLine.trim()
+    let rendered
+    if (tr.startsWith('### ')) rendered = `<h4 class="md-h4">${escapeHtml(tr.slice(4))}</h4>`
+    else if (tr.startsWith('## '))  rendered = `<h3 class="md-h3">${escapeHtml(tr.slice(3))}</h3>`
+    else if (tr.startsWith('# '))   rendered = `<h2 class="md-h2">${escapeHtml(tr.slice(2))}</h2>`
+    else rendered = escapeHtml(workingLine)
+    return isIndented ? `<span class="trans-indent">${rendered}</span>` : rendered
+  })
+  let html = htmlParts.join('\n')
+    .replace(/\n\n/g, '<br><br>').replace(/\n/g, '<br>')
+
+  // 6. 볼드: **...**
+  html = html.replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
+
+  // 7. 수식 플레이스홀더 복원
+  html = html.replace(/::MATH_FLT_PLACEHOLDER_(\d+)::/g, (_, idStr) => {
+    const item = mathBlocks[parseInt(idStr)]
+    if (!item) return _
+    if (window.katex) {
+      try {
+        const r = window.katex.renderToString(item.formula, { displayMode: item.display, throwOnError: false, output: 'htmlAndMathml' })
+        if (item.display) {
+          return `<div class="katex-display-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="true">${r}</div>`
+        } else {
+          return `<span class="katex-inline-wrap" data-formula="${encodeURIComponent(item.formula)}" data-display="false">${r}</span>`
+        }
+      } catch (e) {
+        return `<code class="math-error" data-formula="${encodeURIComponent(item.formula)}" data-display="${item.display}">${escapeHtml(item.formula)}</code>`
+      }
+    }
+    // KaTeX 미로드 시 pending 마킹 → 나중에 applyKatexToElement()로 재처리
+    const delim = item.display ? '$$' : '$'
+    return `<code class="math-pending" data-formula="${encodeURIComponent(item.formula)}" data-display="${item.display}">${escapeHtml(delim + item.formula + delim)}</code>`
+  })
+
+  return html
+}
+
+/** KaTeX 로드 후 .math-pending 코드를 실제 수식으로 교체 */
+export function applyKatexToElement(el) {
+  if (!el || !window.katex) return
+  el.querySelectorAll('code.math-pending').forEach(code => {
+    try {
+      const formula = decodeURIComponent(code.dataset.formula || '')
+      const display = code.dataset.display === 'true'
+      const r = window.katex.renderToString(formula, { displayMode: display, throwOnError: false, output: 'htmlAndMathml' })
+      const wrapper = display
+        ? Object.assign(document.createElement('div'), { className: 'katex-display-wrap', innerHTML: r })
+        : Object.assign(document.createElement('span'), { className: 'katex-inline-wrap', innerHTML: r })
+      wrapper.dataset.formula = encodeURIComponent(formula)
+      wrapper.dataset.display = display.toString()
+
+      if (code.classList.contains('trans-sentence')) {
+        wrapper.classList.add('trans-sentence')
+      }
+      if (code.dataset.page) {
+        wrapper.dataset.page = code.dataset.page
+      }
+      if (code.dataset.sentenceIdx) {
+        wrapper.dataset.sentenceIdx = code.dataset.sentenceIdx
+      }
+      if (code.style.cursor) {
+        wrapper.style.cursor = code.style.cursor
+      }
+
+      code.replaceWith(wrapper)
+    } catch (e) {
+      code.classList.remove('math-pending')
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- AI Chats에서 "대화 열기" 클릭 시 PDF 뷰어 없이 채팅 메시지+입력창만 있는 독립 화면(#chat-screen)을 열도록 변경 (기존 compare 채팅 화면과 동일한 패턴, 백엔드 변경 없음)
- 화면 전환 함수들이 새 채팅 화면을 안 숨겨서 다른 페이지로 이동해도 겹쳐 보이던 버그 수정
- Notes 요약 탭이 primer의 hook 한 줄만 보여주던 것을 훅/질문/체크리스트/연구 계보/파인만 설명/실험 흐름/용어집까지 브리핑 전체 내용으로 확장 (뷰어의 읽기 전 브리핑 모달과 동일한 스타일 재사용)
- 리치 텍스트 포맷터(LaTeX/마크다운 렌더링)를 main.js에서 textFormat.js로 분리해 Notes 페이지에서도 재사용

## Test plan
- [x] `npm run build` 통과
- [x] 실제 문서/채팅 기록을 DB에 심어 Playwright로 독립 채팅 화면 렌더링, 메시지 표시, 뷰어 전환, 뒤로가기 동작 확인
- [x] Notes 요약 탭에서 브리핑 전체 섹션(훅/질문/체크리스트/계보/파인만/실험흐름/용어집) 렌더링 및 KaTeX 수식 렌더링 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>