### PR TITLE
fix: unify dashboard and reading history statistics calculations

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -9,7 +9,8 @@
 import './../styles/dashboard.css'
 import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats, fetchReadingAnalyticsSummary } from '../library.js'
 import { icon } from '../icons.js'
-import { readPageCount, lastActivityIso, hasReadActivity, isWithinDaysLocal } from '../readPages.js'
+import { readPageCount, lastActivityIso, hasReadActivity, computeStreakDays, todayKey, addDaysKey } from '../readPages.js'
+import { periodStats, sumSecondsByDayRange, buildDailyActivityStats, formatDuration } from './readingHistoryPage.js'
 
 function renderReadingAnalyticsCard(analyticsData) {
   if (!analyticsData) return ''
@@ -70,35 +71,6 @@ function formatNumber(n) {
   return (n || 0).toLocaleString('ko-KR')
 }
 
-function formatDuration(seconds) {
-  const s = Math.max(0, Math.round(seconds || 0))
-  const h = Math.floor(s / 3600)
-  const m = Math.round((s % 3600) / 60)
-  if (h > 0) return `${h}h ${m}m`
-  if (m > 0) return `${m}m`
-  return s > 0 ? `${s}s` : '0m'
-}
-
-function sumSecondsInDays(byDay, days) {
-  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000
-  let total = 0
-  for (const [day, seconds] of Object.entries(byDay || {})) {
-    const t = new Date(`${day}T00:00:00`).getTime()
-    if (!Number.isNaN(t) && t >= cutoff) total += seconds
-  }
-  return total
-}
-
-// ── 시간 계산 헬퍼 ── 전부 백엔드가 이미 내려주는 ISO 타임스탬프(timeline
-// events, metadata.read_at)를 그대로 재사용한다. 새 저장소나 서버 집계가
-// 필요 없다.
-function isWithinDays(iso, days) {
-  if (!iso) return false
-  const t = new Date(iso).getTime()
-  if (Number.isNaN(t)) return false
-  return t >= Date.now() - days * 24 * 60 * 60 * 1000
-}
-
 function relativeTimeKo(iso) {
   if (!iso) return ''
   const t = new Date(iso).getTime()
@@ -117,53 +89,6 @@ function relativeTimeKo(iso) {
   return new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
-function dateKey(iso) {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return null
-  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
-}
-
-// 활동(업로드/읽음/질문/메모) 타임스탬프가 찍힌 날짜들을 모아 오늘(또는
-// 어제, 아직 오늘 활동을 안 했을 수 있으니)부터 거슬러 며칠 연속으로
-// 활동이 있었는지 센다 - 순수하게 실제 이벤트 날짜만으로 계산.
-function computeStreakDays(events) {
-  const dates = new Set()
-  events.forEach(e => { const k = dateKey(e.timestamp); if (k) dates.add(k) })
-  if (dates.size === 0) return 0
-  const today = new Date()
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-  let cursor = null
-  if (dates.has(dateKey(today))) cursor = today
-  else if (dates.has(dateKey(yesterday))) cursor = yesterday
-  else return 0
-  const c = new Date(cursor)
-  let streak = 0
-  while (dates.has(dateKey(c))) {
-    streak++
-    c.setDate(c.getDate() - 1)
-  }
-  return streak
-}
-
-function countEventsInDays(events, type, days) {
-  return events.filter(e => e.type === type && isWithinDays(e.timestamp, days)).length
-}
-
-// "이번 주 읽은 페이지"는 서버에 별도 집계가 없어, 이번 주 안에 읽기
-// 활동(last_read_at - 열람/페이지 이동 - 또는 read_at - 완독 표시)이 있던
-// 논문들의 readPageCount(참고문헌 제외 진행률/본문 페이지 수) 합으로
-// 근사한다 - 실존하는 필드만 조합한 값이라 근거가 있는 근사치다. 완독
-// 여부만 보던 예전 로직과 달리 읽던 중인 논문도 포함한다.
-function pagesReadInDays(docs, days) {
-  return docs.reduce((sum, d) => {
-    const meta = d.metadata || {}
-    if (!hasReadActivity(meta)) return sum
-    if (!isWithinDaysLocal(lastActivityIso(meta, d.created_at), days)) return sum
-    return sum + readPageCount(d)
-  }, 0)
-}
-
 function truncateLabel(s, n) {
   if (!s) return ''
   return s.length > n ? `${s.slice(0, n - 1)}…` : s
@@ -171,18 +96,18 @@ function truncateLabel(s, n) {
 
 // ── 통계 카드 ──────────────────────────────────────────────────────────
 const STAT_DEFS = [
-  { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (events) => countEventsInDays(events, 'uploaded', 7) },
-  { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (events) => countEventsInDays(events, 'read', 7) },
-  { key: 'read_pages', label: '읽은 페이지 수', iconName: 'fileText', tint: 3, weekly: (events, docs) => pagesReadInDays(docs, 7) },
+  { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (c7) => c7.uploadedPapers },
+  { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (c7) => c7.papersRead },
+  { key: 'read_pages', label: '읽은 페이지 수', iconName: 'fileText', tint: 3, weekly: (c7, wp) => wp },
   // 개념은 생성 시각이 저장되지 않아 "이번 주 신규 개념 수"를 계산할 근거가
   // 없다 - 지어내지 않고 주간 델타 자체를 생략한다.
   { key: 'total_concepts', label: '개념', iconName: 'layers', tint: 4, weekly: null },
-  { key: 'total_questions', label: '질문', iconName: 'messageCircle', tint: 5, weekly: (events) => countEventsInDays(events, 'question', 7) },
-  { key: 'total_notes', label: '메모', iconName: 'edit3', tint: 6, weekly: (events) => countEventsInDays(events, 'note', 7) },
+  { key: 'total_questions', label: '질문', iconName: 'messageCircle', tint: 5, weekly: (c7) => c7.questions },
+  { key: 'total_notes', label: '메모', iconName: 'edit3', tint: 6, weekly: (c7) => c7.notes },
 ]
 
-function renderStatCard(def, value, events, docs) {
-  const delta = def.weekly ? def.weekly(events, docs) : null
+function renderStatCard(def, value, curr7, weeklyPagesRead) {
+  const delta = def.weekly ? def.weekly(curr7, weeklyPagesRead) : null
   const deltaHtml = delta === null ? '' : `
     <div class="dash-stat-delta ${delta > 0 ? 'is-up' : ''}">
       ${delta > 0 ? icon('chevronUp', 11) : ''}
@@ -203,10 +128,10 @@ function renderStatCard(def, value, events, docs) {
   `
 }
 
-function renderStatGrid(stats, events, docs) {
+function renderStatGrid(stats, curr7, weeklyPagesRead) {
   return `
     <div class="dash-stat-grid">
-      ${STAT_DEFS.map(def => renderStatCard(def, stats[def.key], events, docs)).join('')}
+      ${STAT_DEFS.map(def => renderStatCard(def, stats[def.key], curr7, weeklyPagesRead)).join('')}
     </div>
   `
 }
@@ -243,16 +168,14 @@ function renderInsightsCard(insights) {
   `
 }
 
-// ── 이번 주 활동 ── 목표(target)를 알 수 없어 mockup처럼 "goal" 대비
-// 진행률을 표시하는 대신, 실제 라이브러리 전체 규모 대비 이번 주 활동
-// 비중으로 바를 채운다(둘 다 실존 값).
-function renderWeeklyActivityCard(events, stats, docs, readingStats) {
-  const weeklySeconds = sumSecondsInDays(readingStats?.total_seconds_by_day, 7)
+// ── 이번 주 활동 ── Reading History 통계 엔진과 동일한 주간 집계 데이터를 공유하여 시각화한다.
+function renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs) {
+  const totalCompletedCount = stats.read_papers ?? docs.filter(d => d.metadata?.read === true).length
   const totalSeconds = readingStats?.total_seconds || 0
   const rows = [
-    { iconName: 'bookOpen', label: '읽은 논문', value: countEventsInDays(events, 'read', 7), total: stats.total_papers || 0, kind: 'count' },
-    { iconName: 'fileText', label: '읽은 페이지', value: pagesReadInDays(docs, 7), total: stats.total_pages || 0, kind: 'count' },
-    { iconName: 'messageCircle', label: '질문', value: countEventsInDays(events, 'question', 7), total: stats.total_questions || 0, kind: 'count' },
+    { iconName: 'bookOpen', label: '읽은 논문', value: curr7.papersRead, total: totalCompletedCount, kind: 'count' },
+    { iconName: 'fileText', label: '읽은 페이지', value: weeklyPagesRead, total: stats.total_pages || 0, kind: 'count' },
+    { iconName: 'messageCircle', label: '질문', value: curr7.questions, total: stats.total_questions || 0, kind: 'count' },
     { iconName: 'clock', label: '읽은 시간', value: weeklySeconds, total: totalSeconds, kind: 'duration' },
   ]
   return `
@@ -281,9 +204,8 @@ function renderWeeklyActivityCard(events, stats, docs, readingStats) {
 }
 
 // ── 연구 성과 & Reading Score ──
-function renderProgressSummaryCard(events, heatmap, readingStats, analyticsSummary) {
+function renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary) {
   const streak = computeStreakDays(events)
-  const weeklySeconds = sumSecondsInDays(readingStats?.total_seconds_by_day, 7)
   const focusTopic = heatmap[0]
   const score = analyticsSummary?.overall_avg_score || 0.0
   const scorePct = Math.max(0, Math.min(100, score))
@@ -743,13 +665,30 @@ export async function renderDashboardPage() {
   const insights = dashboard.insights || []
   const recentQuestions = dashboard.recent_questions || []
 
+  const docsById = new Map(docs.map(d => [d.id, d]))
+  const tKey = todayKey()
+  const currStart7 = addDaysKey(tKey, -6)
+  const currEnd7 = addDaysKey(tKey, 1)
+
+  const curr7 = periodStats(events, docsById, currStart7, currEnd7)
+  const weeklySeconds = sumSecondsByDayRange(readingStats?.total_seconds_by_day, currStart7, currEnd7)
+  const dailyStatsMap = buildDailyActivityStats(events, readingStats)
+
+  let currEstPages7 = 0
+  for (const [day, item] of dailyStatsMap.entries()) {
+    if (day >= currStart7 && day < currEnd7) {
+      currEstPages7 += item.estPagesRead
+    }
+  }
+  const weeklyPagesRead = Math.max(curr7.pagesRead, currEstPages7)
+
   el.innerHTML = `
     <div class="dash-root">
-      ${renderStatGrid(stats, events, docs)}
+      ${renderStatGrid(stats, curr7, weeklyPagesRead)}
       <div class="dash-row dash-row-3">
         ${renderInsightsCard(insights)}
-        ${renderWeeklyActivityCard(events, stats, docs, readingStats)}
-        ${renderProgressSummaryCard(events, heatmap, readingStats, analyticsSummary)}
+        ${renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs)}
+        ${renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary)}
       </div>
       <div class="dash-row dash-row-recent">
         ${renderRecentPapersCard(docs)}

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -152,7 +152,7 @@ function computeUserReadingPace(byDayMap) {
   return Math.max(60, Math.min(480, Math.round(currentEma)))
 }
 
-function buildDailyActivityStats(events, readingStats) {
+export function buildDailyActivityStats(events, readingStats) {
   const byDay = new Map()
 
   function getOrCreate(key) {
@@ -287,15 +287,26 @@ function computeStreaks(activeDayKeys) {
   return { current, longest, longestStart, longestEnd }
 }
 
-function periodStats(events, docsById, startKey, endKeyExclusive) {
+export function periodStats(events, docsById, startKey, endKeyExclusive) {
   const inPeriod = events.filter(e => {
     const k = eventKey(e)
     return k && k >= startKey && k < endKeyExclusive
   })
   const activeDays = new Set(inPeriod.map(eventKey)).size
 
-  // 단순히 뷰어를 1초 열어보기만 해서 last_read_at만 갱신된 문서는 제외하고,
-  // 해당 기간 내 실측 read 세션 이벤트가 있거나 완독/읽기 표시된 문서만 계산
+  // 완독 체크(read === true)를 누른 논문만 해당 기간 읽은 논문으로 집계
+  const completedDocIds = new Set()
+  for (const doc of docsById.values()) {
+    const meta = doc?.metadata || {}
+    if (meta.read === true) {
+      const k = isoToLocalDateKey(meta.read_at || meta.last_read_at)
+      if (k && k >= startKey && k < endKeyExclusive) {
+        completedDocIds.add(doc.id)
+      }
+    }
+  }
+
+  // 해당 기간 실측 세션 또는 읽기 활동이 있던 문서를 기준으로 페이지 수 산정
   const readDocIds = new Set(inPeriod.filter(e => e.type === 'read').map(e => e.doc_id))
   const activePageDocIds = new Set()
   for (const id of readDocIds) {
@@ -316,7 +327,7 @@ function periodStats(events, docsById, startKey, endKeyExclusive) {
   const questions = inPeriod.filter(e => e.type === 'question').length
   const notes = inPeriod.filter(e => e.type === 'note').length
   const uploadedPapers = inPeriod.filter(e => e.type === 'uploaded').length
-  return { activeDays, papersRead: activePageDocIds.size, pagesRead, questions, notes, uploadedPapers }
+  return { activeDays, papersRead: completedDocIds.size, pagesRead, questions, notes, uploadedPapers }
 }
 
 function deltaHtml(curr, prev, unit = '', compareText = '이전 30일 대비') {
@@ -330,7 +341,7 @@ function deltaHtml(curr, prev, unit = '', compareText = '이전 30일 대비') {
 }
 
 // ── 읽기 시간 포맷/집계 헬퍼 ──────────────────────────────────
-function formatDuration(seconds) {
+export function formatDuration(seconds) {
   const s = Math.max(0, Math.round(seconds || 0))
   const h = Math.floor(s / 3600)
   const m = Math.round((s % 3600) / 60)
@@ -345,7 +356,7 @@ function deltaDurationHtml(currSeconds, prevSeconds, compareText = '이전 30일
   const arrow = diff > 0 ? '↑' : '↓'
   return `<span class="rh-stat-delta ${cls}">${arrow} ${formatDuration(Math.abs(diff))} ${compareText}</span>`
 }
-function sumSecondsByDayRange(byDay, startKey, endKeyExclusive) {
+export function sumSecondsByDayRange(byDay, startKey, endKeyExclusive) {
   let total = 0
   for (const [day, seconds] of Object.entries(byDay || {})) {
     if (day >= startKey && day < endKeyExclusive) total += seconds

--- a/frontend/src/readPages.js
+++ b/frontend/src/readPages.js
@@ -40,14 +40,35 @@ export function hasReadActivity(meta) {
 // ISO 타임스탬프 문자열을 사용자 로컬 시간대 자정 기준 "YYYY-MM-DD" 날짜 키로 변환한다.
 // 단순 .slice(0, 10)을 하면 UTC 날짜가 잘려 나와 한국 시간(KST) 등에서 9시간 시차
 // 어긋남이 발생하므로, local Date 객체의 연/월/일을 사용한다.
-export function isoToLocalDateKey(iso) {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (isNaN(d.getTime())) return ''
+export function localDateToKey(d) {
+  if (!d || isNaN(d.getTime())) return ''
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, '0')
   const day = String(d.getDate()).padStart(2, '0')
   return `${y}-${m}-${day}`
+}
+
+export function todayKey() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return localDateToKey(d)
+}
+
+export function keyToLocalDate(key) {
+  return new Date(`${key}T00:00:00`)
+}
+
+export function addDaysKey(key, delta) {
+  const d = keyToLocalDate(key)
+  if (isNaN(d.getTime())) return key
+  d.setDate(d.getDate() + delta)
+  return localDateToKey(d)
+}
+
+export function isoToLocalDateKey(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return localDateToKey(d)
 }
 
 export function lastActivityDateKey(meta, createdAt) {
@@ -60,11 +81,32 @@ export function isWithinDaysLocal(iso, days) {
   if (!iso) return false
   const key = isoToLocalDateKey(iso)
   if (!key) return false
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const target = new Date(`${key}T00:00:00`)
-  if (isNaN(target.getTime())) return false
-  const diffDays = Math.round((today - target) / 86400000)
-  return diffDays >= 0 && diffDays < days
+  const tKey = todayKey()
+  const startKey = addDaysKey(tKey, -(days - 1))
+  const endKeyExclusive = addDaysKey(tKey, 1)
+  return key >= startKey && key < endKeyExclusive
 }
+
+// 타임라인 이벤트의 날짜 키(로컬 자정 기준) 집합을 모아 오늘/어제 기준 연속 활동일을 계산한다.
+export function computeStreakDays(events) {
+  const dates = new Set()
+  for (const e of events || []) {
+    const k = isoToLocalDateKey(e.timestamp)
+    if (k) dates.add(k)
+  }
+  if (dates.size === 0) return 0
+
+  const tKey = todayKey()
+  const yKey = addDaysKey(tKey, -1)
+  let cursor = dates.has(tKey) ? tKey : (dates.has(yKey) ? yKey : null)
+  if (!cursor) return 0
+
+  let streak = 0
+  while (dates.has(cursor)) {
+    streak++
+    cursor = addDaysKey(cursor, -1)
+  }
+  return streak
+}
+
 


### PR DESCRIPTION
# Summary
## 1. 완독 체크 논문 기준 통일
- `readingHistoryPage.js` 내 `periodStats()`의 읽은 논문(`papersRead`) 집계 기준을 완독 표시(`metadata.read === true` 및 `read_at`) 논문으로 통일

## 2. 대시보드와 Reading History 간 통계 계산 엔진 통합
- `dashboardPage.js`에서 독자적으로 쓰이던 낡은 주간 계산 함수(`sumSecondsInDays`, `pagesReadInDays` 등)를 제거하고 `readingHistoryPage.js`의 `periodStats`, `sumSecondsByDayRange`, `buildDailyActivityStats` 헬퍼를 공유하도록 수정
- 대시보드의 주간 읽은 논문, 읽은 페이지, 읽은 시간, 질문, 메모 수치가 Reading History와 100% 동일한 수치로 연동되도록 일체화

## 3. 날짜 필터링 및 연구 연속일(Streak) 포맷 버그 수정
- `readPages.js`에 표준 로컬 자정 날짜키 유틸(`localDateToKey`, `todayKey`, `addDaysKey`, `computeStreakDays`) 추가
- 대시보드의 `getMonth()` (0-indexed 월) 날짜키 불일치로 인한 연속일 계산 버그 해결