### PR TITLE
refactor: AI 추천 논문 다시 받기 버튼 헤더 우측 이동

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -379,22 +379,16 @@ function renderRecItemsHtml(recommendations) {
   `
 }
 
-function renderRecsListWithRefreshButton(recommendations) {
-  return `
-    ${renderRecItemsHtml(recommendations)}
-    <button type="button" class="dash-recs-btn dash-recs-btn-refresh" data-recs-refresh-btn title="새로운 추천을 다시 받아옵니다">${icon('refreshCw', 13)}다시 받기</button>
-  `
-}
-
 function renderRecommendationsCard(cachedRecommendations) {
   const hasCached = Array.isArray(cachedRecommendations) && cachedRecommendations.length > 0
   return `
     <div class="dash-card dash-card-list dash-card-recs">
       <div class="dash-card-head">
         <h3>${icon('star', 15)}AI 추천 논문</h3>
+        <button type="button" class="dash-recs-head-btn ${hasCached ? '' : 'is-hidden'}" data-recs-refresh-btn title="새로운 추천을 다시 받아옵니다">${icon('refreshCw', 12)} 다시 받기</button>
       </div>
       <div class="dash-recs-body" data-recs-body>
-        ${hasCached ? renderRecsListWithRefreshButton(cachedRecommendations) : `
+        ${hasCached ? renderRecItemsHtml(cachedRecommendations) : `
           ${emptyNote('읽은 논문들을 바탕으로 다음에 읽으면 좋을 논문을 추천받아 보세요.')}
           <button type="button" class="dash-recs-btn" data-recs-btn>${icon('zap', 13)}추천 받기</button>
         `}
@@ -607,35 +601,37 @@ function attachHandlers(root) {
     elm.addEventListener('click', () => goToGraphNode(elm.dataset.nodeId))
   })
 
-  const recsBody = root.querySelector('[data-recs-body]')
-  if (recsBody) {
-    // "추천 받기"(최초 생성)와 "다시 받기"(캐시 무시하고 재생성) 모두 이
-    // 로직을 공유한다 - 성공하면 목록 아래에 "다시 받기" 버튼을 다시 붙여
-    // 계속 재요청할 수 있게 한다.
-    const bindRefreshBtn = () => {
-      const btn = recsBody.querySelector('[data-recs-refresh-btn]')
-      if (btn) btn.addEventListener('click', () => runRecsFetch(btn, true))
-    }
+  const recsCard = root.querySelector('.dash-card-recs')
+  if (recsCard) {
+    const recsBody = recsCard.querySelector('[data-recs-body]')
+    const refreshBtn = recsCard.querySelector('[data-recs-refresh-btn]')
+
     const runRecsFetch = async (triggerBtn, force) => {
-      triggerBtn.disabled = true
+      if (triggerBtn) triggerBtn.disabled = true
+      if (refreshBtn) refreshBtn.disabled = true
+
       recsBody.innerHTML = emptyNote('추천 논문을 찾는 중입니다... (다소 시간이 걸릴 수 있어요)')
       try {
         const { recommendations } = await fetchReadingRecommendations({ force })
         if (!recommendations || recommendations.length === 0) {
           recsBody.innerHTML = emptyNote('추천할 만한 논문을 찾지 못했습니다.')
+          if (refreshBtn) refreshBtn.classList.add('is-hidden')
           return
         }
-        recsBody.innerHTML = renderRecsListWithRefreshButton(recommendations)
-        bindRefreshBtn()
+        recsBody.innerHTML = renderRecItemsHtml(recommendations)
+        if (refreshBtn) refreshBtn.classList.remove('is-hidden')
       } catch (err) {
         console.error('추천 논문 조회 실패:', err)
         recsBody.innerHTML = `<p class="dash-empty-note dash-error-note">추천 논문을 불러오지 못했습니다.</p>`
+      } finally {
+        if (triggerBtn) triggerBtn.disabled = false
+        if (refreshBtn) refreshBtn.disabled = false
       }
     }
 
-    const recsBtn = recsBody.querySelector('[data-recs-btn]')
+    if (refreshBtn) refreshBtn.addEventListener('click', () => runRecsFetch(refreshBtn, true))
+    const recsBtn = recsBody?.querySelector('[data-recs-btn]')
     if (recsBtn) recsBtn.addEventListener('click', () => runRecsFetch(recsBtn, false))
-    bindRefreshBtn()
   }
 }
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -346,19 +346,29 @@
 .dash-recs-btn:hover { background: var(--bg-hover); }
 .dash-recs-btn:disabled { opacity: 0.6; cursor: default; }
 
-/* 이미 목록이 채워진 상태에서 다시 생성을 요청하는 보조 액션이라, 기본
-   버튼보다 눈에 덜 띄는 ghost 스타일로 구분한다. */
-.dash-recs-btn-refresh {
-  align-self: center;
-  width: 100%;
-  justify-content: center;
-  margin-top: auto;
-  background: transparent;
-  border: 1px dashed var(--border);
+/* AI 추천 논문 카드 상단 우측의 다시 받기 버튼 */
+.dash-recs-head-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: var(--radius-md, 6px);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
   color: var(--text-secondary);
+  font-size: 11.5px;
   font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
 }
-.dash-recs-btn-refresh:hover { background: var(--bg-hover); color: var(--text-primary); }
+.dash-recs-head-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+.dash-recs-head-btn.is-hidden { display: none; }
+.dash-recs-head-btn:disabled { opacity: 0.5; cursor: default; }
 
 .dash-rec-list {
   list-style: none;


### PR DESCRIPTION
# Summary
## 1. AI 추천 논문 다시 받기 버튼 위치 변경
- 다시 받기 버튼(`dash-recs-head-btn`)을 카드 하단에서 카드 오른쪽 상단 헤더(`dash-card-head`)로 이동함
- 추천 결과 존재 여부에 따른 버튼 표시/숨김(`is-hidden`) 및 비동기 요청 처리 시 비활성화 상태(`disabled`) 로직 개선함