### PR TITLE
fix: AI Chats 드로어의 인용 표시 및 배경 불투명도 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4208,7 +4208,8 @@ async function openChatDrawer(doc) {
       renderChatDrawerGreeting(doc)
     } else {
       savedHistory.forEach(msg => {
-        renderChatDrawerMessage(msg.role, msg.role === 'assistant' ? formatChatHtml(msg.content) : msg.content, msg.role === 'assistant')
+        const renderedContent = msg.role === 'assistant' ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content, doc.id)
+        renderChatDrawerMessage(msg.role, renderedContent, true)
         chatDrawerState.history.push({ role: msg.role, content: msg.content })
       })
     }
@@ -10542,7 +10543,7 @@ function formatChatHtml(text) {
   return html
 }
 
-function formatUserChatHtml(content) {
+function formatUserChatHtml(content, sessionId = state.sessionId) {
   if (!content) return ''
   
   if (content.startsWith('[인용된 본문 내용]:')) {
@@ -10577,7 +10578,7 @@ function formatUserChatHtml(content) {
       if (sepIdx !== -1) {
         const quoteId = pageInfo.substring(sepIdx + 1)
         pageInfo = pageInfo.substring(0, sepIdx)
-        imgSrc = getChatQuoteImage(state.sessionId, quoteId)
+        imgSrc = getChatQuoteImage(sessionId, quoteId)
       }
 
       const quoteBodyHtml = imgSrc

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6375,7 +6375,7 @@ body.sidebar-collapsed .chat-drawer-overlay { left: var(--sidebar-w-collapsed); 
   bottom: 0;
   width: auto;
   max-width: none;
-  background: var(--bg-surface);
+  background: var(--bg-panel);
   border-left: 1px solid var(--border);
   box-shadow: var(--shadow-md);
   z-index: 46;


### PR DESCRIPTION
# Summary
## 1. AI Chats 드로어에서 인용(quote) UI가 렌더링되지 않던 문제 수정
- `openChatDrawer()`가 채팅 히스토리를 불러올 때 user 메시지를 raw 텍스트로 렌더링해 `[인용된 본문 내용]:...`, `[인용된 이미지...]` 마커 문자열이 그대로 노출되던 문제 수정 (`frontend/src/main.js:4211-4212`)
- 뷰어 내장 채팅에서 이미 사용 중이던 `formatUserChatHtml()` 파서를 드로어 히스토리 렌더링에도 동일하게 적용
- `formatUserChatHtml()`에 `sessionId` 파라미터를 추가해 드로어 컨텍스트에서는 `doc.id`를 넘기도록 수정 (`main.js:10545`, `10578`) — 인용 이미지가 로컬스토리지에 `sessionId` 기준으로 저장되는데, 드로어에는 전역 `state.sessionId`가 없거나 다른 문서를 가리킬 수 있어 필요

## 2. AI Chats 드로어 배경 반투명 수정
- `.chat-drawer`가 알파값이 있는 `--bg-surface`(backdrop-filter 없음)를 사용해 뒤 화면이 비쳐 보이던 문제 수정
- 다른 불투명 패널들과 동일한 `--bg-panel`로 교체 (`frontend/src/style.css:6378`)

## 테스트
- Playwright로 `/api/**`를 목(mock)하여 드로어를 직접 열어 텍스트 인용/이미지 인용 렌더링, 이미지 fallback, 다크/라이트 테마에서의 배경 불투명도를 모두 시각적으로 확인함