### PR TITLE
fix: update same reading session in place and merge consecutive sessions

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -651,12 +651,45 @@ async def update_doc_metadata(
 
     meta = doc.get("metadata") or {}
     if "read_sessions" in payload and isinstance(payload["read_sessions"], list):
+        from datetime import datetime
         existing_sessions = meta.get("read_sessions") or []
         new_sessions = payload["read_sessions"]
         combined = list(existing_sessions)
+        
         for ns in new_sessions:
-            if ns not in combined:
+            if not isinstance(ns, dict):
+                continue
+            ns_ts = ns.get("timestamp")
+            ns_end = ns.get("end_timestamp")
+            ns_dur = ns.get("duration_seconds") or 0
+
+            updated = False
+            # 1) 동일한 timestamp(시작 시각)를 가진 기존 세션이 있다면 해당 세션 항목을 갱신 (In-place update)
+            for i, es in enumerate(combined):
+                if isinstance(es, dict) and es.get("timestamp") == ns_ts:
+                    combined[i] = {**es, **ns}
+                    updated = True
+                    break
+            
+            # 2) 직전 세션의 end_timestamp와 새 세션의 timestamp 차이가 2분(120초) 이내라면 직전 세션에 병합 (Merge)
+            if not updated and combined and isinstance(combined[-1], dict) and combined[-1].get("end_timestamp") and ns_ts:
+                try:
+                    last_end_dt = datetime.fromisoformat(combined[-1]["end_timestamp"].replace("Z", "+00:00"))
+                    curr_start_dt = datetime.fromisoformat(ns_ts.replace("Z", "+00:00"))
+                    gap_sec = (curr_start_dt - last_end_dt).total_seconds()
+                    if 0 <= gap_sec <= 120:
+                        prev_dur = combined[-1].get("duration_seconds") or 0
+                        combined[-1]["end_timestamp"] = ns_end or ns_ts
+                        combined[-1]["duration_seconds"] = prev_dur + ns_dur + int(gap_sec)
+                        combined[-1]["end_page"] = max(combined[-1].get("end_page", 1), ns.get("end_page", 1))
+                        combined[-1]["verified_pages"] = (combined[-1].get("verified_pages") or 1) + (ns.get("verified_pages") or 1)
+                        updated = True
+                except Exception:
+                    pass
+            
+            if not updated and ns not in combined:
                 combined.append(ns)
+
         meta["read_sessions"] = combined[-100:]
         payload_copy = dict(payload)
         payload_copy.pop("read_sessions")

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -162,6 +162,49 @@ def test_metadata_put_accumulates_read_sessions(test_client, isolated_dirs):
     assert len(updated_meta["read_sessions"]) == 2
 
 
+def test_metadata_put_updates_same_timestamp_session(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-tl-update-same", "testuser", {
+        "title": "Same Session Update Paper",
+        "read_sessions": [
+            {"timestamp": "2026-02-02T10:00:00+00:00", "end_timestamp": "2026-02-02T10:00:20+00:00", "duration_seconds": 20}
+        ]
+    })
+    # 20초 후 하트비트가 동일 세션(시작 시각 동일)의 연장 정보를 보냄
+    new_payload = {
+        "read_sessions": [
+            {"timestamp": "2026-02-02T10:00:00+00:00", "end_timestamp": "2026-02-02T10:00:40+00:00", "duration_seconds": 40}
+        ]
+    }
+    res = test_client.put("/api/library/doc-tl-update-same/metadata", json=new_payload)
+    assert res.status_code == 200
+    updated_meta = res.json()["metadata"]
+    assert len(updated_meta["read_sessions"]) == 1
+    assert updated_meta["read_sessions"][0]["end_timestamp"] == "2026-02-02T10:00:40+00:00"
+    assert updated_meta["read_sessions"][0]["duration_seconds"] == 40
+
+
+def test_metadata_put_merges_consecutive_sessions_within_2min(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-tl-merge-consec", "testuser", {
+        "title": "Consecutive Merge Paper",
+        "read_sessions": [
+            {"timestamp": "2026-02-02T10:00:00+00:00", "end_timestamp": "2026-02-02T10:05:00+00:00", "duration_seconds": 300, "verified_pages": 2}
+        ]
+    })
+    # 직전 종료시각(10:05:00) 후 1분 뒤(10:06:00) 세션 전송 -> 하나의 연속 세션으로 병합되어야 함
+    new_payload = {
+        "read_sessions": [
+            {"timestamp": "2026-02-02T10:06:00+00:00", "end_timestamp": "2026-02-02T10:10:00+00:00", "duration_seconds": 240, "verified_pages": 1}
+        ]
+    }
+    res = test_client.put("/api/library/doc-tl-merge-consec/metadata", json=new_payload)
+    assert res.status_code == 200
+    updated_meta = res.json()["metadata"]
+    assert len(updated_meta["read_sessions"]) == 1
+    assert updated_meta["read_sessions"][0]["end_timestamp"] == "2026-02-02T10:10:00+00:00"
+    assert updated_meta["read_sessions"][0]["duration_seconds"] == 600
+
+
+
 
 # ── Reading Recommendation ───────────────────────────────────────────────
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3519,10 +3519,12 @@ function updatePageDwellTime() {
   session.pageDwellTimes[state.currentPage] = (session.pageDwellTimes[state.currentPage] || 0) + READING_HEARTBEAT_TICK_SECONDS
 }
 
-async function flushActiveReadingSession(userPaceSec = 240) {
+async function flushActiveReadingSession(userPaceSec = 240, isFinal = false) {
   if (!activeViewerSession || !activeViewerSession.docId) return
   const session = activeViewerSession
-  activeViewerSession = null
+  if (isFinal) {
+    activeViewerSession = null
+  }
 
   // 개인 EMA 정독 페이스(userPaceSec)의 50% 이상 체류 시에만 해당 페이지 완독 인정
   const dynamicDwellThreshold = Math.max(1, Math.round(userPaceSec * 0.5))
@@ -3565,7 +3567,7 @@ function tickReadingHeartbeat() {
 async function flushReadingHeartbeat() {
   const buffers = readingHeartbeatBuffers
   readingHeartbeatBuffers = {}
-  flushActiveReadingSession().catch(() => {})
+  flushActiveReadingSession(240, false).catch(() => {})
   const entries = Object.entries(buffers).filter(([, s]) => s > 0)
   if (entries.length === 0) return
   await Promise.all(entries.map(([key, seconds]) => {
@@ -3578,7 +3580,7 @@ async function flushReadingHeartbeat() {
 
 setInterval(tickReadingHeartbeat, READING_HEARTBEAT_TICK_SECONDS * 1000)
 setInterval(flushReadingHeartbeat, READING_HEARTBEAT_FLUSH_MS)
-window.addEventListener('beforeunload', () => { flushReadingHeartbeat(); flushActiveReadingSession() })
+window.addEventListener('beforeunload', () => { flushReadingHeartbeat(); flushActiveReadingSession(240, true) })
 
 // ── 초기화 ────────────────────────────────────────
 checkAuthentication()


### PR DESCRIPTION
# Summary
## 1. 프론트엔드 지속 읽기 세션 유지
- `frontend/src/main.js`: `flushActiveReadingSession`에 `isFinal` 파라미터를 추가하여 동일 논문 읽기 중 주기적 하트비트 flush 시 세션 객체를 파기하지 않고 시작 시각(`startTime`)을 고정한 채 종료 시각 및 정독 시간만 연장 전송하도록 변경함.

## 2. 백엔드 세션 업서트 및 2분 이내 연속 세션 병합
- `backend/routers/library.py`: `update_doc_metadata`에서 `read_sessions` 업데이트 시, 동일 시작 시각(`timestamp`)을 가진 세션은 제자리 갱신(In-place update)하고 직전 세션 종료 시각과 2분(120초) 이내의 연속 세션은 단일 세션으로 병합(Merge)하여 타임라인 기록 중복 분할 생성을 차단함.
- `backend/tests/test_knowledge_graph_v3.py`: 세션 갱신 및 2분 이내 연속 세션 병합을 검증하는 단위 테스트 2건 추가함.