### PR TITLE
feat: add library batch selection mode with floating pill action toolbar

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-D3kYkOqW.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BCA7jfzi.css">
+  <script type="module" crossorigin src="/assets/index-CH0ldQa9.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-BxZ0P-Pa.css">
 </head>
 <body>
 
@@ -211,14 +211,40 @@
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
             </button>
 
-            <!-- 비교하기 선택 모드 하단 플로팅 바 -->
-            <div id="compare-select-bar" class="compare-select-bar hidden">
-              <span id="compare-select-count">0/5개 선택됨</span>
-              <div class="compare-select-bar-actions">
-                <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
-                <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+            <!-- 하단 중앙 알약 모양 툴박스 (선택 모드 일괄 조작 툴바) -->
+            <div id="lib-select-toolbar" class="lib-select-toolbar hidden">
+              <div class="lib-select-toolbar-info">
+                <span id="lib-select-count" class="lib-select-count">0개 선택됨</span>
+                <button type="button" id="lib-select-all-btn" class="lib-select-text-btn" title="전체 선택/해제">전체 선택</button>
               </div>
+              <div class="lib-select-toolbar-divider"></div>
+              <div class="lib-select-toolbar-actions">
+                <button type="button" id="lib-select-read-btn" class="lib-select-action-btn" title="선택한 논문 읽음 상태 변경">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+                  <span>읽음 표시</span>
+                </button>
+                <button type="button" id="lib-select-fav-btn" class="lib-select-action-btn" title="선택한 논문 북마크 토글">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>
+                  <span>북마크</span>
+                </button>
+                <button type="button" id="lib-select-cache-btn" class="lib-select-action-btn" title="선택한 논문의 PDF 추출 캐시 삭제">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+                  <span>캐시 삭제</span>
+                </button>
+                <button type="button" id="lib-select-compare-btn" class="lib-select-action-btn" title="선택한 논문들 비교 대화">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+                  <span>논문 비교</span>
+                </button>
+                <button type="button" id="lib-select-delete-btn" class="lib-select-action-btn danger" title="선택한 논문 삭제">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                  <span>삭제하기</span>
+                </button>
+              </div>
+              <button type="button" id="lib-select-close-btn" class="lib-select-close-btn" title="선택 취소">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              </button>
             </div>
+
           </section>
 
           <!-- Reading History -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -210,14 +210,40 @@
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통 비우기
             </button>
 
-            <!-- 비교하기 선택 모드 하단 플로팅 바 -->
-            <div id="compare-select-bar" class="compare-select-bar hidden">
-              <span id="compare-select-count">0/5개 선택됨</span>
-              <div class="compare-select-bar-actions">
-                <button id="compare-select-cancel-btn" class="file-btn-outline compact">취소</button>
-                <button id="compare-select-start-btn" class="file-btn compact" disabled>비교 채팅 시작</button>
+            <!-- 하단 중앙 알약 모양 툴박스 (선택 모드 일괄 조작 툴바) -->
+            <div id="lib-select-toolbar" class="lib-select-toolbar hidden">
+              <div class="lib-select-toolbar-info">
+                <span id="lib-select-count" class="lib-select-count">0개 선택됨</span>
+                <button type="button" id="lib-select-all-btn" class="lib-select-text-btn" title="전체 선택/해제">전체 선택</button>
               </div>
+              <div class="lib-select-toolbar-divider"></div>
+              <div class="lib-select-toolbar-actions">
+                <button type="button" id="lib-select-read-btn" class="lib-select-action-btn" title="선택한 논문 읽음 상태 변경">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+                  <span>읽음 표시</span>
+                </button>
+                <button type="button" id="lib-select-fav-btn" class="lib-select-action-btn" title="선택한 논문 북마크 토글">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>
+                  <span>북마크</span>
+                </button>
+                <button type="button" id="lib-select-cache-btn" class="lib-select-action-btn" title="선택한 논문의 PDF 추출 캐시 삭제">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
+                  <span>캐시 삭제</span>
+                </button>
+                <button type="button" id="lib-select-compare-btn" class="lib-select-action-btn" title="선택한 논문들 비교 대화">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3"/><path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3"/><path d="M12 3v18"/></svg>
+                  <span>논문 비교</span>
+                </button>
+                <button type="button" id="lib-select-delete-btn" class="lib-select-action-btn danger" title="선택한 논문 삭제">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                  <span>삭제하기</span>
+                </button>
+              </div>
+              <button type="button" id="lib-select-close-btn" class="lib-select-close-btn" title="선택 취소">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              </button>
             </div>
+
           </section>
 
           <!-- Reading History -->

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3867,73 +3867,167 @@ if (workspaceSearchInput) {
 let activeCategoryFilter = 'ALL'
 
 // ── 여러 논문 비교 채팅: 라이브러리 선택 모드 ──────────────
-let compareSelectMode = false
-const compareSelectedDocs = new Map() // doc.id -> doc
-const COMPARE_MAX_DOCS = 5
-const COMPARE_MIN_DOCS = 2
+// ── 라이브러리 논문 선택 모드 & 하단 플로팅 알약 툴바 ──
+const selectedDocIds = new Set()
 
-function updateCompareSelectUI() {
-  const count = compareSelectedDocs.size
-  if (compareSelectCount) compareSelectCount.textContent = `${count}/${COMPARE_MAX_DOCS}개 선택됨`
-  if (compareSelectStartBtn) compareSelectStartBtn.disabled = count < COMPARE_MIN_DOCS
+function getVisibleDocIds() {
+  return currentLibraryDocs.map(d => d.id)
 }
 
-function setCompareCheckboxVisual(container, checked) {
-  const box = container.querySelector('.doc-card-compare-check')
-  if (!box) return
-  box.classList.toggle('checked', checked)
-  box.innerHTML = checked
-    ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>'
-    : ''
-}
-
-function toggleDocCompareSelection(container, doc) {
-  const isSelected = compareSelectedDocs.has(doc.id)
-  if (isSelected) {
-    compareSelectedDocs.delete(doc.id)
-    setCompareCheckboxVisual(container, false)
+function toggleDocSelection(docId) {
+  if (selectedDocIds.has(docId)) {
+    selectedDocIds.delete(docId)
   } else {
-    if (compareSelectedDocs.size >= COMPARE_MAX_DOCS) {
-      showToast(`최대 ${COMPARE_MAX_DOCS}편까지 선택할 수 있습니다.`, 'warning')
+    selectedDocIds.add(docId)
+  }
+  updateDocCardSelectionVisuals(docId)
+  updateSelectToolbarUI()
+}
+
+function updateDocCardSelectionVisuals(docId) {
+  const isSelected = selectedDocIds.has(docId)
+  const els = document.querySelectorAll(`.doc-card[data-id="${CSS.escape(docId)}"], .doc-list-row[data-id="${CSS.escape(docId)}"]`)
+  els.forEach(el => {
+    el.classList.toggle('doc-card-selected', isSelected)
+    const checkBtn = el.querySelector('.doc-card-check-btn')
+    if (checkBtn) {
+      checkBtn.classList.toggle('checked', isSelected)
+      checkBtn.title = isSelected ? '선택 해제' : '선택'
+    }
+  })
+}
+
+function clearDocSelection() {
+  selectedDocIds.clear()
+  document.querySelectorAll('.doc-card-selected').forEach(el => el.classList.remove('doc-card-selected'))
+  document.querySelectorAll('.doc-card-check-btn.checked').forEach(el => {
+    el.classList.remove('checked')
+    el.title = '선택'
+  })
+  updateSelectToolbarUI()
+}
+
+function updateSelectToolbarUI() {
+  const count = selectedDocIds.size
+  const toolbar = $('lib-select-toolbar')
+  if (!toolbar) return
+
+  if (count > 0 && state.currentLibraryTab !== 'trash') {
+    toolbar.classList.remove('hidden')
+    const countEl = $('lib-select-count')
+    if (countEl) countEl.textContent = `${count}개 선택됨`
+
+    const compareBtn = $('lib-select-compare-btn')
+    if (compareBtn) compareBtn.disabled = (count < 2 || count > 5)
+
+    const visibleIds = getVisibleDocIds()
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => selectedDocIds.has(id))
+    const selectAllBtn = $('lib-select-all-btn')
+    if (selectAllBtn) selectAllBtn.textContent = allSelected ? '선택 해제' : '전체 선택'
+  } else {
+    toolbar.classList.add('hidden')
+  }
+}
+
+function initSelectToolbarEvents() {
+  $('lib-select-all-btn')?.addEventListener('click', () => {
+    const visibleIds = getVisibleDocIds()
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => selectedDocIds.has(id))
+    if (allSelected) {
+      clearDocSelection()
+    } else {
+      visibleIds.forEach(id => selectedDocIds.add(id))
+      visibleIds.forEach(id => updateDocCardSelectionVisuals(id))
+      updateSelectToolbarUI()
+    }
+  })
+
+  $('lib-select-read-btn')?.addEventListener('click', async () => {
+    if (selectedDocIds.size === 0) return
+    const selectedDocsList = currentLibraryDocs.filter(d => selectedDocIds.has(d.id))
+    const allRead = selectedDocsList.length > 0 && selectedDocsList.every(d => d.metadata?.read === true)
+    const nextReadState = !allRead
+    const payload = { read: nextReadState, read_at: nextReadState ? new Date().toISOString() : null }
+
+    try {
+      await Promise.all(Array.from(selectedDocIds).map(id => updateLibraryDocMetadata(id, payload)))
+      showToast(nextReadState ? `${selectedDocIds.size}개 논문을 읽음으로 표시했습니다.` : `${selectedDocIds.size}개 논문의 완독 상태를 해제했습니다.`, 'success')
+      clearDocSelection()
+      await renderLibrary()
+    } catch (err) {
+      showToast('상태 변경 실패: ' + err.message, 'error')
+    }
+  })
+
+  $('lib-select-fav-btn')?.addEventListener('click', async () => {
+    if (selectedDocIds.size === 0) return
+    const count = selectedDocIds.size
+    selectedDocIds.forEach(id => toggleFavoriteDoc(id))
+    showToast(`${count}개 논문의 북마크 상태가 변경되었습니다.`, 'success')
+    clearDocSelection()
+    await renderLibrary()
+  })
+
+  $('lib-select-cache-btn')?.addEventListener('click', async () => {
+    if (selectedDocIds.size === 0) return
+    const count = selectedDocIds.size
+    const ok = await showCustomConfirm(`선택한 ${count}개 논문의 PDF 추출 캐시를 삭제할까요?\n(다음 열람 시 PDF를 다시 파싱하게 됩니다.)`, { title: 'PDF 캐시 삭제', confirmText: '캐시 삭제' })
+    if (!ok) return
+    try {
+      await Promise.allSettled(Array.from(selectedDocIds).map(id => clearSingleDocCacheAPI(id)))
+      showToast(`선택한 ${count}개 논문의 PDF 추출 캐시가 삭제되었습니다.`, 'success')
+      clearDocSelection()
+    } catch (err) {
+      showToast('캐시 삭제 실패: ' + err.message, 'error')
+    }
+  })
+
+  $('lib-select-compare-btn')?.addEventListener('click', () => {
+    const ids = Array.from(selectedDocIds)
+    if (ids.length < 2 || ids.length > 5) {
+      showToast('논문 비교는 2~5개 논문을 선택했을 때만 가능합니다.', 'warning')
       return
     }
-    compareSelectedDocs.set(doc.id, doc)
-    setCompareCheckboxVisual(container, true)
-  }
-  updateCompareSelectUI()
-}
-
-function setCompareSelectMode(enabled) {
-  compareSelectMode = enabled
-  compareSelectedDocs.clear()
-  if (libraryGrid) libraryGrid.classList.toggle('compare-select-mode', enabled)
-  if (libCompareToggleBtn) libCompareToggleBtn.classList.toggle('active', enabled)
-  if (compareSelectBar) compareSelectBar.classList.toggle('hidden', !enabled)
-  document.querySelectorAll('.doc-card-compare-check').forEach(box => {
-    box.classList.remove('checked')
-    box.innerHTML = ''
-  })
-  updateCompareSelectUI()
-}
-
-if (libCompareToggleBtn) {
-  libCompareToggleBtn.addEventListener('click', () => {
-    setCompareSelectMode(!compareSelectMode)
-  })
-}
-
-if (compareSelectCancelBtn) {
-  compareSelectCancelBtn.addEventListener('click', () => setCompareSelectMode(false))
-}
-
-if (compareSelectStartBtn) {
-  compareSelectStartBtn.addEventListener('click', () => {
-    const ids = Array.from(compareSelectedDocs.keys())
-    if (ids.length < COMPARE_MIN_DOCS) return
-    setCompareSelectMode(false)
+    clearDocSelection()
     location.hash = `#compare?ids=${ids.map(encodeURIComponent).join(',')}`
   })
+
+  $('lib-select-delete-btn')?.addEventListener('click', async () => {
+    if (selectedDocIds.size === 0) return
+    const count = selectedDocIds.size
+    const ok = await showCustomConfirm(`선택한 ${count}개 논문을 삭제할까요? (휴지통으로 이동합니다)`, { title: '논문 삭제', confirmText: '삭제', danger: true })
+    if (!ok) return
+    try {
+      await Promise.allSettled(Array.from(selectedDocIds).map(id => deleteLibraryDoc(id)))
+      showToast(`${count}개 논문이 휴지통으로 이동되었습니다.`, 'success')
+      clearDocSelection()
+      await renderLibrary()
+    } catch {
+      showToast('삭제 실패', 'error')
+    }
+  })
+
+  $('lib-select-close-btn')?.addEventListener('click', () => {
+    clearDocSelection()
+  })
+
+  if (libCompareToggleBtn) {
+    libCompareToggleBtn.addEventListener('click', () => {
+      if (selectedDocIds.size === 0) {
+        showToast('카드 우상단 체크 버튼을 눌러 비교할 논문을 선택하세요.', 'info')
+      } else if (selectedDocIds.size >= 2 && selectedDocIds.size <= 5) {
+        const ids = Array.from(selectedDocIds)
+        clearDocSelection()
+        location.hash = `#compare?ids=${ids.map(encodeURIComponent).join(',')}`
+      } else {
+        showToast('논문 비교는 2~5개 논문을 선택해야 합니다.', 'warning')
+      }
+    })
+  }
 }
+
+initSelectToolbarEvents()
+
 
 // ── 여러 논문 비교 채팅 화면 ────────────────────────────
 let compareChatState = { docIds: [], docs: [], history: [], activeStream: null, currentText: '' }
@@ -5820,17 +5914,17 @@ function prepareDocItemHtml(doc) {
     dateHtml = `<span class="doc-meta-chip done">완독 ${readDateStr}</span>`
   }
 
-  const compareCheckHtml = state.currentLibraryTab === 'trash' ? '' : `
-    <div class="doc-card-compare-check" data-id="${doc.id}" title="비교할 논문으로 선택"></div>
-  `
+  const isSelected = selectedDocIds.has(doc.id)
+  const compareCheckHtml = ''
 
   const checkBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
-    <button class="doc-card-check-btn ${isRead ? 'checked' : ''}" data-id="${doc.id}" title="${isRead ? '읽지 않음으로 표시' : '읽음으로 표시'}">
+    <button class="doc-card-check-btn ${isSelected ? 'checked' : ''}" data-id="${doc.id}" title="${isSelected ? '선택 해제' : '선택'}">
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="20 6 9 17 4 12"></polyline>
       </svg>
     </button>
   `
+
 
   const expandBtnHtml = state.currentLibraryTab === 'trash' ? '' : `
     <button class="doc-card-expand-btn" data-id="${doc.id}" title="미리보기">${icon('expand', 12)}</button>
@@ -5897,35 +5991,15 @@ function prepareDocItemHtml(doc) {
 // 카드/리스트 뷰 공용: 위임 없이 각 아이템 컨테이너에 직접 붙는 이벤트 리스너를 등록한다.
 // 클래스명(.doc-card-check-btn, .doc-open-btn 등)만 맞으면 어떤 레이아웃이든 동작한다.
 function wireDocItemEvents(container, doc, displayTitle) {
-  const compareCheck = container.querySelector('.doc-card-compare-check')
-  if (compareCheck) {
-    setCompareCheckboxVisual(container, compareSelectedDocs.has(doc.id))
-    compareCheck.addEventListener('click', (e) => {
-      e.stopPropagation()
-      toggleDocCompareSelection(container, doc)
-    })
+  if (selectedDocIds.has(doc.id)) {
+    container.classList.add('doc-card-selected')
   }
 
   const checkBtn = container.querySelector('.doc-card-check-btn')
   if (checkBtn) {
-    checkBtn.addEventListener('click', async (e) => {
+    checkBtn.addEventListener('click', (e) => {
       e.stopPropagation()
-      const currentReadState = doc.metadata?.read === true
-      const nextReadState = !currentReadState
-      const payload = { read: nextReadState }
-      if (nextReadState) {
-        payload.read_at = new Date().toISOString()
-      } else {
-        payload.read_at = null
-      }
-      
-      try {
-        await updateLibraryDocMetadata(doc.id, payload)
-        showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
-        await renderLibrary()
-      } catch (err) {
-        showToast('상태 변경 실패: ' + err.message, 'error')
-      }
+      toggleDocSelection(doc.id)
     })
   }
 
@@ -5933,13 +6007,14 @@ function wireDocItemEvents(container, doc, displayTitle) {
   if (openBtn) {
     openBtn.addEventListener('click', (e) => {
       e.stopPropagation()
-      // 편집/삭제/미리보기 버튼은 비교 선택 모드에서 CSS(pointer-events: none)로
-      // 막혀있지만, "열기" 버튼은 카드 풋터에 별도로 배치되어 그 대상에서 빠져있다.
-      // 막지 않으면 선택 모드 중 클릭 시 선택 대신 뷰어로 즉시 이동해버린다.
-      if (compareSelectMode) { toggleDocCompareSelection(container, doc); return }
+      if (selectedDocIds.size > 0) {
+        toggleDocSelection(doc.id)
+        return
+      }
       openFromLibrary(doc)
     })
   }
+
 
   const kebabBtn = container.querySelector('.doc-card-kebab-btn')
   const kebabMenu = container.querySelector('.doc-card-kebab-menu')
@@ -6090,9 +6165,11 @@ function wireDocItemEvents(container, doc, displayTitle) {
   })
   }
 
-  container.addEventListener('click', () => {
-    if (compareSelectMode) {
-      toggleDocCompareSelection(container, doc)
+  container.addEventListener('click', (e) => {
+    if (e.target.closest('.doc-card-kebab-wrapper, .doc-edit-btn, .doc-open-btn, .doc-restore-btn, .doc-permanent-delete-btn, .doc-card-fav-btn, .doc-card-expand-btn')) return
+
+    if (selectedDocIds.size > 0) {
+      toggleDocSelection(doc.id)
       return
     }
     if (state.currentLibraryTab === 'trash') {
@@ -6169,14 +6246,11 @@ function createDocCard(doc) {
     })
   }
 
-  // 카드 빈 영역 클릭 시 상세 패널을 연다. wireDocItemEvents()가 곧이어 등록할
-  // "카드 전체 클릭 = 뷰어 즉시 열기" 리스너보다 먼저 걸어 stopImmediatePropagation으로
-  // 가로챈다 - 같은 엘리먼트에 등록된 리스너는 등록 순서대로 실행되므로, 여기서
-  // 먼저 등록한 뒤 막으면 이후 리스너는 아예 실행되지 않는다. 비교 선택 모드/휴지통
-  // 안내 동작은 기존과 동일하게 여기서도 복제해 그대로 유지한다.
   card.addEventListener('click', (e) => {
-    if (compareSelectMode) {
-      toggleDocCompareSelection(card, doc)
+    if (e.target.closest('.doc-card-kebab-wrapper, .doc-edit-btn, .doc-open-btn, .doc-restore-btn, .doc-permanent-delete-btn, .doc-card-fav-btn, .doc-card-expand-btn')) return
+
+    if (selectedDocIds.size > 0) {
+      toggleDocSelection(doc.id)
       e.stopImmediatePropagation()
       return
     }
@@ -6188,6 +6262,7 @@ function createDocCard(doc) {
     openLibraryDetailPanel(doc)
     e.stopImmediatePropagation()
   })
+
 
   wireDocItemEvents(card, doc, d.displayTitle)
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6647,3 +6647,141 @@ body.light-theme .chat-drawer {
   border-color: var(--accent-mid);
   background: var(--bg-hover);
 }
+
+/* ── 하단 중앙 알약 모양 선택 툴바 ── */
+.lib-select-toolbar {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px 8px 18px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 9999px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(16px);
+  animation: pillSlideUp 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.lib-select-toolbar.hidden {
+  display: none !important;
+}
+
+@keyframes pillSlideUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+.lib-select-toolbar-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.lib-select-count {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.lib-select-text-btn {
+  background: transparent;
+  border: none;
+  color: var(--accent-mid);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  transition: background 0.15s ease;
+}
+.lib-select-text-btn:hover {
+  background: color-mix(in srgb, var(--accent-mid) 15%, transparent);
+}
+
+.lib-select-toolbar-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border-strong);
+  opacity: 0.6;
+}
+
+.lib-select-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lib-select-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+.lib-select-action-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.lib-select-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.lib-select-action-btn.danger {
+  color: var(--error);
+}
+.lib-select-action-btn.danger:hover {
+  background: color-mix(in srgb, var(--error) 15%, transparent);
+  border-color: color-mix(in srgb, var(--error) 30%, transparent);
+}
+
+.lib-select-close-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  margin-left: 4px;
+}
+.lib-select-close-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* 선택된 논문 카드 / 리스트 행 하이라이트 */
+.doc-card.doc-card-selected, .doc-list-row.doc-card-selected {
+  border-color: var(--accent-mid) !important;
+  box-shadow: 0 0 0 1px var(--accent-mid), 0 8px 24px rgba(126, 196, 232, 0.15) !important;
+  background: color-mix(in srgb, var(--accent-mid) 4%, var(--bg-panel)) !important;
+}
+
+.doc-card-check-btn.checked {
+  background: var(--control-accent) !important;
+  border-color: var(--control-accent) !important;
+  color: #ffffff !important;
+}
+


### PR DESCRIPTION
# Summary
## 1. 라이브러리 카드 일괄 선택 모드 및 체크 버튼 동작 개편
- 논문 카드 우상단 체크 버튼(`doc-card-check-btn`)을 기존 읽음/안읽음 단일 토글에서 논문 선택(Select) 버튼으로 변경함.
- 카드 뷰 및 리스트 뷰에서 선택 아이콘 클릭 시 선택 상태(`selectedDocIds`)가 변경되며 카드에 강조 테두리 및 체크 시각 효과가 적용됨.
- 선택 모드 활성화 상태에서 카드 빈 영역 클릭 시 해당 논문의 선택/선택 해제가 전환되도록 개선함.

## 2. 하단 중앙 알약(Pill) 모양 선택 툴바 구현
- 논문 선택 시 화면 하단 중앙에 모던 유리질감(Glassmorphism) 및 둥근 알약 스타일의 플로팅 툴바(`#lib-select-toolbar`)가 뜨도록 추가함.
- 선택 개수(`N개 선택됨`) 표시 및 전체 선택/선택 해제 텍스트 버튼 제공.
- 일괄 기능 액션 버튼 제공:
  - 📖 **읽음 표시**: 선택한 모든 논문의 완독/미독 상태를 일괄 변경.
  - ⭐️ **북마크**: 선택한 논문들의 즐겨찾기 상태를 일괄 토글.
  - ⚡️ **캐시 삭제**: 선택한 논문들의 PDF 추출 캐시를 확인 후 일괄 삭제.
  - 💬 **논문 비교**: 2~5개 논문 선택 시 논문 비교 AI 대화 화면으로 바로 이동.
  - 🗑️ **삭제하기**: 선택한 논문들을 확인 후 휴지통으로 일괄 이동.
  - ✖️ **닫기**: 선택 모드 종료 및 선택 해제.