### PR TITLE
feat: add single paper extraction cache clear feature to paper card kebab menu

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -640,6 +640,21 @@ async def delete_library_document_permanently(doc_id: str, current_user: str = D
     return {"message": "문서가 영구적으로 삭제되었습니다."}
 
 
+@router.post("/library/{doc_id}/clear-cache")
+async def clear_library_document_cache(doc_id: str, current_user: str = Depends(get_current_user)):
+    """특정 문서의 PDF 텍스트 및 이미지 추출 디스크 캐시를 삭제합니다."""
+    _require_owned_document(doc_id, current_user)
+    from services.cache import clear_document_cache
+    cleared_files, freed_bytes = clear_document_cache(doc_id)
+    return {
+        "message": "PDF 추출 캐시가 삭제되었습니다.",
+        "cleared_files": cleared_files,
+        "freed_bytes": freed_bytes,
+    }
+
+
+
+
 @router.get("/library/{doc_id}/images")
 async def get_library_document_images(doc_id: str, current_user: str = Depends(get_current_user)):
     """특정 문서의 모든 페이지에서 이미지/Figure 좌표 정보(백분율) 목록을 반환합니다.

--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -191,3 +191,31 @@ def clear_all_images_cache() -> "tuple[int, int]":
             except Exception:
                 pass
     return count, freed_bytes
+
+
+def clear_document_cache(doc_id: str) -> "tuple[int, int]":
+    """단일 문서의 PDF 텍스트 및 이미지/표 좌표 추출 디스크 캐시를 삭제합니다.
+    (삭제한 파일 개수, 확보한 바이트 수)를 반환합니다.
+    """
+    count = 0
+    freed_bytes = 0
+    pages_path = _pages_cache_path(doc_id)
+    if os.path.exists(pages_path):
+        try:
+            freed_bytes += os.path.getsize(pages_path)
+            os.remove(pages_path)
+            count += 1
+        except Exception:
+            pass
+
+    images_path = _images_cache_path(doc_id)
+    if os.path.exists(images_path):
+        try:
+            freed_bytes += os.path.getsize(images_path)
+            os.remove(images_path)
+            count += 1
+        except Exception:
+            pass
+
+    return count, freed_bytes
+

--- a/backend/tests/test_clear_document_cache.py
+++ b/backend/tests/test_clear_document_cache.py
@@ -1,0 +1,52 @@
+"""POST /library/{doc_id}/clear-cache 테스트 - 단일 문서의 PDF 텍스트 및 이미지 추출
+디스크 캐시를 정리하는 엔드포인트 및 서비스 함수 테스트."""
+
+from services.cache import save_pages_cache, save_images_cache, get_cached_pages, get_cached_images, clear_document_cache
+from services.library import save_document
+
+
+def test_clear_document_cache_service(isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 300)
+
+    save_pages_cache("doc-1", str(pdf_path), [{"page_num": 1, "text": "a"}])
+    save_images_cache("doc-1", str(pdf_path), [{"page_num": 1, "images": []}])
+    save_pages_cache("doc-2", str(pdf_path), [{"page_num": 1, "text": "b"}])
+
+    # doc-1 캐시만 삭제
+    count, freed_bytes = clear_document_cache("doc-1")
+    assert count == 2
+    assert freed_bytes > 0
+
+    assert get_cached_pages("doc-1", str(pdf_path)) is None
+    assert get_cached_images("doc-1", str(pdf_path)) is None
+    # doc-2 캐시는 유지되어야 함
+    assert get_cached_pages("doc-2", str(pdf_path)) == [{"page_num": 1, "text": "b"}]
+
+
+def test_clear_document_cache_endpoint(test_client, isolated_dirs, tmp_path):
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake" + b"\0" * 300)
+
+    doc_info = save_document("doc-test-1", "test_paper.pdf", str(pdf_path), 5, {}, "testuser")
+
+    doc_id = doc_info["id"]
+
+
+    save_pages_cache(doc_id, str(pdf_path), [{"page_num": 1, "text": "test"}])
+    save_images_cache(doc_id, str(pdf_path), [{"page_num": 1, "images": []}])
+
+    res = test_client.post(f"/api/library/{doc_id}/clear-cache")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cleared_files"] == 2
+    assert body["freed_bytes"] > 0
+    assert body["message"] == "PDF 추출 캐시가 삭제되었습니다."
+
+    assert get_cached_pages(doc_id, str(pdf_path)) is None
+    assert get_cached_images(doc_id, str(pdf_path)) is None
+
+
+def test_clear_document_cache_endpoint_not_found(test_client, isolated_dirs):
+    res = test_client.post("/api/library/non-existent-doc/clear-cache")
+    assert res.status_code == 404

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DuFZcK2S.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-KbhimsyC.css">
+  <script type="module" crossorigin src="/assets/index-D3kYkOqW.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BCA7jfzi.css">
 </head>
 <body>
 
@@ -455,8 +455,13 @@
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
               <span>번역본 다운로드</span>
             </button>
+            <button id="viewer-clear-cache-btn" class="kebab-menu-item" title="현재 논문의 PDF 추출 캐시 삭제">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+              <span>PDF 추출 캐시 삭제</span>
+            </button>
 
             <div class="kebab-menu-divider"></div>
+
 
             <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -454,8 +454,13 @@
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg>
               <span>번역본 다운로드</span>
             </button>
+            <button id="viewer-clear-cache-btn" class="kebab-menu-item" title="현재 논문의 PDF 추출 캐시 삭제">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+              <span>PDF 추출 캐시 삭제</span>
+            </button>
 
             <div class="kebab-menu-divider"></div>
+
 
             <button id="memos-hide-all-btn" class="kebab-menu-item" title="작성된 모든 메모 숨기기 (하이라이트만 표시)">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -592,6 +592,24 @@ export async function clearPagesCacheAPI() {
 }
 
 /**
+ * 특정 문서의 PDF 텍스트/이미지 추출 결과 디스크 캐시를 삭제합니다.
+ */
+export async function clearSingleDocCacheAPI(docId) {
+  const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/clear-cache`, {
+    method: 'POST'
+  })
+  if (!res.ok) {
+    try {
+      const err = await res.json()
+      throw new Error(err.detail || '캐시 삭제 실패')
+    } catch {
+      throw new Error('캐시 삭제 실패')
+    }
+  }
+  return res.json()
+}
+
+/**
  * 특정 문서의 이전 채팅 히스토리를 반환합니다.
  */
 export async function getChatHistoryAPI(sessionId) {

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -54,7 +54,9 @@ const PATHS = {
   activity: '<path d="M3 12h4l3 8 4-16 3 8h4"/>',
   smile: '<circle cx="12" cy="12" r="10"/><path d="M8 15s1.5 2 4 2 4-2 4-2"/><path d="M9 9h.01"/><path d="M15 9h.01"/>',
   flaskConical: '<path d="M9 2v6l-6 10a2 2 0 0 0 2 3h14a2 2 0 0 0 2-3l-6-10V2"/><path d="M9 2h6"/>',
+  moreVertical: '<circle cx="12" cy="12" r="1.8" fill="currentColor" stroke="none"/><circle cx="12" cy="5" r="1.8" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.8" fill="currentColor" stroke="none"/>',
 }
+
 
 // name: PATHS 키, size: 정사각형 픽셀 크기, attrs: svg 태그에 추가로 넣을 속성 문자열(style 등)
 export function icon(name, size = 14, attrs = '') {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,7 +4,7 @@ import './styles/library-page.css'
 import './styles/research-graph.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
 import { icon } from './icons.js'
@@ -1471,7 +1471,28 @@ if (toolbarKebabBtn && toolbarKebabMenu) {
   })
 }
 
+const viewerClearCacheBtn = $('viewer-clear-cache-btn')
+if (viewerClearCacheBtn) {
+  viewerClearCacheBtn.addEventListener('click', async () => {
+    toolbarKebabMenu?.classList.add('hidden')
+    if (!state.sessionId) {
+      showToast('열려있는 논문이 없습니다.', 'error')
+      return
+    }
+    const currentDocTitle = $('doc-title')?.textContent || '현재 논문'
+    const ok = await showCustomConfirm(`"${currentDocTitle}"의 PDF 추출 캐시를 삭제할까요?\n(다음 열람 시 PDF를 다시 파싱하게 됩니다.)`, { title: 'PDF 캐시 삭제', confirmText: '캐시 삭제' })
+    if (!ok) return
+    try {
+      await clearSingleDocCacheAPI(state.sessionId)
+      showToast('PDF 추출 캐시가 삭제되었습니다.', 'success')
+    } catch (err) {
+      showToast('캐시 삭제 실패: ' + err.message, 'error')
+    }
+  })
+}
+
 // ── 다시 번역하기 ──────────────────────────────────
+
 retranslateBtn.addEventListener('click', async () => {
   if (!state.sessionId) return
   
@@ -5850,12 +5871,21 @@ function prepareDocItemHtml(doc) {
       <button class="doc-edit-btn" data-id="${doc.id}" title="제목 수정">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
       </button>
-      <button class="doc-delete-btn" data-id="${doc.id}" title="삭제">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
-          <path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>
-        </svg>
-      </button>
+      <div class="doc-card-kebab-wrapper">
+        <button class="doc-card-kebab-btn" data-id="${doc.id}" title="더보기">
+          ${icon('moreVertical', 14)}
+        </button>
+        <div class="doc-card-kebab-menu hidden" data-id="${doc.id}">
+          <button class="doc-card-kebab-item doc-card-delete-btn" data-id="${doc.id}">
+            ${icon('trash2', 13)}
+            <span>삭제하기</span>
+          </button>
+          <button class="doc-card-kebab-item doc-card-clear-cache-btn" data-id="${doc.id}">
+            ${icon('refreshCw', 13)}
+            <span>캐시 삭제</span>
+          </button>
+        </div>
+      </div>
     `
     ctaBtnHtml = `<button class="doc-open-btn doc-cta-compact" data-id="${doc.id}" title="열기">${openIcon}</button>`
     ctaBtnFullHtml = `<button class="doc-open-btn" data-id="${doc.id}"><span>열기</span>${openIcon}</button>`
@@ -5911,10 +5941,24 @@ function wireDocItemEvents(container, doc, displayTitle) {
     })
   }
 
-  const deleteBtn = container.querySelector('.doc-delete-btn')
-  if (deleteBtn) {
-    deleteBtn.addEventListener('click', async (e) => {
+  const kebabBtn = container.querySelector('.doc-card-kebab-btn')
+  const kebabMenu = container.querySelector('.doc-card-kebab-menu')
+  if (kebabBtn && kebabMenu) {
+    kebabBtn.addEventListener('click', (e) => {
       e.stopPropagation()
+      const isHidden = kebabMenu.classList.contains('hidden')
+      document.querySelectorAll('.doc-card-kebab-menu').forEach(m => m.classList.add('hidden'))
+      if (isHidden) {
+        kebabMenu.classList.remove('hidden')
+      }
+    })
+  }
+
+  const cardDeleteBtn = container.querySelector('.doc-card-delete-btn, .doc-delete-btn')
+  if (cardDeleteBtn) {
+    cardDeleteBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      kebabMenu?.classList.add('hidden')
       const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
       const ok = await showCustomConfirm(`"${displayTitle}"을 삭제할까요? (휴지통으로 이동합니다)`, { title: '논문 삭제', confirmText: '삭제', danger: true })
       if (!ok) return
@@ -5927,6 +5971,24 @@ function wireDocItemEvents(container, doc, displayTitle) {
       }
     })
   }
+
+  const cardClearCacheBtn = container.querySelector('.doc-card-clear-cache-btn')
+  if (cardClearCacheBtn) {
+    cardClearCacheBtn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      kebabMenu?.classList.add('hidden')
+      const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+      const ok = await showCustomConfirm(`"${displayTitle}"의 PDF 추출 캐시를 삭제할까요?\n(다음 열람 시 PDF를 다시 파싱하게 됩니다.)`, { title: 'PDF 캐시 삭제', confirmText: '캐시 삭제' })
+      if (!ok) return
+      try {
+        await clearSingleDocCacheAPI(doc.id)
+        showToast('PDF 추출 캐시가 삭제되었습니다.', 'success')
+      } catch (err) {
+        showToast('캐시 삭제 실패: ' + err.message, 'error')
+      }
+    })
+  }
+
 
   const restoreBtn = container.querySelector('.doc-restore-btn')
   if (restoreBtn) {
@@ -6190,8 +6252,10 @@ function ensureLibraryDetailPanel() {
         <button id="lib-detail-edit-btn" class="lib-detail-icon-btn" title="제목 수정">${icon('edit3', 14)}</button>
         <button id="lib-detail-more-btn" class="lib-detail-icon-btn" title="더보기">${moreIconSvg}</button>
         <div id="lib-detail-more-menu" class="lib-detail-more-menu hidden">
+          <button id="lib-detail-clear-cache-btn" class="lib-detail-more-item">${icon('refreshCw', 13)}<span>PDF 추출 캐시 삭제</span></button>
           <button id="lib-detail-delete-btn" class="lib-detail-more-item danger">${icon('trash2', 13)}<span>삭제 (휴지통으로 이동)</span></button>
         </div>
+
       </div>
       <div class="lib-detail-tabs">
         <button type="button" class="lib-detail-tab active" data-tab="overview">개요</button>
@@ -6258,7 +6322,23 @@ function ensureLibraryDetailPanel() {
     document.addEventListener('click', () => moreMenu.classList.add('hidden'))
   }
 
+  $('lib-detail-clear-cache-btn')?.addEventListener('click', async () => {
+    if (!libraryDetailDoc) return
+    const doc = libraryDetailDoc
+    const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename
+    moreMenu?.classList.add('hidden')
+    const ok = await showCustomConfirm(`"${displayTitle}"의 PDF 추출 캐시를 삭제할까요?\n(다음 열람 시 PDF를 다시 파싱하게 됩니다.)`, { title: 'PDF 캐시 삭제', confirmText: '캐시 삭제' })
+    if (!ok) return
+    try {
+      await clearSingleDocCacheAPI(doc.id)
+      showToast('PDF 추출 캐시가 삭제되었습니다.', 'success')
+    } catch (err) {
+      showToast('캐시 삭제 실패: ' + err.message, 'error')
+    }
+  })
+
   $('lib-detail-delete-btn')?.addEventListener('click', async () => {
+
     if (!libraryDetailDoc) return
     const doc = libraryDetailDoc
     const displayTitle = (doc.metadata && doc.metadata.title) ? doc.metadata.title : doc.filename

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1420,6 +1420,79 @@ body.light-theme .toast.error { color: #dc2626; }
   border-color: var(--accent-mid);
 }
 
+.doc-card-kebab-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.doc-card-kebab-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+.doc-card-kebab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+.doc-card-kebab-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 140px;
+  padding: 6px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(8px);
+  animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.doc-card-kebab-menu.hidden {
+  display: none;
+}
+.doc-card-kebab-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.doc-card-kebab-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.doc-card-kebab-item.doc-card-delete-btn:hover {
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+}
+.doc-card-kebab-item svg {
+  flex-shrink: 0;
+}
+
+
 /* ── 카드/리스트 보기 전환 토글 ── */
 .library-view-toggle {
   display: flex;


### PR DESCRIPTION
# Summary
## 1. 개별 논문 PDF 추출 캐시 삭제 백엔드 서비스 및 API 구현
- `backend/services/cache.py`: 특정 문서(`doc_id`)의 PDF 텍스트 및 이미지/표 추출 디스크 캐시 파일(`{doc_id}_pages_extract.json`, `{doc_id}_images_extract.json`)을 삭제하고 확보한 용량을 반환하는 `clear_document_cache(doc_id)` 함수 추가
- `backend/routers/library.py`: 특정 문서의 디스크 캐시를 삭제하는 `POST /api/library/{doc_id}/clear-cache` 엔드포인트 추가 및 문서 소유권 검증 연결
- `backend/tests/test_clear_document_cache.py`: 단일 문서 캐시 삭제 서비스 및 API 라우터 동작을 검증하는 단위 테스트 추가

## 2. 프론트엔드 논문 카드 및 뷰어 케밥 메뉴 캐시 삭제 기능 추가
- `frontend/src/icons.js`: 세로 케밥 메뉴 전용 `moreVertical` SVG 아이콘 추가
- `frontend/src/api.js`: 단일 문서 캐시 삭제 API를 호출하는 `clearSingleDocCacheAPI(docId)` 함수 추가
- `frontend/src/main.js`:
  - 라이브러리 카드/리스트 뷰의 삭제 버튼을 세로 케밥 메뉴(`⋮`)로 전환 및 메뉴 항목으로 `삭제하기`, `캐시 삭제` 추가
  - 라이브러리 상세 우측 패널(`lib-detail-more-menu`) 및 PDF 뷰어 상단 케밥 메뉴(`toolbar-kebab-menu`)에 `PDF 추출 캐시 삭제` 메뉴 항목 및 클릭 이벤트 추가
  - 케밥 메뉴 오픈 시 외부 영역 클릭 시 자동 닫힘 처리 구현
- `frontend/src/style.css`: `.doc-card-kebab-wrapper`, `.doc-card-kebab-btn`, `.doc-card-kebab-menu`, `.doc-card-kebab-item` 스타일 정의 및 드롭다운 애니메이션 추가