### PR TITLE
fix: resolve duplicate tag filter caused by concurrent renderLibrary() calls

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -23,7 +23,7 @@
     onload="document.dispatchEvent(new Event('katex-ready'))"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.js" crossorigin="anonymous"></script>
-  <script type="module" crossorigin src="/assets/index-i25PYFxM.js"></script>
+  <script type="module" crossorigin src="/assets/index-rm7MEbY8.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-xTcadNDi.css">
 </head>
 <body>
@@ -982,20 +982,6 @@
                 <div style="display: flex; gap: 12px; font-size: 12px; border-top: 1px dashed var(--border); padding-top: 6px;">
                   <div style="flex: 1;"><strong style="color: var(--accent-mid);">장점:</strong> <span id="pdf-parser-card-pros">초고속 (몇 ms 내 처리), 별도 설치 필요 없음</span></div>
                   <div style="flex: 1;"><strong style="color: var(--text-muted);">단점:</strong> <span id="pdf-parser-card-cons">2단 복잡 구조, 수식 텍스트 엉킴 발생 가능</span></div>
-                </div>
-                <!-- 미설치 파서 설치 버튼 -->
-                <div id="pdf-parser-install-row" class="hidden" style="margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--border); display: flex; justify-content: flex-end;">
-                  <button id="pdf-parser-install-btn" type="button" style="display:inline-flex;align-items:center;gap:5px;background:rgba(99,102,241,0.12);border:1px solid rgba(99,102,241,0.4);color:var(--accent-mid, #6366f1);border-radius:6px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;transition:all 0.15s ease;">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg>
-                    패키지 설치
-                  </button>
-                </div>
-                <!-- 설치된 파서 삭제 버튼 -->
-                <div id="pdf-parser-uninstall-row" class="hidden" style="margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--border); display: flex; justify-content: flex-end;">
-                  <button id="pdf-parser-uninstall-btn" type="button" style="display:inline-flex;align-items:center;gap:5px;background:rgba(239,68,68,0.12);border:1px solid rgba(239,68,68,0.4);color:#ef4444;border-radius:6px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;transition:all 0.15s ease;">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-                    패키지 삭제
-                  </button>
                 </div>
                 <!-- 설정 카드 내부 직관적 인라인 다운로드 진행 화면 -->
                 <div id="pdf-parser-inline-progress" class="hidden" style="margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border);">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4236,7 +4236,7 @@ async function showWorkspacePage(pageId, { pushState = true } = {}) {
   }
 
   if (pageId === 'library') {
-    syncLibraryTabUI(state.currentLibraryTab || 'archive')
+    syncLibraryTabUI('archive')
     await renderLibrary()
   } else if (pageId === 'chats') {
     await renderAiChatsPage()
@@ -4278,9 +4278,10 @@ document.querySelectorAll('[data-icon]').forEach(el => {
 if (sidebarNav) {
   sidebarNav.querySelectorAll('.sidebar-nav-item[data-page]').forEach(btn => {
     btn.addEventListener('click', () => {
-      if (btn.dataset.page === 'library') {
-        updateTabUI('archive')
-      }
+      // library 탭 클릭 시 archive 탭으로 초기화는 showWorkspacePage 내부의
+      // syncLibraryTabUI가 담당하므로 여기서 updateTabUI를 별도로 호출하지 않는다.
+      // (updateTabUI → renderLibrary 가 fire-and-forget으로 실행되어
+      //  showWorkspacePage → renderLibrary 와 동시에 돌면 태그 필터가 2배로 렌더링되는 Race Condition 발생)
       if (state.currentWorkspacePage === btn.dataset.page) return
       showWorkspacePage(btn.dataset.page)
     })


### PR DESCRIPTION
## 원인
사이드바 Library 버튼 클릭 시 `updateTabUI('archive')`와 `showWorkspacePage('library')`가 `renderLibrary()`를 동시에 실행해 async Race Condition으로 태그 필터 버튼이 2배 렌더링되던 문제.

## 수정
- 사이드바 클릭 핸들러에서 중복 `updateTabUI('archive')` 호출 제거
- `showWorkspacePage('library')` 내부에서 `syncLibraryTabUI('archive')`로 archive 탭 초기화 일원화
- `renderLibrary()`는 항상 단 한 번만 실행되도록 보장