### PR TITLE
fix: 타임존 시차 오차 수정 및 Reading History 상단 카드 라벨/누적 페이지 명시

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -9,7 +9,7 @@
 import './../styles/dashboard.css'
 import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
-import { readPageCount, lastActivityIso, hasReadActivity } from '../readPages.js'
+import { readPageCount, lastActivityIso, hasReadActivity, isWithinDaysLocal } from '../readPages.js'
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
@@ -113,7 +113,7 @@ function pagesReadInDays(docs, days) {
   return docs.reduce((sum, d) => {
     const meta = d.metadata || {}
     if (!hasReadActivity(meta)) return sum
-    if (!isWithinDays(lastActivityIso(meta, d.created_at), days)) return sum
+    if (!isWithinDaysLocal(lastActivityIso(meta, d.created_at), days)) return sum
     return sum + readPageCount(d)
   }, 0)
 }

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -11,7 +11,7 @@
 
 import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats } from '../library.js'
 import { icon } from '../icons.js'
-import { readPageCount, lastActivityIso, hasReadActivity } from '../readPages.js'
+import { readPageCount, lastActivityIso, hasReadActivity, lastActivityDateKey } from '../readPages.js'
 import '../styles/reading-history.css'
 
 function escapeHtml(str) {
@@ -123,9 +123,8 @@ function periodStats(events, docsById, startKey, endKeyExclusive) {
   for (const doc of docsById.values()) {
     const meta = doc?.metadata || {}
     if (hasReadActivity(meta)) {
-      const actIso = lastActivityIso(meta, doc.created_at)
-      const k = (actIso || '').slice(0, 10)
-      if (k >= startKey && k < endKeyExclusive) {
+      const k = lastActivityDateKey(meta, doc.created_at)
+      if (k && k >= startKey && k < endKeyExclusive) {
         activePageDocIds.add(doc.id)
       }
     }
@@ -269,6 +268,8 @@ export async function renderReadingHistoryPage() {
   const currReadingSeconds = sumSecondsByDayRange(byDay, currStart, currEnd)
   const prevReadingSeconds = sumSecondsByDayRange(byDay, prevStart, prevEnd)
 
+  const totalReadPages = dashboard?.stats?.read_pages ?? Array.from(docsById.values()).reduce((sum, d) => sum + readPageCount(d), 0)
+
   const statCards = [
     {
       icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
@@ -281,9 +282,9 @@ export async function renderReadingHistoryPage() {
       sub: deltaDurationHtml(currReadingSeconds, prevReadingSeconds),
     },
     {
-      icon: 'layers', color: 'var(--rh-c6)', label: '읽은 페이지',
+      icon: 'layers', color: 'var(--rh-c6)', label: '최근 30일 읽은 페이지',
       value: curr.pagesRead.toLocaleString(),
-      sub: deltaHtml(curr.pagesRead, prev.pagesRead),
+      sub: `${deltaHtml(curr.pagesRead, prev.pagesRead)} <span class="rh-stat-total" style="opacity:0.75;font-size:0.8em;margin-left:4px;">(누적 ${totalReadPages.toLocaleString()}p)</span>`,
     },
     {
       icon: 'messageCircle', color: 'var(--rh-c5)', label: '질문 수',

--- a/frontend/src/readPages.js
+++ b/frontend/src/readPages.js
@@ -36,3 +36,35 @@ export function lastActivityIso(meta, createdAt) {
 export function hasReadActivity(meta) {
   return Boolean(meta?.last_read_at || meta?.read_at)
 }
+
+// ISO 타임스탬프 문자열을 사용자 로컬 시간대 자정 기준 "YYYY-MM-DD" 날짜 키로 변환한다.
+// 단순 .slice(0, 10)을 하면 UTC 날짜가 잘려 나와 한국 시간(KST) 등에서 9시간 시차
+// 어긋남이 발생하므로, local Date 객체의 연/월/일을 사용한다.
+export function isoToLocalDateKey(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function lastActivityDateKey(meta, createdAt) {
+  const iso = lastActivityIso(meta, createdAt)
+  return isoToLocalDateKey(iso)
+}
+
+// ISO 시각이 로컬 시간 자정 기준 최근 N일(days) 이내인지 판별한다.
+export function isWithinDaysLocal(iso, days) {
+  if (!iso) return false
+  const key = isoToLocalDateKey(iso)
+  if (!key) return false
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const target = new Date(`${key}T00:00:00`)
+  if (isNaN(target.getTime())) return false
+  const diffDays = Math.round((today - target) / 86400000)
+  return diffDays >= 0 && diffDays < days
+}
+


### PR DESCRIPTION
# Summary
## 1. 타임존 시차(UTC vs KST) 날짜 판별 오차 수정
- `frontend/src/readPages.js`: `isoToLocalDateKey`, `lastActivityDateKey`, `isWithinDaysLocal` 헬퍼를 추가하여 ISO 타임스탬프에서 UTC 대신 사용자의 로컬 시간대 자정 기준 날짜 키(YYYY-MM-DD)를 추출하도록 개선함. 9시간 시차로 인해 읽기 활동 날짜가 어긋나거나 경계에서 빠지던 현상을 방지함.

## 2. 대시보드 로컬 날짜 기준 기간 집계 적용
- `frontend/src/pages/dashboardPage.js`: 주간 읽은 페이지 수(`pagesReadInDays`) 집계 시 `isWithinDaysLocal` 헬퍼를 사용하여 로컬 자정 날짜 기준으로 정확하게 7일 이내 읽기 활동 문서를 판별함.

## 3. Reading History 상단 카드 라벨 및 전체 누적 수치 명시
- `frontend/src/pages/readingHistoryPage.js`: 
  - `periodStats`에서 날짜 판별 시 `lastActivityDateKey`(로컬 날짜)를 사용하여 KST 타임존과 일치시킴.
  - 상단 카드 라벨을 `최근 30일 읽은 페이지`로 명확히 표기하고, 서브 텍스트에 전체 누적 페이지 수(`(누적 Np)`)를 함께 명시하여 대시보드 누적 수치와의 연결 및 명확성을 보장함.