### PR TITLE
fix: safeguard dashboard rendering and refine reading history periodStats

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -96,14 +96,14 @@ function truncateLabel(s, n) {
 
 // ── 통계 카드 ──────────────────────────────────────────────────────────
 const STAT_DEFS = [
-  { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (c7) => c7.uploadedPapers },
-  { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (c7) => c7.papersRead },
-  { key: 'read_pages', label: '읽은 페이지 수', iconName: 'fileText', tint: 3, weekly: (c7, wp) => wp },
+  { key: 'total_papers', label: '논문', iconName: 'bookOpen', tint: 1, weekly: (c7) => c7?.uploadedPapers || 0 },
+  { key: 'read_papers', label: '읽은 논문', iconName: 'checkCircle', tint: 2, weekly: (c7) => c7?.papersRead || 0 },
+  { key: 'read_pages', label: '읽은 페이지 수', iconName: 'fileText', tint: 3, weekly: (c7, wp) => wp || 0 },
   // 개념은 생성 시각이 저장되지 않아 "이번 주 신규 개념 수"를 계산할 근거가
   // 없다 - 지어내지 않고 주간 델타 자체를 생략한다.
   { key: 'total_concepts', label: '개념', iconName: 'layers', tint: 4, weekly: null },
-  { key: 'total_questions', label: '질문', iconName: 'messageCircle', tint: 5, weekly: (c7) => c7.questions },
-  { key: 'total_notes', label: '메모', iconName: 'edit3', tint: 6, weekly: (c7) => c7.notes },
+  { key: 'total_questions', label: '질문', iconName: 'messageCircle', tint: 5, weekly: (c7) => c7?.questions || 0 },
+  { key: 'total_notes', label: '메모', iconName: 'edit3', tint: 6, weekly: (c7) => c7?.notes || 0 },
 ]
 
 function renderStatCard(def, value, curr7, weeklyPagesRead) {
@@ -129,9 +129,10 @@ function renderStatCard(def, value, curr7, weeklyPagesRead) {
 }
 
 function renderStatGrid(stats, curr7, weeklyPagesRead) {
+  const safeStats = stats || {}
   return `
     <div class="dash-stat-grid">
-      ${STAT_DEFS.map(def => renderStatCard(def, stats[def.key], curr7, weeklyPagesRead)).join('')}
+      ${STAT_DEFS.map(def => renderStatCard(def, safeStats[def.key], curr7, weeklyPagesRead)).join('')}
     </div>
   `
 }
@@ -170,13 +171,14 @@ function renderInsightsCard(insights) {
 
 // ── 이번 주 활동 ── Reading History 통계 엔진과 동일한 주간 집계 데이터를 공유하여 시각화한다.
 function renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs) {
-  const totalCompletedCount = stats.read_papers ?? docs.filter(d => d.metadata?.read === true).length
+  const safeDocs = Array.isArray(docs) ? docs : []
+  const totalCompletedCount = stats?.read_papers ?? safeDocs.filter(d => d?.metadata?.read === true).length
   const totalSeconds = readingStats?.total_seconds || 0
   const rows = [
-    { iconName: 'bookOpen', label: '읽은 논문', value: curr7.papersRead, total: totalCompletedCount, kind: 'count' },
-    { iconName: 'fileText', label: '읽은 페이지', value: weeklyPagesRead, total: stats.total_pages || 0, kind: 'count' },
-    { iconName: 'messageCircle', label: '질문', value: curr7.questions, total: stats.total_questions || 0, kind: 'count' },
-    { iconName: 'clock', label: '읽은 시간', value: weeklySeconds, total: totalSeconds, kind: 'duration' },
+    { iconName: 'bookOpen', label: '읽은 논문', value: curr7?.papersRead || 0, total: totalCompletedCount, kind: 'count' },
+    { iconName: 'fileText', label: '읽은 페이지', value: weeklyPagesRead || 0, total: stats?.total_pages || 0, kind: 'count' },
+    { iconName: 'messageCircle', label: '질문', value: curr7?.questions || 0, total: stats?.total_questions || 0, kind: 'count' },
+    { iconName: 'clock', label: '읽은 시간', value: weeklySeconds || 0, total: totalSeconds, kind: 'duration' },
   ]
   return `
     <div class="dash-card">

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -288,7 +288,8 @@ function computeStreaks(activeDayKeys) {
 }
 
 export function periodStats(events, docsById, startKey, endKeyExclusive) {
-  const inPeriod = events.filter(e => {
+  const safeEvents = Array.isArray(events) ? events : []
+  const inPeriod = safeEvents.filter(e => {
     const k = eventKey(e)
     return k && k >= startKey && k < endKeyExclusive
   })
@@ -296,12 +297,15 @@ export function periodStats(events, docsById, startKey, endKeyExclusive) {
 
   // 완독 체크(read === true)를 누른 논문만 해당 기간 읽은 논문으로 집계
   const completedDocIds = new Set()
-  for (const doc of docsById.values()) {
-    const meta = doc?.metadata || {}
-    if (meta.read === true) {
-      const k = isoToLocalDateKey(meta.read_at || meta.last_read_at)
-      if (k && k >= startKey && k < endKeyExclusive) {
-        completedDocIds.add(doc.id)
+  if (docsById && typeof docsById.values === 'function') {
+    for (const doc of docsById.values()) {
+      if (!doc) continue
+      const meta = doc.metadata || {}
+      if (meta.read === true) {
+        const k = isoToLocalDateKey(meta.read_at || meta.last_read_at || doc.created_at)
+        if (k && k >= startKey && k < endKeyExclusive) {
+          completedDocIds.add(doc.id)
+        }
       }
     }
   }
@@ -310,20 +314,23 @@ export function periodStats(events, docsById, startKey, endKeyExclusive) {
   const readDocIds = new Set(inPeriod.filter(e => e.type === 'read').map(e => e.doc_id))
   const activePageDocIds = new Set()
   for (const id of readDocIds) {
-    const doc = docsById.get(id)
+    const doc = docsById?.get(id)
     if (doc) activePageDocIds.add(id)
   }
-  for (const doc of docsById.values()) {
-    const meta = doc?.metadata || {}
-    if (hasReadActivity(meta)) {
-      const k = isoToLocalDateKey(meta.read_at || meta.last_read_at)
-      if (k && k >= startKey && k < endKeyExclusive) {
-        activePageDocIds.add(doc.id)
+  if (docsById && typeof docsById.values === 'function') {
+    for (const doc of docsById.values()) {
+      if (!doc) continue
+      const meta = doc.metadata || {}
+      if (hasReadActivity(meta)) {
+        const k = isoToLocalDateKey(meta.read_at || meta.last_read_at)
+        if (k && k >= startKey && k < endKeyExclusive) {
+          activePageDocIds.add(doc.id)
+        }
       }
     }
   }
 
-  const pagesRead = Array.from(activePageDocIds).reduce((sum, id) => sum + readPageCount(docsById.get(id)), 0)
+  const pagesRead = Array.from(activePageDocIds).reduce((sum, id) => sum + readPageCount(docsById?.get(id)), 0)
   const questions = inPeriod.filter(e => e.type === 'question').length
   const notes = inPeriod.filter(e => e.type === 'note').length
   const uploadedPapers = inPeriod.filter(e => e.type === 'uploaded').length


### PR DESCRIPTION
# Summary
## 1. 대시보드 렌더링 안정화 및 로딩 실패 방지
- `dashboardPage.js` 내 `STAT_DEFS` 주간 델타 콜백 및 `renderWeeklyActivityCard` 내부의 `curr7` 객체 엑세스에 optional chaining(`c7?.uploadedPapers || 0`) 및 수비적 방어를 적용하여 렌더링 에러 차단

## 2. Reading History 기간별 완독 집계 로직 검토 및 보완
- `periodStats()` 완독 시각 판별 시 `meta.read_at || meta.last_read_at || doc.created_at` 폴백을 적용하여 완독 등록 시각이 누락된 문서도 최근 7일/30일/전체 집계에 정상 반영되도록 개선