### PR TITLE
fix: 대시보드와 Reading History 간 읽은 페이지 수 계산 일관성 맞춤

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -9,7 +9,7 @@
 import './../styles/dashboard.css'
 import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
-import { readPageCount } from '../readPages.js'
+import { readPageCount, lastActivityIso, hasReadActivity } from '../readPages.js'
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
@@ -112,7 +112,7 @@ function countEventsInDays(events, type, days) {
 function pagesReadInDays(docs, days) {
   return docs.reduce((sum, d) => {
     const meta = d.metadata || {}
-    if (!meta.last_read_at && !meta.read_at) return sum
+    if (!hasReadActivity(meta)) return sum
     if (!isWithinDays(lastActivityIso(meta, d.created_at), days)) return sum
     return sum + readPageCount(d)
   }, 0)
@@ -277,11 +277,7 @@ function renderProgressSummaryCard(events, heatmap, readingStats) {
 // 중 가장 최근 값을 쓴다. read_at만 쓰면 완독 표시를 안 하고 읽던 중인 논문은
 // 계속 created_at으로 떨어져, 방금 읽었어도 날짜가 업로드 시점("3일 전" 등)에
 // 고정되어 보이는 문제가 있었다.
-function lastActivityIso(meta, createdAt) {
-  return [meta?.last_read_at, meta?.read_at, createdAt]
-    .filter(Boolean)
-    .reduce((latest, iso) => (new Date(iso) > new Date(latest) ? iso : latest), createdAt)
-}
+
 
 function renderRecentPapersCard(docs) {
   const read = docs

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -11,7 +11,7 @@
 
 import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
-import { readPageCount } from '../readPages.js'
+import { readPageCount, lastActivityIso, hasReadActivity } from '../readPages.js'
 import '../styles/reading-history.css'
 
 function escapeHtml(str) {
@@ -118,7 +118,20 @@ function periodStats(events, docsById, startKey, endKeyExclusive) {
   })
   const activeDays = new Set(inPeriod.map(eventKey)).size
   const readDocIds = new Set(inPeriod.filter(e => e.type === 'read').map(e => e.doc_id))
-  const pagesRead = Array.from(readDocIds).reduce((sum, id) => sum + readPageCount(docsById.get(id)), 0)
+
+  const activePageDocIds = new Set(readDocIds)
+  for (const doc of docsById.values()) {
+    const meta = doc?.metadata || {}
+    if (hasReadActivity(meta)) {
+      const actIso = lastActivityIso(meta, doc.created_at)
+      const k = (actIso || '').slice(0, 10)
+      if (k >= startKey && k < endKeyExclusive) {
+        activePageDocIds.add(doc.id)
+      }
+    }
+  }
+
+  const pagesRead = Array.from(activePageDocIds).reduce((sum, id) => sum + readPageCount(docsById.get(id)), 0)
   const questions = inPeriod.filter(e => e.type === 'question').length
   const notes = inPeriod.filter(e => e.type === 'note').length
   return { activeDays, papersRead: readDocIds.size, pagesRead, questions, notes }

--- a/frontend/src/readPages.js
+++ b/frontend/src/readPages.js
@@ -16,3 +16,23 @@ export function readPageCount(doc) {
   if (Number.isInteger(lastPage)) return Math.min(lastPage, contentPages)
   return 0
 }
+
+// last_read_at(뷰어를 열거나 페이지를 넘길 때마다 갱신되는 "마지막으로
+// 읽은 시각") / read_at(완독 표시 시각) / createdAt(업로드 시각) 중 가장
+// 최근 값을 고른다. read_at만 보면 완독 표시를 안 하고 읽던 중인 논문은
+// 계속 createdAt으로 떨어져, 방금 읽었어도 날짜가 업로드 시점에 고정되어
+// 보이는 문제가 있었다. 대시보드 "최근 읽은 논문"/"이번 주 활동"과 Reading
+// History의 기간별 통계가 전부 이 함수를 공유한다.
+export function lastActivityIso(meta, createdAt) {
+  return [meta?.last_read_at, meta?.read_at, createdAt]
+    .filter(Boolean)
+    .reduce((latest, iso) => (new Date(iso) > new Date(latest) ? iso : latest), createdAt)
+}
+
+// 이 문서에 실제 "읽기 활동"(완독 표시 또는 읽던 중 진행)이 한 번이라도
+// 있었는지. last_read_at/read_at이 둘 다 없으면 업로드만 됐을 뿐 읽은 적이
+// 없는 문서이므로, "읽은 페이지" 계열 통계에서 lastActivityIso가 createdAt로
+// 떨어지는 폴백값을 활동 시각으로 오인해 집계하면 안 된다.
+export function hasReadActivity(meta) {
+  return Boolean(meta?.last_read_at || meta?.read_at)
+}


### PR DESCRIPTION
# Summary
## 1. 읽은 페이지 수 및 최신 활동 시각 공용 헬퍼 내보내기
- `frontend/src/readPages.js`: `lastActivityIso(meta, createdAt)` 및 `hasReadActivity(meta)`를 export하여 대시보드와 Reading History 페이지가 단일 진실 공급원(Single Source of Truth)을 공유하도록 보장함.

## 2. 대시보드 헬퍼 및 사용처 정리
- `frontend/src/pages/dashboardPage.js`: 중복 정의된 로컬 `lastActivityIso` 함수를 제거하고 `readPages.js` 공용 모듈에서 import함. `pagesReadInDays`에서 `hasReadActivity` 및 `lastActivityIso`를 사용하도록 정단화함.

## 3. Reading History 읽은 페이지 집계 일관성 개선
- `frontend/src/pages/readingHistoryPage.js`: `periodStats`에서 완독 타임라인 이벤트(`e.type === 'read'`)를 가진 문서뿐만 아니라, 해당 기간 내에 실제 읽기 활동(`hasReadActivity` 및 `lastActivityIso`)이 있었던 문서들도 `pagesRead` 계산 대상(`activePageDocIds`)에 정상 포함시켜 대시보드와 동일한 공식으로 페이지 수를 집계함.