### PR TITLE
fix: repair reading analytics session flow

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -229,13 +229,19 @@ async def start_reading_session_api(doc_id: str, body: Optional[StartSessionRequ
         try:
             last_updated = datetime.fromisoformat(latest["updated_at"])
             diff_sec = (now - last_updated).total_seconds()
-            if diff_sec <= 120:
+            if 0 <= diff_sec <= 120:
+                stored_pages = json.loads(latest.get("page_sessions_json") or "[]")
+                current_page = max(stored_pages, key=lambda p: p.get("leaveTime", 0), default={"page": 1}).get("page", 1)
                 return {
                     "sessionId": latest["id"],
                     "merged": True,
                     "startedAt": latest["started_at"],
                     "activeReadingTime": latest["active_reading_time"],
                     "version": latest["version"],
+                    "currentPage": current_page,
+                    "pageSessions": stored_pages,
+                    "interactionSummary": json.loads(latest.get("interaction_summary_json") or "{}"),
+                    "totalPages": latest.get("total_pages", 0),
                 }
         except Exception:
             pass
@@ -274,48 +280,44 @@ from services.reading_analytics import ReadingSessionPayload
 async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessionPayload, current_user: str = Depends(get_current_user)):
     """Viewer에서 20초 간격으로 전달되는 Heartbeat 데이터를 처리하고 Analytics를 재계산합니다."""
     _require_owned_document(doc_id, current_user)
+    if payload.paperId != doc_id:
+        raise HTTPException(status_code=400, detail="paperId does not match the route document")
+
     import json
     from datetime import datetime, timezone
     from services.db import (
         db_get_user_reading_profile,
-        db_save_user_reading_profile,
         db_save_reading_session,
-        db_add_reading_time,
         db_get_reading_session,
-        get_document,
     )
-    from services.reading_analytics import process_reading_analytics, update_user_ema
+    from services.reading_analytics import process_reading_analytics
 
     doc = get_document(doc_id)
     doc_total_pages = doc.get("total_pages", 0) if doc else 0
 
+    existing = db_get_reading_session(payload.sessionId, current_user)
+    if existing and existing["paper_id"] != doc_id:
+        raise HTTPException(status_code=409, detail="session belongs to another document")
+    if existing and payload.version <= existing["version"]:
+        return {"stale": True, "version": existing["version"]}
+
     profile = db_get_user_reading_profile(current_user)
     user_ema = profile.get("ema_seconds_per_page", 600.0)
-    session_count = profile.get("session_count", 0)
 
     res = process_reading_analytics(payload, doc_total_pages, user_ema)
 
-    new_ema, new_count = update_user_ema(
-        user_ema,
-        session_count,
-        payload.activeReadingTime,
-        len(payload.pageSessions),
-    )
-    db_save_user_reading_profile(current_user, new_ema, new_count)
-
-    existing = db_get_reading_session(payload.sessionId, current_user)
     started_at = existing["started_at"] if existing else datetime.now(timezone.utc).isoformat()
 
-    db_save_reading_session(
+    saved = db_save_reading_session(
         session_id=payload.sessionId,
         username=current_user,
         paper_id=doc_id,
         started_at=started_at,
-        ended_at=None,
+        ended_at=existing["ended_at"] if existing else None,
         active_reading_time=int(payload.activeReadingTime),
         version=payload.version,
-        page_sessions_json=json.dumps([ps.dict() for ps in payload.pageSessions]),
-        interaction_summary_json=json.dumps(payload.interactionSummary.dict()),
+        page_sessions_json=json.dumps([ps.model_dump() for ps in payload.pageSessions]),
+        interaction_summary_json=json.dumps(payload.interactionSummary.model_dump()),
         reading_depth=res.readingDepth,
         reading_score=res.readingScore,
         reading_confidence=res.readingConfidence,
@@ -323,30 +325,44 @@ async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessio
         total_pages=res.totalPages,
     )
 
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    db_add_reading_time(doc_id, current_user, "reading", 20)
-
-    return res.dict()
+    if not saved:
+        current = db_get_reading_session(payload.sessionId, current_user)
+        return {"stale": True, "version": current["version"] if current else payload.version}
+    return res.model_dump()
 
 
 @router.post("/library/{doc_id}/reading-session/end")
 async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, current_user: str = Depends(get_current_user)):
     """Viewer 세션 종료 시 최종 상태를 기록하고 Analytics 결과를 저장합니다."""
     _require_owned_document(doc_id, current_user)
+    if payload.paperId != doc_id:
+        raise HTTPException(status_code=400, detail="paperId does not match the route document")
+
     import json
     from datetime import datetime, timezone
-    from services.db import db_get_reading_session, db_save_reading_session, get_document, update_document_metadata
-    from services.reading_analytics import process_reading_analytics
+    from services.db import (
+        db_get_reading_session,
+        db_get_user_reading_profile,
+        db_save_reading_session,
+        db_save_user_reading_profile,
+    )
+    from services.reading_analytics import process_reading_analytics, update_user_ema
 
     doc = get_document(doc_id)
     doc_total_pages = doc.get("total_pages", 0) if doc else 0
-
-    res = process_reading_analytics(payload, doc_total_pages, 600.0)
     existing = db_get_reading_session(payload.sessionId, current_user)
+    if existing and existing["paper_id"] != doc_id:
+        raise HTTPException(status_code=409, detail="session belongs to another document")
+    if existing and payload.version <= existing["version"]:
+        return {"stale": True, "version": existing["version"]}
+
+    profile = db_get_user_reading_profile(current_user)
+    user_ema = profile.get("ema_seconds_per_page", 600.0)
+    res = process_reading_analytics(payload, doc_total_pages, user_ema)
     started_at = existing["started_at"] if existing else datetime.now(timezone.utc).isoformat()
     now_iso = datetime.now(timezone.utc).isoformat()
 
-    db_save_reading_session(
+    saved = db_save_reading_session(
         session_id=payload.sessionId,
         username=current_user,
         paper_id=doc_id,
@@ -354,8 +370,8 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         ended_at=now_iso,
         active_reading_time=int(payload.activeReadingTime),
         version=payload.version,
-        page_sessions_json=json.dumps([ps.dict() for ps in payload.pageSessions]),
-        interaction_summary_json=json.dumps(payload.interactionSummary.dict()),
+        page_sessions_json=json.dumps([ps.model_dump() for ps in payload.pageSessions]),
+        interaction_summary_json=json.dumps(payload.interactionSummary.model_dump()),
         reading_depth=res.readingDepth,
         reading_score=res.readingScore,
         reading_confidence=res.readingConfidence,
@@ -363,9 +379,22 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         total_pages=res.totalPages,
     )
 
+    if not saved:
+        current = db_get_reading_session(payload.sessionId, current_user)
+        return {"stale": True, "version": current["version"] if current else payload.version}
+
+    if not existing or not existing.get("ended_at"):
+        new_ema, new_count = update_user_ema(
+            user_ema,
+            profile.get("session_count", 0),
+            payload.activeReadingTime,
+            len({ps.page for ps in payload.pageSessions}),
+        )
+        db_save_user_reading_profile(current_user, new_ema, new_count)
+
     update_document_metadata(doc_id, {"last_read_at": now_iso})
 
-    return res.dict()
+    return res.model_dump()
 
 
 @router.get("/library/reading-analytics-summary")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1435,8 +1435,8 @@ def db_save_reading_session(
     reading_confidence: float,
     verified_pages_count: int,
     total_pages: int,
-) -> None:
-    """Inserts or updates a reading session."""
+) -> bool:
+    """Insert a session or replace it only with a newer heartbeat version."""
     now_iso = datetime.now(timezone.utc).isoformat()
     with get_db() as conn:
         cursor = conn.cursor()
@@ -1460,6 +1460,7 @@ def db_save_reading_session(
                 verified_pages_count = excluded.verified_pages_count,
                 total_pages = excluded.total_pages,
                 updated_at = excluded.updated_at
+            WHERE excluded.version > reading_sessions.version
             """,
             (
                 session_id,
@@ -1480,7 +1481,9 @@ def db_save_reading_session(
                 now_iso,
             ),
         )
+        saved = cursor.rowcount > 0
         conn.commit()
+        return saved
 
 
 def db_get_user_reading_profile(username: str) -> Dict[str, Any]:

--- a/backend/services/reading_analytics.py
+++ b/backend/services/reading_analytics.py
@@ -1,39 +1,36 @@
-import json
-import math
-from datetime import datetime, timezone
-from typing import Dict, List, Any, Optional
 from pydantic import BaseModel, Field
+from typing import Dict, List
 
 
 class InteractionSummary(BaseModel):
-    scroll: int = 0
-    selection: int = 0
-    highlight: int = 0
-    underline: int = 0
-    memo: int = 0
-    question: int = 0
-    citationClick: int = 0
-    figureClick: int = 0
-    tableClick: int = 0
-    equationClick: int = 0
+    scroll: int = Field(default=0, ge=0)
+    selection: int = Field(default=0, ge=0)
+    highlight: int = Field(default=0, ge=0)
+    underline: int = Field(default=0, ge=0)
+    memo: int = Field(default=0, ge=0)
+    question: int = Field(default=0, ge=0)
+    citationClick: int = Field(default=0, ge=0)
+    figureClick: int = Field(default=0, ge=0)
+    tableClick: int = Field(default=0, ge=0)
+    equationClick: int = Field(default=0, ge=0)
 
 
 class PageSession(BaseModel):
-    page: int
-    enterTime: float = 0
-    leaveTime: float = 0
-    visibleTime: float = 0
-    activeTime: float = 0
-    scrollCoverage: float = 0.0  # 0.0 ~ 1.0
+    page: int = Field(ge=1)
+    enterTime: float = Field(default=0, ge=0)
+    leaveTime: float = Field(default=0, ge=0)
+    visibleTime: float = Field(default=0, ge=0)
+    activeTime: float = Field(default=0, ge=0)
+    scrollCoverage: float = Field(default=0.0, ge=0.0, le=1.0)
     interaction: InteractionSummary = Field(default_factory=InteractionSummary)
 
 
 class ReadingSessionPayload(BaseModel):
     sessionId: str
     paperId: str
-    version: int = 0
-    currentPage: int = 1
-    activeReadingTime: float = 0.0
+    version: int = Field(default=0, ge=0)
+    currentPage: int = Field(default=1, ge=1)
+    activeReadingTime: float = Field(default=0.0, ge=0)
     pageSessions: List[PageSession] = Field(default_factory=list)
     interactionSummary: InteractionSummary = Field(default_factory=InteractionSummary)
 
@@ -84,7 +81,28 @@ def analyze_page_sessions(
     if not page_sessions:
         return {}, 0, 0.0
 
+    # A client should send one cumulative entry per page, but consolidating here
+    # prevents duplicate page entries from inflating verified-page counts.
+    consolidated: Dict[int, PageSession] = {}
     for ps in page_sessions:
+        previous = consolidated.get(ps.page)
+        if previous is None:
+            consolidated[ps.page] = ps.model_copy(deep=True)
+            continue
+        positive_enter_times = [v for v in (previous.enterTime, ps.enterTime) if v > 0]
+        previous.enterTime = min(positive_enter_times) if positive_enter_times else 0
+        previous.leaveTime = max(previous.leaveTime, ps.leaveTime)
+        previous.visibleTime += ps.visibleTime
+        previous.activeTime += ps.activeTime
+        previous.scrollCoverage = max(previous.scrollCoverage, ps.scrollCoverage)
+        for field_name in InteractionSummary.model_fields:
+            setattr(
+                previous.interaction,
+                field_name,
+                getattr(previous.interaction, field_name) + getattr(ps.interaction, field_name),
+            )
+
+    for ps in consolidated.values():
         page_num = ps.page
         scroll_cov = max(0.0, min(1.0, ps.scrollCoverage))
         active_time = max(0.0, ps.activeTime)
@@ -128,7 +146,7 @@ def analyze_page_sessions(
             verified_count += 1
         total_confidence_sum += final_score
 
-    avg_confidence = round(total_confidence_sum / len(page_sessions), 1) if page_sessions else 0.0
+    avg_confidence = round(total_confidence_sum / len(consolidated), 1) if consolidated else 0.0
     return page_scores, verified_count, avg_confidence
 
 
@@ -235,21 +253,26 @@ def process_reading_analytics(
         total_pages
     )
 
-    total_iq = calculate_interaction_quality(payload.interactionSummary)
-    for ps in payload.pageSessions:
-        total_iq += calculate_interaction_quality(ps.interaction)
+    summary_iq = calculate_interaction_quality(payload.interactionSummary)
+    page_iq = sum(calculate_interaction_quality(ps.interaction) for ps in payload.pageSessions)
+    # Each frontend event is recorded in both representations; do not double count it.
+    total_iq = max(summary_iq, page_iq)
 
-    # Initial score calculation to infer depth
-    temp_depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, 0.0)
-    reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, temp_depth, total_iq)
-    final_depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, reading_score)
+    depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, 0.0)
+    for _ in range(3):
+        reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, depth, total_iq)
+        next_depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, reading_score)
+        if next_depth == depth:
+            break
+        depth = next_depth
+    reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, depth, total_iq)
 
     return ReadingAnalyticsResult(
         sessionId=payload.sessionId,
         paperId=payload.paperId,
         readingScore=reading_score,
         readingConfidence=avg_confidence,
-        readingDepth=final_depth,
+        readingDepth=depth,
         verifiedPagesCount=verified_count,
         totalPages=total_pages,
         activeReadingTime=payload.activeReadingTime,

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -132,5 +132,105 @@ class TestReadingAnalytics(unittest.TestCase):
         self.assertGreater(res.readingScore, 0.0)
 
 
+    def test_duplicate_page_entries_are_consolidated(self):
+        page = PageSession(
+            page=1, activeTime=180.0, scrollCoverage=0.8,
+            interaction=InteractionSummary(highlight=1),
+        )
+        scores, verified, confidence = analyze_page_sessions([page, page], 600.0, 10)
+        self.assertEqual(list(scores), [1])
+        self.assertEqual(verified, 1)
+        self.assertEqual(confidence, scores[1])
+
+    def test_session_and_page_interactions_are_not_double_counted(self):
+        interaction = InteractionSummary(highlight=1)
+        payload = ReadingSessionPayload(
+            sessionId="session", paperId="paper", activeReadingTime=300,
+            pageSessions=[PageSession(
+                page=1, activeTime=300, scrollCoverage=0.8, interaction=interaction,
+            )],
+            interactionSummary=interaction,
+        )
+        result = process_reading_analytics(payload, total_paper_pages=10, user_ema=600)
+        self.assertEqual(result.readingScore, 28.2)
+
+
+def _analytics_payload(session_id, paper_id, version, active_time=60):
+    return {
+        "sessionId": session_id,
+        "paperId": paper_id,
+        "version": version,
+        "currentPage": 1,
+        "activeReadingTime": active_time,
+        "pageSessions": [{
+            "page": 1,
+            "activeTime": active_time,
+            "visibleTime": active_time,
+            "scrollCoverage": 0.8,
+            "interaction": {"highlight": 1},
+        }],
+        "interactionSummary": {"highlight": 1},
+    }
+
+
+def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document("paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5, {})
+
+    started = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    )
+    assert started.status_code == 200
+    session_id = started.json()["sessionId"]
+
+    heartbeat = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat",
+        json=_analytics_payload(session_id, "paper-1", 1),
+    )
+    assert heartbeat.status_code == 200
+    assert db.db_get_user_reading_profile("testuser")["session_count"] == 0
+    assert db.db_get_reading_time_stats("testuser")["total_seconds"] == 0
+
+    stale = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat",
+        json=_analytics_payload(session_id, "paper-1", 1, active_time=999),
+    )
+    assert stale.json() == {"stale": True, "version": 1}
+    assert db.db_get_reading_session(session_id, "testuser")["active_reading_time"] == 60
+
+    merged = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    ).json()
+    assert merged["merged"] is True
+    assert merged["activeReadingTime"] == 60
+    assert merged["pageSessions"][0]["page"] == 1
+    assert merged["interactionSummary"]["highlight"] == 1
+
+    ended = test_client.post(
+        "/api/library/paper-1/reading-session/end",
+        json=_analytics_payload(session_id, "paper-1", 2),
+    )
+    assert ended.status_code == 200
+    assert db.db_get_user_reading_profile("testuser")["session_count"] == 1
+
+    repeated_end = test_client.post(
+        "/api/library/paper-1/reading-session/end",
+        json=_analytics_payload(session_id, "paper-1", 2),
+    )
+    assert repeated_end.json() == {"stale": True, "version": 2}
+    assert db.db_get_user_reading_profile("testuser")["session_count"] == 1
+
+
+def test_reading_session_rejects_mismatched_paper_id(test_client, isolated_dirs):
+    isolated_dirs["db"].db_save_document(
+        "paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5, {},
+    )
+    response = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat",
+        json=_analytics_payload("session", "paper-2", 1),
+    )
+    assert response.status_code == 400
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -682,6 +682,8 @@ async function initScrollViewer() {
     onPageVisible: async (pageNum) => {
       updatePageDisplay(pageNum)
       globalAnalyticsTracker.setCurrentPage(pageNum)
+      const visiblePageEl = viewerScrollContainer.querySelector('.pdf-page-wrapper[data-page="' + pageNum + '"]')
+      globalAnalyticsTracker.trackScroll(pageNum, visiblePageEl, viewerScrollContainer, true, false)
       
       // 페이지가 가시화되었을 때 번역 완료된 페이지인데 캐시가 없는 경우 레이지 로딩 적용
       if (state.translationCache[pageNum]) {
@@ -8182,6 +8184,7 @@ function applyAnnotationToRange(range, type, textLayerDiv, pageNum, color) {
     color: chosenColor
   })
   saveAnnotations(state.sessionId, annotations)
+  globalAnalyticsTracker.trackInteraction(type, pageNum)
   showToast(type === 'highlight' ? '하이라이트가 추가되었습니다 ✓' : '밑줄이 추가되었습니다 ✓', 'success')
 }
 
@@ -9214,6 +9217,7 @@ function createFloatingMemoForSentence(pageNum, sentenceIdx, explicitRange) {
 
   allMemosObj[`page_${pageNum}`].push(newMemo)
   saveMemos(state.sessionId, allMemosObj)
+  globalAnalyticsTracker.trackInteraction('memo', pageNum)
 
   renderPageMemos(pageNum)
 }
@@ -10349,6 +10353,7 @@ function renderImageOverlayLayer(textLayerDiv, pageNum) {
     overlay.addEventListener('click', (e) => {
       e.preventDefault()
       e.stopPropagation()
+      globalAnalyticsTracker.trackInteraction('figureClick', pageNum)
 
       // Clear text selection
       window.getSelection().removeAllRanges()
@@ -10593,6 +10598,7 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
       box.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
+        globalAnalyticsTracker.trackInteraction('citationClick', pageNum)
         showCitationTooltip(docId, validKeys, refMap, box)
       })
       overlay.appendChild(box)
@@ -10845,6 +10851,8 @@ function renderFigureRefOverlayLayer(textLayerDiv, pageNum) {
         e.preventDefault()
         e.stopPropagation()
         window.getSelection().removeAllRanges()
+        const interactionType = kind === 'Table' ? 'tableClick' : (kind === 'Equation' ? 'equationClick' : 'figureClick')
+        globalAnalyticsTracker.trackInteraction(interactionType, pageNum)
         hideFigurePreviewTooltip()
         scrollToPage(viewerScrollContainer, targets[0].page)
       })
@@ -11706,6 +11714,7 @@ async function sendChatMessage() {
   
   const text = chatInput.value.trim()
   if (!text) return
+  globalAnalyticsTracker.trackInteraction('question', state.currentPage)
   
   chatInput.value = ''
   chatInput.style.height = 'auto'

--- a/frontend/src/readingAnalytics.js
+++ b/frontend/src/readingAnalytics.js
@@ -80,6 +80,21 @@ export class ReadingAnalyticsTracker {
         this.version = data.version || 0
         if (data.merged) {
           this.activeReadingTime = data.activeReadingTime || 0
+          this.currentPage = data.currentPage || 1
+          this.interactionSummary = {
+            ...createEmptyInteractionSummary(),
+            ...(data.interactionSummary || {}),
+          }
+          this.pageSessionsMap = {}
+          for (const pageSession of (data.pageSessions || [])) {
+            this.pageSessionsMap[pageSession.page] = {
+              ...pageSession,
+              interaction: {
+                ...createEmptyInteractionSummary(),
+                ...(pageSession.interaction || {}),
+              },
+            }
+          }
         }
       } else {
         this.sessionId = 'local-' + Date.now()
@@ -119,6 +134,10 @@ export class ReadingAnalyticsTracker {
   }
 
   setCurrentPage(pageNumber) {
+    const now = Date.now()
+    if (this.pageSessionsMap[this.currentPage]) {
+      this.pageSessionsMap[this.currentPage].leaveTime = now
+    }
     this.currentPage = pageNumber
     this.ensurePageSession(pageNumber)
   }
@@ -150,11 +169,13 @@ export class ReadingAnalyticsTracker {
     ps.leaveTime = Date.now()
   }
 
-  trackScroll(pageNumber, pageElement = null, containerElement = null, isContinuousView = false) {
+  trackScroll(pageNumber, pageElement = null, containerElement = null, isContinuousView = false, countInteraction = true) {
     if (!this.isTracking) return
     const ps = this.ensurePageSession(pageNumber)
-    ps.interaction.scroll += 1
-    this.interactionSummary.scroll += 1
+    if (countInteraction) {
+      ps.interaction.scroll += 1
+      this.interactionSummary.scroll += 1
+    }
 
     // Calculate Scroll Coverage
     if (pageElement && containerElement) {
@@ -163,12 +184,10 @@ export class ReadingAnalyticsTracker {
         const pageRect = pageElement.getBoundingClientRect()
         const containerRect = containerElement.getBoundingClientRect()
 
-        const visibleTop = Math.max(pageRect.top, containerRect.top)
-        const visibleBottom = Math.min(pageRect.bottom, containerRect.bottom)
-        const visibleHeight = Math.max(0, visibleBottom - visibleTop)
+        const visibleBottom = Math.max(pageRect.top, Math.min(pageRect.bottom, containerRect.bottom))
 
         if (pageRect.height > 0) {
-          coverage = visibleHeight / pageRect.height
+          coverage = (visibleBottom - pageRect.top) / pageRect.height
         }
       } else {
         const scrollTop = containerElement.scrollTop || 0
@@ -217,33 +236,34 @@ export class ReadingAnalyticsTracker {
         body: JSON.stringify(payload),
       })
       if (!res.ok) {
-        this.enqueueOfflinePayload(payload)
+        this.enqueueOfflinePayload(payload, 'heartbeat')
       } else {
         const result = await res.json()
         this.syncOfflineQueue()
         return result
       }
     } catch {
-      this.enqueueOfflinePayload(payload)
+      this.enqueueOfflinePayload(payload, 'heartbeat')
     }
   }
 
   async sendEndSession() {
     const payload = this.buildPayload()
     try {
-      await fetch(`${this.apiBase}/library/${this.paperId}/reading-session/end`, {
+      const res = await fetch(`${this.apiBase}/library/${this.paperId}/reading-session/end`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
+      if (!res.ok) this.enqueueOfflinePayload(payload, 'end')
     } catch {
-      this.enqueueOfflinePayload(payload)
+      this.enqueueOfflinePayload(payload, 'end')
     }
   }
 
-  enqueueOfflinePayload(payload) {
+  enqueueOfflinePayload(payload, type = 'heartbeat') {
     const queue = getOfflineQueue()
-    queue.push(payload)
+    queue.push({ type, payload })
     saveOfflineQueue(queue)
   }
 
@@ -252,18 +272,19 @@ export class ReadingAnalyticsTracker {
     if (queue.length === 0) return
 
     const remaining = []
-    for (const payload of queue) {
+    for (const queuedItem of queue) {
+      const type = queuedItem.type || 'heartbeat'
+      const payload = queuedItem.payload || queuedItem
       try {
-        const res = await fetch(`${this.apiBase}/library/${payload.paperId}/reading-session/heartbeat`, {
+        const endpoint = type === 'end' ? 'end' : 'heartbeat'
+        const res = await fetch(this.apiBase + '/library/' + payload.paperId + '/reading-session/' + endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         })
-        if (!res.ok) {
-          remaining.push(payload)
-        }
+        if (!res.ok) remaining.push(queuedItem)
       } catch {
-        remaining.push(payload)
+        remaining.push(queuedItem)
       }
     }
     saveOfflineQueue(remaining)


### PR DESCRIPTION
# Summary
## 1. Reading Session API 오류 수정
- 잘못된 서비스 import로 heartbeat와 종료 API에서 발생하던 500 오류 수정함
- paper/session 소유 관계 및 heartbeat version 검증 추가
- 2분 내 재진입 시 페이지 세션, 상호작용, 읽기 시간, 마지막 페이지 복원 기능 추가
## 2. 분석 및 동기화 로직 수정
- EMA를 세션 종료 시 한 번만 학습하도록 수정함
- 읽기 시간과 상호작용의 중복 집계 제거
- offline heartbeat와 end 요청을 구분하여 원래 endpoint로 재전송하는 기능 추가
- 중복 페이지 통합 및 Reading Depth 재계산 로직 수정
## 3. Viewer 이벤트 및 회귀 테스트 보강
- 하이라이트, 밑줄, 메모, 질문, 인용, Figure/Table/Equation 이벤트 추적 연결
- 연속 스크롤 coverage 계산 수정
- 세션 병합, stale version, EMA 단회 학습, 중복 집계 방지 회귀 테스트 추가