### PR TITLE
feat: 대시보드 AI 인사이트를 규칙 기반에서 실제 LLM 기반으로 전환

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -39,6 +39,10 @@ logger = logging.getLogger(__name__)
 # 매번 다시 계산하지 않고, 일주일에 한 번만 새로 생성해 app_meta에 저장해둔다.
 READING_RECOMMENDATIONS_CACHE_DAYS = 7
 
+# AI 인사이트 캐시 TTL - 대시보드를 열 때마다 LLM을 호출하지 않으면서도 하루에
+# 한 번은 그날의 최신 활동(질문/메모/읽은 논문)을 반영해 새로 생성되게 한다.
+AI_INSIGHTS_CACHE_HOURS = 24
+
 # 그래프 조회 시점에 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서를
 # 백그라운드로 백필한다. 같은 문서에 대해 중복으로 백필 태스크가 여러 개
 # 뜨는 것을 막기 위한 in-flight 집합.
@@ -616,15 +620,86 @@ async def get_knowledge_gaps(username: str) -> List[dict]:
     return concept_gaps + paper_gaps[:5]
 
 
+def _ai_insights_cache_key(username: str) -> str:
+    return f"ai_insights:{username}"
+
+
+async def get_ai_insights(username: str) -> List[dict]:
+    """대시보드 "AI 인사이트" 카드의 내용을 생성한다. 예전에는 get_knowledge_gaps의
+    규칙 기반 격차 문구를 그대로 노출했지만, 그건 매번 같은 두 패턴("질문이
+    없습니다"/"메모가 없습니다")만 반복해 내용이 다양하지 않았다. 여기서는 실제
+    질문/메모 내용과 읽은 논문 목록을 LLM에 근거로 전달해, 조언/요약/추천/격려처럼
+    더 다양하고 구체적인 인사이트를 생성한다.
+
+    결과는 app_meta에 하루(AI_INSIGHTS_CACHE_HOURS) 동안 캐싱해 대시보드를 열 때마다
+    LLM을 호출하지 않으면서도 매일 새 활동을 반영해 갱신되게 한다(추천 논문 캐싱과
+    동일한 패턴). LLM 호출이 실패하거나 빈 배열을 반환하면(프로바이더 장애, 아직
+    분석할 활동이 전혀 없음 등) 기존 규칙 기반 지식 격차 감지로 조용히 대체해
+    카드가 비지 않게 한다."""
+    from services.db import db_get_meta, db_set_meta
+
+    cache_key = _ai_insights_cache_key(username)
+    cached_raw = db_get_meta(cache_key)
+    if cached_raw:
+        try:
+            cached = json.loads(cached_raw)
+            generated_at = datetime.fromisoformat(cached["generated_at"])
+            age = datetime.now(timezone.utc) - generated_at
+            if age < timedelta(hours=AI_INSIGHTS_CACHE_HOURS):
+                return cached["insights"]
+        except Exception:
+            pass  # 캐시가 손상됐으면 무시하고 새로 생성
+
+    from services.library import list_documents
+    docs = list_documents(username=username)
+    rule_based_gaps = await get_knowledge_gaps(username)
+    if not docs:
+        return rule_based_gaps
+
+    timeline = await get_activity_timeline(username)
+    notes = [f"[{e['doc_title']}] {e['summary']}" for e in timeline if e["type"] == "note" and e.get("summary")][:8]
+    questions = [f"[{e['doc_title']}] {e['summary']}" for e in timeline if e["type"] == "question" and e.get("summary")][:8]
+
+    heatmap = await get_concept_heatmap(username)
+    concepts = [h["name"] for h in heatmap[:8]]
+    categories = sorted({c for d in docs for c in (d.get("metadata") or {}).get("categories", []) or []})
+
+    stats = {
+        "total_papers": len(docs),
+        "read_papers": sum(1 for d in docs if (d.get("metadata") or {}).get("read")),
+        "total_notes": len([e for e in timeline if e["type"] == "note"]),
+        "total_questions": len([e for e in timeline if e["type"] == "question"]),
+    }
+
+    from services.llm_client import generate_dashboard_insights
+    insights = await generate_dashboard_insights({
+        "stats": stats,
+        "notes": notes,
+        "questions": questions,
+        "concepts": concepts,
+        "categories": categories,
+        "gap_hints": [g["message"] for g in rule_based_gaps],
+    }, session_id=username)
+
+    if not insights:
+        insights = rule_based_gaps  # LLM 실패/빈 응답 시 규칙 기반으로 폴백
+
+    db_set_meta(cache_key, json.dumps({
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "insights": insights,
+    }, ensure_ascii=False))
+    return insights
+
+
 async def get_dashboard_summary(username: str) -> dict:
     """지식 그래프 탭의 "대시보드" 뷰에 필요한 데이터를 한 번에 모은다.
-    새 집계 로직 없이 get_concept_heatmap/get_knowledge_gaps/
+    새 집계 로직 없이 get_concept_heatmap/get_ai_insights/
     get_activity_timeline을 조합할 뿐이다."""
     from services.library import list_documents
     docs = list_documents(username=username)  # 이미 created_at DESC 정렬됨
 
     heatmap = await get_concept_heatmap(username)
-    gaps = await get_knowledge_gaps(username)
+    insights = await get_ai_insights(username)
     timeline = await get_activity_timeline(username)
 
     recent_questions = [e for e in timeline if e["type"] == "question"][:10]
@@ -646,7 +721,7 @@ async def get_dashboard_summary(username: str) -> dict:
     return {
         "stats": stats,
         "heatmap": heatmap[:10],
-        "gaps": gaps,
+        "insights": insights,
         "recent_questions": recent_questions,
         "recent_notes": recent_notes,
         "recent_papers": recent_papers,

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2325,3 +2325,42 @@ Already Read:
 JSON Array:"""
     return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="읽을 논문 추천", required_key="title")
 
+
+async def generate_dashboard_insights(profile: dict, session_id: str = None) -> List[dict]:
+    """사용자의 최근 질문/메모 내용, 읽은 논문 통계, 관심 개념/카테고리를 근거로
+    대시보드 "AI 인사이트" 카드에 표시할 개인화된 인사이트 3~5개를 생성한다.
+    규칙 기반 격차 감지(knowledge_graph.get_knowledge_gaps)와 달리 매번 똑같은
+    문구가 아니라, 실제 활동 내용을 반영해 조언/요약/추천/격려처럼 다양한
+    성격의 문장을 만들도록 유도한다. 반환값: [{"type": str, "message": str}, ...].
+    profile 형태는 knowledge_graph.get_ai_insights가 만든다:
+    {"stats": {...}, "notes": [str], "questions": [str], "concepts": [str],
+     "categories": [str], "gap_hints": [str]}."""
+    stats = profile.get("stats") or {}
+    notes_block = "\n".join(f"- {n}" for n in profile.get("notes") or []) or "(없음)"
+    questions_block = "\n".join(f"- {q}" for q in profile.get("questions") or []) or "(없음)"
+    concepts_line = ", ".join(profile.get("concepts") or []) or "(없음)"
+    categories_line = ", ".join(profile.get("categories") or []) or "(알 수 없음)"
+    gap_hints_block = "\n".join(f"- {g}" for g in profile.get("gap_hints") or []) or "(없음)"
+
+    prompt = f"""You are a thoughtful academic research mentor reviewing a researcher's recent activity in their paper-reading app. Based on the data below, write 3 to 5 short, varied, and genuinely useful insights in Korean for their dashboard. Mix DIFFERENT kinds of insights - do not make them all the same type. Ground every insight in the actual data given; do not invent facts, paper titles, or activity that isn't there.
+
+Research areas: {categories_line}
+Frequently studied concepts: {concepts_line}
+Stats: papers {stats.get('total_papers', 0)}, read {stats.get('read_papers', 0)}, questions {stats.get('total_questions', 0)}, notes {stats.get('total_notes', 0)}
+
+Recent notes (memo excerpts, [paper title] content):
+{notes_block}
+
+Recent questions asked (excerpts, [paper title] content):
+{questions_block}
+
+Rule-detected gaps (for reference only, rephrase naturally instead of copying verbatim):
+{gap_hints_block}
+
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with:
+- "type": one of "advice" (조언), "summary" (최근 활동 요약), "recommendation" (다음에 해볼 만한 것 추천), "encouragement" (격려/성과 인정)
+- "message": the insight itself, in Korean, one or two sentences.
+
+JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="AI 인사이트 생성", required_key="message")
+

--- a/backend/tests/test_knowledge_graph_v4.py
+++ b/backend/tests/test_knowledge_graph_v4.py
@@ -1,8 +1,12 @@
 """지식 그래프 4차(Concept Heatmap / Knowledge Gap Detection / Research
 Dashboard) 회귀 테스트. 이전 차수와 동일한 fixture 패턴(test_client/
-isolated_dirs)을 사용한다. 이번 차수는 LLM/외부 API 호출이 전혀 없어
-monkeypatch 없이 순수 데이터로 검증한다.
+isolated_dirs)을 사용한다. Concept Heatmap/Knowledge Gap Detection은
+LLM/외부 API 호출이 전혀 없어 monkeypatch 없이 순수 데이터로 검증하지만,
+Research Dashboard의 AI 인사이트(get_ai_insights)는 LLM을 호출하므로
+test_knowledge_graph_v3.py의 추천 논문 테스트와 동일하게
+llm_client.generate_dashboard_insights를 monkeypatch한다.
 """
+import pytest
 
 
 def _create_doc_owned_by(isolated_dirs, doc_id: str, username: str, metadata: dict = None):
@@ -127,7 +131,14 @@ def test_gap_skips_unread_paper_without_notes(test_client, isolated_dirs):
 
 # ── Research Dashboard ───────────────────────────────────────────────────
 
-def test_dashboard_stats_and_recent_lists(test_client, isolated_dirs):
+def test_dashboard_stats_and_recent_lists(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+
+    async def fake_generate_insights(profile, session_id=None):
+        return [{"type": "summary", "message": "테스트 인사이트"}]
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate_insights)
+
     db = isolated_dirs["db"]
     _create_doc_owned_by(
         isolated_dirs, "doc-dash-1", "testuser",
@@ -154,12 +165,78 @@ def test_dashboard_stats_and_recent_lists(test_client, isolated_dirs):
     assert any(q["summary"] == "질문 테스트" for q in data["recent_questions"])
     assert any(n["summary"] == "메모 테스트" for n in data["recent_notes"])
     assert any(p["doc_id"] == "doc-dash-1" for p in data["recent_papers"])
+    assert data["insights"] == [{"type": "summary", "message": "테스트 인사이트"}]
 
 
 def test_dashboard_excludes_other_users_data(test_client, isolated_dirs):
+    # testuser 소유 문서가 0건이라 get_ai_insights가 LLM을 호출하지 않고 바로
+    # 빈 규칙 기반 결과로 반환하므로(문서가 없으면 근거가 없어 조기 반환)
+    # 별도 monkeypatch가 필요 없다.
     _create_doc_owned_by(isolated_dirs, "doc-dash-other", "otheruser", {"title": "Not Mine"})
 
     res = test_client.get("/api/library/dashboard")
     data = res.json()
     assert data["stats"]["total_papers"] == 0
     assert not any(p["doc_id"] == "doc-dash-other" for p in data["recent_papers"])
+
+
+# ── AI Insights (LLM 기반) ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_ai_insights_uses_llm_result_when_available(isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-insight-1", "testuser", {"title": "Insight Paper"})
+
+    captured = {}
+
+    async def fake_generate_insights(profile, session_id=None):
+        captured["profile"] = profile
+        return [{"type": "advice", "message": "다음엔 관련 논문을 더 찾아보세요."}]
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate_insights)
+
+    result = await knowledge_graph.get_ai_insights("testuser")
+    assert result == [{"type": "advice", "message": "다음엔 관련 논문을 더 찾아보세요."}]
+    assert captured["profile"]["stats"]["total_papers"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ai_insights_falls_back_to_rule_based_gaps_when_llm_empty(isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(
+        isolated_dirs, "doc-insight-nonotes", "testuser",
+        {"title": "No Notes Paper", "read": True, "read_at": "2026-01-01T00:00:00+00:00"},
+    )
+
+    async def fake_generate_insights(profile, session_id=None):
+        return []  # LLM 실패/빈 응답 상황을 흉내
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate_insights)
+
+    result = await knowledge_graph.get_ai_insights("testuser")
+    assert any(g["type"] == "no_notes_paper" and g["doc_id"] == "doc-insight-nonotes" for g in result)
+
+
+@pytest.mark.asyncio
+async def test_ai_insights_caches_result_for_a_day(isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-insight-cache", "testuser", {"title": "Cache Paper"})
+
+    call_count = {"n": 0}
+
+    async def fake_generate_insights(profile, session_id=None):
+        call_count["n"] += 1
+        return [{"type": "summary", "message": f"호출 {call_count['n']}회"}]
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate_insights)
+
+    first = await knowledge_graph.get_ai_insights("testuser")
+    second = await knowledge_graph.get_ai_insights("testuser")
+    assert first == second
+    assert call_count["n"] == 1  # 캐시가 있으면 LLM을 다시 호출하지 않는다

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -161,10 +161,22 @@ function renderStatGrid(stats, events, docs) {
   `
 }
 
-// ── AI 인사이트 ── 지식 격차 감지(services/knowledge_graph.get_knowledge_gaps)
-// 결과를 그대로 인사이트 문구로 노출한다 - 규칙 기반이라 매번 근거가 있다.
-function renderInsightsCard(gaps) {
-  const items = (gaps || []).slice(0, 4)
+// ── AI 인사이트 ── services/knowledge_graph.get_ai_insights가 사용자의 최근
+// 질문/메모/읽은 논문 데이터를 근거로 LLM(llm_client.generate_dashboard_insights)을
+// 호출해 생성한 조언/요약/추천/격려를 보여준다(하루 단위로 캐싱 - 매일 최신화).
+// LLM 호출이 실패하면 백엔드가 조용히 규칙 기반 지식 격차 감지 결과로
+// 대체하므로, 프론트는 type이 둘 중 어느 쪽이든 적절한 아이콘만 골라주면 된다.
+const INSIGHT_TYPE_ICON = {
+  advice: 'lightbulb',
+  summary: 'fileText',
+  recommendation: 'star',
+  encouragement: 'smile',
+  low_question_concept: 'messageCircle',
+  no_notes_paper: 'edit3',
+}
+
+function renderInsightsCard(insights) {
+  const items = (insights || []).slice(0, 4)
   return `
     <div class="dash-card dash-card-insights">
       <div class="dash-card-head"><h3>${icon('lightbulb', 15)}AI 인사이트</h3></div>
@@ -172,7 +184,7 @@ function renderInsightsCard(gaps) {
         ? emptyNote('아직 표시할 인사이트가 없습니다. 논문을 더 읽고 질문/메모를 남기면 여기에 제안이 쌓입니다.')
         : `<ul class="dash-insight-list">${items.map(g => `
             <li class="dash-insight-item">
-              <span class="dash-insight-icon">${icon(g.type === 'no_notes_paper' ? 'edit3' : 'messageCircle', 14)}</span>
+              <span class="dash-insight-icon">${icon(INSIGHT_TYPE_ICON[g.type] || 'lightbulb', 14)}</span>
               <span>${escapeHtml(g.message)}</span>
             </li>`).join('')}</ul>`
       }
@@ -615,14 +627,14 @@ export async function renderDashboardPage() {
   const docs = (libraryData && libraryData.documents) || []
   const stats = dashboard.stats || {}
   const heatmap = dashboard.heatmap || []
-  const gaps = dashboard.gaps || []
+  const insights = dashboard.insights || []
   const recentQuestions = dashboard.recent_questions || []
 
   el.innerHTML = `
     <div class="dash-root">
       ${renderStatGrid(stats, events, docs)}
       <div class="dash-row dash-row-3">
-        ${renderInsightsCard(gaps)}
+        ${renderInsightsCard(insights)}
         ${renderWeeklyActivityCard(events, stats, docs, readingStats)}
         ${renderProgressSummaryCard(events, heatmap, readingStats)}
       </div>


### PR DESCRIPTION
# Summary
## 1. LLM 기반 인사이트 생성 함수 추가
- `backend/services/llm_client.py`에 `generate_dashboard_insights()` 추가 - 최근 질문/메모 내용, 읽은 논문 통계, 관심 개념/카테고리를 근거로 조언(advice)/요약(summary)/추천(recommendation)/격려(encouragement) 등 다양한 성격의 인사이트를 생성. 기존 멀티 프로바이더 분기+재시도 공용 헬퍼(`_llm_json_array_with_retry`)를 그대로 재사용
## 2. 일 단위 캐싱 + 규칙 기반 폴백
- `backend/services/knowledge_graph.py`에 `get_ai_insights()` 추가 - `AI_INSIGHTS_CACHE_HOURS`(24시간) 동안 `app_meta`에 캐싱해 대시보드를 열 때마다 LLM을 호출하지 않으면서도 매일 새로 갱신되게 함(추천 논문 캐싱과 동일한 패턴)
- LLM 호출이 실패하거나 빈 배열을 반환하면 기존 규칙 기반 `get_knowledge_gaps()` 결과로 조용히 대체해 카드가 비지 않게 함
- `get_dashboard_summary()`가 `get_knowledge_gaps` 대신 `get_ai_insights`를 사용하도록 변경, 응답 필드명 `gaps` → `insights`로 변경(별도 `/library/graph/gaps` 엔드포인트는 기존 규칙 기반 그대로 유지)
## 3. 프론트엔드 반영
- `frontend/src/pages/dashboardPage.js`의 `renderInsightsCard`가 새 인사이트 타입(advice/summary/recommendation/encouragement)에 맞는 아이콘을 매핑하도록 업데이트(규칙 기반 폴백 타입 아이콘도 계속 지원)
- `dashboard.gaps` → `dashboard.insights` 참조 변경
## 4. 테스트
- `backend/tests/test_knowledge_graph_v4.py`: 기존 대시보드 테스트에 `generate_dashboard_insights` monkeypatch 추가(실제 LLM 호출 방지)
- `get_ai_insights`의 LLM 성공 경로/빈 응답 시 규칙 기반 폴백/캐싱 동작(같은 날 재호출 시 LLM 재호출 안 함)을 검증하는 테스트 3개 신규 추가

## Test plan
- [x] `pytest backend/tests/test_knowledge_graph_v4.py` 13개 전체 통과
- [x] `pytest backend/tests` 전체 실행 - 293 passed, 1 failed(무관한 기존 실패 `test_project_root_falls_back_when_configured_path_missing`, main 브랜치에서도 동일하게 실패함을 확인)
- [ ] 실제 `.env`에 LLM provider(OpenAI/Gemini/Claude/Ollama 등) 설정 후 대시보드 진입 → AI 인사이트 카드에 실제 질문/메모 내용을 반영한 문구가 뜨는지 확인
- [ ] 하루 이내 재진입 시 캐시된 동일 인사이트가 뜨는지(LLM 재호출 안 함) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)