### PR TITLE
feat: AI 추천 논문 개수 확대 및 다시 받기 버튼 추가

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -104,16 +104,18 @@ async def search_library_graph(q: str = "", current_user: str = Depends(get_curr
 
 
 @router.get("/library/graph/recommendations")
-async def get_library_reading_recommendations(current_user: str = Depends(get_current_user)):
+async def get_library_reading_recommendations(force: bool = False, current_user: str = Depends(get_current_user)):
     """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천합니다. LLM+OpenAlex
     호출이 여러 번 들어가는 무거운 작업이라 프론트에서 사용자가 명시적으로
     요청했을 때만 호출해야 합니다(그래프 조회 시 자동 호출 안 함).
+    force=true면 유효한 캐시가 있어도 무시하고 새로 생성합니다(대시보드의
+    "다시 받기" 버튼용).
 
     /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
     이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
     """
     from services.knowledge_graph import get_reading_recommendations
-    return {"recommendations": await get_reading_recommendations(current_user)}
+    return {"recommendations": await get_reading_recommendations(current_user, force=force)}
 
 
 @router.get("/library/graph/recommendations/cached")

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -514,7 +514,7 @@ async def get_cached_reading_recommendations(username: str) -> Optional[List[dic
     return _read_reading_recommendations_cache(username)
 
 
-async def get_reading_recommendations(username: str) -> List[dict]:
+async def get_reading_recommendations(username: str, force: bool = False) -> List[dict]:
     """읽은 논문들을 근거로 다음에 읽으면 좋을 논문을 추천한다. Primer 기능의
     기존 OpenAlex 검증 로직(_is_plausible_match, resolve_reference)을 그대로
     재사용해 LLM 환각(존재하지 않는 논문을 추천)을 걸러낸다 - 1차의
@@ -525,11 +525,13 @@ async def get_reading_recommendations(username: str) -> List[dict]:
     결과는 app_meta에 사용자별로 캐싱해 READING_RECOMMENDATIONS_CACHE_DAYS(7일)
     동안 재사용하고, 그 기간이 지나면 다음 조회 시 자동으로 새로 생성한다 -
     호출할 때마다 같은 무거운 계산을 반복하지 않으면서도, 추천 목록이 매주
-    한 번씩은 새로 갱신되게 한다.
+    한 번씩은 새로 갱신되게 한다. force=True면 유효한 캐시가 있어도 무시하고
+    새로 생성한다(대시보드의 "다시 받기" 버튼이 사용하는 경로).
     """
-    cached = _read_reading_recommendations_cache(username)
-    if cached is not None:
-        return cached
+    if not force:
+        cached = _read_reading_recommendations_cache(username)
+        if cached is not None:
+            return cached
 
     from services.db import db_set_meta
     from services.library import list_documents

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2308,14 +2308,15 @@ JSON Array:"""
 
 
 async def generate_reading_recommendations(titles: List[str], categories: List[str], session_id: str = None) -> List[dict]:
-    """읽은 논문 제목/카테고리를 근거로 다음에 읽으면 좋을 논문 3~5개와 그
+    """읽은 논문 제목/카테고리를 근거로 다음에 읽으면 좋을 논문 후보와 그
     이유를 추천한다. 반환값: [{"title": str, "reason": str}, ...]. 여기서
     추천된 제목은 LLM의 환각(존재하지 않는 논문을 지어내는 것)이 섞여 있을
-    수 있으므로, 호출부(knowledge_graph.get_reading_recommendations)가
-    OpenAlex로 실존 여부를 검증한 뒤에만 채택해야 한다."""
+    수 있고, 호출부(knowledge_graph.get_reading_recommendations)의 OpenAlex
+    검증에서 일부가 걸러지므로, 최종 노출 목표(5개 이상)보다 넉넉하게
+    8~12개를 요청해 필터링 후에도 충분한 개수가 남게 한다."""
     titles_list = "\n".join(f"- {t}" for t in titles)
     categories_line = ", ".join(categories) if categories else "(알 수 없음)"
-    prompt = f"""You are an expert research advisor. A researcher has read the following papers (research areas: {categories_line}). Recommend 3 to 5 OTHER real, existing academic papers they should read next to deepen or extend this line of research, with a short reason for each.
+    prompt = f"""You are an expert research advisor. A researcher has read the following papers (research areas: {categories_line}). Recommend 8 to 12 OTHER real, existing academic papers they should read next to deepen or extend this line of research, with a short reason for each.
 
 Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "title" key (the paper's real title) and a "reason" key (one short sentence, in Korean, explaining why it's a good next read).
 

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -191,3 +191,64 @@ def test_reading_recommendations_endpoint(test_client, isolated_dirs, monkeypatc
     assert res.status_code == 200
     recs = res.json()["recommendations"]
     assert any(r["title"] == "DINO Self-Supervised Vision Transformers" and r["reason"] == "다음 단계" for r in recs)
+
+
+@pytest.mark.asyncio
+async def test_reading_recommendations_force_bypasses_cache(isolated_dirs, monkeypatch):
+    """대시보드 "다시 받기" 버튼이 쓰는 force=True는 유효한 캐시가 있어도
+    무시하고 새로 생성해야 한다."""
+    import services.llm_client as llm_client
+    import services.reference_linker as reference_linker
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-rec-force-1", "testuser", {"title": "Vision Transformer"})
+    _create_doc_owned_by(isolated_dirs, "doc-rec-force-2", "testuser", {"title": "Masked Autoencoders"})
+
+    call_count = {"n": 0}
+
+    async def fake_generate(titles, categories, session_id=None):
+        call_count["n"] += 1
+        return [{"title": f"Paper Round {call_count['n']}", "reason": "이유"}]
+
+    async def fake_resolve(query_text):
+        return {"title": query_text, "url": "https://example.com/x", "year": 2024}
+
+    monkeypatch.setattr(llm_client, "generate_reading_recommendations", fake_generate)
+    monkeypatch.setattr(reference_linker, "resolve_reference", fake_resolve)
+
+    first = await knowledge_graph.get_reading_recommendations("testuser")
+    assert call_count["n"] == 1
+    cached_again = await knowledge_graph.get_reading_recommendations("testuser")
+    assert call_count["n"] == 1  # 캐시가 있으면 재호출하지 않는다
+    assert cached_again == first
+
+    forced = await knowledge_graph.get_reading_recommendations("testuser", force=True)
+    assert call_count["n"] == 2  # force=True는 캐시를 무시하고 재생성한다
+    assert forced != first
+
+
+def test_reading_recommendations_endpoint_force_query_param(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+    import services.reference_linker as reference_linker
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-rec-force-api-1", "testuser", {"title": "Vision Transformer"})
+    _create_doc_owned_by(isolated_dirs, "doc-rec-force-api-2", "testuser", {"title": "Masked Autoencoders"})
+
+    call_count = {"n": 0}
+
+    async def fake_generate(titles, categories, session_id=None):
+        call_count["n"] += 1
+        return [{"title": f"Paper Round {call_count['n']}", "reason": "이유"}]
+
+    async def fake_resolve(query_text):
+        return {"title": query_text, "url": "https://example.com/x", "year": 2024}
+
+    monkeypatch.setattr(llm_client, "generate_reading_recommendations", fake_generate)
+    monkeypatch.setattr(reference_linker, "resolve_reference", fake_resolve)
+
+    test_client.get("/api/library/graph/recommendations")
+    assert call_count["n"] == 1
+    res = test_client.get("/api/library/graph/recommendations?force=true")
+    assert res.status_code == 200
+    assert call_count["n"] == 2

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -236,8 +236,9 @@ export async function fetchReadingTimeStats(sinceDays) {
   return res.json()
 }
 
-export async function fetchReadingRecommendations() {
-  const res = await fetch(`${API_BASE}/library/graph/recommendations`)
+// force: true면 유효한 캐시가 있어도 무시하고 새로 생성한다("다시 받기" 버튼용).
+export async function fetchReadingRecommendations({ force = false } = {}) {
+  const res = await fetch(`${API_BASE}/library/graph/recommendations${force ? '?force=true' : ''}`)
   if (!res.ok) throw new Error('추천 논문 조회 실패')
   return res.json()
 }

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -362,10 +362,12 @@ function scholarSearchUrl(title) {
   return `https://scholar.google.com/scholar?q=${encodeURIComponent(title || '')}`
 }
 
+const REC_DISPLAY_LIMIT = 10
+
 function renderRecItemsHtml(recommendations) {
   return `
     <ul class="dash-rec-list">
-      ${recommendations.slice(0, 5).map(r => `
+      ${recommendations.slice(0, REC_DISPLAY_LIMIT).map(r => `
         <li class="dash-rec-item">
           <a href="${escapeHtml(scholarSearchUrl(r.title))}" target="_blank" rel="noopener noreferrer" class="dash-rec-title">${escapeHtml(r.title || '')}</a>
           ${r.year ? `<span class="dash-rec-year">${escapeHtml(String(r.year))}</span>` : ''}
@@ -373,6 +375,13 @@ function renderRecItemsHtml(recommendations) {
         </li>
       `).join('')}
     </ul>
+  `
+}
+
+function renderRecsListWithRefreshButton(recommendations) {
+  return `
+    ${renderRecItemsHtml(recommendations)}
+    <button type="button" class="dash-recs-btn dash-recs-btn-refresh" data-recs-refresh-btn title="새로운 추천을 다시 받아옵니다">${icon('refreshCw', 13)}다시 받기</button>
   `
 }
 
@@ -384,7 +393,7 @@ function renderRecommendationsCard(cachedRecommendations) {
         <h3>${icon('star', 15)}AI 추천 논문</h3>
       </div>
       <div class="dash-recs-body" data-recs-body>
-        ${hasCached ? renderRecItemsHtml(cachedRecommendations) : `
+        ${hasCached ? renderRecsListWithRefreshButton(cachedRecommendations) : `
           ${emptyNote('읽은 논문들을 바탕으로 다음에 읽으면 좋을 논문을 추천받아 보세요.')}
           <button type="button" class="dash-recs-btn" data-recs-btn>${icon('zap', 13)}추천 받기</button>
         `}
@@ -596,27 +605,35 @@ function attachHandlers(root) {
     elm.addEventListener('click', () => goToGraphNode(elm.dataset.nodeId))
   })
 
-  const recsBtn = root.querySelector('[data-recs-btn]')
-  if (recsBtn) {
-    recsBtn.addEventListener('click', async () => {
-      const body = root.querySelector('[data-recs-body]')
-      if (!body) return
-      recsBtn.disabled = true
-      body.innerHTML = emptyNote('추천 논문을 찾는 중입니다... (다소 시간이 걸릴 수 있어요)')
+  const recsBody = root.querySelector('[data-recs-body]')
+  if (recsBody) {
+    // "추천 받기"(최초 생성)와 "다시 받기"(캐시 무시하고 재생성) 모두 이
+    // 로직을 공유한다 - 성공하면 목록 아래에 "다시 받기" 버튼을 다시 붙여
+    // 계속 재요청할 수 있게 한다.
+    const bindRefreshBtn = () => {
+      const btn = recsBody.querySelector('[data-recs-refresh-btn]')
+      if (btn) btn.addEventListener('click', () => runRecsFetch(btn, true))
+    }
+    const runRecsFetch = async (triggerBtn, force) => {
+      triggerBtn.disabled = true
+      recsBody.innerHTML = emptyNote('추천 논문을 찾는 중입니다... (다소 시간이 걸릴 수 있어요)')
       try {
-        const { recommendations } = await fetchReadingRecommendations()
+        const { recommendations } = await fetchReadingRecommendations({ force })
         if (!recommendations || recommendations.length === 0) {
-          body.innerHTML = emptyNote('추천할 만한 논문을 찾지 못했습니다.')
+          recsBody.innerHTML = emptyNote('추천할 만한 논문을 찾지 못했습니다.')
           return
         }
-        body.innerHTML = renderRecItemsHtml(recommendations)
+        recsBody.innerHTML = renderRecsListWithRefreshButton(recommendations)
+        bindRefreshBtn()
       } catch (err) {
         console.error('추천 논문 조회 실패:', err)
-        body.innerHTML = `<p class="dash-empty-note dash-error-note">추천 논문을 불러오지 못했습니다.</p>`
-      } finally {
-        if (root.contains(recsBtn)) recsBtn.disabled = false
+        recsBody.innerHTML = `<p class="dash-empty-note dash-error-note">추천 논문을 불러오지 못했습니다.</p>`
       }
-    })
+    }
+
+    const recsBtn = recsBody.querySelector('[data-recs-btn]')
+    if (recsBtn) recsBtn.addEventListener('click', () => runRecsFetch(recsBtn, false))
+    bindRefreshBtn()
   }
 }
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -302,6 +302,19 @@
 .dash-recs-btn:hover { background: var(--bg-hover); }
 .dash-recs-btn:disabled { opacity: 0.6; cursor: default; }
 
+/* 이미 목록이 채워진 상태에서 다시 생성을 요청하는 보조 액션이라, 기본
+   버튼보다 눈에 덜 띄는 ghost 스타일로 구분한다. */
+.dash-recs-btn-refresh {
+  align-self: center;
+  width: 100%;
+  justify-content: center;
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.dash-recs-btn-refresh:hover { background: var(--bg-hover); color: var(--text-primary); }
+
 .dash-rec-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
 .dash-rec-item { padding-bottom: 12px; border-bottom: 1px solid var(--border); }
 .dash-rec-item:last-child { border-bottom: none; padding-bottom: 0; }


### PR DESCRIPTION
# Summary
## 1. 추천 개수 확대
- `backend/services/llm_client.py`의 `generate_reading_recommendations` 프롬프트가 3~5개 대신 8~12개를 요청하도록 변경 - OpenAlex 실존 검증 단계에서 일부가 걸러지는 것을 감안해 최종 5개 이상이 안정적으로 남도록 여유를 둠
- `frontend/src/pages/dashboardPage.js`의 표시 개수 상한을 5 -> 10(`REC_DISPLAY_LIMIT`)으로 확대

## 2. "다시 받기" 버튼 추가
- `backend/services/knowledge_graph.py`의 `get_reading_recommendations`와 `GET /library/graph/recommendations`에 `force` 파라미터 추가 - `force=true`면 유효한 캐시가 있어도 무시하고 새로 생성
- `frontend/src/library.js`의 `fetchReadingRecommendations({ force })`가 이 쿼리스트링을 전달
- 캐시된 추천 목록이 표시된 상태에서도 목록 아래에 "다시 받기" 버튼을 추가해 강제로 새 추천을 재생성할 수 있게 함(재생성 후에도 버튼이 다시 붙어 반복 사용 가능), 기존 "추천 받기" 버튼과 시각적으로 구분되는 ghost 스타일 적용

## 3. 테스트
- `backend/tests/test_knowledge_graph_v3.py`에 `force` 파라미터가 캐시를 무시하고 재생성하는지 검증하는 테스트 2개 추가(서비스 함수 레벨 + API 엔드포인트 레벨)
- Playwright e2e로 수동 검증: 캐시된 추천 8개 이상 표시 확인, "다시 받기" 클릭 시 `force=true`로 호출되고 새 목록으로 교체되며 버튼이 다시 붙는 것 확인

## Test plan
- [x] `pytest backend/tests/test_knowledge_graph_v3.py` 11개 전체 통과
- [ ] 실제 앱에서 "추천 받기" → 5개 이상 표시 확인
- [ ] 캐시된 추천이 있는 상태에서 대시보드 재진입 시 바로 표시 + "다시 받기" 버튼으로 새 추천을 받아오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)