### PR TITLE
fix: AI 추천 논문 목록 높이 확장

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -379,7 +379,7 @@
   gap: 12px;
   flex: 1 1 auto;
   overflow-y: auto;
-  max-height: 260px;
+  max-height: 310px;
 }
 .dash-rec-item { padding-bottom: 12px; border-bottom: 1px solid var(--border); }
 .dash-rec-item:last-child { border-bottom: none; padding-bottom: 0; }


### PR DESCRIPTION
# Summary
## 1. AI 추천 논문 목록 높이 확장
- `dash-rec-list`의 `max-height`를 기존 260px에서 310px로 확장함
- 카드 하단 다시받기 버튼 제거 후 남아있던 50px 빈 여백을 목록 영역으로 채우도록 수정함