### PR TITLE
fix: align library header subtitle and trash compare buttons with status tabs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -154,19 +154,26 @@
           <!-- Library -->
           <section id="page-library" class="workspace-page">
             <div class="library-header">
-              <div class="logo">
-                <span class="logo-text">Library</span>
+              <div>
+                <p class="library-header-subtitle">보관함에 저장된 모든 논문을 한 곳에서 관리하세요</p>
               </div>
-              <div style="display: flex; gap: 10px; align-items: center;">
-                <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통
+              <div>
+                <button id="lib-upload-btn" class="file-btn">
+                  + 새 논문 추가
                 </button>
+              </div>
+            </div>
+
+            <!-- 상태 필터 탭 + 비교하기/휴지통 버튼 툴바 -->
+            <div class="library-toolbar-row">
+              <div id="library-status-tabs" class="lib-status-tabs"></div>
+              <div class="library-toolbar-actions">
                 <button id="lib-compare-toggle-btn" class="file-btn-outline" title="여러 논문을 선택해 비교 질문을 할 수 있습니다">
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
                   비교하기
                 </button>
-                <button id="lib-upload-btn" class="file-btn">
-                  + 새 논문 추가
+                <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통
                 </button>
               </div>
             </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4517,13 +4517,12 @@ function ensureLibraryChrome() {
   if (libraryChromeReady) return
   libraryChromeReady = true
 
-  const headerLogo = document.querySelector('#page-library .library-header .logo')
-  if (headerLogo && !headerLogo.querySelector('.library-header-subtitle')) {
-    headerLogo.insertAdjacentHTML('beforeend', `<p class="library-header-subtitle">보관함에 저장된 모든 논문을 한 곳에서 관리하세요</p>`)
-  }
-
   if (librarySearchBox && !$('library-status-tabs')) {
-    librarySearchBox.insertAdjacentHTML('beforebegin', `<div id="library-status-tabs" class="lib-status-tabs"></div>`)
+    librarySearchBox.insertAdjacentHTML('beforebegin', `
+      <div class="library-toolbar-row">
+        <div id="library-status-tabs" class="lib-status-tabs"></div>
+      </div>
+    `)
   }
 
   const viewToggleEl = $('library-view-toggle')

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -9,10 +9,25 @@
 
 /* ── 라이브러리 헤더 부제목 ── */
 .library-header-subtitle {
-  margin: 3px 0 0;
-  font-size: 13px;
+  margin: 0;
+  font-size: 13.5px;
   color: var(--text-secondary);
   font-weight: 500;
+}
+
+/* ── 상태 필터 탭 + 액션 버튼 툴바 ── */
+.library-toolbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.library-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* ── 상태 필터 탭 (전체 / 읽지 않음 / 읽는 중 / 완료 / 즐겨찾기) ── */


### PR DESCRIPTION
# Summary
## 1. Library 헤더 중복 텍스트 정리 및 부제목 위치 수정을 위한 레이아웃 정돈
- `frontend/index.html`: `workspace-topnav`와 중복되던 `.library-header`의 큰 logo 텍스트를 제거하고, 부제목(`보관함에 저장된 모든 논문을 한 곳에서 관리하세요`)만 상단 헤더에 정돈하여 출력되도록 수정함.
- `frontend/src/styles/library-page.css`: `.library-header-subtitle`의 여백과 글자 크기 스타일을 정제함.

## 2. 휴지통 및 비교하기 버튼 위치 얼라인
- `frontend/index.html`: 상단 헤더에 위치해 있던 `휴지통` 및 `비교하기` 버튼을 상태 필터 탭(`전체/읽지 않음/읽는 중/완독/즐겨찾기`)과 같은 행(`.library-toolbar-row`)의 우측(`.library-toolbar-actions`)으로 이동시켜 수평 align 맞춤.
- `frontend/src/main.js`: `ensureLibraryChrome`에서 동적 요소 삽입 시 툴바 구조가 깨지지 않도록 노드 삽입 로직을 정돈함.