### PR TITLE
fix: make trash tab button icon-only and overlay count badge

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,8 +23,8 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-Bp9IWwzv.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-0lUB8pYs.css">
+  <script type="module" crossorigin src="/assets/index-DMDuPzLu.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DEqzVPF6.css">
 </head>
 <body>
 
@@ -174,7 +174,8 @@
                   비교하기
                 </button>
                 <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통<span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                  <span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
                 </button>
               </div>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -173,7 +173,8 @@
                   비교하기
                 </button>
                 <button id="lib-tab-trash" class="file-btn-outline compact" data-tab="trash" title="휴지통">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>휴지통<span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                  <span id="lib-tab-trash-count" class="lib-tab-trash-count hidden"></span>
                 </button>
               </div>
             </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3657,7 +3657,7 @@ function updateTrashTabVisibility(trashDocs) {
   const countBadge = $('lib-tab-trash-count')
   if (countBadge) {
     if (trashCount > 0) {
-      countBadge.textContent = ` (${trashCount})`
+      countBadge.textContent = trashCount
       countBadge.classList.remove('hidden')
     } else {
       countBadge.textContent = ''

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6505,6 +6505,7 @@ body.light-theme .chat-drawer {
 
 /* 우측 상단 플로팅 패널 내 휴지통 버튼 스타일 */
 #lib-tab-trash {
+  position: relative;
   width: 42px;
   height: 42px;
   border-radius: 50%;
@@ -6519,6 +6520,26 @@ body.light-theme .chat-drawer {
   font-size: 16px;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   padding: 0;
+}
+
+.lib-tab-trash-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  border: 2px solid var(--bg-surface);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  line-height: 1;
 }
 
 #lib-tab-trash:hover {


### PR DESCRIPTION
# Summary
## 1. 휴지통 버튼 순수 아이콘 디자인 적용 및 뱃지 레이아웃 개선
- `frontend/index.html` 및 `frontend/src/main.js`에서 원형 버튼 밖으로 삐져나오던 "휴지통" 텍스트 문구를 제거하고 16px 휴지통 SVG 아이콘만 깔끔히 표시되도록 조치함
- `frontend/src/style.css`에 `.lib-tab-trash-count` 오버레이 배지 스타일을 추가하여 삭제된 논문 수(N)가 원형 아이콘 버튼 우상단에 레드톤 배지로 세련되게 표시되도록 개선함