### PR TITLE
fix: resolve trash bin tab display issue and retain trash button text

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-CH0ldQa9.js"></script>
+  <script type="module" crossorigin src="/assets/index-DcwBkp-5.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BxZ0P-Pa.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3657,7 +3657,8 @@ function updateTrashTabVisibility(trashDocs) {
   if (trashCount > 0 || state.currentLibraryTab === 'trash') {
     libTabTrash.classList.remove('hidden')
     libTabTrash.title = `휴지통 (${trashCount}개 문서)`
-    libTabTrash.innerHTML = icon('trash2', 14)
+    const countBadge = trashCount > 0 ? ` (${trashCount})` : ''
+    libTabTrash.innerHTML = `${icon('trash2', 14, 'style="vertical-align:-2px;margin-right:4px"')}휴지통${countBadge}`
   } else {
     libTabTrash.classList.add('hidden')
   }
@@ -3696,6 +3697,15 @@ function updateTabUI(activeTab) {
   activeCategoryFilter = 'ALL'
   activeStatusFilter = 'all'
   closeLibraryDetailPanel()
+
+  const subtitleEl = document.querySelector('.library-header-subtitle')
+  if (subtitleEl) {
+    if (activeTab === 'trash') {
+      subtitleEl.textContent = '휴지통에 보관 중인 논문입니다. 복원하거나 영구 삭제할 수 있습니다.'
+    } else {
+      subtitleEl.textContent = '보관함에 저장된 모든 논문을 한 곳에서 관리하세요'
+    }
+  }
 
   if (libTabTrash) libTabTrash.classList.toggle('active', activeTab === 'trash')
   if (libEmptyTrashBtn) libEmptyTrashBtn.classList.toggle('hidden', activeTab !== 'trash')
@@ -3837,6 +3847,9 @@ document.querySelectorAll('[data-icon]').forEach(el => {
 if (sidebarNav) {
   sidebarNav.querySelectorAll('.sidebar-nav-item[data-page]').forEach(btn => {
     btn.addEventListener('click', () => {
+      if (btn.dataset.page === 'library') {
+        updateTabUI('archive')
+      }
       if (state.currentWorkspacePage === btn.dataset.page) return
       showWorkspacePage(btn.dataset.page)
     })


### PR DESCRIPTION
# Summary
## 1. 휴지통 탭 전환 및 버튼 표기 버그 수정
- `frontend/src/main.js`의 `updateTrashTabVisibility()` 함수에서 휴지통 버튼 텍스트가 삭제되던 현상을 수정하여 "휴지통 (N)" 표기를 유지함
- `updateTabUI()` 함수에서 휴지통 탭 활성화 시 헤더 서브타이틀이 휴지통 전용 문구로 변경되도록 보완함
- 사이드바 `Library` 메뉴 클릭 시 보관함(`archive`) 탭으로 리셋되도록 라우팅 핸들러를 수정함