### PR TITLE
fix: 대시보드 카드 행의 높이 불일치로 생기던 빈 공간 축소

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -415,19 +415,21 @@ function renderHeatmapCard(heatmap) {
         <a href="#" class="dash-link" data-nav="graph">전체보기 ›</a>
       </div>
       ${heatmap.length === 0 ? emptyNote('아직 추출된 개념이 없습니다.') : `
-      <div class="dash-heat-grid">
-        ${heatmap.slice(0, 8).map(h => {
-          const pct = maxScore > 0 ? Math.max(6, Math.round(((h.score || 0) / maxScore) * 100)) : 6
-          return `
-            <div class="dash-heat-cell" data-node-id="concept:${escapeHtml(String(h.concept_id))}" title="${escapeHtml(h.name)} · 논문 ${h.paper_count}편 · 질문 ${h.question_count}개 · 클릭하면 연구 그래프에서 보기">
-              <div class="dash-heat-swatch" style="--heat-pct:${pct}%"></div>
-              <div class="dash-heat-label">${escapeHtml(h.name)}</div>
-              <div class="dash-heat-count">${formatNumber(h.score)}</div>
-            </div>
-          `
-        }).join('')}
+      <div class="dash-heatmap-body">
+        <div class="dash-heat-grid">
+          ${heatmap.slice(0, 8).map(h => {
+            const pct = maxScore > 0 ? Math.max(6, Math.round(((h.score || 0) / maxScore) * 100)) : 6
+            return `
+              <div class="dash-heat-cell" data-node-id="concept:${escapeHtml(String(h.concept_id))}" title="${escapeHtml(h.name)} · 논문 ${h.paper_count}편 · 질문 ${h.question_count}개 · 클릭하면 연구 그래프에서 보기">
+                <div class="dash-heat-swatch" style="--heat-pct:${pct}%"></div>
+                <div class="dash-heat-label">${escapeHtml(h.name)}</div>
+                <div class="dash-heat-count">${formatNumber(h.score)}</div>
+              </div>
+            `
+          }).join('')}
+        </div>
+        <div class="dash-heat-legend"><span>낮음</span><div class="dash-heat-legend-bar"></div><span>높음</span></div>
       </div>
-      <div class="dash-heat-legend"><span>낮음</span><div class="dash-heat-legend-bar"></div><span>높음</span></div>
       `}
     </div>
   `
@@ -545,7 +547,9 @@ function renderGraphPreviewCard(graphData, heatmap) {
         <h3>${icon('network', 15)}연구 그래프 미리보기</h3>
         <a href="#" class="dash-link" data-nav="graph">그래프 보기 ›</a>
       </div>
-      ${!preview ? emptyNote('아직 미리 볼 만큼 연결된 그래프 데이터가 없습니다.') : renderMiniGraphSvg(preview)}
+      <div class="dash-graph-preview-body">
+        ${!preview ? emptyNote('아직 미리 볼 만큼 연결된 그래프 데이터가 없습니다.') : renderMiniGraphSvg(preview)}
+      </div>
     </div>
   `
 }

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -200,7 +200,10 @@
 .dash-summary-label { font-size: 10.5px; font-weight: 600; color: var(--text-tertiary); }
 
 /* ── 최근 읽은 논문 ── */
-.dash-paper-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+/* flex:1 + justify-content:center: 같은 행의 옆 카드(최근 질문 등)보다
+   항목당 높이가 낮은 카드가 위쪽에 붙어 아래쪽에 큰 공백을 남기는 대신,
+   그리드가 늘려준 카드 높이 안에서 내용이 세로로 가운데 정렬되게 한다. */
+.dash-paper-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; flex: 1; justify-content: center; }
 .dash-paper-item {
   display: flex;
   gap: 12px;
@@ -253,7 +256,7 @@
 }
 
 /* ── 최근 질문 ── */
-.dash-question-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.dash-question-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; flex: 1; justify-content: center; }
 .dash-question-item { display: flex; gap: 10px; cursor: pointer; }
 .dash-question-icon {
   width: 26px;
@@ -282,7 +285,7 @@
 .dash-dot { margin: 0 5px; }
 
 /* ── AI 추천 논문 ── */
-.dash-recs-body { display: flex; flex-direction: column; }
+.dash-recs-body { display: flex; flex-direction: column; flex: 1; justify-content: center; }
 .dash-recs-btn {
   align-self: flex-start;
   display: inline-flex;
@@ -324,6 +327,10 @@
 .dash-rec-reason { margin-top: 4px; font-size: 11.5px; color: var(--text-secondary); line-height: 1.45; }
 
 /* ── 개념 히트맵 ── */
+/* 옆 카드(연구 타임라인)보다 개념 수가 적어 그리드가 짧게 끝나도, 위쪽에
+   붙어 아래에 큰 공백을 남기는 대신 늘려진 카드 높이 안에서 가운데
+   정렬되게 한다(타일 그리드+범례를 한 블록으로 묶어서 함께 정렬). */
+.dash-heatmap-body { display: flex; flex-direction: column; flex: 1; justify-content: center; }
 .dash-heat-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
@@ -369,7 +376,7 @@
 }
 
 /* ── 연구 타임라인 ── */
-.dash-timeline-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+.dash-timeline-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; flex: 1; justify-content: center; }
 .dash-timeline-item { position: relative; display: flex; gap: 10px; padding-bottom: 14px; cursor: pointer; border-radius: var(--radius-sm); transition: background 0.15s ease; }
 .dash-timeline-item:hover { background: var(--bg-hover); }
 .dash-timeline-item:last-child { padding-bottom: 0; }
@@ -406,6 +413,9 @@
 
 /* ── 연구 그래프 미리보기 ── */
 .dash-card-graph { align-items: stretch; }
+/* SVG 크기가 고정이라 옆 카드보다 짧게 끝나기 쉬우므로, 늘려진 카드 높이
+   안에서 세로 가운데 정렬해 아래쪽 공백을 줄인다. */
+.dash-graph-preview-body { display: flex; flex-direction: column; flex: 1; justify-content: center; }
 .dash-graph-svg { width: 100%; height: 168px; }
 .dash-graph-edge { stroke: var(--border-strong); stroke-width: 1.2; }
 .dash-graph-node { cursor: pointer; }


### PR DESCRIPTION
# Summary
## 1. 원인
- 대시보드는 CSS 그리드 행 단위로 카드들을 같은 높이로 늘리지만(align-items: stretch), 카드 내부 콘텐츠(목록/그리드/SVG)는 위쪽에 붙어있어 옆 카드보다 내용이 짧으면 아래쪽에 큰 공백이 남았음
  - `dash-row-recent`: "최근 읽은 논문"(표지 이미지 포함, 항목당 키가 큼) vs "최근 질문"(텍스트만, 항목당 키가 작음)
  - `dash-row-bottom`: "개념 히트맵"(개념 수에 따라 짧아질 수 있음) vs "연구 타임라인"(최대 7개 항목으로 김)

## 2. 수정
- `frontend/src/pages/dashboardPage.js`
  - "개념 히트맵"의 타일 그리드+범례, "연구 그래프 미리보기"의 SVG+범례를 각각 `dash-heatmap-body`/`dash-graph-preview-body`로 감싸 한 블록으로 정렬
- `frontend/src/styles/dashboard.css`
  - `dash-paper-list`/`dash-question-list`/`dash-timeline-list`/`dash-recs-body`/`dash-heatmap-body`/`dash-graph-preview-body`에 `flex: 1; justify-content: center;` 추가
  - 그리드가 늘려준 카드 높이 안에서 내용이 세로로 가운데 정렬되도록 해, 가장 긴 카드는 그대로 위쪽부터 채워지고(효과 없음) 짧은 카드만 중앙 정렬돼 위/아래로 여백이 균등하게 나뉨

## Test plan
- [x] Playwright로 항목 수를 의도적으로 불균형하게(최근 읽은 논문 5개 vs 최근 질문 1개, 개념 히트맵 1개 vs 타임라인 7개) 만들어 스크린샷 확인 - 짧은 카드 내용이 더 이상 위쪽에 붙어 아래 큰 공백을 남기지 않고 카드 높이 안에서 가운데 정렬됨을 확인
- [ ] 실제 앱에서 다양한 데이터 양으로 대시보드 확인(개념/최근 질문이 적은 계정, 많은 계정 모두)

🤖 Generated with [Claude Code](https://claude.com/claude-code)