### PR TITLE
fix: prevent trash button layout shift and fix button layout corruption

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-EM_KO4bo.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BxZ0P-Pa.css">
+  <script type="module" crossorigin src="/assets/index-Bp9IWwzv.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-0lUB8pYs.css">
 </head>
 <body>
 
@@ -174,7 +174,7 @@
                   비교하기
                 </button>
                 <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통<span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
                 </button>
               </div>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -173,7 +173,7 @@
                   비교하기
                 </button>
                 <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통<span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
                 </button>
               </div>
             </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3653,12 +3653,20 @@ function updateUnreadBadge(docs) {
 
 function updateTrashTabVisibility(trashDocs) {
   if (!libTabTrash) return
-  const trashCount = trashDocs.length
+  const trashCount = trashDocs ? trashDocs.length : 0
+  const countBadge = $('lib-tab-trash-count')
+  if (countBadge) {
+    if (trashCount > 0) {
+      countBadge.textContent = ` (${trashCount})`
+      countBadge.classList.remove('hidden')
+    } else {
+      countBadge.textContent = ''
+      countBadge.classList.add('hidden')
+    }
+  }
+  libTabTrash.title = `휴지통${trashCount > 0 ? ` (${trashCount}개 문서)` : ''}`
   if (trashCount > 0 || state.currentLibraryTab === 'trash') {
     libTabTrash.classList.remove('hidden')
-    libTabTrash.title = `휴지통 (${trashCount}개 문서)`
-    const countBadge = trashCount > 0 ? ` (${trashCount})` : ''
-    libTabTrash.innerHTML = `${icon('trash2', 14, 'style="vertical-align:-2px;margin-right:4px"')}휴지통${countBadge}`
   } else {
     libTabTrash.classList.add('hidden')
   }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -28,6 +28,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-left: auto;
 }
 
 /* ── 상태 필터 탭 (전체 / 읽지 않음 / 읽는 중 / 완료 / 즐겨찾기) ── */


### PR DESCRIPTION
# Summary
## 1. 휴지통 버튼 렌더링 깨짐 및 위치 이동 현상 수정
- `frontend/src/styles/library-page.css`의 `.library-toolbar-actions`에 `margin-left: auto;`를 추가하여 상태 탭 감춤 여부와 관계없이 우측 위치를 항상 고정함 (layout shift 방지)
- `frontend/index.html` 및 `frontend/src/main.js`에서 `libTabTrash.innerHTML`을 통째로 재작성하던 기존 로직을 제거하고 독립된 `#lib-tab-trash-count` 스팬만 업데이트하도록 변경하여 아이콘 및 버튼 텍스트 깨짐 현상을 원천 차단함