### PR TITLE
fix: Fig/Table/Equation overlay가 범위를 잘못 인식하던 문제 3건 수정

### DIFF
--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -785,10 +785,23 @@ def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
             # 본문 참조 매칭과 항상 같은 대문자 표기로 라벨을 맞춰야 한다(대문자
             # 로마 숫자가 관례이므로 digit은 그대로 두고 로마 숫자만 사실상 영향받음).
             number = m.group(2).upper()
+            caption_lines = lines[i:]
             caption_text = " ".join(t for t in line_texts[i:] if t).strip()
+            # bbox는 매칭된 첫 줄이 아니라, caption_text와 마찬가지로 블록 끝까지
+            # 이어지는 캡션 전체 줄들의 합집합으로 잡는다 - 캡션이 여러 줄에 걸쳐
+            # 길게 줄바꿈되는 경우(실제 관찰됨: 설명이 긴 Table 캡션이 6~7줄까지
+            # 이어짐) 첫 줄 bbox만 쓰면 실제로는 캡션이 끝나지 않은 지점을 "캡션
+            # 끝"으로 오인해, 그 아래 실제 표/그림까지의 거리가 실제보다 훨씬
+            # 크게 계산된다. 이 거리는 _match_caption_for_rect의 40pt 임계값
+            # 판정에 쓰이는데, 부풀려진 거리 때문에 진짜 인접한 표/그림조차
+            # 캡션과 매칭되지 못하고 라벨 없이 남아버리는 문제가 실측으로 확인됨.
+            bx0 = min(ln["bbox"][0] for ln in caption_lines)
+            by0 = min(ln["bbox"][1] for ln in caption_lines)
+            bx1 = max(ln["bbox"][2] for ln in caption_lines)
+            by1 = max(ln["bbox"][3] for ln in caption_lines)
             captions.append({
                 "label": f"{kind} {number}",
-                "bbox": lines[i]["bbox"],
+                "bbox": (bx0, by0, bx1, by1),
                 "text": caption_text[:600],
             })
             break  # 한 블록에서 캡션은 한 번만 인정 (이후 줄은 caption_text에 이미 포함됨)
@@ -1024,7 +1037,19 @@ _EQ_PROSE_MIN_LONG_WORD_RATIO = 0.5
 _EQ_PAGE_MARGIN_EXCLUDE = 65.0
 
 
+_MATH_OPERATOR_RE = re.compile(r"[=≈≠≤≥±∑∫∏√∇∂∈∉⊂⊆∪∩→⇒↦]")
+
+
 def _looks_like_prose(text: str) -> bool:
+    # "=" 같은 수식 연산자가 한 글자라도 있으면 산문일 수 없다(진짜 문장에는
+    # 거의 등장하지 않음) - 무조건 흡수 후보로 남긴다. 이 가드가 없으면
+    # "r = rcode + rformat."처럼 언더스코어가 빠진 채 추출된 첨자 변수명
+    # (rcode, rformat)이 우연히 길이 3자 이상의 순수 알파벳 단어 조건을
+    # 만족해 산문으로 오판되고, 정작 그 줄에 붙어야 할 수식 번호 "(9)"만
+    # 따로 떨어져 나가 번호 하나만 확대된 아주 작은 오버레이가 되던 문제가
+    # 실제 논문 PDF에서 재현됨.
+    if _MATH_OPERATOR_RE.search(text):
+        return False
     words = text.split()
     if len(words) < _EQ_PROSE_MIN_WORDS:
         return False
@@ -1472,8 +1497,32 @@ def extract_pdf_images(pdf_path: str) -> List[Dict[str, Any]]:
                             table_groups.append(current_group)
                             current_group = [line]
                     table_groups.append(current_group)
-                    
+
+                    # booktabs 스타일 표는 상단 규칙(top rule)-헤더 구분선(header rule)은
+                    # 서로 가까이 붙어 있지만, 데이터 행이 많으면 맨 아래 규칙(bottom
+                    # rule)까지의 거리가 100pt를 훌쩍 넘는 경우가 실제로 있다(실측:
+                    # 데이터 행 없이 top+header rule만 17pt 간격, bottom rule까지는
+                    # 173pt). 이런 경우 위 100pt 임계값 때문에 bottom rule 혼자만의
+                    # group으로 떨어져 나가고, 아래 len(group)>=2 필터에 걸려 완전히
+                    # 버려진다 - 그러면 표의 세로 범위가 top/header rule 사이의
+                    # 얇은 띠 하나로만 잡혀, 실제 표 본문(데이터 행 전체)이 오버레이
+                    # 범위에서 통째로 빠지는 문제가 있었다. 캡션이 사이에 끼지 않은
+                    # (=서로 다른 표의 경계가 아닌) 단독 선 group은 직전 group에
+                    # 이어붙여, 이 단독 선을 "먼 아래쪽 bottom rule"로 인정한다.
+                    merged_groups: list = []
                     for group in table_groups:
+                        if (
+                            len(group) == 1
+                            and merged_groups
+                            and not _has_caption_between(
+                                merged_groups[-1][-1][3], group[0][1], page_captions
+                            )
+                        ):
+                            merged_groups[-1].append(group[0])
+                        else:
+                            merged_groups.append(group)
+
+                    for group in merged_groups:
                         if len(group) >= 2:
                             gx0 = min(l[0] for l in group)
                             gy0 = min(l[1] for l in group)

--- a/backend/tests/test_pdf_parser_equation_crop.py
+++ b/backend/tests/test_pdf_parser_equation_crop.py
@@ -27,6 +27,11 @@ _find_page_equations()의 진화 과정에서 실제로 관찰된 네 가지 오
 10. 수식이 페이지 하단 가까이 있으면, 그 아래 페이지 쪽수(running
     footer)가 좁고 gap도 작아 2단계 흡수 조건을 통과해 함께 캡처되는
     문제(실사용 스크린샷으로 재발견).
+11. 언더스코어가 빠진 채 추출된 첨자 변수명("rcode", "rformat" 등)이
+    길이 3자 이상의 순수 알파벳 단어 조건을 우연히 만족해 수식 본문
+    줄 자체가 산문으로 오판되고, 정작 번호("(9)")만 따로 떨어져 나가
+    번호 하나만 확대된 아주 작은 오버레이가 되던 문제(실제 The
+    Flexibility Trap 논문에서 재현).
 """
 
 import fitz
@@ -323,3 +328,30 @@ def test_wide_caption_line_does_not_inflate_paragraph_width_estimate(tmp_path):
     # 위/아래 문단 줄(각각 y~300-450 부근)까지 통째로 흡수되면 안 된다 -
     # 수식 자신의 좁은 높이(수십 pt 이내)만 캡처해야 한다.
     assert y1 - y0 < 60
+
+
+def test_equation_body_with_subscript_like_variable_names_is_absorbed(tmp_path):
+    """수식 본문에 언더스코어 없이 추출된 첨자 변수명("rcode", "rformat" 등,
+    실제로는 LaTeX에서 r_code/r_format처럼 첨자로 렌더링됨)이 섞여 있으면,
+    산문 판별 휴리스틱(길이 3자 이상의 순수 알파벳 단어 비율)이 우연히
+    "산문처럼 보임"으로 오판할 수 있다. 그러면 번호("(1)")와 같은 행에
+    있는데도 흡수되지 않아, 번호 자신의 아주 작은 bbox만 오버레이가 되고
+    실제 수식 본문("r = rcode + rformat.")은 통째로 빠지던 문제가 있었다.
+    "=" 같은 수식 연산자가 있으면 산문 판별보다 우선해 흡수 대상으로
+    인정해야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((200, 400), "r = rcode + rformat.", fontsize=10)
+    page.insert_text((520, 400), "(1)", fontsize=10)
+    path = tmp_path / "subscript_vars.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    entries = [r for r in result if r.get("label") == "Equation 1"]
+    assert len(entries) == 1
+    x0, _, x1, _ = _pt(entries[0])
+    # 수식 본문("r = rcode...", x=200 부근)까지 왼쪽 경계가 확장돼야 한다 -
+    # 번호("(1)", x=520)만 잡히면 안 된다.
+    assert x0 < 210, f"수식 본문이 산문으로 오판되어 흡수되지 않음: {entries[0]}"
+    assert x1 > 530

--- a/backend/tests/test_pdf_parser_images.py
+++ b/backend/tests/test_pdf_parser_images.py
@@ -310,6 +310,75 @@ def test_body_sentence_starting_with_table_number_is_not_treated_as_caption(tmp_
     )
 
 
+def test_long_wrapped_caption_still_matches_distant_table(tmp_path):
+    """Table 캡션이 여러 줄에 걸쳐 길게 줄바꿈되는 경우(실제 The Flexibility
+    Trap 논문에서 재현 - 설명이 긴 캡션이 6~7줄까지 이어짐), 캡션의 "첫 줄"
+    bbox만 기준으로 표까지의 거리를 재면 실제로는 캡션이 아직 끝나지 않은
+    지점을 "캡션 끝"으로 오인해 거리가 실제보다 훨씬 크게 계산된다. 이
+    거리가 매칭 임계값(40pt)을 넘으면 바로 아래 있는 진짜 표조차 캡션과
+    매칭되지 못하고 라벨 없이 남아버렸다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    caption_rect = fitz.Rect(50, 80, 545, 200)
+    long_caption = (
+        "Table 1: A very long and detailed caption describing the experimental "
+        "setup, baselines, and evaluation protocol used throughout this study in "
+        "extensive detail so that the caption wraps across several physical "
+        "lines before the actual table content begins right below it."
+    )
+    page.insert_textbox(caption_rect, long_caption, fontsize=9)
+
+    # 표 규칙선은 캡션의 "첫 줄" 끝에서는 40pt 넘게 떨어져 있지만, 캡션
+    # 전체(마지막 줄)가 끝나는 지점에서는 40pt 이내다.
+    page.draw_line(fitz.Point(50, 145), fitz.Point(545, 145), color=(0, 0, 0), width=1)
+    page.insert_text((60, 158), "method accuracy", fontsize=7)
+    page.draw_line(fitz.Point(50, 168), fitz.Point(545, 168), color=(0, 0, 0), width=1)
+    page.insert_text((60, 181), "Ours 88.1", fontsize=7)
+    page.draw_line(fitz.Point(50, 191), fitz.Point(545, 191), color=(0, 0, 0), width=1)
+
+    path = tmp_path / "wrapped_caption.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    table1_entries = [r for r in result if r.get("label") == "Table 1"]
+    assert len(table1_entries) == 1, f"여러 줄로 줄바꿈된 캡션 때문에 Table 1 매칭에 실패함: {result}"
+
+
+def test_sparse_booktabs_table_captures_distant_bottom_rule(tmp_path):
+    """구분선이 거의 없는 booktabs 스타일 표(상단 규칙-헤더 구분선만 서로
+    가깝고, 데이터 행 사이에는 선이 없어 맨 아래 규칙까지 100pt 넘게
+    떨어진 경우 - 실제 The Flexibility Trap 논문의 Table 3에서 재현)는
+    맨 아래 규칙이 별도의 1줄짜리 group으로 떨어져 나가 완전히 버려지고,
+    표의 세로 범위가 상단 규칙-헤더 구분선 사이의 얇은 띠 하나로만 잡혀
+    실제 표 본문(데이터 행 전체)이 오버레이 범위에서 빠지던 문제가 있었다."""
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+
+    page.insert_text((50, 90), "Table 1: Sparse booktabs style table with many data rows.", fontsize=9)
+    page.draw_line(fitz.Point(50, 100), fitz.Point(545, 100), color=(0, 0, 0), width=1)
+    page.insert_text((60, 112), "method accuracy", fontsize=7)
+    page.draw_line(fitz.Point(50, 115), fitz.Point(545, 115), color=(0, 0, 0), width=1)
+    # 데이터 행 다수 - booktabs 스타일답게 행 사이에 구분선 없음
+    for i in range(12):
+        page.insert_text((60, 130 + i * 12), f"Row{i} value{i}", fontsize=7)
+    page.draw_line(fitz.Point(50, 280), fitz.Point(545, 280), color=(0, 0, 0), width=1)
+
+    path = tmp_path / "sparse_booktabs.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result = extract_pdf_images(str(path))
+    table1_entries = [r for r in result if r.get("label") == "Table 1"]
+    assert len(table1_entries) == 1, f"맨 아래 규칙이 멀리 떨어져 있어 표 자체가 감지되지 않음: {result}"
+    entry = table1_entries[0]
+    entry_bottom_pt = (entry["top"] + entry["height"]) / 100 * 842
+    # 표의 아래 경계가 맨 아래 규칙(y=280) 근처까지 내려와야 한다 - 상단
+    # 규칙-헤더 구분선 사이(y=100~115)의 얇은 띠 하나로만 잡히면 안 된다.
+    assert entry_bottom_pt > 260, f"표 하단이 맨 아래 규칙까지 확장되지 않음: {entry}"
+
+
 def test_unrelated_unlabeled_regions_are_not_merged(tmp_path):
     """캡션에 매칭되지 않는(라벨이 없는) 영역들은 서로 다른 그림/표의 잔여
     조각일 수 있으므로 하나로 합쳐지면 안 되고, 감지된 개수만큼 개별


### PR DESCRIPTION
# Summary
## 1. Table 캡션-사각형 매칭이 여러 줄 캡션에서 실패하던 문제 수정
- `_find_page_captions`가 캡션의 "첫 줄" bbox만 반환해, 설명이 길어 여러 줄로 줄바꿈되는 캡션(실측: Table 1 캡션이 6~7줄)에서 실제 캡션 끝 지점을 훨씬 위쪽으로 오인
- 캡션-표 사이 거리가 실제보다 크게 계산되어 `_match_caption_for_rect`의 40pt 임계값을 넘겨버려, 바로 아래 있는 진짜 표조차 매칭되지 못하고 라벨 없이 남았음(The Flexibility Trap 논문 Table 1, 2에서 재현)
- bbox를 캡션 전문과 마찬가지로 블록 끝까지 이어지는 모든 줄의 합집합으로 계산하도록 수정

## 2. Booktabs 스타일 표에서 먼 아래쪽 규칙선이 버려지던 문제 수정
- 상단 규칙-헤더 구분선만 서로 가깝고 데이터 행 사이에는 선이 없어 맨 아래 규칙까지 100pt 넘게 떨어진 표(Table 3에서 재현)는, 맨 아래 규칙이 단독 1줄 group으로 떨어져 나가 `len(group) >= 2` 필터에 걸려 완전히 버려짐
- 표의 세로 범위가 상단 규칙-헤더 구분선 사이 얇은 띠 하나로만 잡히고 실제 표 본문(데이터 행 전체)이 빠지던 문제 수정
- 캡션이 사이에 끼지 않은 단독 선 group은 직전 group에 이어붙여 "먼 아래쪽 bottom rule"로 인정하도록 함

## 3. 첨자 변수명이 산문으로 오판되어 수식 본문이 흡수되지 않던 문제 수정
- `_looks_like_prose`가 언더스코어 없이 추출된 첨자 변수명("rcode", "rformat" 등)을 우연히 산문으로 오판(길이 3자 이상 순수 알파벳 단어 조건 충족)
- 수식 본문 줄이 흡수되지 않고 번호("(9)")만 따로 떨어져 나가, 번호 하나만 확대된 아주 작은 오버레이가 되던 문제 수정
- "=" 등 수식 연산자가 있으면 산문 판별보다 우선해 흡수 대상으로 인정하도록 수정

## 4. 검증
- 회귀 방지 테스트 3건 추가
- 실제 논문("The Flexibility Trap") 데이터로 검증: Table 1~3 모두 정상 라벨링, Equation 9 bbox가 번호만 담던 3.6%에서 본문+번호 전체를 포함한 48.4%로 확장