### PR TITLE
feat: Research Graph 개념 히트맵 셀 값을 LLM 논문 분석 기반으로 변경

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -156,14 +156,16 @@ async def get_library_concept_heatmap(current_user: str = Depends(get_current_us
 
 
 @router.get("/library/graph/heatmap/matrix")
-async def get_library_concept_heatmap_matrix(current_user: str = Depends(get_current_user)):
+async def get_library_concept_heatmap_matrix(force: bool = False, current_user: str = Depends(get_current_user)):
     """개념 히트맵을 논문(행) x 개념(열) 매트릭스로 반환합니다(2D 히트맵 UI용).
+    셀 값은 LLM이 논문마다 채점하며 하루 단위로 캐싱됩니다 - force=True면
+    캐시를 무시하고 새로 채점합니다("다시 계산" 버튼).
 
     /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
     이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
     """
     from services.knowledge_graph import get_concept_paper_matrix
-    return await get_concept_paper_matrix(current_user)
+    return await get_concept_paper_matrix(current_user, force=force)
 
 
 @router.get("/library/graph/gaps")

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -606,17 +606,94 @@ async def get_concept_heatmap(username: str) -> List[dict]:
     return result
 
 
-async def get_concept_paper_matrix(username: str, concept_limit: int = 12, paper_limit: int = 10) -> dict:
+# 히트맵 매트릭스 캐시 TTL - 논문마다 LLM 채점 호출이 들어가는 무거운 작업이라
+# AI 인사이트와 동일하게 하루 단위로만 다시 계산한다.
+HEATMAP_MATRIX_CACHE_HOURS = 24
+
+
+def _heatmap_matrix_cache_key(username: str) -> str:
+    return f"heatmap_matrix:{username}"
+
+
+async def _get_paper_text_for_scoring(doc_id: str) -> str:
+    """히트맵 LLM 채점용 논문 서두 텍스트. sync_document_for_graph(개념 추출)와
+    동일하게 첫 2페이지만 써서 비용을 억제하고 근거 범위를 일관되게 유지한다.
+    PDF가 없거나 추출에 실패하면 빈 문자열을 반환한다 - 호출부가 제목만으로도
+    채점을 시도하거나 등장 여부 기반 값으로 대체할 수 있어 파이프라인을
+    막지 않는다."""
+    try:
+        from services.library import get_pdf_path
+        from services.cache import get_cached_pages, save_pages_cache
+        from services.pdf_parser import extract_pages
+        pdf_path = get_pdf_path(doc_id)
+        if not pdf_path:
+            return ""
+        pages = get_cached_pages(doc_id, pdf_path)
+        if pages is None:
+            pages = await asyncio.to_thread(extract_pages, pdf_path)
+            save_pages_cache(doc_id, pdf_path, pages)
+        return "\n".join(p.get("text", "") for p in pages[:2])
+    except Exception:
+        return ""
+
+
+async def _score_one_paper(doc_id: str, title: str, concept_names: List[str]) -> Dict[str, float]:
+    """한 논문에 대해 concept_names 전체를 LLM 호출 1회로 채점한다(개념별로 나눠
+    호출하면 비용이 개념 수 x 논문 수로 늘어나므로, 논문당 1회로 제한). 텍스트
+    추출 실패, LLM 오류, 응답 파싱 실패 등 어떤 이유로든 실패하면 조용히 빈
+    dict를 반환해 호출부가 등장 여부 기반 값으로 대체하게 한다 - 이 함수 하나가
+    실패해도 나머지 논문의 채점이나 매트릭스 자체가 막히면 안 된다."""
+    from services.llm_client import score_paper_concept_relevance
+    text = await _get_paper_text_for_scoring(doc_id)
+    try:
+        raw = await score_paper_concept_relevance(title, text, concept_names, session_id=doc_id)
+    except Exception:
+        return {}
+    scores: Dict[str, float] = {}
+    for item in raw:
+        name = (item.get("concept") or "").strip()
+        if not name:
+            continue
+        try:
+            score = float(item.get("score", 0))
+        except (TypeError, ValueError):
+            continue
+        scores[name.lower()] = max(0.0, min(1.0, score))
+    return scores
+
+
+async def get_concept_paper_matrix(username: str, concept_limit: int = 12, paper_limit: int = 10, force: bool = False) -> dict:
     """개념 히트맵을 논문(행) x 개념(열) 매트릭스로 구성한다(seaborn류 2D 히트맵 UI용).
-    새 테이블이나 새 LLM 호출 없이 기존 3개 테이블만 재사용한다:
-    - paper_concepts: 논문에 개념이 등장했는지(이진 링크)
-    - question_papers/question_concepts: 그 논문·개념 조합에 대한 질문이 몇 개 있었는지
-      (db_get_question_doc_concept_counts가 chat_id로 두 테이블을 조인해 집계)
-    셀 값(raw) = 등장 여부(0/1) + 그 조합에 대한 질문 수. "논문 내 개념 언급 빈도"를 정밀하게
-    분석한 값이 아니라 "등장 + 얼마나 논의됐는가"를 결합한 근사 강도이며, 프런트에서 행/열/전체
-    기준으로 정규화해 색상에 매핑한다. 열은 get_concept_heatmap과 동일한 활동량 순위 상위
-    concept_limit개, 행은 그 개념들과 실제로 연결된 논문 중 활동량 상위 paper_limit개만 골라
-    표가 스크린 안에 들어오게 한다(현재 히트맵 개편의 동기 - 항목이 너무 많으면 비직관적)."""
+
+    열/행 선정은 기존 3개 테이블(paper_concepts, question_papers, question_concepts)만
+    재사용하는 규칙 기반 집계다 - get_concept_heatmap과 동일한 활동량 순위로 상위
+    concept_limit개 개념을, 그 개념들과 실제로 연결된 논문 중 활동량 상위 paper_limit개
+    논문만 골라 표가 스크린 안에 들어오게 한다(항목이 너무 많으면 비직관적이라는
+    피드백에서 시작된 제약).
+
+    셀 값(score)은 선정된 논문마다 제목+서두 텍스트를 근거로 LLM이 각 개념을
+    0.0~1.0으로 직접 채점한 값이다. 이전 버전은 "등장 여부 + 질문 수"로 근사했지만,
+    개념 중복 제거가 완벽하지 않아(concepts.normalized_name이 소문자+trim만 함) 논문이
+    실제로 다루는 개념인데도 다른 concept_id로 잡혀 0으로 뜨는 문제가 있었다 - 텍스트를
+    직접 읽고 판단하므로 그 문제에서 자유롭다. 논문당 LLM 호출 1회로 비용을 제한하고
+    (그 논문에 대해 concept_limit개 전부를 한 번에 채점), 논문들은 asyncio.gather로
+    병렬 호출해 전체 지연 시간을 줄인다. 결과는 HEATMAP_MATRIX_CACHE_HOURS 동안
+    app_meta에 캐싱해 히트맵을 열 때마다 다시 채점하지 않는다(get_reading_recommendations와
+    동일한 캐싱 패턴). force=True면 캐시를 무시하고 새로 채점한다("다시 계산" 버튼)."""
+    from services.db import db_get_meta, db_set_meta
+
+    cache_key = _heatmap_matrix_cache_key(username)
+    if not force:
+        cached_raw = db_get_meta(cache_key)
+        if cached_raw:
+            try:
+                cached = json.loads(cached_raw)
+                generated_at = datetime.fromisoformat(cached["generated_at"])
+                if datetime.now(timezone.utc) - generated_at < timedelta(hours=HEATMAP_MATRIX_CACHE_HOURS):
+                    return cached["matrix"]
+            except Exception:
+                pass  # 캐시가 손상됐으면 무시하고 새로 계산
+
     from services.library import list_documents
     from services.db import db_get_concepts_for_docs, db_get_question_count_for_concepts, db_get_question_doc_concept_counts
 
@@ -639,6 +716,7 @@ async def get_concept_paper_matrix(username: str, concept_limit: int = 12, paper
         reverse=True,
     )[:concept_limit]
     concept_ids = {c["concept_id"] for c in ranked_concepts}
+    concept_names = [c["name"] for c in ranked_concepts]
 
     pair_question_counts = db_get_question_doc_concept_counts(doc_ids)
 
@@ -666,25 +744,47 @@ async def get_concept_paper_matrix(username: str, concept_limit: int = 12, paper
             "category": (meta.get("categories") or [None])[0],
         })
 
+    if not ranked_concepts or not papers:
+        # 아직 채점할 데이터가 없는 상태를 24시간짜리 빈 캐시로 굳히지 않는다 -
+        # 다음 조회 때 데이터가 쌓여 있으면 바로 반영되게 캐싱을 건너뛴다.
+        return {"concepts": [], "papers": [], "cells": []}
+
+    score_results = await asyncio.gather(
+        *[_score_one_paper(p["doc_id"], p["title"], concept_names) for p in papers],
+        return_exceptions=True,
+    )
+    scores_by_doc: Dict[str, Dict[str, float]] = {
+        p["doc_id"]: (result if isinstance(result, dict) else {})
+        for p, result in zip(papers, score_results)
+    }
+
     cells = []
     for doc_id in ranked_doc_ids:
+        doc_scores_by_name = scores_by_doc.get(doc_id, {})
         for c in ranked_concepts:
             cid = c["concept_id"]
             present = (doc_id, cid) in doc_concept_present
             qcount = pair_question_counts.get((doc_id, cid), 0)
+            llm_score = doc_scores_by_name.get(c["name"].strip().lower())
+            score = llm_score if llm_score is not None else (1.0 if present else 0.0)
             cells.append({
                 "doc_id": doc_id,
                 "concept_id": cid,
                 "present": present,
                 "question_count": qcount,
-                "raw": (1 if present else 0) + qcount,
+                "score": round(score, 3),
             })
 
-    return {
+    matrix = {
         "concepts": [{"concept_id": c["concept_id"], "name": c["name"], "kind": c["kind"]} for c in ranked_concepts],
         "papers": papers,
         "cells": cells,
     }
+    db_set_meta(cache_key, json.dumps({
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "matrix": matrix,
+    }, ensure_ascii=False))
+    return matrix
 
 
 async def get_knowledge_gaps(username: str) -> List[dict]:

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -2307,6 +2307,31 @@ JSON Array:"""
     return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="유사 개념 탐색")
 
 
+async def score_paper_concept_relevance(title: str, text: str, concept_names: List[str], session_id: str = None) -> List[dict]:
+    """논문 제목+서두 텍스트를 근거로, 주어진 개념 목록 각각을 이 논문이 얼마나
+    깊이/중심적으로 다루는지 0.0~1.0으로 채점한다(Concept Heatmap 매트릭스의
+    셀 값). match_question_to_concepts와 같은 폐쇄형 목록(concept_names에
+    없는 개념을 지어내면 안 됨)이지만, 부분집합을 고르는 대신 목록 전체에
+    점수를 매긴다는 점이 다르다. 반환값: [{"concept": str, "score": number}, ...]
+    (concept_names와 정확히 같은 이름, 순서는 무관)."""
+    if not concept_names:
+        return []
+    names_list = "\n".join(f"- {n}" for n in concept_names)
+    prompt = f"""You are an academic paper analyst. Given a paper's title and beginning text (abstract/introduction), score how deeply and centrally EACH concept in the list below is discussed in this paper, on a scale from 0.0 (not discussed at all / irrelevant) to 1.0 (a central, deeply discussed topic of the paper).
+
+Output ONLY a pure JSON array, with no markdown code fences, no explanations, and no extra prose. Each element must be an object with a "concept" key whose value is copied EXACTLY (verbatim) from the list below, and a "score" key (a number between 0.0 and 1.0). You MUST include EVERY concept from the list, even if its score is 0.0.
+
+Concept List:
+{names_list}
+
+Title: {title}
+Beginning Text:
+{text[:2000]}
+
+JSON Array:"""
+    return await _llm_json_array_with_retry(prompt, session_id=session_id, log_label="논문-개념 관련도 채점", required_key="concept")
+
+
 async def generate_reading_recommendations(titles: List[str], categories: List[str], session_id: str = None) -> List[dict]:
     """읽은 논문 제목/카테고리를 근거로 다음에 읽으면 좋을 논문 후보와 그
     이유를 추천한다. 반환값: [{"title": str, "reason": str}, ...]. 여기서

--- a/backend/tests/test_knowledge_graph_v4.py
+++ b/backend/tests/test_knowledge_graph_v4.py
@@ -68,16 +68,28 @@ def test_heatmap_excludes_other_users_data(test_client, isolated_dirs):
     assert not any(h["concept_id"] == concept_id for h in heatmap)
 
 
-# ── Concept Heatmap Matrix (논문 x 개념 2D) ───────────────────────────────
+# ── Concept Heatmap Matrix (논문 x 개념 2D, LLM 채점) ─────────────────────
 
-def test_heatmap_matrix_cell_combines_presence_and_questions(test_client, isolated_dirs):
+def _setup_one_paper_one_concept(isolated_dirs, doc_id="doc-mx-1", title="Paper A"):
     db = isolated_dirs["db"]
-    _create_doc_owned_by(isolated_dirs, "doc-mx-1", "testuser", {"title": "Paper A"})
+    _create_doc_owned_by(isolated_dirs, doc_id, "testuser", {"title": title})
     concept_id = db.db_upsert_concept("Attention", "attention", "method")
-    db.db_link_paper_concept("doc-mx-1", concept_id)
-    chat_id = db.db_save_chat_message("doc-mx-1", "user", "How does attention work?")
-    db.db_link_question_paper(chat_id, "doc-mx-1")
+    db.db_link_paper_concept(doc_id, concept_id)
+    chat_id = db.db_save_chat_message(doc_id, "user", "How does attention work?")
+    db.db_link_question_paper(chat_id, doc_id)
     db.db_link_question_concept(chat_id, concept_id)
+    return concept_id
+
+
+def test_heatmap_matrix_uses_llm_score(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+
+    async def fake_score(title, text, concept_names, session_id=None):
+        return [{"concept": name, "score": 0.75} for name in concept_names]
+
+    monkeypatch.setattr(llm_client, "score_paper_concept_relevance", fake_score)
+
+    concept_id = _setup_one_paper_one_concept(isolated_dirs)
 
     res = test_client.get("/api/library/graph/heatmap/matrix")
     assert res.status_code == 200
@@ -88,11 +100,55 @@ def test_heatmap_matrix_cell_combines_presence_and_questions(test_client, isolat
     cell = next(c for c in body["cells"] if c["doc_id"] == "doc-mx-1" and c["concept_id"] == concept_id)
     assert cell["present"] is True
     assert cell["question_count"] == 1
-    assert cell["raw"] == 2  # 등장(1) + 질문 1개
+    assert cell["score"] == 0.75
+
+
+def test_heatmap_matrix_falls_back_to_presence_when_llm_fails(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+
+    async def failing_score(title, text, concept_names, session_id=None):
+        raise RuntimeError("LLM 호출 실패")
+
+    monkeypatch.setattr(llm_client, "score_paper_concept_relevance", failing_score)
+
+    concept_id = _setup_one_paper_one_concept(isolated_dirs)
+
+    res = test_client.get("/api/library/graph/heatmap/matrix")
+    assert res.status_code == 200
+    body = res.json()
+    cell = next(c for c in body["cells"] if c["doc_id"] == "doc-mx-1" and c["concept_id"] == concept_id)
+    # LLM 채점이 실패해도 매트릭스 자체는 무너지지 않고 등장 여부(1.0)로 대체된다.
+    assert cell["present"] is True
+    assert cell["score"] == 1.0
+
+
+def test_heatmap_matrix_caches_result_without_recalling_llm(test_client, isolated_dirs, monkeypatch):
+    import services.llm_client as llm_client
+
+    call_count = {"n": 0}
+
+    async def fake_score(title, text, concept_names, session_id=None):
+        call_count["n"] += 1
+        return [{"concept": name, "score": 0.5} for name in concept_names]
+
+    monkeypatch.setattr(llm_client, "score_paper_concept_relevance", fake_score)
+
+    _setup_one_paper_one_concept(isolated_dirs)
+
+    res1 = test_client.get("/api/library/graph/heatmap/matrix")
+    assert res1.status_code == 200
+    assert call_count["n"] == 1
+
+    res2 = test_client.get("/api/library/graph/heatmap/matrix")
+    assert res2.status_code == 200
+    assert call_count["n"] == 1  # 캐시가 유효한 동안은 LLM을 다시 호출하지 않는다
+
+    res3 = test_client.get("/api/library/graph/heatmap/matrix?force=true")
+    assert res3.status_code == 200
+    assert call_count["n"] == 2  # force=true는 캐시를 무시하고 새로 채점한다
 
 
 def test_heatmap_matrix_omits_papers_without_ranked_concepts(test_client, isolated_dirs):
-    db = isolated_dirs["db"]
     _create_doc_owned_by(isolated_dirs, "doc-mx-unrelated", "testuser", {"title": "Unrelated Paper"})
 
     res = test_client.get("/api/library/graph/heatmap/matrix")

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -199,8 +199,9 @@ export async function fetchLibraryHeatmap() {
   return res.json()
 }
 
-export async function fetchLibraryHeatmapMatrix() {
-  const res = await fetch(`${API_BASE}/library/graph/heatmap/matrix`)
+// force: true면 서버 캐시(하루 단위)를 무시하고 LLM 채점을 새로 돌린다("다시 계산" 버튼용).
+export async function fetchLibraryHeatmapMatrix({ force = false } = {}) {
+  const res = await fetch(`${API_BASE}/library/graph/heatmap/matrix${force ? '?force=true' : ''}`)
   if (!res.ok) throw new Error('개념 히트맵 매트릭스 조회 실패')
   return res.json()
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4657,33 +4657,15 @@ for (const [view, cfg] of Object.entries(GRAPH_SUBVIEWS)) {
   if (btn) btn.addEventListener('click', () => switchGraphSubView(view))
 }
 
-// 개념 히트맵: 논문(행) x 개념(열) 2D 매트릭스(seaborn류 히트맵 참고). 셀 색
-// 진하기는 정규화된 강도값을 인코딩한다 - accent 색 1종의 sequential 램프라
-// (color-mix가 --control-accent 기준) 사용자가 고른 테마 색과 라이트/다크
-// 모드에 자동으로 맞춰진다. 정규화 기준(행/열/전체)을 바꾸면 재요청 없이
-// 이미 받아둔 원본 데이터(heatmapMatrixData)로 다시 계산해 그린다.
-let heatmapMatrixData = null
-let heatmapNormalizeMode = 'row' // 'row' | 'col' | 'global'
-
-function computeHeatmapMaxes(cells) {
-  const rowMax = {}, colMax = {}
-  let globalMax = 0
-  for (const cell of cells) {
-    rowMax[cell.doc_id] = Math.max(rowMax[cell.doc_id] || 0, cell.raw)
-    colMax[cell.concept_id] = Math.max(colMax[cell.concept_id] || 0, cell.raw)
-    globalMax = Math.max(globalMax, cell.raw)
-  }
-  return { rowMax, colMax, globalMax }
-}
-
-function normalizedHeatmapValue(cell, maxes, mode) {
-  const denom = mode === 'row' ? maxes.rowMax[cell.doc_id] : mode === 'col' ? maxes.colMax[cell.concept_id] : maxes.globalMax
-  return denom > 0 ? cell.raw / denom : 0
-}
-
+// 개념 히트맵: 논문(행) x 개념(열) 2D 매트릭스(seaborn류 히트맵 참고). 셀 값은
+// 서버가 논문 텍스트를 근거로 LLM으로 직접 채점한 0.0~1.0 관련도 점수라(하루
+// 단위로 캐싱됨) 이미 그 자체로 비교 가능한 절대 스케일이다 - 과거의
+// "등장 여부+질문 수" 근사치와 달리 행/열/전체 기준으로 다시 정규화하면 오히려
+// 절대값의 의미를 왜곡하므로, 점수를 그대로 색 진하기(accent 색 sequential
+// 램프, color-mix가 --control-accent 기준이라 테마/다크모드에 자동으로
+// 맞춰짐)와 셀 텍스트에 쓴다.
 function renderHeatmapMatrix(data) {
   const { concepts, papers, cells } = data
-  const maxes = computeHeatmapMaxes(cells)
   const cellByKey = {}
   for (const c of cells) cellByKey[`${c.doc_id}:${c.concept_id}`] = c
 
@@ -4691,10 +4673,10 @@ function renderHeatmapMatrix(data) {
   const bodyRows = papers.map(p => {
     const rowCells = concepts.map(c => {
       const cell = cellByKey[`${p.doc_id}:${c.concept_id}`]
-      const val = cell ? normalizedHeatmapValue(cell, maxes, heatmapNormalizeMode) : 0
+      const val = cell ? cell.score : 0
       const pct = Math.round(val * 100)
       const detail = cell
-        ? `${escapeHtml(p.title)} · ${escapeHtml(c.name)} · ${cell.present ? '개념 등장' : '개념 미등장'} · 관련 질문 ${cell.question_count}개`
+        ? `${escapeHtml(p.title)} · ${escapeHtml(c.name)} · 관련도 ${val.toFixed(2)} · ${cell.present ? '개념 등장' : '개념 미등장'} · 관련 질문 ${cell.question_count}개`
         : `${escapeHtml(p.title)} · ${escapeHtml(c.name)} · 연관 없음`
       return `<td class="rg-heatmap-cell${val >= 0.55 ? ' rg-heatmap-cell-dark' : ''}" style="background:color-mix(in srgb, var(--control-accent) ${pct}%, var(--bg-elevated))" title="${detail}">${val.toFixed(2)}</td>`
     }).join('')
@@ -4714,16 +4696,9 @@ function renderHeatmapMatrix(data) {
       <div class="rg-heatmap-toolbar">
         <div class="rg-heatmap-heading">
           <h4>개념 히트맵</h4>
-          <p>선택된 논문에서 개념이 얼마나 등장하고 논의됐는지를 색상 강도로 보여줍니다.</p>
+          <p>선택된 논문의 본문을 AI가 읽고, 각 개념을 얼마나 깊이 다루는지 0~1 관련도로 채점한 값입니다.</p>
         </div>
-        <label class="rg-heatmap-normalize">
-          정규화
-          <select id="rg-heatmap-normalize-select">
-            <option value="row"${heatmapNormalizeMode === 'row' ? ' selected' : ''}>행 기준</option>
-            <option value="col"${heatmapNormalizeMode === 'col' ? ' selected' : ''}>열 기준</option>
-            <option value="global"${heatmapNormalizeMode === 'global' ? ' selected' : ''}>전체 기준</option>
-          </select>
-        </label>
+        <button type="button" id="rg-heatmap-refresh-btn" class="rg-refresh-btn">${icon('refreshCw', 13)}<span>다시 계산</span></button>
       </div>
       <div class="rg-heatmap-body">
         <div class="rg-heatmap-main">
@@ -4755,17 +4730,20 @@ function renderHeatmapMatrix(data) {
   `
 }
 
-async function renderLibraryHeatmapView() {
+// force=true는 "다시 계산" 버튼용 - 서버 캐시(하루 단위)를 무시하고 LLM을
+// 다시 호출하므로, 첫 로드보다 오래 걸릴 수 있다는 걸 로딩 문구로 알려준다.
+async function renderLibraryHeatmapView(force = false) {
   if (!libraryHeatmapList) return
-  libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>불러오는 중...</p></div>'
+  libraryHeatmapList.innerHTML = force
+    ? '<div class="lib-empty"><p>AI가 논문을 다시 읽고 채점하는 중입니다... (다소 시간이 걸릴 수 있어요)</p></div>'
+    : '<div class="lib-empty"><p>불러오는 중...</p></div>'
   try {
-    const data = await fetchLibraryHeatmapMatrix()
+    const data = await fetchLibraryHeatmapMatrix({ force })
     if (state.currentWorkspacePage !== 'graph') return
     if (!data.concepts?.length || !data.papers?.length) {
       libraryHeatmapList.innerHTML = '<div class="lib-empty"><p>아직 히트맵을 그릴 만큼 개념/논문 데이터가 쌓이지 않았습니다.</p></div>'
       return
     }
-    heatmapMatrixData = data
     libraryHeatmapList.innerHTML = renderHeatmapMatrix(data)
   } catch (err) {
     console.error('개념 히트맵 로드 실패:', err)
@@ -4773,16 +4751,15 @@ async function renderLibraryHeatmapView() {
   }
 }
 
-// 정규화 기준 셀렉트는 재요청 없이 이미 받아둔 데이터로 다시 그린다. 행 헤더/
-// 사이드 패널의 논문 클릭은 목록마다 리스너를 다는 대신 컨테이너에 위임
-// 리스너를 한 번만 건다.
+// "다시 계산" 버튼과 행 헤더/사이드 패널의 논문 클릭은 매번 innerHTML로 새로
+// 그려지는 요소라, 항목마다 리스너를 다는 대신 컨테이너에 위임 리스너를
+// 한 번만 건다.
 if (libraryHeatmapList) {
-  libraryHeatmapList.addEventListener('change', (event) => {
-    if (event.target.id !== 'rg-heatmap-normalize-select') return
-    heatmapNormalizeMode = event.target.value
-    if (heatmapMatrixData) libraryHeatmapList.innerHTML = renderHeatmapMatrix(heatmapMatrixData)
-  })
   libraryHeatmapList.addEventListener('click', async (event) => {
+    if (event.target.closest('#rg-heatmap-refresh-btn')) {
+      renderLibraryHeatmapView(true)
+      return
+    }
     const target = event.target.closest('[data-doc-id]')
     const docId = target?.dataset.docId
     if (!docId) return

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5335,10 +5335,10 @@ body.light-theme .library-tab-btn.active {
 .kg-insight-item svg { flex-shrink: 0; margin-top: 2px; color: var(--control-accent-text); }
 
 /* ── Research Graph · 개념 히트맵 (논문 x 개념 2D 매트릭스, seaborn류) ──
-   셀 색 진하기는 정규화된 강도값을 accent 색 1종의 sequential 램프로
-   인코딩한다(color-mix가 --control-accent 기준이라 테마 색/라이트-다크에
-   자동으로 맞춰진다). 값이 진해지면(0.55 이상) 텍스트를 밝은 색으로
-   전환해 대비를 유지한다. */
+   셀 색 진하기는 서버가 LLM으로 채점한 0.0~1.0 관련도 점수를 accent 색
+   1종의 sequential 램프로 인코딩한다(color-mix가 --control-accent 기준이라
+   테마 색/라이트-다크에 자동으로 맞춰진다). 값이 진해지면(0.55 이상)
+   텍스트를 밝은 색으로 전환해 대비를 유지한다. */
 .rg-heatmap { display: flex; flex-direction: column; gap: 14px; height: 100%; min-height: 0; }
 
 .rg-heatmap-toolbar {
@@ -5348,24 +5348,11 @@ body.light-theme .library-tab-btn.active {
   gap: 16px;
   flex-wrap: wrap;
 }
+/* .rg-refresh-btn(research-graph.css)은 원래 사이드바 카드용이라 width:100%다 -
+   여기 툴바 행에서는 텍스트 폭만큼만 차지하도록 되돌린다. */
+.rg-heatmap-toolbar .rg-refresh-btn { width: auto; flex-shrink: 0; }
 .rg-heatmap-heading h4 { margin: 0 0 4px; font-size: 15px; font-weight: 700; color: var(--text-primary); }
 .rg-heatmap-heading p { margin: 0; font-size: 12.5px; color: var(--text-secondary); }
-.rg-heatmap-normalize {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12.5px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.rg-heatmap-normalize select {
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  font-size: 12.5px;
-}
 
 .rg-heatmap-body { display: flex; gap: 20px; min-height: 0; flex: 1; }
 .rg-heatmap-main { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 10px; }


### PR DESCRIPTION
# Summary
## 1. 배경 - 기존 방식의 문제
- 직전 PR(#310)에서 셀 값 = 등장 여부(0/1) + 질문 수로 근사했는데, 실사용 시 대부분 0.0/1.0 이진값으로만 보이고 **논문이 실제로 다루는 개념인데도 0.0으로 표시되는 사례**가 확인됨
- 원인: 개념 중복 제거가 `normalized_name`(소문자+trim)만으로 이뤄져, 논문마다 LLM이 뽑은 표현이 조금만 달라도 서로 다른 concept row로 등록됨 → 히트맵 열의 "정확히 그 concept_id"와 링크가 없으면 등장 자체가 0으로 표시
- 사용자 확인 후, 텍스트/규칙 기반 보정 대신 **LLM이 논문을 직접 읽고 관련도를 채점**하는 방식으로 교체하기로 결정

## 2. 백엔드 - LLM 기반 관련도 채점
- `backend/services/llm_client.py`: `score_paper_concept_relevance(title, text, concept_names, session_id)` 추가 — 논문 제목+서두 텍스트를 근거로 주어진 개념 목록 전체를 0.0~1.0으로 한 번에 채점(폐쇄형 목록, `match_question_to_concepts`와 동일한 검증 패턴)
- `backend/services/knowledge_graph.py`:
  - `get_concept_paper_matrix`: 열/행 선정(활동량 상위 개념/논문)은 기존 규칙 기반 집계 그대로 유지, 셀 값만 LLM 채점으로 교체
  - 논문당 LLM 호출 1회로 비용 제한, `asyncio.gather`로 논문들을 병렬 채점해 지연시간 단축
  - 결과를 `app_meta`에 24시간 캐싱(`get_reading_recommendations`와 동일한 캐싱 패턴), `force=True`로 캐시 무시 가능
  - 텍스트 추출 실패/LLM 오류 시 조용히 등장 여부(0/1) 기반 값으로 대체 — 이 기능 하나의 실패가 히트맵 전체를 막지 않음
- `backend/routers/library.py`: `GET /library/graph/heatmap/matrix`에 `force` 쿼리 파라미터 추가
- `backend/tests/test_knowledge_graph_v4.py`: LLM 채점 사용, LLM 실패 시 폴백, 캐싱 후 재호출 안 함, `force=true`로 재채점하는 케이스 검증(총 6건)

## 3. 프런트엔드
- `frontend/src/library.js`: `fetchLibraryHeatmapMatrix({ force })` 추가
- `frontend/src/main.js`:
  - LLM 점수(`cell.score`, 이미 절대 스케일)를 그대로 색상 강도/셀 텍스트에 사용
  - 기존 행/열/전체 정규화 토글 제거 — 절대값인 LLM 점수를 다시 정규화하면 오히려 의미가 왜곡되므로 삭제
  - "다시 계산" 버튼 추가(대시보드 "다시 받기"와 동일한 UX 패턴), 클릭 시 `force=true`로 재요청
- `frontend/src/style.css`: 정규화 드롭다운 스타일 제거, `.rg-refresh-btn`(원래 사이드바 카드용 `width:100%`)을 툴바 행에서 쓰기 위한 오버라이드 추가

## Test plan
- [x] `pytest backend/tests/test_knowledge_graph_v4.py` — 18건 통과(히트맵 매트릭스 6건 포함)
- [x] `pytest backend` 전체 — 기존에도 실패하던 `test_config_cross_platform.py` 1건 제외 306건 통과(본 변경과 무관)
- [x] `npm run build` — 정상 빌드
- [ ] 실제 브라우저에서의 시각적 검증은 수행하지 못함(헤드리스 브라우저 툴 미보유) — 병합 전 로컬에서 직접 확인 권장. 특히 LLM 채점 응답 지연(논문 수만큼 병렬 호출)과 "다시 계산" 버튼 동작을 실제 데이터로 확인해보시면 좋겠습니다.