### PR TITLE
fix: skip short reading timeline sessions

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -455,7 +455,8 @@ async def get_activity_timeline(username: str) -> List[dict]:
             if isinstance(page, dict) and isinstance(page.get("page"), int)
         })
         active_time = max(0, row.get("active_reading_time") or 0)
-        if not pages and active_time <= 0:
+        verified_pages = max(0, row.get("verified_pages_count") or 0)
+        if verified_pages == 0 and active_time < 30:
             continue
         start_ts = row.get("started_at") or row.get("updated_at")
         end_ts = row.get("ended_at")
@@ -471,7 +472,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
             "duration_seconds": active_time,
             "start_page": min(pages) if pages else None,
             "end_page": max(pages) if pages else None,
-            "verified_pages": max(0, row.get("verified_pages_count") or 0),
+            "verified_pages": verified_pages,
             "reading_score": row.get("reading_score") or 0.0,
             "reading_confidence": row.get("reading_confidence") or 0.0,
             "reading_depth": row.get("reading_depth") or "Opened",

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -143,6 +143,44 @@ def test_timeline_prefers_reading_analytics_verified_pages(test_client, isolated
     assert read_events[0]["reading_depth"] == "Reading"
 
 
+def test_timeline_skips_accidental_short_open(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-short-open", "testuser")
+    common = {
+        "username": "testuser", "paper_id": "doc-short-open",
+        "started_at": "2026-02-02T10:00:00+00:00", "ended_at": None,
+        "version": 1, "page_sessions_json": json.dumps([{"page": 1}]),
+        "interaction_summary_json": "{}", "reading_depth": "Opened",
+        "reading_score": 0.0, "reading_confidence": 0.0,
+        "verified_pages_count": 0, "total_pages": 10,
+    }
+    db.db_save_reading_session(
+        session_id="short-open", active_reading_time=29, **common,
+    )
+
+    events = test_client.get("/api/library/timeline").json()["events"]
+    assert not any(event.get("reading_session_id") == "short-open" for event in events)
+
+
+def test_timeline_keeps_long_session_with_zero_verified_pages(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-long-browse", "testuser")
+    db.db_save_reading_session(
+        session_id="long-browse", username="testuser", paper_id="doc-long-browse",
+        started_at="2026-02-02T10:00:00+00:00", ended_at=None,
+        active_reading_time=30, version=1,
+        page_sessions_json=json.dumps([{"page": 1}]),
+        interaction_summary_json="{}", reading_depth="Browsing",
+        reading_score=5.0, reading_confidence=10.0,
+        verified_pages_count=0, total_pages=10,
+    )
+
+    events = test_client.get("/api/library/timeline").json()["events"]
+    event = next(item for item in events if item.get("reading_session_id") == "long-browse")
+    assert event["verified_pages"] == 0
+    assert event["duration_seconds"] == 30
+
+
 def test_timeline_ignores_malformed_memo_ids(test_client, isolated_dirs):
     db = isolated_dirs["db"]
     _create_doc_owned_by(isolated_dirs, "doc-tl-2", "testuser", {"title": "Bad Memo Id"})


### PR DESCRIPTION
# Summary
## 1. 실수로 연 Reading Session 제외
- verified page가 0개이고 Active Reading Time이 30초 미만인 세션을 Timeline에서 제외하도록 수정함
- 30초 이상 체류한 세션은 verified page가 0개여도 Browsing 기록으로 유지
## 2. 경계값 회귀 테스트 추가
- 29초 세션이 Timeline에 기록되지 않는 검증 추가
- 30초 세션이 0 verified page 상태로 기록되는 검증 추가