### PR TITLE
fix: add catch fallback for fetchLibraryTimeline in readingHistoryPage

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CWMflAnG.js"></script>
+  <script type="module" crossorigin src="/assets/index-BUfeM4aH.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-Ds--dOaW.css">
 </head>
 <body>

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -398,7 +398,7 @@ export async function renderReadingHistoryPage() {
   let analyticsSummary = null
   try {
     const [timelineRes, dashboardRes, libraryRes, readingStatsRes, analyticsSummaryRes] = await Promise.all([
-      fetchLibraryTimeline(),
+      fetchLibraryTimeline().catch(() => ({ events: [] })),
       fetchLibraryDashboard().catch(() => null),
       fetchLibrary().catch(() => ({ documents: [] })),
       fetchReadingTimeStats().catch(() => null),


### PR DESCRIPTION
# Summary
## 1. Reading History 타임라인 예외 처리 폴백 추가
- frontend/src/pages/readingHistoryPage.js: fetchLibraryTimeline()에 .catch(() => ({ events: [] })) 폴백을 추가하여 API 실패 상황에서도 페이지가 전체 실패 없이 안전하게 로딩되도록 보장함