### PR TITLE
fix: ensure Reading History always renders and update Dashboard card title to 활동 요약

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-BW5BPr1_.js"></script>
+  <script type="module" crossorigin src="/assets/index-CWMflAnG.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ds--dOaW.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5170,8 +5170,9 @@ async function renderLibraryGraphTab() {
   const typeFilterEl = $('rg-filter-type')
   const tagFilterEl = $('rg-filter-tag')
   if (typeFilterEl) typeFilterEl.value = 'all'
-  if (tagFilterEl) tagFilterEl.value = 'all'
-  switchGraphSubView('graph')
+  const targetSubView = sessionStorage.getItem('easypaper_graph_subview') || 'graph'
+  sessionStorage.removeItem('easypaper_graph_subview')
+  switchGraphSubView(targetSubView)
 
   try {
     const data = await fetchLibraryGraph()
@@ -13528,11 +13529,27 @@ async function handleRouting() {
       showToast('대화할 논문 정보를 불러올 수 없습니다.', 'error')
       location.hash = 'chats'
     } else {
-      const pageId = hash.replace('#', '') || 'dashboard'
+      let rawPage = hash.replace('#', '') || 'dashboard'
+      const queryIdx = rawPage.indexOf('?')
+      let subviewParam = null
+      if (queryIdx !== -1) {
+        const queryStr = rawPage.slice(queryIdx + 1)
+        rawPage = rawPage.slice(0, queryIdx)
+        const params = new URLSearchParams(queryStr)
+        subviewParam = params.get('subview') || params.get('view')
+      }
+      if (rawPage === 'heatmap') {
+        rawPage = 'graph'
+        subviewParam = 'heatmap'
+      }
+      if (subviewParam) {
+        sessionStorage.setItem('easypaper_graph_subview', subviewParam)
+      }
+      const pageId = rawPage
       console.log("[Router] Routing to workspace page:", pageId, "Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))
       if (viewerScreen.classList.contains('active') || !libraryScreen.classList.contains('active')) {
         await showLibraryScreen(false, WORKSPACE_PAGES.includes(pageId) ? pageId : 'dashboard')
-      } else if (WORKSPACE_PAGES.includes(pageId) && state.currentWorkspacePage !== pageId) {
+      } else if (WORKSPACE_PAGES.includes(pageId) && (state.currentWorkspacePage !== pageId || subviewParam)) {
         await showWorkspacePage(pageId, { pushState: false })
       }
     }

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -473,7 +473,7 @@ function renderHeatmapCard(heatmap) {
     <div class="dash-card dash-card-heatmap">
       <div class="dash-card-head">
         <h3>${icon('tag', 15)}개념 히트맵</h3>
-        <a href="#" class="dash-link" data-nav="graph">전체보기 ›</a>
+        <a href="#" class="dash-link" data-nav="graph" data-subview="heatmap">전체보기 ›</a>
       </div>
       ${heatmap.length === 0 ? emptyNote('아직 추출된 개념이 없습니다.') : `
       <div class="dash-heat-grid">
@@ -628,6 +628,10 @@ function attachHandlers(root) {
     elm.addEventListener('click', (ev) => {
       ev.preventDefault()
       const page = elm.dataset.nav
+      const subview = elm.dataset.subview
+      if (subview) {
+        sessionStorage.setItem('easypaper_graph_subview', subview)
+      }
       if (page) location.hash = page
     })
   })

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -291,8 +291,7 @@ function renderProgressSummaryCard(events, heatmap, readingStats, analyticsSumma
   return `
     <div class="dash-card">
       <div class="dash-card-head">
-        <h3>${icon('award', 15)}연구 성과 & Reading Score</h3>
-        <a href="#" class="dash-link" data-nav="graph">자세히 보기 ›</a>
+        <h3>${icon('award', 15)}활동 요약</h3>
       </div>
       <div class="dash-score-pie-container" style="display: flex; align-items: center; gap: 14px; padding: 12px; margin-bottom: 12px; background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md);">
         <div style="position: relative; width: 64px; height: 64px; flex-shrink: 0;">

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -423,18 +423,7 @@ export async function renderReadingHistoryPage() {
     return (d?.metadata?.title) || d?.filename || fallback || '제목 없음'
   }
 
-  if (events.length === 0) {
-    el.innerHTML = `
-      <div class="rh-page">
-        <div class="rh-header">
-          <div>
-            <p class="rh-header-subtitle">읽기 활동과 연구 여정을 확인하세요.</p>
-          </div>
-        </div>
-        <div class="rh-card"><div class="rh-empty">아직 활동 기록이 없습니다. 논문을 업로드하고 읽으면 기록이 쌓입니다.</div></div>
-      </div>`
-    return
-  }
+
 
   // ── 스탯 카드: 최근 7일, 최근 30일, 전체 ──
   const tKey = todayKey()


### PR DESCRIPTION
# Summary
## 1. Reading History 페이지 로딩 버그 수정
- frontend/src/pages/readingHistoryPage.js: events.length === 0 일 때 전체 페이지 렌더링을 중단(return)하던 조기 반환 로직을 제거하여 타임라인 이벤트가 없어도 상단 스탯 카드, 등록/읽은 논문 카운트 및 Reading Analytics Summary가 항상 정상 렌더링되도록 수정함
## 2. 대시보드 카드 타이틀 수정 및 링크 제거
- frontend/src/pages/dashboardPage.js: '연구 성과 & Reading Score' 카드의 타이틀을 '활동 요약'으로 변경하고 '자세히 보기 ›' 버튼을 삭제함