### PR TITLE
feat: reading history 전체 기록 필터 칩 추가 및 텍스트 수정

### DIFF
--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -424,33 +424,69 @@ export async function renderReadingHistoryPage() {
   const fallbackTotalReadPages = dashboard?.stats?.read_pages ?? Array.from(docsById.values()).reduce((sum, d) => sum + readPageCount(d), 0)
   const totalReadPagesDisplay = totalEstPages > 0 ? totalEstPages : fallbackTotalReadPages
 
-  const statCards = [
-    {
-      icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
-      value: `${curr.activeDays} / 30`,
-      sub: `<span class="rh-stat-delta">최근 30일 중 ${activeDaysPct}%</span>`,
-    },
-    {
-      icon: 'clock', color: 'var(--rh-c3)', label: '읽은 시간',
-      value: formatDuration(currReadingSeconds),
-      sub: deltaDurationHtml(currReadingSeconds, prevReadingSeconds),
-    },
-    {
-      icon: 'layers', color: 'var(--rh-c6)', label: '최근 30일 읽은 페이지',
-      value: currPagesReadDisplay.toLocaleString(),
-      sub: `${deltaHtml(currPagesReadDisplay, prevPagesReadDisplay)} <span class="rh-stat-total" style="opacity:0.75;font-size:0.8em;margin-left:4px;">(누적 ${totalReadPagesDisplay.toLocaleString()}p)</span>`,
-    },
-    {
-      icon: 'messageCircle', color: 'var(--rh-c5)', label: '질문 수',
-      value: curr.questions.toLocaleString(),
-      sub: deltaHtml(curr.questions, prev.questions),
-    },
-    {
-      icon: 'edit3', color: 'var(--rh-c2)', label: '작성한 메모',
-      value: curr.notes.toLocaleString(),
-      sub: deltaHtml(curr.notes, prev.notes),
-    },
-  ]
+  const allReadingSeconds = mixTotalSeconds > 0
+    ? mixTotalSeconds
+    : Object.values(byDay).reduce((sum, sec) => sum + (Number(sec) || 0), 0)
+
+  const getStatCards = (period) => {
+    if (period === 'all') {
+      return [
+        {
+          icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
+          value: `${allActiveKeys.size}일`,
+          sub: `<span class="rh-stat-delta">총 ${allActiveKeys.size}일 동안 활동</span>`,
+        },
+        {
+          icon: 'clock', color: 'var(--rh-c3)', label: '읽은 시간',
+          value: formatDuration(allReadingSeconds),
+          sub: `<span class="rh-stat-delta">전체 누적 시간</span>`,
+        },
+        {
+          icon: 'layers', color: 'var(--rh-c6)', label: '읽은 페이지',
+          value: totalReadPagesDisplay.toLocaleString(),
+          sub: `<span class="rh-stat-delta">전체 누적 페이지</span>`,
+        },
+        {
+          icon: 'messageCircle', color: 'var(--rh-c5)', label: '질문 수',
+          value: totalQuestions.toLocaleString(),
+          sub: `<span class="rh-stat-delta">전체 누적 질문</span>`,
+        },
+        {
+          icon: 'edit3', color: 'var(--rh-c2)', label: '작성한 메모',
+          value: totalNotes.toLocaleString(),
+          sub: `<span class="rh-stat-delta">전체 누적 메모</span>`,
+        },
+      ]
+    }
+
+    return [
+      {
+        icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
+        value: `${curr.activeDays} / 30`,
+        sub: `<span class="rh-stat-delta">최근 30일 중 ${activeDaysPct}%</span>`,
+      },
+      {
+        icon: 'clock', color: 'var(--rh-c3)', label: '읽은 시간',
+        value: formatDuration(currReadingSeconds),
+        sub: deltaDurationHtml(currReadingSeconds, prevReadingSeconds),
+      },
+      {
+        icon: 'layers', color: 'var(--rh-c6)', label: '읽은 페이지',
+        value: currPagesReadDisplay.toLocaleString(),
+        sub: deltaHtml(currPagesReadDisplay, prevPagesReadDisplay),
+      },
+      {
+        icon: 'messageCircle', color: 'var(--rh-c5)', label: '질문 수',
+        value: curr.questions.toLocaleString(),
+        sub: deltaHtml(curr.questions, prev.questions),
+      },
+      {
+        icon: 'edit3', color: 'var(--rh-c2)', label: '작성한 메모',
+        value: curr.notes.toLocaleString(),
+        sub: deltaHtml(curr.notes, prev.notes),
+      },
+    ]
+  }
 
   // ── 캘린더 히트맵: 최근 12주(84일), 월~일 ──
   const WEEKS = 12
@@ -592,6 +628,8 @@ export async function renderReadingHistoryPage() {
     return `<span class="${cls.join(' ')}" title="${escapeHtml(formatShortDate(k))}">${label}</span>`
   }).join('')
 
+  const initialCards = getStatCards('30')
+
   // ── HTML 조립 ──
   el.innerHTML = `
     <div class="rh-page">
@@ -599,11 +637,14 @@ export async function renderReadingHistoryPage() {
         <div>
           <p class="rh-header-subtitle">읽기 활동과 연구 여정을 확인하세요.</p>
         </div>
-        <span class="rh-header-period">${icon('calendar', 13)} 최근 30일</span>
+        <div class="rh-header-chips" id="rh-period-chips">
+          <button type="button" class="rh-chip active" data-period="30">${icon('calendar', 13)} 최근 30일</button>
+          <button type="button" class="rh-chip" data-period="all">${icon('clock', 13)} 전체 기록</button>
+        </div>
       </div>
 
-      <div class="rh-stat-grid">
-        ${statCards.map(c => `
+      <div class="rh-stat-grid" id="rh-stat-grid">
+        ${initialCards.map(c => `
           <div class="rh-stat-card">
             <div class="rh-stat-icon" style="--rh-stat-color:${c.color}">${icon(c.icon, 17)}</div>
             <div class="rh-stat-body">
@@ -647,7 +688,7 @@ export async function renderReadingHistoryPage() {
 
           <div class="rh-card">
             <div class="rh-card-head">
-              <span class="rh-card-title">${icon('list', 15)} 전체 활동</span>
+              <span class="rh-card-title">${icon('list', 15)} <span id="rh-timeline-title">최근 30일 활동</span></span>
             </div>
             <div class="rh-tabs" id="rh-filter-tabs">
               <button type="button" class="rh-tab-btn active" data-type="all">전체</button>
@@ -714,7 +755,40 @@ export async function renderReadingHistoryPage() {
   `
 
   // ── All Activities: 필터 + 더보기 상태 ──
-  const sortedEvents = events.slice().sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
+  let currentPeriod = '30'
+  let activeType = 'all'
+  const INITIAL_GROUPS = 4
+  let visibleGroups = INITIAL_GROUPS
+
+  const timelineListEl = el.querySelector('#rh-timeline-list')
+  const moreBtn = el.querySelector('#rh-more-btn')
+
+  function renderStatGrid(period) {
+    const gridEl = el.querySelector('#rh-stat-grid')
+    if (!gridEl) return
+    const cards = getStatCards(period)
+    gridEl.innerHTML = cards.map(c => `
+      <div class="rh-stat-card">
+        <div class="rh-stat-icon" style="--rh-stat-color:${c.color}">${icon(c.icon, 17)}</div>
+        <div class="rh-stat-body">
+          <div class="rh-stat-label">${escapeHtml(c.label)}</div>
+          <div class="rh-stat-value">${c.value}</div>
+          <div>${c.sub}</div>
+        </div>
+      </div>
+    `).join('')
+  }
+
+  const getTimelineEvents = () => {
+    if (currentPeriod === '30') {
+      return events.filter(e => {
+        const k = eventKey(e)
+        return k && k >= currStart && k < currEnd
+      })
+    }
+    return events
+  }
+
   const groupByDay = (list) => {
     const groups = new Map()
     for (const e of list) {
@@ -725,17 +799,12 @@ export async function renderReadingHistoryPage() {
     return Array.from(groups.entries()).sort((a, b) => b[0].localeCompare(a[0]))
   }
 
-  const INITIAL_GROUPS = 4
-  let activeType = 'all'
-  let visibleGroups = INITIAL_GROUPS
-
-  const timelineListEl = el.querySelector('#rh-timeline-list')
-  const moreBtn = el.querySelector('#rh-more-btn')
-
   function renderTimeline() {
+    const periodEvents = getTimelineEvents()
+    const sortedEvents = periodEvents.slice().sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
     const filtered = activeType === 'all' ? sortedEvents : sortedEvents.filter(e => e.type === activeType)
     if (filtered.length === 0) {
-      timelineListEl.innerHTML = '<div class="rh-empty">이 유형의 활동이 아직 없습니다.</div>'
+      timelineListEl.innerHTML = '<div class="rh-empty">이 기간의 활동이 아직 없습니다.</div>'
       moreBtn.classList.add('hidden')
       return
     }
@@ -773,6 +842,19 @@ export async function renderReadingHistoryPage() {
 
     moreBtn.classList.toggle('hidden', shown.length >= dayGroups.length)
   }
+
+  const periodChipsEl = el.querySelector('#rh-period-chips')
+  periodChipsEl?.addEventListener('click', (event) => {
+    const btn = event.target.closest('.rh-chip')
+    if (!btn || btn.classList.contains('active')) return
+    periodChipsEl.querySelectorAll('.rh-chip').forEach(b => b.classList.toggle('active', b === btn))
+    currentPeriod = btn.dataset.period
+    renderStatGrid(currentPeriod)
+    const titleEl = el.querySelector('#rh-timeline-title')
+    if (titleEl) titleEl.textContent = currentPeriod === '30' ? '최근 30일 활동' : '전체 활동'
+    visibleGroups = INITIAL_GROUPS
+    renderTimeline()
+  })
 
   const tabsEl = el.querySelector('#rh-filter-tabs')
   tabsEl.addEventListener('click', (event) => {
@@ -819,3 +901,4 @@ export async function renderReadingHistoryPage() {
 
   renderTimeline()
 }
+

--- a/frontend/src/styles/reading-history.css
+++ b/frontend/src/styles/reading-history.css
@@ -44,18 +44,38 @@ body.light-theme {
   font-size: 13.5px;
   color: var(--text-secondary);
 }
-.rh-header-period {
+.rh-header-chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg-elevated);
+  padding: 3px;
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+}
+.rh-chip {
   font-size: 12px;
   font-weight: 600;
   color: var(--text-tertiary);
-  padding: 6px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
+  padding: 5px 12px;
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 100px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
   white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.rh-chip:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.rh-chip.active {
+  background: var(--control-accent-soft);
+  color: var(--control-accent-text);
+  font-weight: 700;
 }
 
 /* ── 공통 카드 ── */


### PR DESCRIPTION
# Summary
## 1. Reading History 기간 필터 칩(최근 30일 / 전체 기록) 추가
- `frontend/src/pages/readingHistoryPage.js`: 우측 상단 헤더 텍스트를 `rh-header-chips` 칩 버튼으로 수정함. `최근 30일` 및 `전체 기록` 필터 선택 시 `getStatCards`와 `getTimelineEvents`를 매핑해 5개 통계 카드와 세로 타임라인의 기간 데이터가 전환되도록 구현함.
- `frontend/src/styles/reading-history.css`: `.rh-header-chips` 및 `.rh-chip` hover/active 스타일 토큰 추가함.

## 2. 읽은 페이지 카드 텍스트 및 서브 텍스트 수정
- `frontend/src/pages/readingHistoryPage.js`: 3번째 카드 라벨을 `최근 30일 읽은 페이지`에서 `읽은 페이지`로 수정함.
- `frontend/src/pages/readingHistoryPage.js`: 서브 텍스트 중 `(누적 XXXp)` 표기를 제거하고 최근 30일 대비 증감 델타 수치만 명확히 노출되도록 함.