### PR TITLE
fix: resolve ReferenceError for analyticsSummary in readingHistoryPage

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-h2MCSngp.js"></script>
+  <script type="module" crossorigin src="/assets/index-CgEoNCmQ.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ds--dOaW.css">
 </head>
 <body>

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -9,7 +9,7 @@
 // 이전의 활동에는 시간 데이터가 없을 수 있다 - 그런 경우 위젯은 "아직 기록된
 // 읽기 시간이 없습니다"로 정직하게 표시한다.
 
-import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats } from '../library.js'
+import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReadingTimeStats, fetchReadingAnalyticsSummary } from '../library.js'
 import { icon } from '../icons.js'
 import { readPageCount, lastActivityIso, hasReadActivity, lastActivityDateKey, isoToLocalDateKey } from '../readPages.js'
 import '../styles/reading-history.css'
@@ -348,17 +348,20 @@ export async function renderReadingHistoryPage() {
   let dashboard = null
   let libraryDocs = []
   let readingStats = null
+  let analyticsSummary = null
   try {
-    const [timelineRes, dashboardRes, libraryRes, readingStatsRes] = await Promise.all([
+    const [timelineRes, dashboardRes, libraryRes, readingStatsRes, analyticsSummaryRes] = await Promise.all([
       fetchLibraryTimeline(),
       fetchLibraryDashboard().catch(() => null),
       fetchLibrary().catch(() => ({ documents: [] })),
       fetchReadingTimeStats().catch(() => null),
+      fetchReadingAnalyticsSummary().catch(() => null),
     ])
     events = timelineRes?.events || []
     dashboard = dashboardRes
     libraryDocs = libraryRes?.documents || []
     readingStats = readingStatsRes
+    analyticsSummary = analyticsSummaryRes
   } catch (err) {
     console.error('Reading History 로드 실패:', err)
     el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">읽기 기록을 불러오지 못했습니다.</div></div>'


### PR DESCRIPTION
# Summary
## 1. Reading History 페이지 변수 미선언 에러 수정
- frontend/src/pages/readingHistoryPage.js: analyticsSummary 변수 선언 누락으로 인한 ReferenceError 수정 및 Promise.all 내 fetchReadingAnalyticsSummary 호출 추가함