### PR TITLE
fix: resolve reading history timeline start and end time overlap issue

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -650,7 +650,19 @@ async def update_doc_metadata(
     doc = _require_owned_document(doc_id, current_user)
 
     meta = doc.get("metadata") or {}
-    meta.update(payload)
+    if "read_sessions" in payload and isinstance(payload["read_sessions"], list):
+        existing_sessions = meta.get("read_sessions") or []
+        new_sessions = payload["read_sessions"]
+        combined = list(existing_sessions)
+        for ns in new_sessions:
+            if ns not in combined:
+                combined.append(ns)
+        meta["read_sessions"] = combined[-100:]
+        payload_copy = dict(payload)
+        payload_copy.pop("read_sessions")
+        meta.update(payload_copy)
+    else:
+        meta.update(payload)
     
     update_document_metadata(doc_id, meta)
     

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -460,6 +460,8 @@ async def get_activity_timeline(username: str) -> List[dict]:
                         end_ts = (dt + timedelta(seconds=duration)).isoformat()
                     except Exception:
                         pass
+                if end_ts and ts and end_ts == ts:
+                    end_ts = None
                 events.append({
                     "type": "read",
                     "doc_id": doc_id,

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -125,6 +125,44 @@ def test_timeline_excludes_other_users_events(test_client, isolated_dirs):
     assert not any(e["doc_id"] == "doc-tl-other" for e in events)
 
 
+def test_timeline_read_session_identical_start_end_timestamp(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-tl-same-ts", "testuser", {
+        "title": "Same Timestamp Paper",
+        "read_sessions": [
+            {
+                "timestamp": "2026-02-02T10:00:00+00:00",
+                "end_timestamp": "2026-02-02T10:00:00+00:00",
+                "duration_seconds": 0,
+            }
+        ]
+    })
+    res = test_client.get("/api/library/timeline")
+    assert res.status_code == 200
+    events = res.json()["events"]
+    read_events = [e for e in events if e.get("doc_id") == "doc-tl-same-ts" and e["type"] == "read"]
+    assert len(read_events) == 1
+    assert read_events[0]["end_timestamp"] is None
+
+
+def test_metadata_put_accumulates_read_sessions(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-tl-accum", "testuser", {
+        "title": "Accumulation Paper",
+        "read_sessions": [
+            {"timestamp": "2026-02-02T10:00:00+00:00", "end_timestamp": "2026-02-02T10:05:00+00:00", "duration_seconds": 300}
+        ]
+    })
+    new_payload = {
+        "read_sessions": [
+            {"timestamp": "2026-02-02T11:00:00+00:00", "end_timestamp": "2026-02-02T11:05:00+00:00", "duration_seconds": 300}
+        ]
+    }
+    res = test_client.put("/api/library/doc-tl-accum/metadata", json=new_payload)
+    assert res.status_code == 200
+    updated_meta = res.json()["metadata"]
+    assert len(updated_meta["read_sessions"]) == 2
+
+
+
 # ── Reading Recommendation ───────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -889,11 +889,12 @@ export async function renderReadingHistoryPage() {
               if (e.type === 'read') {
                 const startStr = formatTime(e.timestamp)
                 const endStr = e.end_timestamp ? formatTime(e.end_timestamp) : null
-                if (startStr && endStr) {
+                if (startStr && endStr && startStr !== endStr) {
                   timeLabel = `${startStr} ~ ${endStr}`
                   hoverTitle = `읽기 시간: ${startStr} 시작 ~ ${endStr} 종료 | 클릭하여 이 논문 열기`
                 } else if (startStr) {
-                  hoverTitle = `읽기 시작: ${startStr} | 클릭하여 이 논문 열기`
+                  timeLabel = startStr
+                  hoverTitle = `읽기 시각: ${startStr} | 클릭하여 이 논문 열기`
                 }
 
                 if (e.start_page && e.end_page) {


### PR DESCRIPTION
# Summary
## 1. 타임라인 읽음 항목 시간 범위 표시 조건 개선
- `frontend/src/pages/readingHistoryPage.js`: 타임라인 읽음(`read`) 이벤트 출력 시 시작 시간과 종료 시간의 문자열 포맷이 서로 다를 때만(`startStr !== endStr`) `${startStr} ~ ${endStr}` 구간으로 표시하고, 시작 시간과 종료 시간이 동일하거나 분 단위 변환 결과가 같은 경우 `startStr` 단일 시각으로만 표기하도록 수정함.

## 2. 동시간 타임스탬프 처리 및 read_sessions 메타데이터 보존
- `backend/services/knowledge_graph.py`: 타임라인 이벤트를 집계하는 `get_activity_timeline` 함수에서 `end_ts`와 `ts`가 동일한 경우 `end_ts`를 `None`으로 정리하여 동시간 타임스탬프 중복 렌더링을 차단함.
- `backend/routers/library.py`: `update_doc_metadata` (PUT `/library/{doc_id}/metadata`)에서 `read_sessions`가 전달되면 기존 메타데이터의 `read_sessions` 배열을 덮어쓰지 않고 최신 세션을 기존 목록에 누적(append)하여 보존함.
- `backend/tests/test_knowledge_graph_v3.py`: 동일 시각 타임스탬프 처리 및 메타데이터 `read_sessions` 누적 저장 기능을 검증하는 단위 테스트 추가함.