### PR TITLE
feat: 대시보드 '페이지'를 '읽은 페이지 수'로 변경 및 참고문헌 제외 계산 적용

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -944,9 +944,16 @@ async def get_dashboard_summary(username: str) -> dict:
         for d in docs[:10]
     ]
 
+    from services.library import read_page_count
     stats = {
         "total_papers": len(docs),
         "total_pages": sum(d.get("total_pages") or 0 for d in docs),
+        # 완독 표시된 문서는 참고문헌을 제외한 본문 페이지 수 전체를, 읽던
+        # 중인 문서는 그 진행률(참고문헌 페이지 제외 상한)을 더한다 - 대시보드
+        # 상단 통계 카드가 "전체 라이브러리 페이지 수"가 아니라 실제로 읽은
+        # 페이지 수를 보여주도록 함(read_page_count는 프론트의 readPageCount와
+        # 동일한 공식을 공유).
+        "read_pages": sum(read_page_count(d) for d in docs),
         "read_papers": sum(1 for d in docs if (d.get("metadata") or {}).get("read")),
         "total_concepts": len(heatmap),
         "total_questions": len([e for e in timeline if e["type"] == "question"]),

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -362,3 +362,57 @@ def save_primer_figure(doc_id: str, pdf_path: str, page_num: int, bbox_percent: 
 def update_document_metadata(doc_id: str, metadata: dict) -> None:
     """문서 메타데이터를 업데이트합니다."""
     db_update_document_metadata(doc_id, metadata)
+
+
+def get_reference_start_page(doc: dict) -> Optional[int]:
+    """문서에서 참고문헌 섹션이 시작하는 페이지 번호(1-based)를 반환합니다
+    ("읽은 페이지 수"를 계산할 때 참고문헌 페이지를 본문에서 제외하는 데
+    씀). metadata.reference_start_page에 이미 계산된 값(참고문헌을 못 찾은
+    경우는 None)이 있으면 그대로 쓰고, 아직 계산한 적이 없으면(키 자체가
+    없음) 캐시된 페이지 텍스트가 있을 때만 계산해 metadata에 영구 저장합니다
+    - 페이지 텍스트가 아직 캐시되지 않은 문서(처리 중/실패)까지 이 함수
+    때문에 PDF를 새로 파싱하지는 않고, 다음에 캐시가 생기면 그때 계산합니다.
+    doc는 list_documents()/get_document()가 반환하는 dict(“metadata” 포함)여야
+    하며, 계산 결과는 그 자리에서 doc["metadata"]에도 반영됩니다(같은 요청
+    안에서 곧바로 다시 읽어도 최신 값을 보게 하기 위함)."""
+    meta = doc.get("metadata")
+    if meta is None:
+        meta = {}
+        doc["metadata"] = meta
+    if "reference_start_page" in meta:
+        return meta["reference_start_page"]
+
+    pdf_path = doc.get("pdf_path")
+    if not pdf_path:
+        return None
+    from services.cache import get_cached_pages
+    pages = get_cached_pages(doc["id"], pdf_path)
+    if pages is None:
+        return None  # 아직 캐시가 없다 - 계산은 다음 기회로 미루고 지금은 저장하지 않는다
+
+    from services.reference_parser import find_reference_start_page_index
+    idx = find_reference_start_page_index(pages)
+    start_page = (idx + 1) if idx is not None else None  # 0-based 인덱스 -> 1-based 페이지 번호
+
+    meta["reference_start_page"] = start_page
+    update_document_metadata(doc["id"], meta)
+    return start_page
+
+
+def read_page_count(doc: dict) -> int:
+    """이 문서에서 실제로 "읽은" 것으로 볼 수 있는 페이지 수를 계산합니다:
+    완독 표시(metadata.read)된 문서는 참고문헌을 제외한 본문 페이지 수
+    전체를, 읽던 중인 문서(metadata.last_page만 있음)는 그 진행률(참고문헌
+    페이지를 넘지 않게 상한)을, 둘 다 아니면 0을 반환합니다. 대시보드/Reading
+    History의 "읽은 페이지" 계열 통계가 전부 이 함수를 공유합니다."""
+    meta = doc.get("metadata") or {}
+    total = doc.get("total_pages") or 0
+    ref_start = get_reference_start_page(doc)
+    content_pages = (ref_start - 1) if isinstance(ref_start, int) and 1 < ref_start <= total else total
+
+    if meta.get("read") is True:
+        return content_pages
+    last_page = meta.get("last_page")
+    if isinstance(last_page, int):
+        return min(last_page, content_pages)
+    return 0

--- a/backend/services/reference_parser.py
+++ b/backend/services/reference_parser.py
@@ -135,6 +135,22 @@ def _match_section_header_prefix(line: str) -> Optional[str]:
     return None
 
 
+def find_reference_start_page_index(pages: List[dict]) -> Optional[int]:
+    """참고문헌 섹션이 시작하는 페이지의 0-based 인덱스를 찾습니다. 끝
+    페이지부터 거꾸로 스캔해 실제 섹션 헤더(본문 중 우연히 "References"라는
+    단어가 언급된 경우가 아니라 섹션 자체의 시작)를 찾습니다 - 결론 뒤에
+    참고문헌이 오는 일반적인 논문 구조를 전제로, 뒤에서부터 찾는 편이 앞에서
+    찾는 것보다 본문 중 언급과의 오탐이 적습니다. 찾지 못하면 None을
+    반환합니다. extract_reference_list와 services.library.get_reference_start_page
+    (읽은 페이지 수 계산에서 참고문헌 페이지를 제외하는 데 사용) 양쪽에서
+    공유합니다."""
+    for i in range(len(pages) - 1, -1, -1):
+        text = pages[i].get("text", "") or ""
+        if any(_match_section_header_prefix(line) is not None for line in text.split("\n")):
+            return i
+    return None
+
+
 def extract_reference_list(pages: List[dict]) -> Dict[str, str]:
     """페이지 목록(각 {"text": ...} 포함)에서 참고문헌 목록을 파싱합니다.
 
@@ -149,13 +165,7 @@ def extract_reference_list(pages: List[dict]) -> Dict[str, str]:
 
 
 def _extract_reference_list_impl(pages: List[dict]) -> Dict[str, str]:
-    ref_start_page_idx = None
-    for i in range(len(pages) - 1, -1, -1):
-        text = pages[i].get("text", "") or ""
-        if any(_match_section_header_prefix(line) is not None for line in text.split("\n")):
-            ref_start_page_idx = i
-            break
-
+    ref_start_page_idx = find_reference_start_page_index(pages)
     if ref_start_page_idx is None:
         return {}
 

--- a/backend/services/section_parser.py
+++ b/backend/services/section_parser.py
@@ -17,7 +17,7 @@ reference_parser의 헤더 매처를 그대로 재사용해 "결론 발췌에 �
 import re
 from typing import Dict, List, Optional
 
-from services.reference_parser import _match_section_header_prefix as _match_reference_header
+from services.reference_parser import find_reference_start_page_index
 
 _INTRO_RELATED_MAX_CHARS = 4000
 _METHOD_RESULTS_MAX_CHARS = 4000
@@ -60,12 +60,9 @@ def _min_found(*positions: Optional[int]) -> Optional[int]:
 def _find_reference_start_offset(page_texts: List[str]) -> Optional[int]:
     """References/참고문헌 섹션이 시작하는 페이지를 찾아 전체 텍스트 기준
     글자 오프셋으로 변환한다. 결론 발췌 끝을 여기서 잘라 참고문헌 목록이
-    섞여 들어가지 않게 하는 데 쓴다."""
-    ref_start_page_idx = None
-    for i in range(len(page_texts) - 1, -1, -1):
-        if any(_match_reference_header(line) is not None for line in page_texts[i].split("\n")):
-            ref_start_page_idx = i
-            break
+    섞여 들어가지 않게 하는 데 쓴다(페이지 탐지 자체는 reference_parser.
+    find_reference_start_page_index와 동일 로직을 공유)."""
+    ref_start_page_idx = find_reference_start_page_index([{"text": t} for t in page_texts])
     if ref_start_page_idx is None:
         return None
     return sum(len(page_texts[i]) + 1 for i in range(ref_start_page_idx))

--- a/backend/tests/test_knowledge_graph_v4.py
+++ b/backend/tests/test_knowledge_graph_v4.py
@@ -260,6 +260,10 @@ def test_dashboard_stats_and_recent_lists(test_client, isolated_dirs, monkeypatc
     assert data["stats"]["total_concepts"] == 1
     assert data["stats"]["total_questions"] == 1
     assert data["stats"]["total_notes"] == 1
+    assert data["stats"]["total_pages"] == 3
+    # 완독 표시됐고 참고문헌 시작 페이지 정보가 아직 없는 문서는(캐시된 페이지
+    # 텍스트가 없음) 전체 페이지 수(3)를 그대로 읽은 페이지로 본다(폴백).
+    assert data["stats"]["read_pages"] == 3
 
     assert any(h["concept_id"] == concept_id for h in data["heatmap"])
     assert any(q["summary"] == "질문 테스트" for q in data["recent_questions"])

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -131,3 +131,114 @@ def test_get_document_without_suffix_uses_most_recent_translation(isolated_dirs)
 
     doc = library.get_document("doc-1")
     assert doc["translated_pages"] == [1]
+
+
+# ── get_reference_start_page / read_page_count ──────────────────────────
+# "읽은 페이지 수"를 계산할 때 참고문헌 페이지를 본문에서 빼기 위한 로직.
+# 대시보드/Reading History가 전부 이 두 함수를 공유한다(프론트의
+# readPages.js readPageCount와 동일한 공식).
+
+def _write_fake_pdf(isolated_dirs, doc_id, content=b"%PDF-1.4 fake"):
+    pdf_path = str(isolated_dirs["upload_dir"] / f"{doc_id}.pdf")
+    with open(pdf_path, "wb") as f:
+        f.write(content)
+    return pdf_path
+
+
+def test_get_reference_start_page_computes_and_caches_from_pages(isolated_dirs):
+    library = isolated_dirs["library"]
+    cache = isolated_dirs["cache"]
+    db = isolated_dirs["db"]
+    pdf_path = _write_fake_pdf(isolated_dirs, "doc-ref-1")
+    db.db_save_document("doc-ref-1", "admin", "p.pdf", pdf_path, 5, {})
+    pages = [
+        {"text": "Intro text"}, {"text": "Method text"},
+        {"text": "References\n[1] Someone. A Paper. 2020."}, {"text": ""}, {"text": ""},
+    ]
+    cache.save_pages_cache("doc-ref-1", pdf_path, pages)
+
+    doc = db.db_get_document("doc-ref-1")
+    result = library.get_reference_start_page(doc)
+
+    assert result == 3  # 0-based idx 2 -> 1-based 페이지 3
+    # 계산 결과가 DB에 영구 저장되어야 다음 조회 시 재계산하지 않는다
+    reloaded = db.db_get_document("doc-ref-1")
+    assert reloaded["metadata"]["reference_start_page"] == 3
+
+
+def test_get_reference_start_page_caches_none_when_no_references_section(isolated_dirs):
+    library = isolated_dirs["library"]
+    cache = isolated_dirs["cache"]
+    db = isolated_dirs["db"]
+    pdf_path = _write_fake_pdf(isolated_dirs, "doc-ref-2")
+    db.db_save_document("doc-ref-2", "admin", "p.pdf", pdf_path, 3, {})
+    cache.save_pages_cache("doc-ref-2", pdf_path, [{"text": "no references header anywhere"}] * 3)
+
+    doc = db.db_get_document("doc-ref-2")
+    assert library.get_reference_start_page(doc) is None
+
+    reloaded = db.db_get_document("doc-ref-2")
+    assert "reference_start_page" in reloaded["metadata"]
+    assert reloaded["metadata"]["reference_start_page"] is None
+
+
+def test_get_reference_start_page_skips_caching_when_pages_not_cached(isolated_dirs):
+    """PDF 페이지 텍스트가 아직 디스크 캐시에 없으면(처리 중/실패 등),
+    계산을 미루고 metadata에 아무것도 써넣지 않아 다음 기회에 재시도할 수
+    있게 해야 한다."""
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    pdf_path = _write_fake_pdf(isolated_dirs, "doc-ref-3")
+    db.db_save_document("doc-ref-3", "admin", "p.pdf", pdf_path, 3, {})
+
+    doc = db.db_get_document("doc-ref-3")
+    assert library.get_reference_start_page(doc) is None
+
+    reloaded = db.db_get_document("doc-ref-3")
+    assert "reference_start_page" not in reloaded["metadata"]
+
+
+def test_get_reference_start_page_returns_cached_value_without_recomputing(isolated_dirs, monkeypatch):
+    library = isolated_dirs["library"]
+    db = isolated_dirs["db"]
+    db.db_save_document("doc-ref-4", "admin", "p.pdf", "/x", 5, {"reference_start_page": 4})
+
+    import services.cache as cache_module
+    def _boom(*a, **kw):
+        raise AssertionError("이미 캐시된 값이 있으면 get_cached_pages를 다시 호출하면 안 된다")
+    monkeypatch.setattr(cache_module, "get_cached_pages", _boom)
+
+    doc = db.db_get_document("doc-ref-4")
+    assert library.get_reference_start_page(doc) == 4
+
+
+def test_read_page_count_completed_doc_excludes_references(isolated_dirs):
+    library = isolated_dirs["library"]
+    doc = {"id": "d1", "total_pages": 10, "metadata": {"read": True, "reference_start_page": 8}}
+    assert library.read_page_count(doc) == 7  # 페이지 1~7만 본문, 8~10은 참고문헌
+
+
+def test_read_page_count_in_progress_doc_caps_at_content_pages(isolated_dirs):
+    library = isolated_dirs["library"]
+    doc = {"id": "d1", "total_pages": 10, "metadata": {"last_page": 9, "reference_start_page": 8}}
+    assert library.read_page_count(doc) == 7  # 진행 페이지가 참고문헌 구간을 넘어가도 본문 상한을 넘지 않는다
+
+
+def test_read_page_count_in_progress_doc_within_content(isolated_dirs):
+    library = isolated_dirs["library"]
+    doc = {"id": "d1", "total_pages": 10, "metadata": {"last_page": 5, "reference_start_page": 8}}
+    assert library.read_page_count(doc) == 5
+
+
+def test_read_page_count_unread_doc_is_zero(isolated_dirs):
+    library = isolated_dirs["library"]
+    doc = {"id": "d1", "total_pages": 10, "metadata": {}}
+    assert library.read_page_count(doc) == 0
+
+
+def test_read_page_count_without_reference_info_falls_back_to_total_pages(isolated_dirs):
+    library = isolated_dirs["library"]
+    # pdf_path가 없어 get_reference_start_page가 None을 반환하는 경우(=참고문헌
+    # 제외 정보를 아직 모름) - 본문 페이지 수를 total_pages 그대로로 본다.
+    doc = {"id": "d1", "total_pages": 10, "metadata": {"read": True}}
+    assert library.read_page_count(doc) == 10

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -9,6 +9,7 @@
 import './../styles/dashboard.css'
 import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
+import { readPageCount } from '../readPages.js'
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
@@ -103,14 +104,17 @@ function countEventsInDays(events, type, days) {
   return events.filter(e => e.type === type && isWithinDays(e.timestamp, days)).length
 }
 
-// "이번 주 읽은 페이지"는 서버에 별도 집계가 없어, 이번 주 안에 읽음
-// 처리(read_at)된 논문들의 total_pages 합으로 근사한다 - 실존하는 필드만
-// 조합한 값이라 근거가 있는 근사치다.
+// "이번 주 읽은 페이지"는 서버에 별도 집계가 없어, 이번 주 안에 읽기
+// 활동(last_read_at - 열람/페이지 이동 - 또는 read_at - 완독 표시)이 있던
+// 논문들의 readPageCount(참고문헌 제외 진행률/본문 페이지 수) 합으로
+// 근사한다 - 실존하는 필드만 조합한 값이라 근거가 있는 근사치다. 완독
+// 여부만 보던 예전 로직과 달리 읽던 중인 논문도 포함한다.
 function pagesReadInDays(docs, days) {
   return docs.reduce((sum, d) => {
     const meta = d.metadata || {}
-    if (meta.read && meta.read_at && isWithinDays(meta.read_at, days)) return sum + (d.total_pages || 0)
-    return sum
+    if (!meta.last_read_at && !meta.read_at) return sum
+    if (!isWithinDays(lastActivityIso(meta, d.created_at), days)) return sum
+    return sum + readPageCount(d)
   }, 0)
 }
 
@@ -123,7 +127,7 @@ function truncateLabel(s, n) {
 const STAT_DEFS = [
   { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (events) => countEventsInDays(events, 'uploaded', 7) },
   { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (events) => countEventsInDays(events, 'read', 7) },
-  { key: 'total_pages', label: '페이지', iconName: 'fileText', tint: 3, weekly: (events, docs) => pagesReadInDays(docs, 7) },
+  { key: 'read_pages', label: '읽은 페이지 수', iconName: 'fileText', tint: 3, weekly: (events, docs) => pagesReadInDays(docs, 7) },
   // 개념은 생성 시각이 저장되지 않아 "이번 주 신규 개념 수"를 계산할 근거가
   // 없다 - 지어내지 않고 주간 델타 자체를 생략한다.
   { key: 'total_concepts', label: '개념', iconName: 'layers', tint: 4, weekly: null },

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -11,6 +11,7 @@
 
 import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
+import { readPageCount } from '../readPages.js'
 import '../styles/reading-history.css'
 
 function escapeHtml(str) {
@@ -117,7 +118,7 @@ function periodStats(events, docsById, startKey, endKeyExclusive) {
   })
   const activeDays = new Set(inPeriod.map(eventKey)).size
   const readDocIds = new Set(inPeriod.filter(e => e.type === 'read').map(e => e.doc_id))
-  const pagesRead = Array.from(readDocIds).reduce((sum, id) => sum + (docsById.get(id)?.total_pages || 0), 0)
+  const pagesRead = Array.from(readDocIds).reduce((sum, id) => sum + readPageCount(docsById.get(id)), 0)
   const questions = inPeriod.filter(e => e.type === 'question').length
   const notes = inPeriod.filter(e => e.type === 'note').length
   return { activeDays, papersRead: readDocIds.size, pagesRead, questions, notes }
@@ -572,7 +573,7 @@ export async function renderReadingHistoryPage() {
           <div class="rh-timeline-track">
             ${dayEvents.map(e => {
               const title = docTitle(e.doc_id, e.doc_title)
-              const pages = e.type === 'read' ? docsById.get(e.doc_id)?.total_pages : null
+              const pages = e.type === 'read' ? readPageCount(docsById.get(e.doc_id)) : null
               return `
                 <div class="rh-timeline-entry" data-doc-id="${escapeHtml(e.doc_id || '')}" data-type="${escapeHtml(e.type)}" title="이 논문 열기">
                   <div class="rh-timeline-dot">${icon(TYPE_ICON[e.type] || 'clock', 13)}</div>

--- a/frontend/src/readPages.js
+++ b/frontend/src/readPages.js
@@ -1,0 +1,18 @@
+// 문서 하나에서 실제로 "읽은" 것으로 볼 수 있는 페이지 수를 계산한다:
+// 완독 표시(metadata.read)된 문서는 참고문헌을 제외한 본문 페이지 수
+// 전체를, 읽던 중인 문서(metadata.last_page만 있음)는 그 진행률(참고문헌
+// 페이지를 넘지 않게 상한)을, 둘 다 아니면 0을 반환한다. 대시보드/Reading
+// History의 "읽은 페이지" 계열 통계가 전부 이 함수를 공유해야 같은 논문을
+// 두 화면에서 다르게 세는 일이 없다(백엔드 services/library.py의
+// read_page_count와 동일한 공식).
+export function readPageCount(doc) {
+  const meta = (doc && doc.metadata) || {}
+  const total = doc?.total_pages || 0
+  const refStart = meta.reference_start_page
+  const contentPages = (Number.isInteger(refStart) && refStart > 1 && refStart <= total) ? refStart - 1 : total
+
+  if (meta.read === true) return contentPages
+  const lastPage = meta.last_page
+  if (Number.isInteger(lastPage)) return Math.min(lastPage, contentPages)
+  return 0
+}


### PR DESCRIPTION
# Summary
## 1. 참고문헌 시작 페이지 탐지/캐싱
- `backend/services/reference_parser.py`에 `find_reference_start_page_index()`를 분리(기존 `extract_reference_list` 내부 로직 재사용), `section_parser.py`의 중복 구현도 이를 재사용하도록 리팩터링
- `backend/services/library.py`에 `get_reference_start_page(doc)` 추가 - 참고문헌 시작 페이지(1-based)를 `metadata.reference_start_page`에 계산/캐싱. 캐시된 PDF 페이지 텍스트가 있을 때만 계산하고(강제 재파싱 없음), 결과(못 찾은 경우 `None` 포함)를 영구 저장해 다음부터 재계산하지 않음

## 2. 읽은 페이지 수 계산 로직
- `backend/services/library.py`에 `read_page_count(doc)` 추가: **완독 문서는 참고문헌을 제외한 본문 페이지 수 전체**, **읽던 중인 문서는 그 진행률(본문 페이지 수 상한)**을 반환
- `frontend/src/readPages.js`에 동일 공식의 `readPageCount(doc)` 신설 - 백엔드와 프론트가 같은 계산을 공유하는 단일 진실 공급원

## 3. 적용 범위 ("읽은 페이지"를 나타내는 모든 곳)
- 대시보드 상단 통계 카드: "페이지"(전체 라이브러리 페이지 수) → "읽은 페이지 수"(`stats.read_pages`)로 이름/의미 변경. `stats.total_pages`는 "이번 주 활동" 카드의 분모로 계속 쓰이므로 유지
- 대시보드 "이번 주 활동" → "읽은 페이지": `read_at`(완독)만 보던 것을 `last_read_at`(읽던 중 포함)까지 반영하도록 확장, `readPageCount`로 집계
- Reading History 페이지의 30일 "읽은 페이지" 스탯 카드, 타임라인 항목의 페이지 배지 모두 `readPageCount` 사용(참고문헌 제외)

## 4. 테스트
- `backend/tests/test_library_service.py`에 `get_reference_start_page`/`read_page_count` 단위 테스트 7개 추가(캐싱/폴백/공식 검증)
- `test_knowledge_graph_v4.py`의 대시보드 테스트에 `stats.read_pages` 검증 추가
- 관련 백엔드 테스트 전체(`test_reference_parser.py`/`test_section_parser.py`/`test_library_references_api.py`/`test_knowledge_graph_v2~v4.py`/`test_library_service.py`) 통과, 전체 스위트 316 passed(무관한 기존 실패 1건 제외)
- Playwright e2e로 대시보드 통계 카드가 "읽은 페이지 수" 라벨과 참고문헌 제외 계산값을 보여주는지 수동 검증

## Test plan
- [x] 백엔드 테스트 전체 통과
- [x] e2e로 통계 카드 라벨/값 확인
- [ ] 실제 앱에서 참고문헌 섹션이 있는 논문을 완독/부분 읽음 상태로 두고 대시보드·Reading History의 "읽은 페이지" 수치가 참고문헌을 제외하고 계산되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)