### PR TITLE
feat: relocate Reading Analytics summary and update Dashboard and History cards

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CgEoNCmQ.js"></script>
+  <script type="module" crossorigin src="/assets/index-BW5BPr1_.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ds--dOaW.css">
 </head>
 <body>

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -280,19 +280,40 @@ function renderWeeklyActivityCard(events, stats, docs, readingStats) {
   `
 }
 
-// ── 연구 진행 요약 ── mockup의 "연구 점수"(0~100 + 스파크라인)는 뒷받침할
-// 시계열 데이터가 전혀 없어 생략했다(임의 가중치로 점수를 지어내는 건
-// 지시사항 위반). 대신 실제 타임스탬프/읽기 시간 하트비트에서 계산 가능한
-// 세 지표(연구 연속일, 주간 읽기 시간, 집중 주제)를 보여준다.
-function renderProgressSummaryCard(events, heatmap, readingStats) {
+// ── 연구 성과 & Reading Score ──
+function renderProgressSummaryCard(events, heatmap, readingStats, analyticsSummary) {
   const streak = computeStreakDays(events)
   const weeklySeconds = sumSecondsInDays(readingStats?.total_seconds_by_day, 7)
   const focusTopic = heatmap[0]
+  const score = analyticsSummary?.overall_avg_score || 0.0
+  const scorePct = Math.max(0, Math.min(100, score))
+
   return `
     <div class="dash-card">
       <div class="dash-card-head">
-        <h3>${icon('award', 15)}연구 진행 요약</h3>
+        <h3>${icon('award', 15)}연구 성과 & Reading Score</h3>
         <a href="#" class="dash-link" data-nav="graph">자세히 보기 ›</a>
+      </div>
+      <div class="dash-score-pie-container" style="display: flex; align-items: center; gap: 14px; padding: 12px; margin-bottom: 12px; background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md);">
+        <div style="position: relative; width: 64px; height: 64px; flex-shrink: 0;">
+          <svg width="64" height="64" viewBox="0 0 36 36" style="transform: rotate(-90deg);">
+            <path stroke="var(--bg-hover)" stroke-width="3.6" fill="none" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
+            <path stroke="url(#dashReadingScoreGrad)" stroke-width="3.6" stroke-dasharray="${scorePct.toFixed(1)}, 100" stroke-linecap="round" fill="none" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
+            <defs>
+              <linearGradient id="dashReadingScoreGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#3b82f6" />
+                <stop offset="100%" stop-color="#8b5cf6" />
+              </linearGradient>
+            </defs>
+          </svg>
+          <div style="position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 13px; color: var(--text-primary);">
+            ${score.toFixed(1)}
+          </div>
+        </div>
+        <div style="flex: 1;">
+          <div style="font-size: 13px; font-weight: 700; color: var(--text-primary);">Reading Score Engine</div>
+          <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 2px;">정독 패턴, verified pages & interaction 종합 평가</div>
+        </div>
       </div>
       <div class="dash-summary-grid">
         <div class="dash-summary-box">
@@ -722,11 +743,10 @@ export async function renderDashboardPage() {
   el.innerHTML = `
     <div class="dash-root">
       ${renderStatGrid(stats, events, docs)}
-      ${renderReadingAnalyticsCard(analyticsSummary)}
       <div class="dash-row dash-row-3">
         ${renderInsightsCard(insights)}
         ${renderWeeklyActivityCard(events, stats, docs, readingStats)}
-        ${renderProgressSummaryCard(events, heatmap, readingStats)}
+        ${renderProgressSummaryCard(events, heatmap, readingStats, analyticsSummary)}
       </div>
       <div class="dash-row dash-row-recent">
         ${renderRecentPapersCard(docs)}

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -13,6 +13,53 @@ import { fetchLibraryTimeline, fetchLibraryDashboard, fetchLibrary, fetchReading
 import { icon } from '../icons.js'
 import { readPageCount, lastActivityIso, hasReadActivity, lastActivityDateKey, isoToLocalDateKey } from '../readPages.js'
 import '../styles/reading-history.css'
+import '../styles/dashboard.css'
+
+function renderReadingAnalyticsSummaryCard(analyticsSummary) {
+  if (!analyticsSummary) return ''
+
+  const avgScore = analyticsSummary.overall_avg_score || 0.0
+  const avgConfidence = analyticsSummary.overall_avg_confidence || 0.0
+  const verifiedPages = analyticsSummary.overall_verified_pages || 0
+  const profile = analyticsSummary.user_profile || {}
+  const emaMinPerPage = Math.round((profile.ema_seconds_per_page || 600.0) / 60)
+
+  return `
+    <div class="rh-card" style="margin-top: 16px;">
+      <div class="rh-card-head">
+        <span class="rh-card-title">${icon('activity', 15)} Reading Analytics Summary</span>
+        <span class="reading-depth-badge depth-reading">Score Engine Active</span>
+      </div>
+      <div class="dash-analytics-grid">
+        <div class="dash-analytics-metric">
+          <span class="dash-analytics-metric-label">평균 Reading Score</span>
+          <div class="dash-analytics-metric-value">${avgScore.toFixed(1)} <span style="font-size: 14px; font-weight: normal; color: var(--text-tertiary);">/ 100</span></div>
+          <div class="reading-score-bar-bg">
+            <div class="reading-score-bar-fill" style="width: ${Math.min(100, avgScore)}%;"></div>
+          </div>
+        </div>
+
+        <div class="dash-analytics-metric">
+          <span class="dash-analytics-metric-label">평균 Reading Confidence</span>
+          <div class="dash-analytics-metric-value">${avgConfidence.toFixed(1)}%</div>
+          <span class="dash-analytics-metric-sub">페이지 정독 확률 기반</span>
+        </div>
+
+        <div class="dash-analytics-metric">
+          <span class="dash-analytics-metric-label">Verified Pages (검증 페이지)</span>
+          <div class="dash-analytics-metric-value">${verifiedPages.toLocaleString()} <span style="font-size: 13px; font-weight: normal;">p</span></div>
+          <span class="dash-analytics-metric-sub">실제 읽기 패턴 인정 페이지</span>
+        </div>
+
+        <div class="dash-analytics-metric">
+          <span class="dash-analytics-metric-label">개인 EMA 정독 페이스</span>
+          <div class="dash-analytics-metric-value">~${emaMinPerPage} <span style="font-size: 13px; font-weight: normal;">분/p</span></div>
+          <span class="dash-analytics-metric-sub">EMA 지수이동평균 학습</span>
+        </div>
+      </div>
+    </div>
+  `
+}
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
@@ -467,9 +514,22 @@ export async function renderReadingHistoryPage() {
     ? mixTotalSeconds
     : Object.values(byDay).reduce((sum, sec) => sum + (Number(sec) || 0), 0)
 
+  const totalUploadedCount = dashboard?.stats?.total_papers ?? docsById.size
+  const totalReadCount = dashboard?.stats?.read_papers ?? Array.from(docsById.values()).filter(d => hasReadActivity(d.metadata)).length
+
   const getStatCards = (period) => {
     if (period === '7') {
       return [
+        {
+          icon: 'bookOpen', color: 'var(--rh-c4)', label: '등록 논문',
+          value: curr7.uploadedPapers.toLocaleString(),
+          sub: deltaHtml(curr7.uploadedPapers, prev7.uploadedPapers, '', '이전 7일 대비'),
+        },
+        {
+          icon: 'checkCircle', color: 'var(--rh-c2)', label: '읽은 논문',
+          value: curr7.papersRead.toLocaleString(),
+          sub: deltaHtml(curr7.papersRead, prev7.papersRead, '', '이전 7일 대비'),
+        },
         {
           icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
           value: `${curr7.activeDays} / 7`,
@@ -501,6 +561,16 @@ export async function renderReadingHistoryPage() {
     if (period === 'all') {
       return [
         {
+          icon: 'bookOpen', color: 'var(--rh-c4)', label: '등록 논문',
+          value: totalUploadedCount.toLocaleString(),
+          sub: `<span class="rh-stat-delta">전체 등록 논문</span>`,
+        },
+        {
+          icon: 'checkCircle', color: 'var(--rh-c2)', label: '읽은 논문',
+          value: totalReadCount.toLocaleString(),
+          sub: `<span class="rh-stat-delta">전체 완독/읽기 문서</span>`,
+        },
+        {
           icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
           value: `${allActiveKeys.size}일`,
           sub: `<span class="rh-stat-delta">총 ${allActiveKeys.size}일 동안 활동</span>`,
@@ -529,6 +599,16 @@ export async function renderReadingHistoryPage() {
     }
 
     return [
+      {
+        icon: 'bookOpen', color: 'var(--rh-c4)', label: '등록 논문',
+        value: curr.uploadedPapers.toLocaleString(),
+        sub: deltaHtml(curr.uploadedPapers, prev.uploadedPapers),
+      },
+      {
+        icon: 'checkCircle', color: 'var(--rh-c2)', label: '읽은 논문',
+        value: curr.papersRead.toLocaleString(),
+        sub: deltaHtml(curr.papersRead, prev.papersRead),
+      },
       {
         icon: 'calendar', color: 'var(--rh-c1)', label: '활동일',
         value: `${curr.activeDays} / 30`,
@@ -727,6 +807,8 @@ export async function renderReadingHistoryPage() {
           </div>
         `).join('')}
       </div>
+
+      ${renderReadingAnalyticsSummaryCard(analyticsSummary)}
 
       <div class="rh-columns">
         <div class="rh-col">


### PR DESCRIPTION
# Summary
## 1. Reading Analytics Summary 위젯 이동 및 대시보드 UI 개선
- frontend/src/pages/dashboardPage.js: Reading Analytics Summary 독립 위젯 제거 및 '연구 성과 & Reading Score' 카드로 타이틀 변경 후 Reading Score SVG Donut 파이 차트 추가함
- frontend/src/pages/readingHistoryPage.js: Reading History 화면으로 Reading Analytics Summary 위젯 이관함
## 2. Reading History 상단 스탯 카드 추가
- frontend/src/pages/readingHistoryPage.js: 최상단 스탯 카드에 '등록 논문' 및 '읽은 논문' 카드를 추가하여 최근 7일/30일/전체 필터 조작 시 동적 반영되도록 구현함