### PR TITLE
feat: 채팅 인용 이미지를 문서별 디렉터리에도 저장해 기기 간 동기화 지원

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import re
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -14,8 +15,12 @@ from services.db import (
     db_upsert_compare_session,
     db_list_compare_chat_sessions,
 )
-from services.library import get_document as lib_get_document
+from services.library import get_document as lib_get_document, save_chat_quote_image
 from services.auth import get_current_user
+
+# 프론트가 이미지 인용 메시지에 붙이는 "[인용된 이미지 (Page N)|quoteId]" 마커에서
+# quoteId만 뽑아낸다 - main.js의 sendChatMessage()가 만드는 placeholder 형식과 맞춰야 한다.
+_QUOTE_IMAGE_MARKER_RE = re.compile(r'^\[인용된 이미지[^\]|]*\|([A-Za-z0-9_]+)\]')
 
 router = APIRouter()
 
@@ -111,6 +116,18 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
     if data.messages:
         latest_msg = data.messages[-1]
         question_chat_id = db_save_chat_message(session_id, latest_msg.role, latest_msg.content)
+
+        # 이미지 인용 메시지라면, 이번 요청에 실려온 이미지를 문서별 디렉터리에도
+        # 저장한다(브라우저 localStorage에만 있으면 다른 기기/브라우저에서 이
+        # 히스토리를 다시 열었을 때 이미지가 사라지고 텍스트 placeholder만
+        # 남는 문제가 있었음). 저장에 실패해도 채팅 자체는 그대로 진행된다.
+        if data.image_base64:
+            marker_match = _QUOTE_IMAGE_MARKER_RE.match(latest_msg.content)
+            if marker_match:
+                try:
+                    save_chat_quote_image(session_id, marker_match.group(1), data.image_base64)
+                except Exception as e:
+                    print(f"[chat_stream] 인용 이미지 서버 저장 실패 ({session_id}): {e}")
 
     async def event_generator():
         yield " "

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -4,7 +4,8 @@ from services.auth import get_current_user
 from services.library import (
     list_documents, search_documents, get_document, permanently_delete_document,
     soft_delete_document, restore_document, empty_trash,
-    get_translation, get_pdf_path, get_cover_path, update_document_metadata
+    get_translation, get_pdf_path, get_cover_path, update_document_metadata,
+    get_chat_quote_image_path
 )
 from pydantic import BaseModel
 import json
@@ -362,6 +363,18 @@ async def get_library_cover(doc_id: str, current_user: str = Depends(get_current
     if not cover_path:
         raise HTTPException(status_code=404, detail="미리보기 이미지를 생성할 수 없습니다.")
     return FileResponse(cover_path, media_type="image/jpeg", headers={"Cache-Control": "public, max-age=86400"})
+
+
+@router.get("/library/{doc_id}/chat-image/{quote_id}")
+async def get_library_chat_quote_image(doc_id: str, quote_id: str, current_user: str = Depends(get_current_user)):
+    """채팅에서 인용한 이미지를 서빙합니다. 채팅을 보낸 브라우저의 localStorage에
+    이미지가 있으면 프론트는 이 엔드포인트를 거치지 않고 그걸 우선 쓰고, 없을
+    때(다른 기기/브라우저에서 히스토리를 열었을 때)만 여기서 복원합니다."""
+    _require_owned_document(doc_id, current_user)
+    image_path = get_chat_quote_image_path(doc_id, quote_id)
+    if not image_path:
+        raise HTTPException(status_code=404, detail="인용 이미지를 찾을 수 없습니다.")
+    return FileResponse(image_path, media_type="image/png", headers={"Cache-Control": "public, max-age=86400"})
 
 
 @router.delete("/library/{doc_id}")

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -1,6 +1,8 @@
 import os
+import re
 import shutil
 import json
+import base64
 from typing import Optional, List
 from config import LIBRARY_DIR, UPLOAD_DIR
 from services.cache import clear_session_cache
@@ -48,6 +50,15 @@ def _cover_path(doc_id: str) -> str:
 
 def _primer_figure_path(doc_id: str) -> str:
     return os.path.join(LIBRARY_DIR, doc_id, "primer_figure.png")
+
+# 프론트에서 생성하는 quoteId(예: qimg_1700000000000_ab12cd) 형식만 허용해
+# 파일 경로로 그대로 써도 경로 순회(path traversal)가 불가능하게 한다.
+_CHAT_QUOTE_IMAGE_ID_RE = re.compile(r'^[A-Za-z0-9_]+$')
+
+def _chat_quote_image_path(doc_id: str, quote_id: str) -> Optional[str]:
+    if not _CHAT_QUOTE_IMAGE_ID_RE.match(quote_id):
+        return None
+    return os.path.join(LIBRARY_DIR, doc_id, "chat_images", f"{quote_id}.png")
 
 
 # ── 문서 저장 ─────────────────────────────────────────────────────────────────
@@ -316,6 +327,26 @@ def get_primer_figure_path(doc_id: str) -> Optional[str]:
     파이프라인(save_primer_figure)에서만 생성되므로, 아직 생성되지 않았다면 None."""
     path = _primer_figure_path(doc_id)
     return path if os.path.exists(path) else None
+
+
+def save_chat_quote_image(doc_id: str, quote_id: str, image_base64: str) -> None:
+    """채팅에서 인용한 이미지를 문서별 디렉터리에 PNG로 저장한다. 기존에는
+    브라우저 localStorage에만 저장돼 다른 기기/브라우저로 접속하면 이미지가
+    사라지고 텍스트 placeholder만 남았는데, 여기(document.pdf/cover.jpg와
+    같은 문서별 디렉터리)에도 남겨 어디서든 복원할 수 있게 한다."""
+    path = _chat_quote_image_path(doc_id, quote_id)
+    if not path:
+        raise ValueError("잘못된 quote_id입니다.")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(base64.b64decode(image_base64))
+
+
+def get_chat_quote_image_path(doc_id: str, quote_id: str) -> Optional[str]:
+    """서버에 저장된 인용 이미지 경로를 반환한다. 저장된 적이 없다면(이번 기능
+    추가 이전 메시지이거나 저장에 실패했던 경우) None."""
+    path = _chat_quote_image_path(doc_id, quote_id)
+    return path if path and os.path.exists(path) else None
 
 
 def save_primer_figure(doc_id: str, pdf_path: str, page_num: int, bbox_percent: dict) -> bool:

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10554,6 +10554,17 @@ function formatChatHtml(text) {
   return html
 }
 
+// 인용 이미지를 로컬/서버 어디서도 복원하지 못했을 때(<img onerror>에서 호출)
+// 기존과 동일한 텍스트 placeholder로 자연스럽게 대체한다.
+window.__quoteImgFallback = function(imgEl, pageInfoText) {
+  const span = document.createElement('span')
+  span.className = 'quote-body'
+  span.style.fontSize = '11px'
+  span.style.opacity = '0.85'
+  span.innerHTML = `${icon('image', 12, 'style="vertical-align:-2px;margin-right:2px"')}${escapeHtml(pageInfoText)}`
+  imgEl.replaceWith(span)
+}
+
 function formatUserChatHtml(content, sessionId = state.sessionId) {
   if (!content) return ''
   
@@ -10581,19 +10592,24 @@ function formatUserChatHtml(content, sessionId = state.sessionId) {
       let pageInfo = content.substring(1, markerIdx)
       const questionText = content.substring(markerIdx + marker.length)
 
-      // "(Page N)|quoteId" 형태면 quoteId로 로컬에 저장해둔 실제 이미지를
-      // 복원한다 - 옛 형식(quoteId 없음)이거나 이 브라우저에 저장된 게
-      // 없으면 기존과 동일한 텍스트 placeholder로 자연스럽게 대체된다.
+      // "(Page N)|quoteId" 형태면 quoteId로 먼저 로컬(같은 브라우저)에 저장해둔
+      // 실제 이미지를 복원하고, 없으면(다른 기기/브라우저에서 열람 중) 서버
+      // (문서별 디렉터리)에 저장된 이미지를 대신 요청한다 - 그마저도 없으면
+      // (옛 형식이거나 저장에 실패했던 경우) onerror가 기존과 동일한 텍스트
+      // placeholder로 자연스럽게 대체한다.
       let imgSrc = null
       const sepIdx = pageInfo.lastIndexOf('|')
       if (sepIdx !== -1) {
         const quoteId = pageInfo.substring(sepIdx + 1)
         pageInfo = pageInfo.substring(0, sepIdx)
         imgSrc = getChatQuoteImage(sessionId, quoteId)
+        if (!imgSrc && sessionId) {
+          imgSrc = `/api/library/${encodeURIComponent(sessionId)}/chat-image/${encodeURIComponent(quoteId)}`
+        }
       }
 
       const quoteBodyHtml = imgSrc
-        ? `<img class="message-quote-img" src="${imgSrc}" alt="Quoted Figure" />`
+        ? `<img class="message-quote-img" src="${imgSrc}" alt="Quoted Figure" onerror="${escapeHtml(`window.__quoteImgFallback(this, ${JSON.stringify(pageInfo)})`)}" />`
         : `<span class="quote-body" style="font-size: 11px; opacity: 0.85;">${icon('image', 12, 'style="vertical-align:-2px;margin-right:2px"')}${escapeHtml(pageInfo)}</span>`
       return `<div class="message-quote"><span class="quote-symbol">❝</span>${quoteBodyHtml}</div><div class="message-text">${escapeHtml(questionText)}</div>`
     }


### PR DESCRIPTION
# Summary
## 1. 인용 이미지를 서버(문서별 디렉터리)에도 저장
- 채팅에서 이미지를 인용하면 지금까지는 브라우저 `localStorage`에만 실제 이미지(base64)가 저장되고, 채팅 DB에는 `[인용된 이미지 (Page N)|quoteId]` 텍스트 placeholder만 남아 다른 컴퓨터/브라우저에서 히스토리를 열면 이미지가 사라지는 문제가 있었음
- AI CLI 세션 격리에도 쓰이는 기존 문서별 디렉터리(`LIBRARY_DIR/{doc_id}/`, `document.pdf`/`cover.jpg`/`chat_captures/`가 있는 바로 그 폴더)에 `chat_images/` 서브폴더를 새로 만들어, 프론트에서 이미 생성해 쓰던 `quoteId`를 파일명(`chat_images/{quoteId}.png`)으로 그대로 재사용해 저장 (`backend/services/library.py`: `save_chat_quote_image`, `get_chat_quote_image_path`)
- DB 스키마 변경 없이, `POST /chat/stream` 핸들러에서 저장 직전 메시지 content의 `quoteId` 마커를 정규식으로 추출해 이미지 저장 (`backend/routers/chat.py`) — 저장 실패해도 채팅 응답 자체는 그대로 진행
- quote_id는 `^[A-Za-z0-9_]+$` 형식만 허용해 경로 순회(path traversal) 공격을 원천 차단

## 2. 인용 이미지 서빙 엔드포인트 추가
- `GET /api/library/{doc_id}/chat-image/{quote_id}` 신규 엔드포인트 추가 (`backend/routers/library.py`) — 기존 `/library/{doc_id}/cover`, `/library/{doc_id}/figure-image/{index}`와 동일한 컨벤션(`_require_owned_document`로 소유권 확인, `FileResponse` + 캐시 헤더)

## 3. 프론트엔드: 로컬에 없으면 서버로 폴백
- `formatUserChatHtml()`이 로컬스토리지에 이미지가 없을 때(다른 기기/브라우저) 서버 엔드포인트를 대신 요청하도록 수정 (`frontend/src/main.js`)
- 서버에도 없으면(이 기능 추가 이전 메시지 등) `<img onerror>`가 기존과 동일한 텍스트 placeholder로 자연스럽게 대체 (`window.__quoteImgFallback`)

## 테스트
- 격리된 백엔드 인스턴스(별도 venv/DB/library 디렉터리)를 띄워 실제 PDF 업로드 → 이미지 인용 채팅 전송 → `chat_images/{quoteId}.png` 파일 생성 확인
- 신규 서빙 엔드포인트를 curl로 검증: 정상 조회(바이트 일치), 존재하지 않는 quote_id(404), 미인증 요청(401), path traversal 시도(404) 모두 기대대로 동작
- Playwright로 프론트엔드 폴백 로직을 mock API 기반으로 검증: 로컬스토리지가 비어있는 상태(다른 컴퓨터 시뮬레이션)에서 서버에 이미지가 있으면 정상 렌더링, 서버에도 없으면 텍스트 placeholder로 정상 폴백