### PR TITLE
fix: AI 추천 논문 위젯 개선 (더보기 삭제/캐시 즉시표시/구글 스칼라 링크)

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -116,6 +116,20 @@ async def get_library_reading_recommendations(current_user: str = Depends(get_cu
     return {"recommendations": await get_reading_recommendations(current_user)}
 
 
+@router.get("/library/graph/recommendations/cached")
+async def get_library_reading_recommendations_cached(current_user: str = Depends(get_current_user)):
+    """대시보드 진입 시 호출하는 가벼운 버전입니다. 유효한 캐시가 있으면 그대로
+    반환하고, 없거나 만료됐으면 LLM+OpenAlex를 호출해 새로 생성하지 않고
+    recommendations: null을 반환합니다(대시보드를 열 때마다 무거운 재계산이
+    도는 것을 방지 - 새로 생성은 여전히 "추천 받기" 버튼을 눌렀을 때만 함).
+
+    /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
+    이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
+    """
+    from services.knowledge_graph import get_cached_reading_recommendations
+    return {"recommendations": await get_cached_reading_recommendations(current_user)}
+
+
 @router.get("/library/timeline")
 async def get_library_timeline(current_user: str = Depends(get_current_user)):
     """업로드/읽음/질문/메모를 시간순으로 병합한 개인 활동 타임라인을 반환합니다.

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -480,6 +480,36 @@ def _reading_recommendations_cache_key(username: str) -> str:
     return f"reading_recommendations:{username}"
 
 
+def _read_reading_recommendations_cache(username: str) -> Optional[List[dict]]:
+    """캐시에 유효한(READING_RECOMMENDATIONS_CACHE_DAYS 이내) 추천 결과가 있으면
+    그대로 반환하고, 없거나 만료/손상됐으면 None을 반환한다 - 새로 생성하지는
+    않는다(get_reading_recommendations와 get_cached_reading_recommendations가
+    공유하는 순수 조회 로직)."""
+    from services.db import db_get_meta
+
+    cached_raw = db_get_meta(_reading_recommendations_cache_key(username))
+    if not cached_raw:
+        return None
+    try:
+        cached = json.loads(cached_raw)
+        generated_at = datetime.fromisoformat(cached["generated_at"])
+        age = datetime.now(timezone.utc) - generated_at
+        if age < timedelta(days=READING_RECOMMENDATIONS_CACHE_DAYS):
+            return cached["recommendations"]
+    except Exception:
+        pass  # 캐시가 손상됐으면 무시하고 새로 생성
+    return None
+
+
+async def get_cached_reading_recommendations(username: str) -> Optional[List[dict]]:
+    """대시보드 진입 시 호출하는 가벼운 버전 - 유효한 캐시가 있으면 그대로
+    반환하고, 없으면 LLM+OpenAlex를 호출해 새로 생성하지 않고 None을 반환한다
+    (무거운 재계산 없이 캐시 유무만 확인). 이전에는 캐시가 있어도 사용자가
+    "추천 받기" 버튼을 다시 눌러야만 보였는데, 대시보드 로드 시 이 함수로
+    미리 조회해 캐시가 있으면 버튼 없이 바로 보여주기 위한 용도다."""
+    return _read_reading_recommendations_cache(username)
+
+
 async def get_reading_recommendations(username: str) -> List[dict]:
     """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천한다. Primer 기능의
     기존 OpenAlex 검증 로직(_is_plausible_match, resolve_reference)을 그대로
@@ -493,20 +523,11 @@ async def get_reading_recommendations(username: str) -> List[dict]:
     호출할 때마다 같은 무거운 계산을 반복하지 않으면서도, 추천 목록이 매주
     한 번씩은 새로 갱신되게 한다.
     """
-    from services.db import db_get_meta, db_set_meta
+    cached = _read_reading_recommendations_cache(username)
+    if cached is not None:
+        return cached
 
-    cache_key = _reading_recommendations_cache_key(username)
-    cached_raw = db_get_meta(cache_key)
-    if cached_raw:
-        try:
-            cached = json.loads(cached_raw)
-            generated_at = datetime.fromisoformat(cached["generated_at"])
-            age = datetime.now(timezone.utc) - generated_at
-            if age < timedelta(days=READING_RECOMMENDATIONS_CACHE_DAYS):
-                return cached["recommendations"]
-        except Exception:
-            pass  # 캐시가 손상됐으면 무시하고 새로 생성
-
+    from services.db import db_set_meta
     from services.library import list_documents
     docs = list_documents(username=username)
     if len(docs) < 2:
@@ -537,7 +558,7 @@ async def get_reading_recommendations(username: str) -> List[dict]:
             continue  # 이미 읽은 논문과 같은 논문이면 제외
         results.append({**resolved, "reason": r.get("reason", "")})
 
-    db_set_meta(cache_key, json.dumps({
+    db_set_meta(_reading_recommendations_cache_key(username), json.dumps({
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "recommendations": results,
     }, ensure_ascii=False))

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -242,6 +242,14 @@ export async function fetchReadingRecommendations() {
   return res.json()
 }
 
+// 대시보드 진입 시 호출하는 가벼운 버전 - 유효한 캐시가 있으면 바로 보여주고,
+// 없으면 무거운 재계산 없이 recommendations: null을 반환받아 "추천 받기" 버튼을 띄운다.
+export async function fetchCachedReadingRecommendations() {
+  const res = await fetch(`${API_BASE}/library/graph/recommendations/cached`)
+  if (!res.ok) throw new Error('추천 논문 캐시 조회 실패')
+  return res.json()
+}
+
 export async function fetchLibraryTrash(options = {}) {
   const res = await fetch(`${API_BASE}/library/trash${buildQuery(options)}`)
   if (!res.ok) throw new Error('휴지통 조회 실패')

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -7,7 +7,7 @@
 // (뷰어/비교 화면이 보이고 포커스된 동안 적립 → 서버 전송)가 쌓은 실측치를
 // fetchReadingTimeStats()로 가져온 것이다.
 import './../styles/dashboard.css'
-import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
+import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
 
 function escapeHtml(str) {
@@ -328,20 +328,42 @@ function renderRecentQuestionsCard(list) {
   `
 }
 
-// ── AI 추천 논문 ── /library/graph/recommendations는 LLM+OpenAlex를 여러 번
-// 호출하는 무거운 엔드포인트라, 백엔드 주석과 기존 그래프 탭 구현이 그러듯
-// 대시보드 진입 시 자동 호출하지 않고 사용자가 버튼을 눌렀을 때만 지연
-// 로드한다(불필요한 지연/비용을 방지).
-function renderRecommendationsCard() {
+// ── AI 추천 논문 ── /library/graph/recommendations(전체 생성)는 LLM+OpenAlex를
+// 여러 번 호출하는 무거운 엔드포인트라, 백엔드 주석과 기존 그래프 탭 구현이
+// 그러듯 사용자가 버튼을 눌렀을 때만 새로 생성한다(불필요한 지연/비용 방지).
+// 다만 이미 생성된 캐시가 있으면(/recommendations/cached, 유효기간 이내 조회만
+// 하고 새로 생성하진 않는 가벼운 엔드포인트) 대시보드 진입 시 바로 보여줘,
+// 캐시가 있는데도 매번 버튼을 눌러야 했던 문제를 없앤다.
+function scholarSearchUrl(title) {
+  return `https://scholar.google.com/scholar?q=${encodeURIComponent(title || '')}`
+}
+
+function renderRecItemsHtml(recommendations) {
+  return `
+    <ul class="dash-rec-list">
+      ${recommendations.slice(0, 5).map(r => `
+        <li class="dash-rec-item">
+          <a href="${escapeHtml(scholarSearchUrl(r.title))}" target="_blank" rel="noopener noreferrer" class="dash-rec-title">${escapeHtml(r.title || '')}</a>
+          ${r.year ? `<span class="dash-rec-year">${escapeHtml(String(r.year))}</span>` : ''}
+          ${r.reason ? `<div class="dash-rec-reason">${escapeHtml(r.reason)}</div>` : ''}
+        </li>
+      `).join('')}
+    </ul>
+  `
+}
+
+function renderRecommendationsCard(cachedRecommendations) {
+  const hasCached = Array.isArray(cachedRecommendations) && cachedRecommendations.length > 0
   return `
     <div class="dash-card dash-card-list dash-card-recs">
       <div class="dash-card-head">
         <h3>${icon('star', 15)}AI 추천 논문</h3>
-        <a href="#" class="dash-link" data-nav="library">더 보기 ›</a>
       </div>
       <div class="dash-recs-body" data-recs-body>
-        ${emptyNote('읽은 논문들을 바탕으로 다음에 읽으면 좋을 논문을 추천받아 보세요.')}
-        <button type="button" class="dash-recs-btn" data-recs-btn>${icon('zap', 13)}추천 받기</button>
+        ${hasCached ? renderRecItemsHtml(cachedRecommendations) : `
+          ${emptyNote('읽은 논문들을 바탕으로 다음에 읽으면 좋을 논문을 추천받아 보세요.')}
+          <button type="button" class="dash-recs-btn" data-recs-btn>${icon('zap', 13)}추천 받기</button>
+        `}
       </div>
     </div>
   `
@@ -563,17 +585,7 @@ function attachHandlers(root) {
           body.innerHTML = emptyNote('추천할 만한 논문을 찾지 못했습니다.')
           return
         }
-        body.innerHTML = `
-          <ul class="dash-rec-list">
-            ${recommendations.slice(0, 5).map(r => `
-              <li class="dash-rec-item">
-                <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" class="dash-rec-title">${escapeHtml(r.title || '')}</a>
-                ${r.year ? `<span class="dash-rec-year">${escapeHtml(String(r.year))}</span>` : ''}
-                ${r.reason ? `<div class="dash-rec-reason">${escapeHtml(r.reason)}</div>` : ''}
-              </li>
-            `).join('')}
-          </ul>
-        `
+        body.innerHTML = renderRecItemsHtml(recommendations)
       } catch (err) {
         console.error('추천 논문 조회 실패:', err)
         body.innerHTML = `<p class="dash-empty-note dash-error-note">추천 논문을 불러오지 못했습니다.</p>`
@@ -591,7 +603,7 @@ export async function renderDashboardPage() {
 
   el.innerHTML = `<div class="dash-loading">${icon('refreshCw', 20)}<span>대시보드를 불러오는 중...</span></div>`
 
-  let dashboard, timelineData, libraryData, graphData, readingStats
+  let dashboard, timelineData, libraryData, graphData, readingStats, cachedRecs
   try {
     const results = await Promise.all([
       fetchLibraryDashboard(),
@@ -599,12 +611,14 @@ export async function renderDashboardPage() {
       fetchLibrary(),
       fetchLibraryGraph().catch(() => null),
       fetchReadingTimeStats().catch(() => null),
+      fetchCachedReadingRecommendations().catch(() => ({ recommendations: null })),
     ])
     dashboard = results[0]
     timelineData = results[1]
     libraryData = results[2]
     graphData = results[3]
     readingStats = results[4]
+    cachedRecs = results[5]
   } catch (err) {
     console.error('대시보드 데이터 로드 실패:', err)
     el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
@@ -629,7 +643,7 @@ export async function renderDashboardPage() {
       <div class="dash-row dash-row-recent">
         ${renderRecentPapersCard(docs)}
         ${renderRecentQuestionsCard(recentQuestions)}
-        ${renderRecommendationsCard()}
+        ${renderRecommendationsCard(cachedRecs && cachedRecs.recommendations)}
       </div>
       <div class="dash-row dash-row-bottom">
         ${renderHeatmapCard(heatmap)}


### PR DESCRIPTION
# Summary
## 1. AI 추천 논문 더보기 삭제
- `frontend/src/pages/dashboardPage.js`의 `renderRecommendationsCard()` 카드 헤더에서 "더 보기 ›" 링크 제거
## 2. 캐시된 추천 결과 즉시 표시
- 백엔드: `backend/services/knowledge_graph.py`에 캐시 조회 전용 로직 `_read_reading_recommendations_cache()`/`get_cached_reading_recommendations()` 추가(새로 생성은 하지 않고 유효 캐시가 있으면 반환, 없으면 None). 기존 `get_reading_recommendations()`는 이 헬퍼를 재사용하도록 리팩터링
- `backend/routers/library.py`에 가벼운 조회 엔드포인트 `GET /library/graph/recommendations/cached` 추가
- 프론트: `frontend/src/library.js`에 `fetchCachedReadingRecommendations()` 추가, `dashboardPage.js`의 `renderDashboardPage()`가 대시보드 로드 시 이를 함께 호출해 유효한 캐시가 있으면 "추천 받기" 버튼 없이 바로 목록을 렌더링
## 3. 추천 논문 클릭 시 Google Scholar로 이동
- `renderRecItemsHtml()`에서 링크를 기존 `r.url`(OpenAlex/arXiv 등) 대신 `scholarSearchUrl(r.title)`(Google Scholar 검색 링크)로 변경

## Test plan
- [ ] 추천을 아직 받은 적 없는 계정에서 대시보드 진입 → 빈 상태 문구 + "추천 받기" 버튼 노출 확인
- [ ] "추천 받기" 클릭 후 결과가 뜨는지, 그리고 새로고침(대시보드 재진입) 시 버튼 없이 캐시된 목록이 바로 뜨는지 확인
- [ ] 추천 논문 제목 클릭 시 Google Scholar 검색 결과로 새 탭이 열리는지 확인
- [ ] 카드 헤더에 "더 보기" 링크가 더 이상 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)