### PR TITLE
뷰어 종료 시 읽은 페이지 저장 누락 및 채팅 드로어 상단 레이아웃 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1028,12 +1028,35 @@ function updatePageDisplay(pageNum) {
 // ── 마지막으로 읽던 위치(책갈피) 자동 저장 ─────────
 // 스크롤 중 페이지가 바뀔 때마다 API를 호출하지 않도록 디바운스한다.
 let saveLastReadPageTimer = null
+let pendingLastReadPage = null
 function scheduleSaveLastReadPage(pageNum) {
   if (!state.currentDocId || state.disableBookmark) return
   if (saveLastReadPageTimer) clearTimeout(saveLastReadPageTimer)
+  pendingLastReadPage = pageNum
   saveLastReadPageTimer = setTimeout(() => {
-    updateLibraryDocMetadata(state.currentDocId, { last_page: pageNum }).catch(() => {})
+    saveLastReadPageTimer = null
+    const p = pendingLastReadPage
+    pendingLastReadPage = null
+    updateLibraryDocMetadata(state.currentDocId, { last_page: p }).catch(() => {})
   }, 1500)
+}
+
+// 뷰어를 나갈 때(뒤로가기 등) 위 디바운스가 아직 안 끝났으면 그대로 잊혀지진
+// 않지만(setTimeout 자체는 계속 살아있음) 그 사이에 Dashboard/Library가 먼저
+// 옛날 last_page로 렌더링을 끝내버린다 - "논문을 읽고 나오면 최근 읽은
+// 논문이 업데이트 안 된다"는 원인이 이것이었다. 화면을 벗어나기 직전 대기
+// 중인 저장을 즉시(await로) 끝내, 다음 화면이 최신 값을 읽어가게 한다.
+async function flushSaveLastReadPage() {
+  if (saveLastReadPageTimer === null) return
+  clearTimeout(saveLastReadPageTimer)
+  saveLastReadPageTimer = null
+  const docId = state.currentDocId
+  const pageNum = pendingLastReadPage
+  pendingLastReadPage = null
+  if (!docId || pageNum == null) return
+  try {
+    await updateLibraryDocMetadata(docId, { last_page: pageNum })
+  } catch {}
 }
 
 function updateProgressMini() {
@@ -3605,6 +3628,11 @@ document.querySelectorAll('.view-toggle-btn').forEach(btn => {
 updateViewToggleUI()
 
 async function showLibraryScreen(shouldPushState = true, targetPage) {
+  // 뷰어에서 나가는 시점이므로, 아직 디바운스 대기 중인 "마지막으로 읽은
+  // 페이지" 저장이 있으면 Dashboard/Library가 새 데이터를 가져오기 전에
+  // 먼저 끝마친다 (스크롤 직후 바로 뒤로가기를 눌렀을 때 최근 읽은 논문
+  // 카드가 갱신되지 않던 문제 수정).
+  await flushSaveLastReadPage()
   hasLibraryStateInHistory = true
   loginScreen.classList.remove('active')
   viewerScreen.classList.remove('active')

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6348,8 +6348,10 @@ body.light-theme .figure-preview-tooltip {
 
 /* ── 단일 논문 대화 드로어 (AI Chats 목록 → "대화") ──────────────────
    Library 상세 패널(.lib-detail-panel/.lib-detail-overlay, library-page.css)과
-   동일한 "우측에서 슬라이드 인" 패턴 - 사이드바/탑바를 그대로 둔 채 열려서
-   페이지 이동 없이 대화만 확인할 수 있다. */
+   비슷한 "우측에서 슬라이드 인" 패턴이지만, 좌측 사이드바 내비게이션은
+   그대로 둔 채 상단 탑바(--topbar-h) 영역까지 꽉 채워 위아래로 이어지는
+   하나의 패널처럼 보이게 한다(탑바 한 겹 + 드로어 자체 헤더 한 겹이 layered
+   보이는 걸 피하려고 top:0부터 시작). */
 .chat-drawer-overlay {
   position: fixed;
   inset: 0;
@@ -6363,7 +6365,7 @@ body.light-theme .figure-preview-tooltip {
 
 .chat-drawer {
   position: fixed;
-  top: var(--topbar-h);
+  top: 0;
   right: 0;
   bottom: 0;
   width: 480px;


### PR DESCRIPTION
## Summary
- 뷰어에서 페이지를 이동한 직후(1.5초 디바운스가 끝나기 전) 바로 "뒤로가기"를 누르면, 마지막으로 읽은 페이지 저장이 서버에 반영되기 전에 Dashboard가 옛 데이터로 먼저 렌더링을 끝내버려 "최근 읽은 논문" 카드가 갱신되지 않는 것처럼 보이던 버그 수정. 뷰어를 나가는 시점(`showLibraryScreen()`)에 대기 중인 디바운스 저장이 있으면 즉시 끝내고 넘어가도록 변경
- AI Chats 대화 드로어가 상단 탑바 아래에서 시작해 탑바+드로어 자체 헤더가 이중으로 겹쳐 보이던 것을, 드로어를 화면 최상단(top:0)까지 확장해 하나로 이어지는 패널처럼 보이도록 수정(좌측 사이드바 내비게이션은 그대로 유지)

## Test plan
- [x] `npm run build` 통과
- [x] 실제 10페이지 PDF를 업로드해 5페이지로 이동 직후(1초 이내) 뒤로가기 → Dashboard가 즉시 정확한 진행률(40%)을 표시하는 것을 Playwright로 확인
- [x] AI Chats에서 드로어를 열어 상단이 화면 맨 위까지 확장되고 좌측 사이드바는 그대로 유지되는 것을 스크린샷으로 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>