### PR TITLE
fix: 대시보드 최근 읽은 논문 날짜가 업로드 시점에 고정되는 문제 수정

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1037,7 +1037,11 @@ function scheduleSaveLastReadPage(pageNum) {
     saveLastReadPageTimer = null
     const p = pendingLastReadPage
     pendingLastReadPage = null
-    updateLibraryDocMetadata(state.currentDocId, { last_page: p }).catch(() => {})
+    // last_page와 함께 last_read_at(마지막으로 읽은 시각)도 갱신한다 - 완독
+    // 표시(read_at)를 하지 않고 읽던 중인 논문은 이 필드가 없으면 대시보드
+    // "최근 읽은 논문"의 정렬/날짜 표시가 read_at||created_at로 떨어져
+    // 계속 업로드 날짜("3일 전" 등)로만 보이는 문제가 있었다.
+    updateLibraryDocMetadata(state.currentDocId, { last_page: p, last_read_at: new Date().toISOString() }).catch(() => {})
   }, 1500)
 }
 
@@ -1055,7 +1059,7 @@ async function flushSaveLastReadPage() {
   pendingLastReadPage = null
   if (!docId || pageNum == null) return
   try {
-    await updateLibraryDocMetadata(docId, { last_page: pageNum })
+    await updateLibraryDocMetadata(docId, { last_page: pageNum, last_read_at: new Date().toISOString() })
   } catch {}
 }
 
@@ -7004,6 +7008,13 @@ async function openFromLibrary(doc, shouldPushState = true) {
     // (아래 loadPDF에서 페이지를 렌더링하며 바로 참조한다) 서버 미러 데이터를
     // 먼저 끌어와야 다른 기기에서 저장한 하이라이트/메모가 반영된다.
     await hydrateAnnotationsAndMemosFromServer(doc.id)
+
+    // 논문을 여는 시점 자체를 "마지막으로 읽은 시각"으로 기록한다(fire-and-forget).
+    // 스크롤로 페이지가 바뀔 때만 last_read_at이 갱신되면, 열자마자 바로 나가거나
+    // (이 fix 이전에 이미 last_page가 있던 예전 문서처럼) 페이지 이동이 없는
+    // 경우 대시보드 "최근 읽은 논문"의 날짜가 계속 업로드 시각에 머물러 있었다.
+    state.currentDocMetadata.last_read_at = new Date().toISOString()
+    updateLibraryDocMetadata(doc.id, { last_read_at: state.currentDocMetadata.last_read_at }).catch(() => {})
 
     if (viewerReadToggleBtn) {
       const isRead = state.currentDocMetadata.read === true

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -266,10 +266,22 @@ function renderProgressSummaryCard(events, heatmap, readingStats) {
 // 함께 보여준다("최근 읽은" = 최근에 펼쳐본 논문). 퍼센트는 번역 진행률이 아니라
 // last_page/total_pages로 계산한 실제 읽은 진행률이고, 완독 표시된 논문은
 // 퍼센트 대신 "완료" 칩을 보여준다.
+//
+// 정렬/날짜 표시 기준: last_read_at(뷰어를 열거나 페이지를 넘길 때마다 갱신되는
+// "마지막으로 읽은 시각") / read_at(완독 표시 시각) / created_at(업로드 시각)
+// 중 가장 최근 값을 쓴다. read_at만 쓰면 완독 표시를 안 하고 읽던 중인 논문은
+// 계속 created_at으로 떨어져, 방금 읽었어도 날짜가 업로드 시점("3일 전" 등)에
+// 고정되어 보이는 문제가 있었다.
+function lastActivityIso(meta, createdAt) {
+  return [meta?.last_read_at, meta?.read_at, createdAt]
+    .filter(Boolean)
+    .reduce((latest, iso) => (new Date(iso) > new Date(latest) ? iso : latest), createdAt)
+}
+
 function renderRecentPapersCard(docs) {
   const read = docs
     .filter(d => (d.metadata && d.metadata.read) || Number.isInteger(d.metadata?.last_page))
-    .sort((a, b) => new Date(b.metadata.read_at || b.created_at).getTime() - new Date(a.metadata.read_at || a.created_at).getTime())
+    .sort((a, b) => new Date(lastActivityIso(b.metadata, b.created_at)).getTime() - new Date(lastActivityIso(a.metadata, a.created_at)).getTime())
     .slice(0, 5)
 
   return `
@@ -300,7 +312,7 @@ function renderRecentPapersCard(docs) {
                 <div class="dash-paper-title">${escapeHtml(title)}</div>
                 <div class="dash-paper-meta">
                   <span>${cats.length ? escapeHtml(cats.join(' · ')) : ''}</span>
-                  <span class="dash-paper-time">${relativeTimeKo(d.metadata.read_at || d.created_at)}</span>
+                  <span class="dash-paper-time">${relativeTimeKo(lastActivityIso(d.metadata, d.created_at))}</span>
                 </div>
                 <div class="dash-paper-progress-row">
                   ${progressHtml}


### PR DESCRIPTION
# Summary
## 1. 원인
- 완독 표시(`metadata.read`/`read_at`)를 하지 않고 읽던 중인 논문(`metadata.last_page`만 존재)은 활동을 나타낼 타임스탬프가 없었음
- `frontend/src/pages/dashboardPage.js`의 `renderRecentPapersCard`가 정렬/날짜 표시에 `read_at || created_at`만 사용해, 오늘 다시 읽어도 계속 업로드 시각("3일 전", "5일 전" 등)으로 고정되어 보임

## 2. 수정
- `frontend/src/main.js`
  - `scheduleSaveLastReadPage`/`flushSaveLastReadPage`가 `last_page`와 함께 `last_read_at`(마지막으로 읽은 시각)도 저장
  - `openFromLibrary`에서 문서를 여는 시점 자체를 `last_read_at`으로 기록(fire-and-forget) - 스크롤 없이 열기만 해도, 그리고 이 수정 이전부터 이미 `last_page`가 있던 예전 문서를 다시 열어도 날짜가 갱신되도록 함
- `frontend/src/pages/dashboardPage.js`
  - `lastActivityIso(meta, createdAt)` 헬퍼 추가 - `last_read_at`/`read_at`/`created_at` 중 가장 최근 값을 계산
  - `renderRecentPapersCard`의 정렬/날짜 표시를 이 헬퍼 기준으로 변경

## Test plan
- [x] Playwright e2e로 재현: `last_page`만 있고(5일 전 업로드) `last_read_at`/`read_at`이 없는 문서를 오늘 다시 열었다가 뒤로가기 → 대시보드에 "방금 전"으로 표시되는 것 확인(수정 전에는 "5일 전"으로 고정)
- [ ] 실제 앱에서 며칠 전 읽던 논문을 다시 열람 → 대시보드 "최근 읽은 논문" 날짜가 즉시 갱신되는지 확인
- [ ] 완독 표시된 논문의 날짜/정렬이 기존과 동일하게 동작하는지 확인(회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)