### PR TITLE
fix: resolve double renderLibrary invocation and broken library page entry

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-DcwBkp-5.js"></script>
+  <script type="module" crossorigin src="/assets/index-7Ty7aSp9.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BxZ0P-Pa.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3692,7 +3692,7 @@ async function loadLibraryCount() {
 // 탭 클릭 이벤트 리스너 등록
 // Library 페이지 내부 탭(archive: 전체 / trash: 휴지통) 전환. 채팅/주석/그래프/히스토리는
 // 더 이상 Library의 내부 탭이 아니라 사이드바의 독립된 최상위 페이지다 - showWorkspacePage() 참고.
-function updateTabUI(activeTab) {
+function syncLibraryTabUI(activeTab) {
   state.currentLibraryTab = activeTab
   activeCategoryFilter = 'ALL'
   activeStatusFilter = 'all'
@@ -3712,7 +3712,10 @@ function updateTabUI(activeTab) {
   if (libUploadBtn) libUploadBtn.classList.toggle('hidden', activeTab === 'trash')
   if (libCompareToggleBtn) libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash')
   setCompareSelectMode(false)
+}
 
+function updateTabUI(activeTab) {
+  syncLibraryTabUI(activeTab)
   renderLibrary()
 }
 
@@ -3806,6 +3809,7 @@ async function showWorkspacePage(pageId, { pushState = true } = {}) {
   }
 
   if (pageId === 'library') {
+    syncLibraryTabUI(state.currentLibraryTab || 'archive')
     await renderLibrary()
   } else if (pageId === 'chats') {
     await renderAiChatsPage()
@@ -3847,9 +3851,6 @@ document.querySelectorAll('[data-icon]').forEach(el => {
 if (sidebarNav) {
   sidebarNav.querySelectorAll('.sidebar-nav-item[data-page]').forEach(btn => {
     btn.addEventListener('click', () => {
-      if (btn.dataset.page === 'library') {
-        updateTabUI('archive')
-      }
       if (state.currentWorkspacePage === btn.dataset.page) return
       showWorkspacePage(btn.dataset.page)
     })


### PR DESCRIPTION
# Summary
## 1. 라이브러리 진입 및 이중 렌더링 수정
- 사이드바 클릭 핸들러에서 `updateTabUI('archive')` 호출로 발생하던 이중 `renderLibrary()` 비동기 경합 및 먹통 현상을 제거함
- `syncLibraryTabUI()` 헬퍼 함수를 분리하여 `showWorkspacePage('library')` 라우팅 시 중복 렌더링 없이 UI 상태(서브타이틀 및 탭 활성화)가 안전하게 동기화되도록 수정함