### PR TITLE
fix: (Author, Year) 참고문헌 목록이 소수 항목으로 뭉쳐 파싱되던 문제 수정

### DIFF
--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -55,17 +55,53 @@ _BRACKET_MARKER_RE = re.compile(r"\[(" + _BRACKET_KEY_RE.pattern + r")\]")
 # 우연히 일치하는 페이지/연도 숫자를 걸러낸다.
 _PLAIN_NUMBERED_MARKER_RE = re.compile(r"(?:^|\s)(\d{1,3})[.)]\s+(?=[A-Z가-힣])")
 
+# References 섹션 뒤에 곧바로 이어지는 Appendix 표제 - 표제만 딱 담긴 줄에만
+# 일치하도록(문장 중간의 "see Appendix B" 같은 언급과 구분) 줄 전체를 앵커링한다.
+_APPENDIX_HEADER_RE = re.compile(
+    r"^(?:appendix|supplementary material|supplemental material)(?:\s+[A-Z0-9]{1,3})?\.?$",
+    re.IGNORECASE,
+)
+
 # (Author, Year) 스타일 항목의 시작 판별용 - "Surname, Initial..." 형태로
 # 시작하는 구간을 새 항목의 시작으로 본다. 실제로 참고문헌 항목인지는 flush
 # 시점에 텍스트 전체에서 연도가 발견되는지로 한 번 더 검증한다(오탐 방지).
-_AUTHOR_YEAR_ENTRY_START_RE = re.compile(r"^\s*([A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+),\s")
+#
+# 첫 저자가 "Inception Labs," "Google DeepMind," 처럼 여러 단어로 된 기관명인
+# 경우도 있어("Inception Labs, Khanna, S., ..." - 실제로 관찰된 문서), 성 뒤에
+# 공백으로 이어지는 대문자 단어를 추가로 몇 개 더 허용한다. 키(=프론트엔드
+# main.js의 extractAuthorYearClauses와 맞춰야 하는 부분)는 항상 첫 단어만
+# 쓰므로 캡처 그룹은 첫 단어에만 건다.
+#
+# 다만 이 다중 단어 허용은 "In NeurIPS, 2020." "In ICML, 2015." 같은 학회명
+# 인용구(항목 안의 문장이지 새 항목이 아님)까지 오탐하게 만든다 - "In"과
+# "NeurIPS"가 둘 다 대문자로 시작해 SURNAME_SRC에 그대로 걸림. 실제 저자
+# 목록은 콤마 뒤에 보통 이니셜("S.", "J. C.")이나 또 다른 저자 성이 이어지고
+# 곧바로 4자리 숫자가 오지 않는 반면, 학회명 인용구는 콤마 뒤에 곧장 연도가
+# 온다는 차이가 있어, 콤마 뒤에 숫자가 바로 오는 경우는 항목 시작으로 인정하지
+# 않는다(그 대가로 저자 이니셜 없이 "Google, 2023."처럼 곧장 연도가 오는
+# 극히 드문 기관 저자 항목은 놓칠 수 있음).
+_AUTHOR_YEAR_SURNAME_WORD_SRC = r"[A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']*"
+_AUTHOR_YEAR_SURNAME_SRC = (
+    "(" + _AUTHOR_YEAR_SURNAME_WORD_SRC + ")"
+    r"(?:\s" + _AUTHOR_YEAR_SURNAME_WORD_SRC + r")*"
+)
+_AUTHOR_YEAR_SURNAME_END_SRC = r",\s(?!\d)"
+_AUTHOR_YEAR_ENTRY_START_RE = re.compile(r"^\s*" + _AUTHOR_YEAR_SURNAME_SRC + _AUTHOR_YEAR_SURNAME_END_SRC)
 # 항목 경계 자체를 텍스트 전체에서 찾을 때 쓴다(_parse_author_year_entries 참고) -
 # 문장 경계(마침표/느낌표/물음표 + 공백) 또는 텍스트 시작 바로 뒤에 "Surname,"
 # 패턴이 오는 지점을 새 항목의 시작으로 본다. 항목 안의 공저자 나열은 보통
 # 세미콜론이나 "&"로 구분되고 성 뒤에 곧바로 마침표+공백이 오는 경우가 거의
 # 없어(이니셜 뒤에는 대개 쉼표나 세미콜론이 옴) 오탐 위험이 낮다.
+#
+# 일부 논문(backref 패키지 사용)은 각 항목 끝에 "이 문헌이 인용된 페이지 번호"
+# 목록을 덧붙인다(예: "... 2023. 1" 또는 "... 2025. 8, 9, 10") - 이 숫자
+# 목록이 마침표와 다음 항목의 "Surname," 사이에 끼어들면 경계를 못 찾고 다음
+# 수십 개 항목 전체가 앞 항목 하나에 뭉쳐 흡수돼버리는 문제가 실제로 관찰됨.
+# 마침표 뒤에 그런 숫자 목록이 있으면 건너뛰고 그 다음에서 Surname을 찾는다.
+_AUTHOR_YEAR_CITED_PAGES_SRC = r"\d{1,4}(?:,\s*\d{1,4})*\s+"
 _AUTHOR_YEAR_ENTRY_BOUNDARY_RE = re.compile(
-    r"(?:^|[.!?]\s+)(?=[A-ZÀ-Ö][A-Za-zÀ-ÖØ-öø-ÿ\-']+,\s)"
+    r"(?:^|[.!?]\s+(?:" + _AUTHOR_YEAR_CITED_PAGES_SRC + r")?)"
+    r"(?=" + _AUTHOR_YEAR_SURNAME_SRC + _AUTHOR_YEAR_SURNAME_END_SRC + r")"
 )
 # 연도는 APA류처럼 괄호로 싸인 경우("(2020)")뿐 아니라, AAAI/IJCAI류처럼
 # 저자 목록 바로 뒤에 괄호 없이 오는 경우("... 2020. Title...")도 지원한다.
@@ -142,6 +178,23 @@ def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
             start_idx = idx
             break
     body_lines = lines[start_idx:]
+
+    # 많은 논문이 References 섹션 바로 뒤에 Appendix를 이어 붙인다(같은 PDF,
+    # 페이지 구분 없음). References 시작 페이지부터 문서 끝까지를 통째로
+    # 가져오는 위 combined_text 구성 방식상, Appendix 헤더를 걷어내지 않으면
+    # 부록 본문 전체가 마지막 참고문헌 항목 하나에 통째로 흡수된다(실제로
+    # 부록 안의 "Notably, evidence shows..." 같은 일반 문장까지 "Surname,"
+    # 패턴에 우연히 걸려 항목 경계로 오인되는 경우도 있어 더 위험함). Appendix
+    # 표제만 있는 줄을 만나면 그 지점에서 자른다 - "... see Appendix B" 처럼
+    # 문장 중간에 낀 언급은 줄 전체가 표제와 일치하지 않으므로 걸리지 않는다.
+    for idx, line in enumerate(body_lines):
+        if idx == 0:
+            continue
+        stripped = re.sub(r"\*+", "", line).strip()
+        if _APPENDIX_HEADER_RE.match(stripped):
+            body_lines = body_lines[:idx]
+            break
+
     # 항목 경계 탐지는 줄바꿈에 기대지 않는다(아래 _extract_marker_entries
     # 참고) - 여기서는 그냥 하나의 문자열로 이어붙이기만 한다.
     body_text = "\n".join(body_lines)

--- a/backend/tests/test_reference_parser.py
+++ b/backend/tests/test_reference_parser.py
@@ -259,3 +259,73 @@ def test_author_year_supports_plain_year_without_parentheses():
     refs = extract_reference_list(pages)
     assert set(refs.keys()) == {"smith2020"}
     assert "without parenthesized year" in refs["smith2020"]
+
+
+def test_author_year_supports_multi_word_organization_author():
+    """"Inception Labs, Khanna, S., ..."처럼 첫 저자가 여러 단어로 된 기관명인
+    항목도 독립된 항목으로 인식해야 한다(실제 The Flexibility Trap 논문에서
+    재현된 케이스). 키는 프론트엔드(main.js의 extractAuthorYearClauses)와
+    맞춰 첫 단어만 사용한다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Huang, Z., Chen, Z., and Li, T. Reinforcing the diffusion chain. "
+        "In NeurIPS, 2025.\n\n"
+        "Inception Labs, Khanna, S., and Kharbanda, S. Mercury: Ultra-fast "
+        "language models based on diffusion. arXiv preprint arXiv:2506.17298, 2025."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"huang2025", "inception2025"}
+    assert "Mercury" in refs["inception2025"]
+    assert "Mercury" not in refs["huang2025"]
+
+
+def test_author_year_boundary_tolerates_backref_cited_page_numbers():
+    """backref 패키지를 쓰는 논문은 각 항목 끝에 "이 문헌이 인용된 페이지
+    번호" 목록을 덧붙인다(예: "... 2023. 1" 또는 "... 2025. 8, 9, 10"). 이
+    숫자 목록이 마침표와 다음 항목의 "Surname," 사이에 끼면 경계를 놓쳐
+    뒤따르는 항목 전부가 앞 항목 하나에 흡수되던 문제가 실제로 있었다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Achiam, J., Adler, S. GPT-4 technical report. arXiv preprint "
+        "arXiv:2303.08774, 2023. 1\n\n"
+        "Ben-Hamu, H., Gat, I. Accelerated sampling from masked diffusion "
+        "models. In NeurIPS, 2025. 8, 9, 10"
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"achiam2023", "ben-hamu2025"}
+    assert "Ben-Hamu" not in refs["achiam2023"]
+
+
+def test_author_year_venue_citation_is_not_mistaken_for_new_entry():
+    """"In NeurIPS, 2020."처럼 항목 안에 등장하는 학회명 인용구는(두 단어 다
+    대문자로 시작해 다중 단어 기관 저자 패턴과 겉보기 형태가 같음) 새 항목의
+    시작으로 오인되면 안 된다 - 콤마 뒤에 곧장 연도가 오는지로 구분한다."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Ho, J., Jain, A., and Abbeel, P. Denoising diffusion probabilistic "
+        "models. In NeurIPS, 2020. Some further description continues here."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"ho2020"}
+    assert "NeurIPS" in refs["ho2020"]
+
+
+def test_author_year_stops_before_appendix_section():
+    """References 섹션 바로 뒤에 Appendix가 페이지 구분 없이 이어 붙는 논문이
+    흔하다. Appendix 표제를 걷어내지 않으면 부록 본문 전체가 마지막 참고문헌
+    항목 하나에 통째로 흡수된다(실제 The Flexibility Trap 논문에서 재현된
+    케이스 - 부록 안의 일반 문장이 "Surname," 패턴에 우연히 걸려 경계로
+    오인되는 경우까지 있어 더 위험함)."""
+    pages = [{"page_num": 1, "text": (
+        "References\n\n"
+        "Zhu, F., Wang, R. LLaDA 1.5: Variance-reduced preference optimization. "
+        "arXiv preprint arXiv:2505.19223, 2025. 1, 4, 8\n"
+        "**Appendix**\n\n"
+        "**A. Experimental Details**\n\n"
+        "Notably, even under these optimized settings, the arbitrary order mode "
+        "does not recover the same coverage."
+    )}]
+    refs = extract_reference_list(pages)
+    assert set(refs.keys()) == {"zhu2025"}
+    assert "Notably" not in refs["zhu2025"]
+    assert "Appendix" not in refs["zhu2025"]


### PR DESCRIPTION
# Summary
## 1. (Author, Year) 참고문헌 파싱 뭉침 버그 수정
- "The Flexibility Trap" 논문 등에서 본문 인용 오버레이가 극히 일부만 동작하던 근본 원인 - 실측 시 65개 이상의 참고문헌이 단 2개 키로 뭉쳐 파싱되고 있었음
- `_AUTHOR_YEAR_ENTRY_START_RE`/`_AUTHOR_YEAR_ENTRY_BOUNDARY_RE`가 "Inception Labs, Khanna, ..."처럼 여러 단어로 된 기관명 저자를 항목 시작으로 인식하지 못해 뒤이은 수십 개 항목이 앞 항목 하나에 흡수되던 문제 수정
  - 성 뒤에 대문자로 시작하는 단어를 추가로 허용(키는 기존처럼 첫 단어만 사용해 프론트엔드 `main.js`의 `extractAuthorYearClauses`와 키 형식을 맞춤)
- 다중 단어 허용의 부작용으로 "In NeurIPS, 2020."류 학회명 인용구까지 새 항목으로 오탐하던 문제 수정
  - 콤마 뒤에 곧장 숫자(연도)가 오면 항목 시작으로 인정하지 않도록 제한
- backref 패키지가 각 항목 끝에 붙이는 "인용된 페이지 번호" 목록(예: "2023. 1", "2025. 8, 9, 10")이 마침표와 다음 저자 성 사이에 끼어 경계 인식을 방해하던 문제 수정
  - 마침표 뒤 숫자 목록은 건너뛰고 그 다음에서 항목 시작을 판정
- References 섹션이 페이지 구분 없이 Appendix로 바로 이어지는 논문에서 부록 본문 전체가 마지막 참고문헌 항목 하나에 통째로 흡수되던 문제 수정
  - Appendix 표제 줄을 만나면 그 지점에서 파싱 범위를 자름
- 회귀 방지 테스트 4건 추가, 실제 논문 데이터로 검증(파싱된 항목 수 2 → 41)