### PR TITLE
fix: use analytics for reading timeline

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1486,6 +1486,32 @@ def db_save_reading_session(
         return saved
 
 
+def db_get_reading_sessions_for_user(username: str) -> List[Dict[str, Any]]:
+    """Return Reading Analytics sessions for Timeline, newest first."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT rs.id, rs.paper_id, rs.started_at, rs.ended_at,
+                   rs.active_reading_time, rs.version, rs.page_sessions_json,
+                   rs.reading_depth, rs.reading_score, rs.reading_confidence,
+                   rs.verified_pages_count, rs.total_pages, rs.updated_at,
+                   titles.doc_title
+            FROM reading_sessions AS rs
+            LEFT JOIN (
+                SELECT doc_id, MAX(doc_title) AS doc_title
+                FROM reading_time
+                WHERE username = ? AND doc_title IS NOT NULL
+                GROUP BY doc_id
+            ) AS titles ON titles.doc_id = rs.paper_id
+            WHERE rs.username = ?
+            ORDER BY rs.started_at DESC
+            """,
+            (username, username),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
 def db_get_user_reading_profile(username: str) -> Dict[str, Any]:
     """Gets or initializes the user EMA reading profile."""
     with get_db() as conn:

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -431,7 +431,10 @@ async def get_activity_timeline(username: str) -> List[dict]:
     """업로드/읽음/질문/메모를 시간순(최신순)으로 병합한 활동 타임라인을
     반환한다. 삭제된 논문의 활동도 타임라인에 유지되며 holds is_deleted=True."""
     from services.library import list_documents
-    from services.db import db_get_memos, db_get_related_questions_for_doc, get_db
+    from services.db import (
+        db_get_memos, db_get_reading_sessions_for_user,
+        db_get_related_questions_for_doc, get_db,
+    )
 
     docs = list_documents(username=username, include_deleted=True)
     titles_by_doc = {d["id"]: (d.get("metadata") or {}).get("title") or d["filename"] for d in docs}
@@ -439,6 +442,42 @@ async def get_activity_timeline(username: str) -> List[dict]:
 
     doc_ids_seen = set(titles_by_doc.keys())
     events = []
+
+    analytics_rows = db_get_reading_sessions_for_user(username)
+    analytics_doc_ids = {row["paper_id"] for row in analytics_rows}
+    for row in analytics_rows:
+        try:
+            page_sessions = json.loads(row.get("page_sessions_json") or "[]")
+        except (TypeError, json.JSONDecodeError):
+            page_sessions = []
+        pages = sorted({
+            page.get("page") for page in page_sessions
+            if isinstance(page, dict) and isinstance(page.get("page"), int)
+        })
+        active_time = max(0, row.get("active_reading_time") or 0)
+        if not pages and active_time <= 0:
+            continue
+        start_ts = row.get("started_at") or row.get("updated_at")
+        end_ts = row.get("ended_at")
+        if end_ts == start_ts:
+            end_ts = None
+        doc_id = row["paper_id"]
+        events.append({
+            "type": "read",
+            "doc_id": doc_id,
+            "doc_title": titles_by_doc.get(doc_id) or row.get("doc_title") or "삭제된 논문",
+            "timestamp": start_ts,
+            "end_timestamp": end_ts,
+            "duration_seconds": active_time,
+            "start_page": min(pages) if pages else None,
+            "end_page": max(pages) if pages else None,
+            "verified_pages": max(0, row.get("verified_pages_count") or 0),
+            "reading_score": row.get("reading_score") or 0.0,
+            "reading_confidence": row.get("reading_confidence") or 0.0,
+            "reading_depth": row.get("reading_depth") or "Opened",
+            "reading_session_id": row["id"],
+            "is_deleted": doc_id not in doc_ids_seen or deleted_by_doc.get(doc_id, False),
+        })
     for doc in docs:
         doc_id = doc["id"]
         title = titles_by_doc[doc_id]
@@ -452,7 +491,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
 
         meta = doc.get("metadata") or {}
         read_sessions = meta.get("read_sessions") or []
-        if read_sessions:
+        if read_sessions and doc_id not in analytics_doc_ids:
             for s in read_sessions:
                 ts = s.get("timestamp") or s.get("read_at") or meta.get("last_read_at") or doc["created_at"]
                 end_ts = s.get("end_timestamp")
@@ -477,7 +516,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
                     "verified_pages": s.get("verified_pages", 1),
                     "is_deleted": is_deleted,
                 })
-        elif meta.get("read") and meta.get("read_at"):
+        elif doc_id not in analytics_doc_ids and meta.get("read") and meta.get("read_at"):
             events.append({
                 "type": "read", "doc_id": doc_id, "doc_title": title,
                 "timestamp": meta["read_at"],
@@ -486,7 +525,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
                 "verified_pages": meta.get("last_page") or 1,
                 "is_deleted": is_deleted,
             })
-        elif meta.get("last_read_at"):
+        elif doc_id not in analytics_doc_ids and meta.get("last_read_at"):
             events.append({
                 "type": "read", "doc_id": doc_id, "doc_title": title,
                 "timestamp": meta["last_read_at"],
@@ -539,7 +578,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
             for r in rows:
                 r_dict = dict(r)
                 d_id = r_dict["doc_id"]
-                if d_id not in doc_ids_seen:
+                if d_id not in doc_ids_seen and d_id not in analytics_doc_ids:
                     # reading_time에 저장된 제목을 우선 사용, 없으면 "삭제된 논문"
                     stored_title = r_dict.get("stored_title") or "삭제된 논문"
                     events.append({

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -2,6 +2,8 @@
 회귀 테스트. 이전 차수와 동일한 fixture 패턴(test_client/isolated_dirs)을
 사용한다.
 """
+import json
+
 import pytest
 
 
@@ -102,6 +104,43 @@ def test_timeline_endpoint_merges_event_types(test_client, isolated_dirs):
     assert types == {"uploaded", "read", "question", "note"}
     assert any(e["type"] == "note" and e["summary"] == "핵심 메모" for e in events)
     assert any(e["type"] == "question" and e["summary"] == "What is this about?" for e in events)
+
+
+def test_timeline_prefers_reading_analytics_verified_pages(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-analytics", "testuser", {
+        "title": "Analytics Paper",
+        "read_sessions": [{
+            "timestamp": "2026-02-02T10:00:00+00:00",
+            "start_page": 1, "end_page": 9, "verified_pages": 9,
+        }],
+    })
+    db.db_save_reading_session(
+        session_id="analytics-session", username="testuser", paper_id="doc-analytics",
+        started_at="2026-02-02T10:00:00+00:00",
+        ended_at="2026-02-02T10:05:00+00:00", active_reading_time=300, version=1,
+        page_sessions_json=json.dumps([{
+            "page": 1, "activeTime": 180, "scrollCoverage": 0.8,
+        }, {
+            "page": 3, "activeTime": 120, "scrollCoverage": 0.7,
+        }]),
+        interaction_summary_json="{}", reading_depth="Reading",
+        reading_score=62.5, reading_confidence=58.0,
+        verified_pages_count=2, total_pages=10,
+    )
+
+    events = test_client.get("/api/library/timeline").json()["events"]
+    read_events = [
+        event for event in events
+        if event["type"] == "read" and event["doc_id"] == "doc-analytics"
+    ]
+    assert len(read_events) == 1
+    assert read_events[0]["verified_pages"] == 2
+    assert read_events[0]["start_page"] == 1
+    assert read_events[0]["end_page"] == 3
+    assert read_events[0]["reading_score"] == 62.5
+    assert read_events[0]["reading_confidence"] == 58.0
+    assert read_events[0]["reading_depth"] == "Reading"
 
 
 def test_timeline_ignores_malformed_memo_ids(test_client, isolated_dirs):

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -191,6 +191,14 @@ def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
     assert db.db_get_user_reading_profile("testuser")["session_count"] == 0
     assert db.db_get_reading_time_stats("testuser")["total_seconds"] == 0
 
+    timeline = test_client.get("/api/library/timeline").json()["events"]
+    timeline_session = next(
+        event for event in timeline
+        if event.get("reading_session_id") == session_id
+    )
+    assert timeline_session["verified_pages"] == 0
+    assert timeline_session["reading_score"] == heartbeat.json()["readingScore"]
+
     stale = test_client.post(
         "/api/library/paper-1/reading-session/heartbeat",
         json=_analytics_payload(session_id, "paper-1", 1, active_time=999),

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3982,62 +3982,8 @@ function currentReadingContext() {
   return null
 }
 
-let activeViewerSession = null
-
-function updatePageDwellTime() {
-  if (!isReadingTimeActive() || !state.sessionId || !state.currentPage) return
-  if (!activeViewerSession || activeViewerSession.docId !== state.sessionId) {
-    activeViewerSession = {
-      docId: state.sessionId,
-      startPage: state.currentPage,
-      endPage: state.currentPage,
-      startTime: new Date().toISOString(),
-      pageDwellTimes: {},
-    }
-  }
-  const session = activeViewerSession
-  session.endPage = Math.max(session.endPage, state.currentPage)
-  session.startPage = Math.min(session.startPage, state.currentPage)
-  session.pageDwellTimes[state.currentPage] = (session.pageDwellTimes[state.currentPage] || 0) + READING_HEARTBEAT_TICK_SECONDS
-}
-
-async function flushActiveReadingSession(userPaceSec = 240, isFinal = false) {
-  if (!activeViewerSession || !activeViewerSession.docId) return
-  const session = activeViewerSession
-  if (isFinal) {
-    activeViewerSession = null
-  }
-
-  // 개인 EMA 정독 페이스(userPaceSec)의 50% 이상 체류 시에만 해당 페이지 완독 인정
-  const dynamicDwellThreshold = Math.max(1, Math.round(userPaceSec * 0.5))
-  const verifiedPagesCount = Object.values(session.pageDwellTimes).filter(s => s >= dynamicDwellThreshold).length || 1
-
-  try {
-    const docId = session.docId
-    const now = new Date()
-    const startTimeIso = session.startTime || now.toISOString()
-    const endTimeIso = now.toISOString()
-    const durationSec = Math.max(1, Math.round((now - (new Date(startTimeIso).getTime() ? new Date(startTimeIso) : now)) / 1000))
-
-    const newSession = {
-      start_page: session.startPage,
-      end_page: session.endPage,
-      verified_pages: verifiedPagesCount,
-      timestamp: startTimeIso,
-      end_timestamp: endTimeIso,
-      duration_seconds: durationSec,
-    }
-    await updateLibraryDocMetadata(docId, {
-      read_sessions: [newSession],
-      last_page: session.endPage,
-      last_read_at: endTimeIso,
-    }).catch(() => {})
-  } catch {}
-}
-
 function tickReadingHeartbeat() {
   if (!isReadingTimeActive()) return
-  updatePageDwellTime()
   const ctx = currentReadingContext()
   if (!ctx) return
   for (const docId of ctx.docIds) {
@@ -4049,7 +3995,6 @@ function tickReadingHeartbeat() {
 async function flushReadingHeartbeat() {
   const buffers = readingHeartbeatBuffers
   readingHeartbeatBuffers = {}
-  flushActiveReadingSession(240, false).catch(() => {})
   const entries = Object.entries(buffers).filter(([, s]) => s > 0)
   if (entries.length === 0) return
   await Promise.all(entries.map(([key, seconds]) => {
@@ -4062,7 +4007,7 @@ async function flushReadingHeartbeat() {
 
 setInterval(tickReadingHeartbeat, READING_HEARTBEAT_TICK_SECONDS * 1000)
 setInterval(flushReadingHeartbeat, READING_HEARTBEAT_FLUSH_MS)
-window.addEventListener('beforeunload', () => { flushReadingHeartbeat(); flushActiveReadingSession(240, true) })
+window.addEventListener('beforeunload', () => { flushReadingHeartbeat(); globalAnalyticsTracker.stopSession() })
 
 // ── 초기화 ────────────────────────────────────────
 checkAuthentication()

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -160,6 +160,8 @@ export function buildDailyActivityStats(events, readingStats) {
       byDay.set(key, {
         readingSeconds: 0,
         estPagesRead: 0,
+        verifiedPages: 0,
+        hasVerifiedPages: false,
         questions: 0,
         notes: 0,
         uploaded: 0,
@@ -188,7 +190,10 @@ export function buildDailyActivityStats(events, readingStats) {
     else if (e.type === 'uploaded') item.uploaded += 1
     else if (e.type === 'read') {
       item.readEvents += 1
-      item.verifiedPages = (item.verifiedPages || 0) + (e.verified_pages || 1)
+      if (e.verified_pages !== null && e.verified_pages !== undefined) {
+        item.hasVerifiedPages = true
+        item.verifiedPages += e.verified_pages
+      }
     }
   }
 
@@ -200,7 +205,7 @@ export function buildDailyActivityStats(events, readingStats) {
     if (item.readingSeconds > 0) {
       item.estPagesRead = Math.floor(item.readingSeconds / userPaceSec)
     }
-    const displayPages = item.verifiedPages || item.estPagesRead || 0
+    const displayPages = item.hasVerifiedPages ? item.verifiedPages : (item.estPagesRead || 0)
 
     const readTimeScore = Math.floor(item.readingSeconds / 60)
     const pageScore = displayPages * 3
@@ -1031,7 +1036,7 @@ export async function renderReadingHistoryPage() {
 
                 if (e.start_page && e.end_page) {
                   const range = e.start_page === e.end_page ? `${e.start_page}p` : `${e.start_page}p ~ ${e.end_page}p`
-                  const verified = e.verified_pages || 1
+                  const verified = e.verified_pages ?? 0
                   pageMeta = `${range} (${verified}p 정독)`
                 } else {
                   const p = readPageCount(docsById.get(e.doc_id))

--- a/frontend/src/readingAnalytics.js
+++ b/frontend/src/readingAnalytics.js
@@ -250,8 +250,9 @@ export class ReadingAnalyticsTracker {
   async sendEndSession() {
     const payload = this.buildPayload()
     try {
-      const res = await fetch(`${this.apiBase}/library/${this.paperId}/reading-session/end`, {
+      const res = await fetch(this.apiBase + "/library/" + this.paperId + "/reading-session/end", {
         method: 'POST',
+        keepalive: true,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })


### PR DESCRIPTION
# Summary
## 1. Reading Analytics Timeline 연동
- Timeline 읽음 이벤트를 metadata.read_sessions 대신 reading_sessions DB에서 우선 생성하도록 수정함
- Score Engine의 verified_pages, Reading Score, Confidence, Depth를 Timeline 이벤트에 연결
- 방문 페이지 범위를 PageSession 데이터에서 산출하는 기능 추가
## 2. 잘못된 읽은 페이지 추정 제거
- verified_pages가 0인 경우 1페이지로 강제하던 fallback 제거
- Analytics 검증값이 있으면 읽기 시간 기반 페이지 추정을 사용하지 않도록 수정함
- 기존 간이 체류시간 read_sessions 생성 로직 제거
## 3. 호환성 및 검증 보강
- Reading Analytics 데이터가 없는 legacy 문서만 기존 metadata 기록을 사용하도록 유지
- heartbeat 결과와 Timeline verified_pages 일치 통합 테스트 추가
- Analytics와 legacy 기록 중복 방지 회귀 테스트 추가