### PR TITLE
fix: classify reading evidence in timeline

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -323,6 +323,8 @@ async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessio
         reading_confidence=res.readingConfidence,
         verified_pages_count=res.verifiedPagesCount,
         total_pages=res.totalPages,
+        reading_activity=res.readingActivity,
+        minimum_evidence_time=res.minimumEvidenceTime,
     )
 
     if not saved:
@@ -377,6 +379,8 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         reading_confidence=res.readingConfidence,
         verified_pages_count=res.verifiedPagesCount,
         total_pages=res.totalPages,
+        reading_activity=res.readingActivity,
+        minimum_evidence_time=res.minimumEvidenceTime,
     )
 
     if not saved:

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -300,6 +300,8 @@ def init_db():
             reading_confidence REAL DEFAULT 0.0,
             verified_pages_count INTEGER DEFAULT 0,
             total_pages INTEGER DEFAULT 0,
+            reading_activity TEXT DEFAULT 'unclassified',
+            minimum_evidence_time REAL DEFAULT 90.0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         )
@@ -329,6 +331,16 @@ def init_db():
             conn.commit()
         except sqlite3.OperationalError:
             pass  # 이미 존재하면 무시
+
+        for column_sql in (
+            "ALTER TABLE reading_sessions ADD COLUMN reading_activity TEXT DEFAULT 'unclassified'",
+            "ALTER TABLE reading_sessions ADD COLUMN minimum_evidence_time REAL DEFAULT 90.0",
+        ):
+            try:
+                cursor.execute(column_sql)
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass
 
         # WAL: 여러 읽기 커넥션이 번역 잡의 쓰기 커넥션과 부딪혀 잠기는
         # 문제를 줄인다. 커넥션 단위 PRAGMA가 아니라 DB 파일에 영속되는
@@ -1386,7 +1398,7 @@ def db_get_latest_reading_session(paper_id: str, username: str) -> Optional[Dict
             SELECT id, paper_id, started_at, ended_at, active_reading_time, version,
                    page_sessions_json, interaction_summary_json, reading_depth,
                    reading_score, reading_confidence, verified_pages_count, total_pages,
-                   created_at, updated_at
+                   reading_activity, minimum_evidence_time, created_at, updated_at
             FROM reading_sessions
             WHERE username = ? AND paper_id = ?
             ORDER BY updated_at DESC LIMIT 1
@@ -1408,7 +1420,7 @@ def db_get_reading_session(session_id: str, username: str) -> Optional[Dict[str,
             SELECT id, paper_id, started_at, ended_at, active_reading_time, version,
                    page_sessions_json, interaction_summary_json, reading_depth,
                    reading_score, reading_confidence, verified_pages_count, total_pages,
-                   created_at, updated_at
+                   reading_activity, minimum_evidence_time, created_at, updated_at
             FROM reading_sessions
             WHERE id = ? AND username = ?
             """,
@@ -1435,6 +1447,8 @@ def db_save_reading_session(
     reading_confidence: float,
     verified_pages_count: int,
     total_pages: int,
+    reading_activity: str = "unclassified",
+    minimum_evidence_time: float = 90.0,
 ) -> bool:
     """Insert a session or replace it only with a newer heartbeat version."""
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -1446,8 +1460,8 @@ def db_save_reading_session(
                 id, username, paper_id, started_at, ended_at, active_reading_time, version,
                 page_sessions_json, interaction_summary_json, reading_depth,
                 reading_score, reading_confidence, verified_pages_count, total_pages,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                reading_activity, minimum_evidence_time, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 ended_at = excluded.ended_at,
                 active_reading_time = excluded.active_reading_time,
@@ -1459,6 +1473,8 @@ def db_save_reading_session(
                 reading_confidence = excluded.reading_confidence,
                 verified_pages_count = excluded.verified_pages_count,
                 total_pages = excluded.total_pages,
+                reading_activity = excluded.reading_activity,
+                minimum_evidence_time = excluded.minimum_evidence_time,
                 updated_at = excluded.updated_at
             WHERE excluded.version > reading_sessions.version
             """,
@@ -1477,6 +1493,8 @@ def db_save_reading_session(
                 reading_confidence,
                 verified_pages_count,
                 total_pages,
+                reading_activity,
+                minimum_evidence_time,
                 now_iso,
                 now_iso,
             ),
@@ -1495,7 +1513,8 @@ def db_get_reading_sessions_for_user(username: str) -> List[Dict[str, Any]]:
             SELECT rs.id, rs.paper_id, rs.started_at, rs.ended_at,
                    rs.active_reading_time, rs.version, rs.page_sessions_json,
                    rs.reading_depth, rs.reading_score, rs.reading_confidence,
-                   rs.verified_pages_count, rs.total_pages, rs.updated_at,
+                   rs.verified_pages_count, rs.total_pages, rs.reading_activity,
+                   rs.minimum_evidence_time, rs.updated_at,
                    titles.doc_title
             FROM reading_sessions AS rs
             LEFT JOIN (

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -432,7 +432,7 @@ async def get_activity_timeline(username: str) -> List[dict]:
     반환한다. 삭제된 논문의 활동도 타임라인에 유지되며 holds is_deleted=True."""
     from services.library import list_documents
     from services.db import (
-        db_get_memos, db_get_reading_sessions_for_user,
+        db_get_memos, db_get_reading_sessions_for_user, db_get_user_reading_profile,
         db_get_related_questions_for_doc, get_db,
     )
 
@@ -443,20 +443,42 @@ async def get_activity_timeline(username: str) -> List[dict]:
     doc_ids_seen = set(titles_by_doc.keys())
     events = []
 
+    from services.reading_analytics import PageSession, classify_reading_activity
+
     analytics_rows = db_get_reading_sessions_for_user(username)
+    user_ema = db_get_user_reading_profile(username).get("ema_seconds_per_page", 600.0)
     analytics_doc_ids = {row["paper_id"] for row in analytics_rows}
     for row in analytics_rows:
         try:
             page_sessions = json.loads(row.get("page_sessions_json") or "[]")
         except (TypeError, json.JSONDecodeError):
             page_sessions = []
-        pages = sorted({
-            page.get("page") for page in page_sessions
-            if isinstance(page, dict) and isinstance(page.get("page"), int)
-        })
+        page_models = []
+        for page in page_sessions:
+            if not isinstance(page, dict):
+                continue
+            try:
+                page_models.append(PageSession(**page))
+            except (TypeError, ValueError):
+                continue
+        pages = sorted({page.page for page in page_models})
         active_time = max(0, row.get("active_reading_time") or 0)
         verified_pages = max(0, row.get("verified_pages_count") or 0)
-        if verified_pages == 0 and active_time < 30:
+        stored_activity = row.get("reading_activity")
+        if stored_activity in {"read", "browsed"}:
+            activity_type = stored_activity
+            minimum_evidence_time = max(
+                0.0, row.get("minimum_evidence_time") or 0.0,
+            )
+        else:
+            activity_type, minimum_evidence_time = classify_reading_activity(
+                active_time,
+                verified_pages,
+                max(0.0, row.get("reading_confidence") or 0.0),
+                user_ema,
+                page_models,
+            )
+        if activity_type == "ignored":
             continue
         start_ts = row.get("started_at") or row.get("updated_at")
         end_ts = row.get("ended_at")
@@ -464,7 +486,9 @@ async def get_activity_timeline(username: str) -> List[dict]:
             end_ts = None
         doc_id = row["paper_id"]
         events.append({
-            "type": "read",
+            "type": activity_type,
+            "reading_activity": activity_type,
+            "minimum_evidence_time": minimum_evidence_time,
             "doc_id": doc_id,
             "doc_title": titles_by_doc.get(doc_id) or row.get("doc_title") or "삭제된 논문",
             "timestamp": start_ts,

--- a/backend/services/reading_analytics.py
+++ b/backend/services/reading_analytics.py
@@ -45,6 +45,8 @@ class ReadingAnalyticsResult(BaseModel):
     totalPages: int
     activeReadingTime: float
     pageScores: Dict[int, float] = Field(default_factory=dict)
+    readingActivity: str  # ignored | browsed | read
+    minimumEvidenceTime: float
 
 
 # --- 1. Interaction Quality Calculation ---
@@ -62,6 +64,46 @@ def calculate_interaction_quality(interaction: InteractionSummary) -> float:
         + interaction.tableClick * 2.0
         + interaction.equationClick * 2.0
     )
+
+
+def calculate_minimum_evidence_time(user_ema: float) -> float:
+    """Personalized active-time floor for reliable reading evidence."""
+    return round(max(45.0, min(120.0, user_ema * 0.15)), 1)
+
+
+def has_suspicious_reading_pattern(page_sessions: List[PageSession]) -> bool:
+    """Detect known AFK patterns that must not qualify as reading."""
+    for page_session in page_sessions:
+        interaction_quality = calculate_interaction_quality(page_session.interaction)
+        if (
+            page_session.activeTime > 900.0
+            and interaction_quality == 0.0
+            and page_session.scrollCoverage < 0.3
+        ):
+            return True
+    return False
+
+
+def classify_reading_activity(
+    active_reading_time: float,
+    verified_pages_count: int,
+    reading_confidence: float,
+    user_ema: float,
+    page_sessions: List[PageSession],
+) -> tuple[str, float]:
+    """Classify Timeline activity using multiple independent reading signals."""
+    minimum_time = calculate_minimum_evidence_time(user_ema)
+    qualifies_as_read = (
+        active_reading_time >= minimum_time
+        and verified_pages_count >= 1
+        and reading_confidence >= 50.0
+        and not has_suspicious_reading_pattern(page_sessions)
+    )
+    if qualifies_as_read:
+        return "read", minimum_time
+    if active_reading_time >= 30.0 or verified_pages_count >= 1:
+        return "browsed", minimum_time
+    return "ignored", minimum_time
 
 
 # --- 2. Feature Extraction & Page Analyzer ---
@@ -266,6 +308,9 @@ def process_reading_analytics(
             break
         depth = next_depth
     reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, depth, total_iq)
+    reading_activity, minimum_evidence_time = classify_reading_activity(
+        payload.activeReadingTime, verified_count, avg_confidence, user_ema, payload.pageSessions,
+    )
 
     return ReadingAnalyticsResult(
         sessionId=payload.sessionId,
@@ -277,4 +322,6 @@ def process_reading_analytics(
         totalPages=total_pages,
         activeReadingTime=payload.activeReadingTime,
         pageScores=page_scores,
+        readingActivity=reading_activity,
+        minimumEvidenceTime=minimum_evidence_time,
     )

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -141,6 +141,8 @@ def test_timeline_prefers_reading_analytics_verified_pages(test_client, isolated
     assert read_events[0]["reading_score"] == 62.5
     assert read_events[0]["reading_confidence"] == 58.0
     assert read_events[0]["reading_depth"] == "Reading"
+    assert read_events[0]["reading_activity"] == "read"
+    assert read_events[0]["minimum_evidence_time"] == 90.0
 
 
 def test_timeline_skips_accidental_short_open(test_client, isolated_dirs):
@@ -177,8 +179,31 @@ def test_timeline_keeps_long_session_with_zero_verified_pages(test_client, isola
 
     events = test_client.get("/api/library/timeline").json()["events"]
     event = next(item for item in events if item.get("reading_session_id") == "long-browse")
+    assert event["type"] == "browsed"
     assert event["verified_pages"] == 0
     assert event["duration_seconds"] == 30
+
+
+def test_timeline_uses_persisted_reading_activity(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(isolated_dirs, "doc-stable-browse", "testuser")
+    db.db_save_reading_session(
+        session_id="stable-browse", username="testuser", paper_id="doc-stable-browse",
+        started_at="2026-02-02T10:00:00+00:00", ended_at=None,
+        active_reading_time=300, version=1,
+        page_sessions_json=json.dumps([{
+            "page": 1, "activeTime": 300, "scrollCoverage": 0.8,
+        }]),
+        interaction_summary_json="{}", reading_depth="Reading",
+        reading_score=60.0, reading_confidence=80.0,
+        verified_pages_count=1, total_pages=10,
+        reading_activity="browsed", minimum_evidence_time=75.0,
+    )
+
+    events = test_client.get("/api/library/timeline").json()["events"]
+    event = next(item for item in events if item.get("reading_session_id") == "stable-browse")
+    assert event["type"] == "browsed"
+    assert event["minimum_evidence_time"] == 75.0
 
 
 def test_timeline_ignores_malformed_memo_ids(test_client, isolated_dirs):

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -8,6 +8,8 @@ from services.reading_analytics import (
     analyze_page_sessions,
     determine_reading_depth,
     calculate_reading_score,
+    calculate_minimum_evidence_time,
+    classify_reading_activity,
     update_user_ema,
 )
 
@@ -100,6 +102,45 @@ class TestReadingAnalytics(unittest.TestCase):
         self.assertEqual(new_ema_fast, 575.0)
         self.assertEqual(count_fast, 3)
 
+    def test_minimum_evidence_time_is_personalized_and_bounded(self):
+        self.assertEqual(calculate_minimum_evidence_time(100.0), 45.0)
+        self.assertEqual(calculate_minimum_evidence_time(600.0), 90.0)
+        self.assertEqual(calculate_minimum_evidence_time(1000.0), 120.0)
+
+    def test_reading_activity_requires_independent_evidence(self):
+        page = PageSession(
+            page=1, activeTime=90.0, scrollCoverage=0.8,
+            interaction=InteractionSummary(scroll=3),
+        )
+        self.assertEqual(
+            classify_reading_activity(29.0, 0, 0.0, 600.0, [page])[0],
+            "ignored",
+        )
+        self.assertEqual(
+            classify_reading_activity(30.0, 0, 0.0, 600.0, [page])[0],
+            "browsed",
+        )
+        self.assertEqual(
+            classify_reading_activity(89.0, 1, 60.0, 600.0, [page])[0],
+            "browsed",
+        )
+        self.assertEqual(
+            classify_reading_activity(90.0, 1, 49.9, 600.0, [page])[0],
+            "browsed",
+        )
+        self.assertEqual(
+            classify_reading_activity(90.0, 1, 50.0, 600.0, [page])[0],
+            "read",
+        )
+
+    def test_suspicious_afk_pattern_does_not_qualify_as_read(self):
+        suspicious_page = PageSession(
+            page=1, activeTime=901.0, scrollCoverage=0.1,
+            interaction=InteractionSummary(),
+        )
+        activity, _ = classify_reading_activity(901.0, 1, 80.0, 600.0, [suspicious_page])
+        self.assertEqual(activity, "browsed")
+
     def test_process_reading_analytics(self):
         payload = ReadingSessionPayload(
             sessionId="test-session-1",
@@ -130,6 +171,8 @@ class TestReadingAnalytics(unittest.TestCase):
         self.assertEqual(res.verifiedPagesCount, 2)
         self.assertIn(res.readingDepth, ["Reading", "Deep Reading"])
         self.assertGreater(res.readingScore, 0.0)
+        self.assertEqual(res.readingActivity, "read")
+        self.assertEqual(res.minimumEvidenceTime, 90.0)
 
 
     def test_duplicate_page_entries_are_consolidated(self):
@@ -196,6 +239,7 @@ def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
         event for event in timeline
         if event.get("reading_session_id") == session_id
     )
+    assert timeline_session["type"] == "browsed"
     assert timeline_session["verified_pages"] == 0
     assert timeline_session["reading_score"] == heartbeat.json()["readingScore"]
 

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -420,7 +420,7 @@ function renderHeatmapCard(heatmap) {
 
 // ── 연구 타임라인(최근 7일) ── /library/timeline 이벤트를 그대로 시간순
 // 미니 리스트로 보여준다.
-const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
+const TIMELINE_TYPE_LABEL = { uploaded: '업로드', read: '읽음', browsed: '열람', question: '질문', note: '메모' }
 
 function renderTimelineCard(events) {
   const safeEvents = Array.isArray(events) ? events : []

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -66,12 +66,12 @@ function escapeHtml(str) {
   return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
 
-const TYPE_LABEL = { uploaded: '업로드', read: '읽음', question: '질문', note: '메모' }
-const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', question: 'messageCircle', note: 'edit3' }
-// 활동 구성 막대(part-to-whole)의 분류 색 - dataviz 팔레트의 앞 4개 슬롯을
+const TYPE_LABEL = { uploaded: '업로드', read: '읽음', browsed: '열람', question: '질문', note: '메모' }
+const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', browsed: 'activity', question: 'messageCircle', note: 'edit3' }
+// 활동 구성 막대(part-to-whole)의 분류 색 - dataviz 팔레트 슬롯을
 // 고정 순서(blue→orange→aqua→yellow)로만 사용해 색맹 인접성 검증을 그대로 유지한다.
-const TYPE_COLOR_VAR = { read: '--rh-c1', question: '--rh-c2', note: '--rh-c3', uploaded: '--rh-c4' }
-const TYPE_ORDER = ['read', 'question', 'note', 'uploaded']
+const TYPE_COLOR_VAR = { read: '--rh-c1', browsed: '--rh-c5', question: '--rh-c2', note: '--rh-c3', uploaded: '--rh-c4' }
+const TYPE_ORDER = ['read', 'browsed', 'question', 'note', 'uploaded']
 
 const DAY_MS = 86400000
 const WEEKDAY_LABELS = ['월', '', '수', '', '금', '', '일']
@@ -188,8 +188,8 @@ export function buildDailyActivityStats(events, readingStats) {
     if (e.type === 'question') item.questions += 1
     else if (e.type === 'note') item.notes += 1
     else if (e.type === 'uploaded') item.uploaded += 1
-    else if (e.type === 'read') {
-      item.readEvents += 1
+    else if (e.type === 'read' || e.type === 'browsed') {
+      if (e.type === 'read') item.readEvents += 1
       if (e.verified_pages !== null && e.verified_pages !== undefined) {
         item.hasVerifiedPages = true
         item.verifiedPages += e.verified_pages
@@ -249,7 +249,7 @@ function formatActivityTooltip(dateKey, item) {
   }
 
   const parts = []
-  const pages = item.verifiedPages || item.estPagesRead || 0
+  const pages = item.hasVerifiedPages ? item.verifiedPages : (item.estPagesRead || 0)
   if (item.readingSeconds > 0 || pages > 0) {
     const durStr = formatDuration(item.readingSeconds)
     const pageStr = pages > 0 ? ` [실제 ${pages}페이지 정독]` : ''
@@ -1023,7 +1023,7 @@ export async function renderReadingHistoryPage() {
               let timeLabel = formatTime(e.timestamp)
               let hoverTitle = isDeleted ? '삭제된 논문입니다' : '이 논문 열기'
 
-              if (e.type === 'read') {
+              if (e.type === 'read' || e.type === 'browsed') {
                 const startStr = formatTime(e.timestamp)
                 const endStr = e.end_timestamp ? formatTime(e.end_timestamp) : null
                 if (startStr && endStr && startStr !== endStr) {
@@ -1037,7 +1037,9 @@ export async function renderReadingHistoryPage() {
                 if (e.start_page && e.end_page) {
                   const range = e.start_page === e.end_page ? `${e.start_page}p` : `${e.start_page}p ~ ${e.end_page}p`
                   const verified = e.verified_pages ?? 0
-                  pageMeta = `${range} (${verified}p 정독)`
+                  pageMeta = `${range} (${verified}p 검증)`
+                } else if (e.verified_pages !== null && e.verified_pages !== undefined) {
+                  pageMeta = `${e.verified_pages}p 검증`
                 } else {
                   const p = readPageCount(docsById.get(e.doc_id))
                   if (p) pageMeta = `${p}페이지`

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -481,6 +481,7 @@
 }
 .dash-timeline-uploaded .dash-timeline-dot { background: var(--accent-mid); }
 .dash-timeline-read .dash-timeline-dot { background: var(--success); }
+.dash-timeline-browsed .dash-timeline-dot { background: var(--text-muted); }
 .dash-timeline-question .dash-timeline-dot { background: var(--warning); }
 .dash-timeline-note .dash-timeline-dot { background: var(--control-accent-text); }
 .dash-timeline-body { flex: 1 1 auto; min-width: 0; }

--- a/frontend/src/styles/reading-history.css
+++ b/frontend/src/styles/reading-history.css
@@ -416,14 +416,16 @@ body.light-theme {
   color: var(--control-accent-text);
   white-space: nowrap;
 }
-/* 활동 타입(읽음/질문/메모/업로드)별로 서로 다른 색을 준다 - Reading Time
-   Distribution 등 다른 위젯에서 이미 쓰는 --rh-c1..c4 dataviz 팔레트와 동일한
+/* 활동 타입(읽음/열람/질문/메모/업로드)별로 서로 다른 색을 준다 - Reading Time
+   Distribution 등 다른 위젯에서 이미 쓰는 --rh-c1..c5 dataviz 팔레트와 동일한
    타입→색 매핑(TYPE_COLOR_VAR)을 그대로 재사용해 페이지 안에서 일관되게 한다. */
 .rh-timeline-entry[data-type="read"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c1) 18%, transparent); color: var(--rh-c1); }
+.rh-timeline-entry[data-type="browsed"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c5) 18%, transparent); color: var(--rh-c5); }
 .rh-timeline-entry[data-type="question"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c2) 18%, transparent); color: var(--rh-c2); }
 .rh-timeline-entry[data-type="note"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c3) 18%, transparent); color: var(--rh-c3); }
 .rh-timeline-entry[data-type="uploaded"] .rh-timeline-type { background: color-mix(in srgb, var(--rh-c4) 18%, transparent); color: var(--rh-c4); }
 .rh-timeline-entry[data-type="read"] .rh-timeline-dot { color: var(--rh-c1); border-color: color-mix(in srgb, var(--rh-c1) 40%, var(--border-strong)); }
+.rh-timeline-entry[data-type="browsed"] .rh-timeline-dot { color: var(--rh-c5); border-color: color-mix(in srgb, var(--rh-c5) 40%, var(--border-strong)); }
 .rh-timeline-entry[data-type="question"] .rh-timeline-dot { color: var(--rh-c2); border-color: color-mix(in srgb, var(--rh-c2) 40%, var(--border-strong)); }
 .rh-timeline-entry[data-type="note"] .rh-timeline-dot { color: var(--rh-c3); border-color: color-mix(in srgb, var(--rh-c3) 40%, var(--border-strong)); }
 .rh-timeline-entry[data-type="uploaded"] .rh-timeline-dot { color: var(--rh-c4); border-color: color-mix(in srgb, var(--rh-c4) 40%, var(--border-strong)); }


### PR DESCRIPTION
# Summary
## 1. 읽기 증거 기반 세션 분류
- 개인 EMA의 15%를 45~120초로 제한한 최소 읽기 시간 적용
- 검증 페이지 1개 이상, 신뢰도 50% 이상, AFK 이상 패턴 부재를 모두 충족한 세션만 읽음으로 판정
- 30초 이상이지만 읽음 조건을 충족하지 못한 세션을 열람으로 분리하고 30초 미만 무증거 세션 제외
## 2. Timeline 판정 영속화 및 표시
- 세션 판정과 적용 임계치를 DB에 저장해 사용자 EMA 변경 후에도 과거 기록 유지
- Reading History와 Dashboard에 읽음/열람 라벨, 필터, 색상, 검증 페이지 표시 추가
- 경계값, AFK, 판정 영속성 테스트 추가