### PR TITLE
fix: resolve ReferenceError by replacing setCompareSelectMode with clearDocSelection

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-7Ty7aSp9.js"></script>
+  <script type="module" crossorigin src="/assets/index-EM_KO4bo.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BxZ0P-Pa.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3711,7 +3711,7 @@ function syncLibraryTabUI(activeTab) {
   if (libEmptyTrashBtn) libEmptyTrashBtn.classList.toggle('hidden', activeTab !== 'trash')
   if (libUploadBtn) libUploadBtn.classList.toggle('hidden', activeTab === 'trash')
   if (libCompareToggleBtn) libCompareToggleBtn.classList.toggle('hidden', activeTab === 'trash')
-  setCompareSelectMode(false)
+  clearDocSelection()
 }
 
 function updateTabUI(activeTab) {


### PR DESCRIPTION
# Summary
## 1. 라이브러리 진입 및 논문 로딩 차단 오류 수정
- `syncLibraryTabUI()` 내부에서 존재하지 않는 함수인 `setCompareSelectMode(false)` 호출로 인해 발생하던 `ReferenceError`를 수정함
- 해당 위치를 `clearDocSelection()`으로 대체하여 라이브러리 탭 전환 및 초기 진입 시 자바스크립트 실행 중단을 방지하고 정상적으로 논문 목록이 로딩되도록 개선함