### PR TITLE
AI Chats 대화 드로어 전환 + 논문 추천 캐싱/주간 갱신

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -28,11 +28,16 @@
   호출 불필요 - 순수 데이터 노출).
 """
 import asyncio
+import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+# 추천 논문 목록 캐시 TTL - LLM+OpenAlex 검증이 여러 번 들어가는 무거운 작업이라
+# 매번 다시 계산하지 않고, 일주일에 한 번만 새로 생성해 app_meta에 저장해둔다.
+READING_RECOMMENDATIONS_CACHE_DAYS = 7
 
 # 그래프 조회 시점에 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서를
 # 백그라운드로 백필한다. 같은 문서에 대해 중복으로 백필 태스크가 여러 개
@@ -471,13 +476,37 @@ async def get_activity_timeline(username: str) -> List[dict]:
     return events
 
 
+def _reading_recommendations_cache_key(username: str) -> str:
+    return f"reading_recommendations:{username}"
+
+
 async def get_reading_recommendations(username: str) -> List[dict]:
     """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천한다. Primer 기능의
     기존 OpenAlex 검증 로직(_is_plausible_match, resolve_reference)을 그대로
     재사용해 LLM 환각(존재하지 않는 논문을 추천)을 걸러낸다 - 1차의
     _match_library_references 재사용과 동일한 패턴. LLM+OpenAlex 호출이
     여러 번 들어가는 무거운 작업이라 그래프 조회 시 자동 실행하지 않고,
-    프론트에서 사용자가 명시적으로 요청했을 때만 호출한다."""
+    프론트에서 사용자가 명시적으로 요청했을 때만 호출한다.
+
+    결과는 app_meta에 사용자별로 캐싱해 READING_RECOMMENDATIONS_CACHE_DAYS(7일)
+    동안 재사용하고, 그 기간이 지나면 다음 조회 시 자동으로 새로 생성한다 -
+    호출할 때마다 같은 무거운 계산을 반복하지 않으면서도, 추천 목록이 매주
+    한 번씩은 새로 갱신되게 한다.
+    """
+    from services.db import db_get_meta, db_set_meta
+
+    cache_key = _reading_recommendations_cache_key(username)
+    cached_raw = db_get_meta(cache_key)
+    if cached_raw:
+        try:
+            cached = json.loads(cached_raw)
+            generated_at = datetime.fromisoformat(cached["generated_at"])
+            age = datetime.now(timezone.utc) - generated_at
+            if age < timedelta(days=READING_RECOMMENDATIONS_CACHE_DAYS):
+                return cached["recommendations"]
+        except Exception:
+            pass  # 캐시가 손상됐으면 무시하고 새로 생성
+
     from services.library import list_documents
     docs = list_documents(username=username)
     if len(docs) < 2:
@@ -507,6 +536,11 @@ async def get_reading_recommendations(username: str) -> List[dict]:
         if any(len(result_words & seen) / len(result_words) >= 0.6 for seen in exclude_word_sets):
             continue  # 이미 읽은 논문과 같은 논문이면 제외
         results.append({**resolved, "reason": r.get("reason", "")})
+
+    db_set_meta(cache_key, json.dumps({
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "recommendations": results,
+    }, ensure_ascii=False))
     return results
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -310,29 +310,32 @@
     </div>
   </div>
 
-  <!-- 단일 논문 대화 화면 (뷰어 없이 채팅 메시지 + 입력창만) -->
-  <div id="chat-screen" class="screen">
+  <!-- 단일 논문 대화 드로어 (AI Chats 목록에서 열리는, 뷰어 없이 채팅
+       메시지 + 입력창만 있는 패널 - Library 상세 패널(#lib-detail-panel)과
+       동일하게 사이드바/탑바는 그대로 둔 채 우측에서 슬라이드로 열린다) -->
+  <div id="chat-drawer-overlay" class="chat-drawer-overlay"></div>
+  <aside id="chat-drawer" class="chat-drawer" aria-hidden="true">
     <header class="compare-topbar">
-      <button id="chat-screen-back-btn" class="icon-btn" title="AI Chats로 돌아가기">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
+      <button id="chat-drawer-close-btn" class="icon-btn" title="닫기">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
       </button>
       <div class="compare-topbar-title">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"/></svg>
-        <span id="chat-screen-title">AI 대화</span>
+        <span id="chat-drawer-title">AI 대화</span>
       </div>
-      <button type="button" id="chat-screen-viewer-btn" class="file-btn-outline compact" title="뷰어에서 열기">
+      <button type="button" id="chat-drawer-viewer-btn" class="file-btn-outline compact" title="뷰어에서 열기">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>뷰어에서 열기
       </button>
     </header>
 
     <div class="compare-chat-body">
-      <div class="chat-messages" id="chat-screen-messages"></div>
+      <div class="chat-messages" id="chat-drawer-messages"></div>
       <div class="chat-input-area compare-chat-input-area">
         <div class="chat-input-box">
-          <textarea id="chat-screen-input" class="chat-input-textarea" placeholder="이 논문에 대해 질문해보세요..." rows="1"></textarea>
+          <textarea id="chat-drawer-input" class="chat-input-textarea" placeholder="이 논문에 대해 질문해보세요..." rows="1"></textarea>
           <div class="chat-input-footer">
             <span class="compare-chat-hint">Enter로 전송 · Shift+Enter로 줄바꿈</span>
-            <button id="chat-screen-send-btn" class="chat-send-btn" title="전송">
+            <button id="chat-drawer-send-btn" class="chat-send-btn" title="전송">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="22" y1="2" x2="11" y2="13"/>
                 <polygon points="22 2 15 22 11 13 2 9 22 2"/>
@@ -342,7 +345,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </aside>
 
   <!-- 뷰어 화면 -->
   <div id="viewer-screen" class="screen">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -273,14 +273,15 @@ const compareChatMessages  = $('compare-chat-messages')
 const compareChatInput     = $('compare-chat-input')
 const compareChatSendBtn   = $('compare-chat-send-btn')
 
-// ── 단일 논문 대화 화면 (뷰어 없이 채팅만) ──
-const chatScreenEl         = $('chat-screen')
-const chatScreenBackBtn    = $('chat-screen-back-btn')
-const chatScreenTitle      = $('chat-screen-title')
-const chatScreenViewerBtn  = $('chat-screen-viewer-btn')
-const chatScreenMessages   = $('chat-screen-messages')
-const chatScreenInput      = $('chat-screen-input')
-const chatScreenSendBtn    = $('chat-screen-send-btn')
+// ── 단일 논문 대화 드로어 (AI Chats 목록에서 뷰어 없이 여는 우측 슬라이드 패널) ──
+const chatDrawerOverlayEl  = $('chat-drawer-overlay')
+const chatDrawerEl         = $('chat-drawer')
+const chatDrawerCloseBtn   = $('chat-drawer-close-btn')
+const chatDrawerTitle      = $('chat-drawer-title')
+const chatDrawerViewerBtn  = $('chat-drawer-viewer-btn')
+const chatDrawerMessages   = $('chat-drawer-messages')
+const chatDrawerInput      = $('chat-drawer-input')
+const chatDrawerSendBtn    = $('chat-drawer-send-btn')
 
 const docPreviewOverlay  = $('doc-preview-overlay')
 const docPreviewClose    = $('doc-preview-close')
@@ -428,7 +429,7 @@ function showLogin() {
   viewerScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
-  if (chatScreenEl) chatScreenEl.classList.remove('active')
+  closeChatDrawer()
   loginScreen.classList.add('active')
   // 글로벌 테마 토글 표시, 로그아웃 및 설정 버튼 숨김
   const globalToggle = $('global-theme-toggle')
@@ -441,7 +442,7 @@ function showViewer() {
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
-  if (chatScreenEl) chatScreenEl.classList.remove('active')
+  closeChatDrawer()
   viewerScreen.classList.add('active')
   // 글로벌 테마 토글 숨김 (뷰어 상단바 테마 버튼 사용)
   const globalToggle = $('global-theme-toggle')
@@ -453,24 +454,10 @@ function showCompareScreen() {
   loginScreen.classList.remove('active')
   libraryScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
-  if (chatScreenEl) chatScreenEl.classList.remove('active')
+  closeChatDrawer()
   if (compareScreen) compareScreen.classList.add('active')
   // 라이브러리 화면과 동일하게 글로벌 테마/로그아웃/설정 버튼을 표시한다
   // (비교 화면 자체에는 별도의 테마 버튼이 없음)
-  const globalToggle = $('global-theme-toggle')
-  if (globalToggle) globalToggle.classList.remove('hidden')
-  globalLogoutBtn.classList.remove('hidden')
-  globalSettingsBtn.classList.remove('hidden')
-}
-
-function showChatScreen() {
-  stopLibraryPolling()
-  loginScreen.classList.remove('active')
-  libraryScreen.classList.remove('active')
-  viewerScreen.classList.remove('active')
-  if (compareScreen) compareScreen.classList.remove('active')
-  chatScreenEl.classList.add('active')
-  // compare 화면과 동일하게 글로벌 테마/로그아웃/설정 버튼을 표시한다
   const globalToggle = $('global-theme-toggle')
   if (globalToggle) globalToggle.classList.remove('hidden')
   globalLogoutBtn.classList.remove('hidden')
@@ -3622,7 +3609,6 @@ async function showLibraryScreen(shouldPushState = true, targetPage) {
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')
   if (compareScreen) compareScreen.classList.remove('active')
-  if (chatScreenEl) chatScreenEl.classList.remove('active')
   libraryScreen.classList.add('active')
   // 워크스페이스 화면(사이드바+탑네비)에서는 테마 토글/Settings/로그아웃이 전부
   // 사이드바 푸터에 있으므로, 로그인/비교 화면 전용인 플로팅 버튼 묶음은 통째로 숨긴다
@@ -3651,6 +3637,10 @@ const WORKSPACE_PAGE_TITLES = {
 
 async function showWorkspacePage(pageId, { pushState = true } = {}) {
   if (!WORKSPACE_PAGES.includes(pageId)) pageId = 'dashboard'
+  // 채팅 드로어가 열린 채로 다른 워크스페이스 페이지로 이동하면(사이드바 클릭 등)
+  // 드로어를 닫아준다. '#chat?id=' 라우팅 분기가 이 함수 호출 직후 다시
+  // openChatDrawer()를 부르는 경우엔 그냥 무해한 no-op이다.
+  if (pageId !== 'chats' || state.currentWorkspacePage !== 'chats') closeChatDrawer()
   state.currentWorkspacePage = pageId
 
   if (sidebarNav) {
@@ -4058,11 +4048,17 @@ if (compareBackBtn) {
 // 요청에 따라 이 화면으로 대신 연다. 백엔드는 그대로 재사용한다 - streamChatAPI/
 // getChatHistoryAPI는 이미 뷰어를 실제로 "연" 적이 없어도 동작한다
 // (require_session_owner → ensure_session이 세션이 메모리에 없으면 DB 문서로부터
-// 알아서 복구한다, backend/routers/upload.py). 화면 구조/상태 관리는 바로 위
+// 알아서 복구한다, backend/routers/upload.py). 채팅 렌더링/전송 로직은 바로 위
 // compareChatState/openCompareScreen 패턴을 논문 1편짜리로 그대로 옮긴 것이다.
-let soloChatState = { docId: null, doc: null, history: [], activeStream: null, currentText: '' }
+//
+// 화면 자체는 처음에 뷰어 없는 전체화면(#chat-screen)으로 만들었었는데,
+// 목록에서 다른 페이지로 완전히 이동해버려 사이드바/탑바가 사라지는 게
+// 어색하다는 피드백을 받아 Library 상세 패널(openLibraryDetailPanel)과 동일한
+// "우측 슬라이드 드로어" 패턴으로 바꿨다 - AI Chats 페이지는 그 자리에 계속
+// 떠 있고, 드로어만 그 위에 열고 닫는다.
+let chatDrawerState = { docId: null, doc: null, history: [], activeStream: null, currentText: '' }
 
-function renderSoloChatMessage(role, content, isHtml = false) {
+function renderChatDrawerMessage(role, content, isHtml = false) {
   const msgEl = document.createElement('div')
   msgEl.className = `chat-message ${role}`
 
@@ -4072,14 +4068,14 @@ function renderSoloChatMessage(role, content, isHtml = false) {
   else bubbleEl.textContent = content
   msgEl.appendChild(bubbleEl)
 
-  if (content) appendSoloActionButtons(msgEl, role, content)
+  if (content) appendChatDrawerActionButtons(msgEl, role, content)
 
-  chatScreenMessages.appendChild(msgEl)
-  chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+  chatDrawerMessages.appendChild(msgEl)
+  chatDrawerMessages.scrollTop = chatDrawerMessages.scrollHeight
   return msgEl
 }
 
-function appendSoloActionButtons(msgEl, role, content) {
+function appendChatDrawerActionButtons(msgEl, role, content) {
   if (!content || content.includes('chat-error-text')) return
   const actionsEl = document.createElement('div')
   actionsEl.className = 'message-actions'
@@ -4109,36 +4105,36 @@ function appendSoloActionButtons(msgEl, role, content) {
   msgEl.appendChild(actionsEl)
 }
 
-function appendSoloTypingIndicator() {
+function appendChatDrawerTypingIndicator() {
   const msgEl = document.createElement('div')
   msgEl.className = 'chat-message assistant temp-typing'
   const bubbleEl = document.createElement('div')
   bubbleEl.className = 'message-bubble'
   bubbleEl.innerHTML = `<div class="typing-container" style="display: flex; align-items: center; gap: 8px;"><span class="typing-text" style="font-size: 12px; color: var(--text-secondary);">AI가 답변을 준비하고 있습니다</span><div class="typing-indicator" style="display: flex; gap: 3px; align-items: center;"><span></span><span></span><span></span></div></div>`
   msgEl.appendChild(bubbleEl)
-  chatScreenMessages.appendChild(msgEl)
-  chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+  chatDrawerMessages.appendChild(msgEl)
+  chatDrawerMessages.scrollTop = chatDrawerMessages.scrollHeight
   return msgEl
 }
 
-function removeSoloTypingIndicator() {
-  chatScreenMessages.querySelectorAll('.temp-typing').forEach(el => el.remove())
+function removeChatDrawerTypingIndicator() {
+  chatDrawerMessages.querySelectorAll('.temp-typing').forEach(el => el.remove())
 }
 
-function updateSoloChatSendBtnIcon(isGenerating) {
-  if (!chatScreenSendBtn) return
+function updateChatDrawerSendBtnIcon(isGenerating) {
+  if (!chatDrawerSendBtn) return
   if (isGenerating) {
-    chatScreenSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2" /></svg>`
-    chatScreenSendBtn.title = '답변 생성 중단'
+    chatDrawerSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2" /></svg>`
+    chatDrawerSendBtn.title = '답변 생성 중단'
   } else {
-    chatScreenSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`
-    chatScreenSendBtn.title = '전송'
+    chatDrawerSendBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`
+    chatDrawerSendBtn.title = '전송'
   }
 }
 
-function renderSoloGreeting(doc) {
+function renderChatDrawerGreeting(doc) {
   const title = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
-  renderSoloChatMessage('assistant',
+  renderChatDrawerMessage('assistant',
     `<strong>${escapeHtml(title)}</strong>에 대해 무엇이든 물어보세요.<br><br>` +
     `<strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong>` +
     `<ul><li>이 논문의 핵심 기여는 무엇인가요?</li><li>실험 설정을 요약해줄 수 있나요?</li><li>이 방법론의 한계점은 뭔가요?</li></ul>`,
@@ -4147,155 +4143,180 @@ function renderSoloGreeting(doc) {
 
 // location.hash 대입은 popstate/hashchange를 둘 다 발생시킬 수 있어(openCompareScreen과
 // 동일한 이유), 같은 문서에 대한 재진입 호출을 걸러낸다.
-let soloChatOpeningDocId = null
+let chatDrawerOpeningDocId = null
 
-async function openSoloChatScreen(doc, shouldPushState = true) {
-  if (soloChatOpeningDocId === doc.id) return
-  if (chatScreenEl.classList.contains('active') && soloChatState.docId === doc.id) return
-  soloChatOpeningDocId = doc.id
+// 드로어를 여는 유일한 경로는 handleRouting()의 '#chat?id=' 분기다(AI Chats
+// 목록의 "대화" 버튼은 location.hash를 그 형태로 바꿀 뿐이라 hash 갱신은
+// 호출부에서 이미 끝난 상태) - 그래서 여기서는 URL을 직접 건드리지 않는다.
+async function openChatDrawer(doc) {
+  if (chatDrawerOpeningDocId === doc.id) return
+  if (chatDrawerEl.classList.contains('open') && chatDrawerState.docId === doc.id) return
+  chatDrawerOpeningDocId = doc.id
 
-  if (soloChatState.activeStream) { soloChatState.activeStream(); soloChatState.activeStream = null }
-  soloChatState = { docId: doc.id, doc, history: [], activeStream: null, currentText: '' }
-
-  if (shouldPushState) {
-    history.pushState({ screen: 'chat', id: doc.id }, '', `#chat?id=${encodeURIComponent(doc.id)}`)
-  }
+  if (chatDrawerState.activeStream) { chatDrawerState.activeStream(); chatDrawerState.activeStream = null }
+  chatDrawerState = { docId: doc.id, doc, history: [], activeStream: null, currentText: '' }
 
   const title = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
-  if (chatScreenTitle) chatScreenTitle.textContent = title
+  if (chatDrawerTitle) chatDrawerTitle.textContent = title
 
-  if (chatScreenMessages) chatScreenMessages.innerHTML = ''
-  showChatScreen()
+  if (chatDrawerMessages) chatDrawerMessages.innerHTML = ''
+  chatDrawerOverlayEl.classList.add('open')
+  chatDrawerEl.classList.add('open')
+  chatDrawerEl.setAttribute('aria-hidden', 'false')
 
   try {
     const res = await getChatHistoryAPI(doc.id)
     const savedHistory = res.history || []
     if (savedHistory.length === 0) {
-      renderSoloGreeting(doc)
+      renderChatDrawerGreeting(doc)
     } else {
       savedHistory.forEach(msg => {
-        renderSoloChatMessage(msg.role, msg.role === 'assistant' ? formatChatHtml(msg.content) : msg.content, msg.role === 'assistant')
-        soloChatState.history.push({ role: msg.role, content: msg.content })
+        renderChatDrawerMessage(msg.role, msg.role === 'assistant' ? formatChatHtml(msg.content) : msg.content, msg.role === 'assistant')
+        chatDrawerState.history.push({ role: msg.role, content: msg.content })
       })
     }
   } catch (err) {
     console.warn('논문 채팅 기록 로드 실패:', err)
-    renderSoloGreeting(doc)
+    renderChatDrawerGreeting(doc)
   } finally {
-    if (soloChatOpeningDocId === doc.id) soloChatOpeningDocId = null
+    if (chatDrawerOpeningDocId === doc.id) chatDrawerOpeningDocId = null
   }
 }
 
-async function sendSoloChatMessage() {
-  if (!soloChatState.docId) return
-  if (soloChatState.activeStream) return
+// UI만 닫는다(URL 정리는 호출부 책임) - showWorkspacePage()에서 다른 페이지로
+// 넘어갈 때도 방어적으로 호출하므로, 여기서 훅 자체를 hash에 대입하면
+// hashchange가 다시 발생해 라우팅이 두 번 도는 문제가 생긴다.
+function closeChatDrawer() {
+  if (!chatDrawerState.docId) return
+  if (chatDrawerState.activeStream) { chatDrawerState.activeStream(); chatDrawerState.activeStream = null }
+  chatDrawerState = { docId: null, doc: null, history: [], activeStream: null, currentText: '' }
+  chatDrawerOverlayEl.classList.remove('open')
+  chatDrawerEl.classList.remove('open')
+  chatDrawerEl.setAttribute('aria-hidden', 'true')
+}
 
-  const text = chatScreenInput.value.trim()
+// 닫기 버튼/오버레이 클릭/Esc처럼 "사용자가 직접 닫은" 경우에만 URL도
+// 같이 정리한다(뒤로가기로 닫힌 경우는 popstate가 이미 hash를 바꿔놨음).
+function requestCloseChatDrawer() {
+  closeChatDrawer()
+  if (location.hash.startsWith('#chat?id=')) {
+    history.pushState(null, '', '#chats')
+  }
+}
+
+async function sendChatDrawerMessage() {
+  if (!chatDrawerState.docId) return
+  if (chatDrawerState.activeStream) return
+
+  const text = chatDrawerInput.value.trim()
   if (!text) return
 
-  chatScreenInput.value = ''
-  chatScreenInput.style.height = 'auto'
+  chatDrawerInput.value = ''
+  chatDrawerInput.style.height = 'auto'
 
-  renderSoloChatMessage('user', text)
-  soloChatState.history.push({ role: 'user', content: text })
+  renderChatDrawerMessage('user', text)
+  chatDrawerState.history.push({ role: 'user', content: text })
 
-  appendSoloTypingIndicator()
-  chatScreenInput.disabled = true
-  updateSoloChatSendBtnIcon(true)
+  appendChatDrawerTypingIndicator()
+  chatDrawerInput.disabled = true
+  updateChatDrawerSendBtnIcon(true)
 
   let accumulatedText = ''
   let replyBubble = null
   let firstToken = true
-  soloChatState.currentText = ''
+  chatDrawerState.currentText = ''
 
-  soloChatState.activeStream = streamChatAPI(
-    soloChatState.docId,
-    soloChatState.history,
+  chatDrawerState.activeStream = streamChatAPI(
+    chatDrawerState.docId,
+    chatDrawerState.history,
     // onToken
     (token) => {
       if (firstToken) {
         if (!token.trim()) return
-        removeSoloTypingIndicator()
-        replyBubble = renderSoloChatMessage('assistant', '', true).querySelector('.message-bubble')
+        removeChatDrawerTypingIndicator()
+        replyBubble = renderChatDrawerMessage('assistant', '', true).querySelector('.message-bubble')
         firstToken = false
       }
       accumulatedText += token
-      soloChatState.currentText = accumulatedText
+      chatDrawerState.currentText = accumulatedText
       replyBubble.innerHTML = formatChatHtml(accumulatedText)
-      chatScreenMessages.scrollTop = chatScreenMessages.scrollHeight
+      chatDrawerMessages.scrollTop = chatDrawerMessages.scrollHeight
     },
     // onDone
     () => {
-      soloChatState.activeStream = null
-      soloChatState.history.push({ role: 'assistant', content: accumulatedText })
+      chatDrawerState.activeStream = null
+      chatDrawerState.history.push({ role: 'assistant', content: accumulatedText })
       if (replyBubble) {
         replyBubble.innerHTML = formatChatHtml(accumulatedText)
-        if (replyBubble.parentElement) appendSoloActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+        if (replyBubble.parentElement) appendChatDrawerActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
       }
-      chatScreenInput.disabled = false
-      updateSoloChatSendBtnIcon(false)
-      chatScreenInput.focus()
+      chatDrawerInput.disabled = false
+      updateChatDrawerSendBtnIcon(false)
+      chatDrawerInput.focus()
     },
     // onError
     (err) => {
-      removeSoloTypingIndicator()
-      soloChatState.activeStream = null
+      removeChatDrawerTypingIndicator()
+      chatDrawerState.activeStream = null
       if (firstToken) {
-        renderSoloChatMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
+        renderChatDrawerMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
       } else if (replyBubble) {
         replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${err.message}]</span>`
       }
-      chatScreenInput.disabled = false
-      updateSoloChatSendBtnIcon(false)
-      chatScreenInput.focus()
+      chatDrawerInput.disabled = false
+      updateChatDrawerSendBtnIcon(false)
+      chatDrawerInput.focus()
     }
   )
 }
 
-if (chatScreenSendBtn) {
-  chatScreenSendBtn.addEventListener('click', () => {
-    if (soloChatState.activeStream) {
-      soloChatState.activeStream()
-      soloChatState.activeStream = null
-      removeSoloTypingIndicator()
-      if (soloChatState.currentText) {
-        soloChatState.history.push({ role: 'assistant', content: soloChatState.currentText })
+if (chatDrawerSendBtn) {
+  chatDrawerSendBtn.addEventListener('click', () => {
+    if (chatDrawerState.activeStream) {
+      chatDrawerState.activeStream()
+      chatDrawerState.activeStream = null
+      removeChatDrawerTypingIndicator()
+      if (chatDrawerState.currentText) {
+        chatDrawerState.history.push({ role: 'assistant', content: chatDrawerState.currentText })
       } else {
-        soloChatState.history.pop()
+        chatDrawerState.history.pop()
       }
       showToast('답변 생성이 중단되었습니다.', 'info')
-      chatScreenInput.disabled = false
-      updateSoloChatSendBtnIcon(false)
-      chatScreenInput.focus()
+      chatDrawerInput.disabled = false
+      updateChatDrawerSendBtnIcon(false)
+      chatDrawerInput.focus()
     } else {
-      sendSoloChatMessage()
+      sendChatDrawerMessage()
     }
   })
 }
 
-if (chatScreenInput) {
-  chatScreenInput.addEventListener('keydown', (e) => {
+if (chatDrawerInput) {
+  chatDrawerInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      sendSoloChatMessage()
+      sendChatDrawerMessage()
     }
   })
-  chatScreenInput.addEventListener('input', () => {
-    chatScreenInput.style.height = 'auto'
-    chatScreenInput.style.height = `${chatScreenInput.scrollHeight}px`
+  chatDrawerInput.addEventListener('input', () => {
+    chatDrawerInput.style.height = 'auto'
+    chatDrawerInput.style.height = `${chatDrawerInput.scrollHeight}px`
   })
 }
 
-if (chatScreenBackBtn) {
-  chatScreenBackBtn.addEventListener('click', () => {
-    if (soloChatState.activeStream) { soloChatState.activeStream(); soloChatState.activeStream = null }
-    location.hash = 'chats'
-  })
-}
+if (chatDrawerCloseBtn) chatDrawerCloseBtn.addEventListener('click', requestCloseChatDrawer)
+if (chatDrawerOverlayEl) chatDrawerOverlayEl.addEventListener('click', requestCloseChatDrawer)
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && chatDrawerEl.classList.contains('open')) requestCloseChatDrawer()
+})
 
-if (chatScreenViewerBtn) {
-  chatScreenViewerBtn.addEventListener('click', () => {
-    if (soloChatState.docId) location.hash = `viewer?id=${encodeURIComponent(soloChatState.docId)}`
+if (chatDrawerViewerBtn) {
+  chatDrawerViewerBtn.addEventListener('click', () => {
+    if (chatDrawerState.docId) {
+      const docId = chatDrawerState.docId
+      closeChatDrawer()
+      location.hash = `viewer?id=${encodeURIComponent(docId)}`
+    }
   })
 }
 
@@ -13333,16 +13354,25 @@ async function handleRouting() {
       showToast('비교할 논문 정보를 불러올 수 없습니다.', 'error')
       location.hash = 'library'
     } else if (hash.startsWith('#chat?id=')) {
+      // AI Chats 목록의 "대화" 버튼이 이 해시로 바꾸면(hashchange) 여기로
+      // 들어온다 - 드로어는 별도 화면이 아니라 AI Chats 페이지 위에 뜨는
+      // 오버레이라서, 먼저 AI Chats 페이지가 보이는 상태를 만든 다음 그
+      // 위에 드로어를 연다.
       const params = new URLSearchParams(hash.slice('#chat?'.length))
       const docId = params.get('id')
       if (docId) {
-        if (soloChatState.docId === docId && chatScreenEl.classList.contains('active')) {
+        if (chatDrawerState.docId === docId && chatDrawerEl.classList.contains('open')) {
           return
         }
         try {
           const doc = await fetchLibraryDoc(docId)
           if (doc) {
-            await openSoloChatScreen(doc, false)
+            if (viewerScreen.classList.contains('active') || !libraryScreen.classList.contains('active')) {
+              await showLibraryScreen(false, 'chats')
+            } else if (state.currentWorkspacePage !== 'chats') {
+              await showWorkspacePage('chats', { pushState: false })
+            }
+            await openChatDrawer(doc)
             return
           }
         } catch (err) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6346,6 +6346,61 @@ body.light-theme .figure-preview-tooltip {
   color: var(--text-muted);
 }
 
+/* ── 단일 논문 대화 드로어 (AI Chats 목록 → "대화") ──────────────────
+   Library 상세 패널(.lib-detail-panel/.lib-detail-overlay, library-page.css)과
+   동일한 "우측에서 슬라이드 인" 패턴 - 사이드바/탑바를 그대로 둔 채 열려서
+   페이지 이동 없이 대화만 확인할 수 있다. */
+.chat-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.32);
+  z-index: 45;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.chat-drawer-overlay.open { opacity: 1; pointer-events: auto; }
+
+.chat-drawer {
+  position: fixed;
+  top: var(--topbar-h);
+  right: 0;
+  bottom: 0;
+  width: 480px;
+  max-width: 94vw;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  z-index: 46;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.chat-drawer.open { transform: translateX(0); }
+.chat-drawer .compare-chat-body { height: 0; flex: 1 1 auto; min-height: 0; }
+/* 비교 화면(.compare-topbar-title)은 전체 화면 폭을 쓸 수 있어 제목이 안
+   잘렸지만, 이 드로어는 폭이 480px로 훨씬 좁아 긴 논문 제목이 닫기/뷰어
+   버튼을 밀어내 화면 밖으로 나가버린다 - 제목만 줄여서 말줄임표 처리한다. */
+.chat-drawer .compare-topbar-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.chat-drawer .compare-topbar-title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-drawer .compare-topbar-title svg,
+.chat-drawer .icon-btn,
+.chat-drawer #chat-drawer-viewer-btn {
+  flex-shrink: 0;
+}
+
+@media (max-width: 900px) {
+  .chat-drawer { width: 100vw; max-width: 100vw; }
+}
+
 /* 키워드/단어 탭 용어 클릭 시 원문 위치 하이라이트 - 스크롤이 끝난 뒤에 표시되므로
    citation 클릭용 pulse보다 오래 보이도록 별도 애니메이션을 둔다(일정 시간 유지 후 페이드) */
 @keyframes locateHighlightPulse {


### PR DESCRIPTION
## Summary
- AI Chats 목록에서 "대화" 클릭 시 전체 화면(#chat-screen)으로 이동하던 것을, Library 상세 패널과 동일한 우측 슬라이드 드로어로 열도록 변경 — 사이드바/탑바가 그대로 유지된 채 목록 위에 드로어만 열림/닫힘
- 드로어 헤더에서 긴 논문 제목이 닫기/뷰어 버튼을 밀어내던 문제 수정(제목 말줄임표 처리)
- ESC / 오버레이 클릭 / 닫기 버튼으로 드로어 닫기, "뷰어에서 열기"는 드로어를 닫고 실제 PDF 뷰어로 이동
- 논문 추천(`GET /library/graph/recommendations`)이 호출할 때마다 LLM+OpenAlex 검증을 처음부터 다시 하던 것을, `app_meta` 테이블에 사용자별로 결과를 캐싱해 7일간 재사용하도록 변경(새 테이블 없이 기존 범용 key-value 테이블 재사용). 7일이 지나면 다음 조회 시 자동으로 새로 생성

## Test plan
- [x] `npm run build` 통과
- [x] 실제 문서/채팅 기록을 DB에 심어 Playwright로 드로어 열림(사이드바/탑바 유지, 목록 그대로 보임), ESC/오버레이 닫기, 뷰어 전환 확인
- [x] 캐시 TTL 로직을 신선한/만료된 타임스탬프로 단위 테스트해 캐시 히트 시 무거운 경로를 타지 않고, 만료 시 재생성 경로를 타는 것 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>