### PR TITLE
fix: resolve dashboard endless loading and correct all-time read papers count

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -637,9 +637,9 @@ export async function renderDashboardPage() {
   let dashboard, timelineData, libraryData, graphData, readingStats, cachedRecs, analyticsSummary
   try {
     const results = await Promise.all([
-      fetchLibraryDashboard(),
-      fetchLibraryTimeline(),
-      fetchLibrary(),
+      fetchLibraryDashboard().catch(() => null),
+      fetchLibraryTimeline().catch(() => ({ events: [] })),
+      fetchLibrary().catch(() => ({ documents: [] })),
       fetchLibraryGraph().catch(() => null),
       fetchReadingTimeStats().catch(() => null),
       fetchCachedReadingRecommendations().catch(() => ({ recommendations: null })),
@@ -658,50 +658,55 @@ export async function renderDashboardPage() {
     return
   }
 
-  const events = (timelineData && timelineData.events) || []
-  const docs = (libraryData && libraryData.documents) || []
-  const stats = dashboard.stats || {}
-  const heatmap = dashboard.heatmap || []
-  const insights = dashboard.insights || []
-  const recentQuestions = dashboard.recent_questions || []
+  try {
+    const events = (timelineData && Array.isArray(timelineData.events)) ? timelineData.events : []
+    const docs = (libraryData && Array.isArray(libraryData.documents)) ? libraryData.documents : []
+    const stats = (dashboard && dashboard.stats) ? dashboard.stats : {}
+    const heatmap = (dashboard && Array.isArray(dashboard.heatmap)) ? dashboard.heatmap : []
+    const insights = (dashboard && Array.isArray(dashboard.insights)) ? dashboard.insights : []
+    const recentQuestions = (dashboard && Array.isArray(dashboard.recent_questions)) ? dashboard.recent_questions : []
 
-  const docsById = new Map(docs.map(d => [d.id, d]))
-  const tKey = todayKey()
-  const currStart7 = addDaysKey(tKey, -6)
-  const currEnd7 = addDaysKey(tKey, 1)
+    const docsById = new Map(docs.map(d => [d.id, d]))
+    const tKey = todayKey()
+    const currStart7 = addDaysKey(tKey, -6)
+    const currEnd7 = addDaysKey(tKey, 1)
 
-  const curr7 = periodStats(events, docsById, currStart7, currEnd7)
-  const weeklySeconds = sumSecondsByDayRange(readingStats?.total_seconds_by_day, currStart7, currEnd7)
-  const dailyStatsMap = buildDailyActivityStats(events, readingStats)
+    const curr7 = periodStats(events, docsById, currStart7, currEnd7)
+    const weeklySeconds = sumSecondsByDayRange(readingStats?.total_seconds_by_day, currStart7, currEnd7)
+    const dailyStatsMap = buildDailyActivityStats(events, readingStats)
 
-  let currEstPages7 = 0
-  for (const [day, item] of dailyStatsMap.entries()) {
-    if (day >= currStart7 && day < currEnd7) {
-      currEstPages7 += item.estPagesRead
+    let currEstPages7 = 0
+    for (const [day, item] of dailyStatsMap.entries()) {
+      if (day >= currStart7 && day < currEnd7) {
+        currEstPages7 += item.estPagesRead
+      }
     }
+    const weeklyPagesRead = Math.max(curr7.pagesRead, currEstPages7)
+
+    el.innerHTML = `
+      <div class="dash-root">
+        ${renderStatGrid(stats, curr7, weeklyPagesRead)}
+        <div class="dash-row dash-row-3">
+          ${renderInsightsCard(insights)}
+          ${renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs)}
+          ${renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary)}
+        </div>
+        <div class="dash-row dash-row-recent">
+          ${renderRecentPapersCard(docs)}
+          ${renderRecentQuestionsCard(recentQuestions)}
+          ${renderRecommendationsCard(cachedRecs && cachedRecs.recommendations)}
+        </div>
+        <div class="dash-row dash-row-bottom">
+          ${renderHeatmapCard(heatmap)}
+          ${renderTimelineCard(events)}
+          ${renderGraphPreviewCard(graphData, heatmap)}
+        </div>
+      </div>
+    `
+
+    attachHandlers(el)
+  } catch (renderErr) {
+    console.error('대시보드 렌더링 예외 발생:', renderErr)
+    el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
   }
-  const weeklyPagesRead = Math.max(curr7.pagesRead, currEstPages7)
-
-  el.innerHTML = `
-    <div class="dash-root">
-      ${renderStatGrid(stats, curr7, weeklyPagesRead)}
-      <div class="dash-row dash-row-3">
-        ${renderInsightsCard(insights)}
-        ${renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs)}
-        ${renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary)}
-      </div>
-      <div class="dash-row dash-row-recent">
-        ${renderRecentPapersCard(docs)}
-        ${renderRecentQuestionsCard(recentQuestions)}
-        ${renderRecommendationsCard(cachedRecs && cachedRecs.recommendations)}
-      </div>
-      <div class="dash-row dash-row-bottom">
-        ${renderHeatmapCard(heatmap)}
-        ${renderTimelineCard(events)}
-        ${renderGraphPreviewCard(graphData, heatmap)}
-      </div>
-    </div>
-  `
-
-  attachHandlers(el)
 }

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -517,27 +517,9 @@ export async function renderReadingHistoryPage() {
     ? mixTotalSeconds
     : Object.values(byDay).reduce((sum, sec) => sum + (Number(sec) || 0), 0)
 
-  const allReadDocIds = new Set()
-  for (const e of events) {
-    if (e.type === 'read' && e.doc_id && docsById.has(e.doc_id)) {
-      allReadDocIds.add(e.doc_id)
-    }
-  }
-  const byDocSeconds = readingStats?.total_seconds_by_doc || {}
-  for (const [docId, sec] of Object.entries(byDocSeconds)) {
-    if (sec > 0 && docsById.has(docId)) {
-      allReadDocIds.add(docId)
-    }
-  }
-  for (const doc of docsById.values()) {
-    const meta = doc?.metadata || {}
-    if (meta.read || hasReadActivity(meta)) {
-      allReadDocIds.add(doc.id)
-    }
-  }
-
   const totalUploadedCount = Math.max(dashboard?.stats?.total_papers ?? 0, docsById.size)
-  const totalReadCount = Math.max(allReadDocIds.size, curr.papersRead, curr7.papersRead)
+  const completedDocsCount = Array.from(docsById.values()).filter(d => d.metadata?.read === true).length
+  const totalReadCount = Math.max(dashboard?.stats?.read_papers ?? 0, completedDocsCount, curr.papersRead, curr7.papersRead)
 
   const getStatCards = (period) => {
     if (period === '7') {


### PR DESCRIPTION
# Summary
## 1. 대시보드 무한 로딩 버그 수정
- `dashboardPage.js` 내 API `Promise.all` 및 렌더링 블록 전반에 `try-catch` 및 `.catch()` 폴백을 적용하여 개별 API 실패나 런타임 수치 계산 예외 시 무한 로딩 상태에 갇히는 버그 방지

## 2. Reading History 전체 기록 완독 문서 수 집계 오류 수정
- 전체 기록 카드의 `totalReadCount` 집계 시 기존에 남아있던 열람 이력(`type === 'read'`), 실측 읽은 시간, `hasReadActivity` 유니크 문서 수 집계 코드(`allReadDocIds`)를 제거하고 완독 표시(`metadata.read === true`)인 문서 개수로 정확히 카운트하도록 수정 (실제 완독 문서 4개로 정합성 보장)