### PR TITLE
feat: Research Graph 추천 논문 캐시 자동 조회, 접힘/펼침 토글 및 다시받기 버튼 추가

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,7 +6,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 import { renderDashboardPage } from './pages/dashboardPage.js'
@@ -4910,6 +4910,100 @@ function renderGraphLegend(nodes, edges) {
 // 코드, off-limits)가 rowRect.right 기준으로 상세 패널 폭을 계산하므로
 // display:flex 구조를 그대로 유지해야 한다 - 왼쪽에 범례를 끼워 넣는 것은
 // 그 계산에 영향을 주지 않는다.
+let cachedGraphRecommendations = null
+let isGraphRecommendationsExpanded = false
+
+function renderGraphRecItemsHtml(recommendations) {
+  if (!recommendations || recommendations.length === 0) {
+    return `<p class="rg-recommend-status">추천할 만한 논문을 찾지 못했습니다.</p>`
+  }
+  return recommendations.map(r => `
+    <div class="rg-recommend-item">
+      <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" class="rg-recommend-item-title">${escapeHtml(r.title || '')}</a>
+      ${r.reason ? `<div class="rg-recommend-item-reason">${escapeHtml(r.reason)}</div>` : ''}
+    </div>
+  `).join('')
+}
+
+function updateGraphRecommendationsUI() {
+  if (!libraryRecommendationsBtn) return
+  const refreshBtn = $('rg-recommend-refresh-btn')
+  const hasCached = Array.isArray(cachedGraphRecommendations) && cachedGraphRecommendations.length > 0
+
+  if (hasCached) {
+    if (refreshBtn) refreshBtn.classList.remove('hidden')
+    const count = cachedGraphRecommendations.length
+    const chevronIcon = isGraphRecommendationsExpanded ? icon('chevronUp', 13) : icon('chevronDown', 13)
+    libraryRecommendationsBtn.innerHTML = `${icon('sparkles', 13)}<span>AI 추천 논문 (${count}개)</span>${chevronIcon}`
+    libraryRecommendationsBtn.title = isGraphRecommendationsExpanded ? '클릭하여 접기' : '클릭하여 추천 논문 펼치기'
+
+    if (libraryRecommendationsList) {
+      if (isGraphRecommendationsExpanded) {
+        libraryRecommendationsList.innerHTML = renderGraphRecItemsHtml(cachedGraphRecommendations)
+        libraryRecommendationsList.classList.remove('hidden')
+      } else {
+        libraryRecommendationsList.classList.add('hidden')
+      }
+    }
+  } else {
+    if (refreshBtn) refreshBtn.classList.add('hidden')
+    libraryRecommendationsBtn.innerHTML = `${icon('zap', 13)}<span>다음에 읽을 논문 추천받기</span>`
+    libraryRecommendationsBtn.title = '다음에 읽을 논문 추천받기'
+    if (libraryRecommendationsList) {
+      if (!isGraphRecommendationsExpanded && (!libraryRecommendationsList.innerHTML || libraryRecommendationsList.children.length === 0)) {
+        libraryRecommendationsList.classList.add('hidden')
+      }
+    }
+  }
+}
+
+async function loadCachedGraphRecommendations() {
+  try {
+    const res = await fetchCachedReadingRecommendations()
+    if (res && Array.isArray(res.recommendations) && res.recommendations.length > 0) {
+      cachedGraphRecommendations = res.recommendations
+      isGraphRecommendationsExpanded = false
+    } else {
+      cachedGraphRecommendations = null
+    }
+  } catch (err) {
+    console.error('추천 논문 캐시 조회 실패:', err)
+    cachedGraphRecommendations = null
+  }
+  updateGraphRecommendationsUI()
+}
+
+async function runGraphRecommendationsFetch({ force = false } = {}) {
+  if (!libraryRecommendationsBtn || !libraryRecommendationsList) return
+  const refreshBtn = $('rg-recommend-refresh-btn')
+
+  libraryRecommendationsBtn.disabled = true
+  if (refreshBtn) refreshBtn.disabled = true
+
+  isGraphRecommendationsExpanded = true
+  libraryRecommendationsList.classList.remove('hidden')
+  const statusText = force ? '추천 논문을 다시 찾는 중... (시간이 걸릴 수 있습니다)' : '추천 논문을 찾는 중... (시간이 걸릴 수 있습니다)'
+  libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">${statusText}</p>`
+
+  try {
+    const { recommendations } = await fetchReadingRecommendations({ force })
+    if (!recommendations || recommendations.length === 0) {
+      libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">추천할 만한 논문을 찾지 못했습니다.</p>`
+      cachedGraphRecommendations = null
+    } else {
+      cachedGraphRecommendations = recommendations
+      libraryRecommendationsList.innerHTML = renderGraphRecItemsHtml(recommendations)
+    }
+  } catch (err) {
+    console.error('추천 논문 조회 실패:', err)
+    libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status rg-recommend-error">추천 논문을 불러오지 못했습니다.</p>`
+  } finally {
+    libraryRecommendationsBtn.disabled = false
+    if (refreshBtn) refreshBtn.disabled = false
+    updateGraphRecommendationsUI()
+  }
+}
+
 let graphLayoutReady = false
 function ensureGraphLayout() {
   if (graphLayoutReady) return
@@ -4960,6 +5054,18 @@ function ensureGraphLayout() {
     libraryRecommendationsBtn.className = 'rg-recommend-btn'
     libraryRecommendationsBtn.innerHTML = `${icon('zap', 13)}<span>다음에 읽을 논문 추천받기</span>`
     toolbarRight.appendChild(libraryRecommendationsBtn)
+
+    let refreshRecoBtn = $('rg-recommend-refresh-btn')
+    if (!refreshRecoBtn) {
+      refreshRecoBtn = document.createElement('button')
+      refreshRecoBtn.id = 'rg-recommend-refresh-btn'
+      refreshRecoBtn.type = 'button'
+      refreshRecoBtn.className = 'rg-recommend-refresh-btn hidden'
+      refreshRecoBtn.title = '새로운 추천을 다시 받아옵니다'
+      refreshRecoBtn.innerHTML = `${icon('refreshCw', 12)}<span>다시받기</span>`
+      refreshRecoBtn.addEventListener('click', () => runGraphRecommendationsFetch({ force: true }))
+      toolbarRight.appendChild(refreshRecoBtn)
+    }
   }
 
   const recoPanel = document.createElement('div')
@@ -5136,6 +5242,7 @@ async function renderLibraryGraphTab() {
   }
   if (!libraryGraphCanvas) return
   ensureGraphLayout()
+  loadCachedGraphRecommendations()
   if (libraryGraphDetailPanel) {
     libraryGraphDetailPanel.innerHTML = renderGraphDetailEmptyState()
   }
@@ -5417,31 +5524,14 @@ if (libraryGraphSearchInput) {
   })
 }
 
-// 추천은 LLM+OpenAlex 호출이 여러 번 들어가는 무거운 작업이라 그래프 탭
-// 진입 시 자동 실행하지 않고, 사용자가 버튼을 눌렀을 때만 요청한다(2차의
-// "관련 질문 보기" 지연 로드와 동일한 절제 원칙).
+// 추천 논문: 캐시가 있는 경우 버튼 클릭 시 접힘/펼침 토글, 없는 경우 새로 추천 요청.
 if (libraryRecommendationsBtn) {
   libraryRecommendationsBtn.addEventListener('click', async () => {
-    if (!libraryRecommendationsList) return
-    libraryRecommendationsBtn.disabled = true
-    libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">추천 논문을 찾는 중... (시간이 걸릴 수 있습니다)</p>`
-    try {
-      const { recommendations } = await fetchReadingRecommendations()
-      if (!recommendations || recommendations.length === 0) {
-        libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status">추천할 만한 논문을 찾지 못했습니다.</p>`
-      } else {
-        libraryRecommendationsList.innerHTML = recommendations.map(r => `
-          <div class="rg-recommend-item">
-            <a href="${escapeHtml(r.url || '#')}" target="_blank" rel="noopener noreferrer" class="rg-recommend-item-title">${escapeHtml(r.title || '')}</a>
-            ${r.reason ? `<div class="rg-recommend-item-reason">${escapeHtml(r.reason)}</div>` : ''}
-          </div>
-        `).join('')
-      }
-    } catch (err) {
-      console.error('추천 논문 조회 실패:', err)
-      libraryRecommendationsList.innerHTML = `<p class="rg-recommend-status rg-recommend-error">추천 논문을 불러오지 못했습니다.</p>`
-    } finally {
-      libraryRecommendationsBtn.disabled = false
+    if (cachedGraphRecommendations && cachedGraphRecommendations.length > 0) {
+      isGraphRecommendationsExpanded = !isGraphRecommendationsExpanded
+      updateGraphRecommendationsUI()
+    } else {
+      await runGraphRecommendationsFetch({ force: false })
     }
   })
 }

--- a/frontend/src/styles/research-graph.css
+++ b/frontend/src/styles/research-graph.css
@@ -98,9 +98,39 @@
 .rg-recommend-btn:active:not(:disabled) { transform: scale(0.98); }
 .rg-recommend-btn:disabled { opacity: 0.65; cursor: default; }
 
-/* library-recommendations-list는 클릭 전엔 완전히 비어 있는 <div>라
-   :empty로 걸러내면 카드 테두리가 미리 나타나지 않는다. */
-#library-recommendations-list:not(:empty) {
+.rg-recommend-refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 38px;
+  padding: 0 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.rg-recommend-refresh-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+}
+.rg-recommend-refresh-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.rg-recommend-refresh-btn.hidden {
+  display: none !important;
+}
+
+/* library-recommendations-list는 클릭 전이나 접힌 상태에서는 hidden이라
+   :not(:empty):not(.hidden)으로 걸러내면 카드 테두리가 미리 나타나지 않는다. */
+#library-recommendations-list:not(:empty):not(.hidden) {
   margin-bottom: 12px;
   padding: 4px 14px;
   background: var(--bg-elevated);


### PR DESCRIPTION
# Summary
## 1. Research Graph 추천 논문 캐시 자동 확인 및 접힘/펼침 토글 구현
- Research Graph 탭 진입 시 loadCachedGraphRecommendations()를 호출하여 fetchCachedReadingRecommendations()로 서버의 유효 캐시 자동 조회
- 유효 캐시가 있는 경우 추천 목록을 접힌 상태(hidden)로 시작하며 버튼을 ✨ AI 추천 논문 (N개) ▼ 로 변경
- 버튼 클릭 시 isGraphRecommendationsExpanded 상태 토글 및 접기/펼치기 UI (▼/▲) 연동
## 2. 추천 논문 다시받기(강제 갱신) 버튼 추가
- ensureGraphLayout에서 툴바 우측에 다시받기 (#rg-recommend-refresh-btn) 버튼 동적 생성 및 배치
- 클릭 시 fetchReadingRecommendations({ force: true })를 호출하여 유효 캐시를 무시하고 서버 재계산을 요청하여 결과를 갱신하도록 구현
- #library-recommendations-list:not(:empty):not(.hidden) CSS 스타일 수정으로 접힌 상태에서 카드 테두리가 잔류하지 않도록 개선