### PR TITLE
fix: 대시보드 최근 질문 클릭 시 AI Chats 채팅 드로어 열기

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -556,11 +556,12 @@ function attachHandlers(root) {
     })
   })
 
-  // 최근 질문 → 해당 논문을 채팅 사이드바가 열린 채로 연다.
+  // 최근 질문 → 논문 뷰어가 아니라 AI Chats의 채팅 드로어를 바로 연다
+  // (aiChatsPage.js의 "대화" 버튼과 동일한 '#chat?id=' 해시 라우트 사용).
   root.querySelectorAll('.dash-question-item[data-doc-id]').forEach(elm => {
     elm.addEventListener('click', () => {
       const id = elm.dataset.docId
-      if (id) location.hash = `viewer?id=${encodeURIComponent(id)}&chat=1`
+      if (id) location.hash = `chat?id=${encodeURIComponent(id)}`
     })
   })
 


### PR DESCRIPTION
# Summary
## 1. 최근 질문 클릭 액션 변경
- `frontend/src/pages/dashboardPage.js`의 `dash-question-item` 클릭 핸들러가 논문 뷰어(`#viewer?id=...&chat=1`)를 여는 대신, AI Chats 페이지의 채팅 드로어(`#chat?id=...`, `aiChatsPage.js`의 "대화" 버튼과 동일한 라우트)를 바로 열도록 변경

## Test plan
- [ ] 대시보드의 "최근 질문" 카드에서 항목 클릭 시 논문 뷰어가 아니라 AI Chats 페이지 위에 채팅 드로어가 열리는지 확인
- [ ] 존재하지 않는/삭제된 논문의 질문 클릭 시 기존 에러 토스트("대화할 논문 정보를 불러올 수 없습니다.")가 정상 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)