### PR TITLE
feat: AI 인사이트를 지도교수 관점의 진짜 조언으로 개선

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -649,8 +649,10 @@ async def get_ai_insights(username: str) -> List[dict]:
     """대시보드 "AI 인사이트" 카드의 내용을 생성한다. 예전에는 get_knowledge_gaps의
     규칙 기반 격차 문구를 그대로 노출했지만, 그건 매번 같은 두 패턴("질문이
     없습니다"/"메모가 없습니다")만 반복해 내용이 다양하지 않았다. 여기서는 실제
-    질문/메모 내용과 읽은 논문 목록을 LLM에 근거로 전달해, 조언/요약/추천/격려처럼
-    더 다양하고 구체적인 인사이트를 생성한다.
+    질문/메모 내용을 LLM(지도교수 관점의 멘토 페르소나 - llm_client.
+    generate_dashboard_insights 참고)에 근거로 전달해, 질문에서 드러나는 이해
+    부족/개념 공백 진단, 교수자 관점의 조언, 스스로를 돌아보게 하는 관점 제시,
+    근거 있는 격려처럼 실질적으로 도움이 되는 인사이트를 생성한다.
 
     결과는 app_meta에 하루(AI_INSIGHTS_CACHE_HOURS) 동안 캐싱해 대시보드를 열 때마다
     LLM을 호출하지 않으면서도 매일 새 활동을 반영해 갱신되게 한다(추천 논문 캐싱과
@@ -677,9 +679,38 @@ async def get_ai_insights(username: str) -> List[dict]:
     if not docs:
         return rule_based_gaps
 
-    timeline = await get_activity_timeline(username)
-    notes = [f"[{e['doc_title']}] {e['summary']}" for e in timeline if e["type"] == "note" and e.get("summary")][:8]
-    questions = [f"[{e['doc_title']}] {e['summary']}" for e in timeline if e["type"] == "question" and e.get("summary")][:8]
+    # get_activity_timeline의 summary는 UI 카드용으로 80자로 잘려있어, 질문에서
+    # 이해 부족/개념 공백을 실제로 진단하기엔 근거가 너무 짧다. 여기서는 같은
+    # 원본(memos/questions)을 직접 조회해 더 긴 내용(최대 200자)을 LLM에 넘긴다.
+    from services.db import db_get_memos, db_get_related_questions_for_doc
+    titles_by_doc = {d["id"]: (d.get("metadata") or {}).get("title") or d["filename"] for d in docs}
+    note_entries = []
+    question_entries = []
+    for doc in docs:
+        doc_id = doc["id"]
+        title = titles_by_doc[doc_id]
+        mirrored = db_get_memos(doc_id)
+        for items in (mirrored or {}).get("data", {}).values():
+            for item in items or []:
+                item_id = (item or {}).get("id", "") if isinstance(item, dict) else ""
+                if not item_id.startswith("memo_"):
+                    continue
+                try:
+                    ts_ms = int(item_id[len("memo_"):])
+                except ValueError:
+                    continue
+                content = (item.get("content") or "").strip()
+                if content:
+                    note_entries.append((ts_ms, title, content))
+        for q in db_get_related_questions_for_doc(doc_id, limit=50):
+            content = (q["content"] or "").strip()
+            if content:
+                question_entries.append((q["created_at"], title, content))
+
+    note_entries.sort(key=lambda e: e[0], reverse=True)
+    question_entries.sort(key=lambda e: e[0], reverse=True)
+    notes = [f"[{title}] {content[:200]}" for _, title, content in note_entries[:8]]
+    questions = [f"[{title}] {content[:200]}" for _, title, content in question_entries[:8]]
 
     heatmap = await get_concept_heatmap(username)
     concepts = [h["name"] for h in heatmap[:8]]
@@ -688,8 +719,8 @@ async def get_ai_insights(username: str) -> List[dict]:
     stats = {
         "total_papers": len(docs),
         "read_papers": sum(1 for d in docs if (d.get("metadata") or {}).get("read")),
-        "total_notes": len([e for e in timeline if e["type"] == "note"]),
-        "total_questions": len([e for e in timeline if e["type"] == "question"]),
+        "total_notes": len(note_entries),
+        "total_questions": len(question_entries),
     }
 
     from services.llm_client import generate_dashboard_insights

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2329,12 +2329,14 @@ JSON Array:"""
 async def generate_dashboard_insights(profile: dict, session_id: str = None) -> List[dict]:
     """사용자의 최근 질문/메모 내용, 읽은 논문 통계, 관심 개념/카테고리를 근거로
     대시보드 "AI 인사이트" 카드에 표시할 개인화된 인사이트 3~5개를 생성한다.
-    규칙 기반 격차 감지(knowledge_graph.get_knowledge_gaps)와 달리 매번 똑같은
-    문구가 아니라, 실제 활동 내용을 반영해 조언/요약/추천/격려처럼 다양한
-    성격의 문장을 만들도록 유도한다. 반환값: [{"type": str, "message": str}, ...].
-    profile 형태는 knowledge_graph.get_ai_insights가 만든다:
-    {"stats": {...}, "notes": [str], "questions": [str], "concepts": [str],
-     "categories": [str], "gap_hints": [str]}."""
+    규칙 기반 격차 감지(knowledge_graph.get_knowledge_gaps)처럼 매번 똑같은 두
+    문구를 반복하는 대신, 지도교수가 실제로 학생의 질문/메모를 읽고 1:1 면담에서
+    해줄 법한 - 이해 부족/개념 공백을 콕 짚어주고, 스스로를 돌아보게 하는 관점을
+    던지는 - 실질적인 조언을 생성하도록 유도한다. 반환값:
+    [{"type": str, "message": str}, ...]. profile 형태는
+    knowledge_graph.get_ai_insights가 만든다: {"stats": {...}, "notes": [str],
+    "questions": [str], "concepts": [str], "categories": [str],
+    "gap_hints": [str]}."""
     stats = profile.get("stats") or {}
     notes_block = "\n".join(f"- {n}" for n in profile.get("notes") or []) or "(없음)"
     questions_block = "\n".join(f"- {q}" for q in profile.get("questions") or []) or "(없음)"
@@ -2342,7 +2344,14 @@ async def generate_dashboard_insights(profile: dict, session_id: str = None) -> 
     categories_line = ", ".join(profile.get("categories") or []) or "(알 수 없음)"
     gap_hints_block = "\n".join(f"- {g}" for g in profile.get("gap_hints") or []) or "(없음)"
 
-    prompt = f"""You are a thoughtful academic research mentor reviewing a researcher's recent activity in their paper-reading app. Based on the data below, write 3 to 5 short, varied, and genuinely useful insights in Korean for their dashboard. Mix DIFFERENT kinds of insights - do not make them all the same type. Ground every insight in the actual data given; do not invent facts, paper titles, or activity that isn't there.
+    prompt = f"""You are an experienced professor and thesis advisor mentoring this researcher on their reading and research practice, reviewing their actual recent questions and notes below before a 1-on-1 meeting. Do NOT write generic praise or generic advice that could apply to anyone - every insight must be clearly traceable to something specific in the data given.
+
+Write 3 to 5 short insights in Korean, covering a MIX of these four angles (skip an angle entirely if there isn't real evidence for it - never force a filler insight):
+
+1. "gap_diagnosis" (이해도 진단) - Read the QUESTIONS closely for signs of shallow or missing understanding: repeated confusion about the same concept, a surface-level question about something conceptually deep, or a prerequisite concept they seem to be missing given what they're reading. When you spot one, name the specific concept and suggest a concrete next step (what to review, what paper/section to revisit, or a sharper question to ask themselves).
+2. "mentor_advice" (교수자의 조언) - Give the kind of pointed, sometimes candid feedback a thesis advisor gives about research direction, reading habits, or blind spots - grounded in the actual pattern of what they've read/asked/noted, not generic productivity tips.
+3. "perspective" (바라보는 관점) - Help them step back and see their own recent activity from an angle they probably haven't noticed themselves: a connection between papers/concepts, a shift in focus over time, or a way to reframe what they're working on.
+4. "encouragement" (근거 있는 격려) - When there is concrete evidence of real progress (a well-formed question, growing depth, consistent effort), name that evidence specifically. Do not hand out generic cheerleading with no basis.
 
 Research areas: {categories_line}
 Frequently studied concepts: {concepts_line}
@@ -2354,12 +2363,12 @@ Recent notes (memo excerpts, [paper title] content):
 Recent questions asked (excerpts, [paper title] content):
 {questions_block}
 
-Rule-detected gaps (for reference only, rephrase naturally instead of copying verbatim):
+Rule-detected gaps (for reference only, rephrase naturally and go deeper instead of copying verbatim):
 {gap_hints_block}
 
 Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with:
-- "type": one of "advice" (조언), "summary" (최근 활동 요약), "recommendation" (다음에 해볼 만한 것 추천), "encouragement" (격려/성과 인정)
-- "message": the insight itself, in Korean, one or two sentences.
+- "type": exactly one of "gap_diagnosis", "mentor_advice", "perspective", "encouragement"
+- "message": the insight itself, in Korean, one to three sentences, specific enough that the researcher would recognize exactly what it's referring to.
 
 JSON Array:"""
     return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="AI 인사이트 생성", required_key="message")

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -162,14 +162,15 @@ function renderStatGrid(stats, events, docs) {
 }
 
 // ── AI 인사이트 ── services/knowledge_graph.get_ai_insights가 사용자의 최근
-// 질문/메모/읽은 논문 데이터를 근거로 LLM(llm_client.generate_dashboard_insights)을
-// 호출해 생성한 조언/요약/추천/격려를 보여준다(하루 단위로 캐싱 - 매일 최신화).
-// LLM 호출이 실패하면 백엔드가 조용히 규칙 기반 지식 격차 감지 결과로
-// 대체하므로, 프론트는 type이 둘 중 어느 쪽이든 적절한 아이콘만 골라주면 된다.
+// 질문/메모 내용을 근거로 LLM(llm_client.generate_dashboard_insights, 지도교수
+// 멘토 페르소나)을 호출해 이해도 진단/교수자 조언/관점 제시/근거 있는 격려를
+// 생성한다(하루 단위로 캐싱 - 매일 최신화). LLM 호출이 실패하면 백엔드가
+// 조용히 규칙 기반 지식 격차 감지 결과로 대체하므로, 프론트는 type이 둘 중
+// 어느 체계든 적절한 아이콘만 골라주면 된다.
 const INSIGHT_TYPE_ICON = {
-  advice: 'lightbulb',
-  summary: 'fileText',
-  recommendation: 'star',
+  gap_diagnosis: 'helpCircle',
+  mentor_advice: 'lightbulb',
+  perspective: 'compare',
   encouragement: 'smile',
   low_question_concept: 'messageCircle',
   no_notes_paper: 'edit3',


### PR DESCRIPTION
# Summary
## 1. 프롬프트 재설계 (llm_client.py)
- `generate_dashboard_insights`가 막연한 조언/요약/추천/격려 대신, 지도교수가 학생의 질문/메모를 직접 읽고 1:1 면담에서 해줄 법한 네 가지 관점으로 인사이트를 생성하도록 프롬프트 재작성:
  - `gap_diagnosis`(이해도 진단): 질문에서 드러나는 이해 부족/개념 공백을 구체적으로 짚고 보완 방향 제시
  - `mentor_advice`(교수자의 조언): 연구 방향/습관/맹점에 대한 지도교수 관점의 직설적 조언
  - `perspective`(바라보는 관점): 스스로 눈치채지 못했을 각도에서 최근 활동을 돌아보게 하는 관점 제시
  - `encouragement`(근거 있는 격려): 막연한 칭찬이 아니라 구체적 근거를 든 격려
- 데이터가 부족한 관점은 억지로 채우지 말고 건너뛰도록 명시

## 2. 더 풍부한 진단 근거 (knowledge_graph.py)
- `get_ai_insights`가 UI 카드용으로 80자로 잘려있던 `get_activity_timeline`의 summary 대신, `db_get_memos`/`db_get_related_questions_for_doc`로 원본 질문/메모 내용(최대 200자)을 직접 조회해 LLM에 전달 - 짧은 발췌만으로는 이해 부족을 제대로 진단하기 어려웠음

## 3. 프론트 아이콘 매핑 업데이트
- `frontend/src/pages/dashboardPage.js`의 `INSIGHT_TYPE_ICON`을 새 타입 체계에 맞게 갱신(규칙 기반 폴백 타입 아이콘은 그대로 유지, LLM 실패 시 카드가 비지 않음)

## Test plan
- [x] `pytest backend/tests/test_knowledge_graph_v4.py` 13개 전체 통과(회귀 없음)
- [ ] 실제 LLM provider 설정 후 대시보드 진입 → 질문/메모 내용에 근거한 구체적인 이해도 진단/조언/관점/격려가 뜨는지 확인
- [ ] 활동 데이터가 거의 없는 계정에서도 카드가 비지 않고(규칙 기반 폴백 또는 빈 상태 문구) 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)