### PR TITLE
fix: 대시보드 AI 인사이트 카드 마크다운/LaTeX 렌더링 수정

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -11,6 +11,7 @@ import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendation
 import { icon } from '../icons.js'
 import { readPageCount, lastActivityIso, hasReadActivity, computeStreakDays, todayKey, addDaysKey, isWithinDaysLocal } from '../readPages.js'
 import { periodStats, sumSecondsByDayRange, buildDailyActivityStats, formatDuration } from './readingHistoryPage.js'
+import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
 function renderReadingAnalyticsCard(analyticsData) {
   if (!analyticsData) return ''
@@ -162,7 +163,7 @@ function renderInsightsCard(insights) {
         : `<ul class="dash-insight-list">${items.map(g => `
             <li class="dash-insight-item">
               <span class="dash-insight-icon">${icon(INSIGHT_TYPE_ICON[g.type] || 'lightbulb', 14)}</span>
-              <span>${escapeHtml(g.message)}</span>
+              <span>${formatTranslationHtml(g.message)}</span>
             </li>`).join('')}</ul>`
       }
     </div>
@@ -715,6 +716,7 @@ export async function renderDashboardPage() {
       </div>
     `
 
+    applyKatexToElement(el.querySelector('.dash-insight-list'))
     attachHandlers(el)
   } catch (renderErr) {
     console.error('대시보드 렌더링 예외 발생:', renderErr)


### PR DESCRIPTION
# Summary
## 1. 대시보드 AI 인사이트 카드 마크다운/LaTeX 렌더링 미지원 문제 수정
- `frontend/src/pages/dashboardPage.js`의 `renderInsightsCard`에서 인사이트 메시지(`g.message`)를 `escapeHtml()`로만 렌더링해 LLM이 생성한 `**볼드**`, `$...$` 수식 등이 원문 기호 그대로 노출되던 문제 수정
- 번역창/읽기 전 브리핑(primer)에서 이미 사용 중인 공용 리치텍스트 포맷터 `formatTranslationHtml`/`applyKatexToElement`(`frontend/src/textFormat.js`)를 재사용해 마크다운 헤더/볼드와 LaTeX 수식($...$, $$...$$, \(...\), \[...\]) 렌더링 지원
- KaTeX가 아직 로드되지 않은 타이밍 대비, 대시보드 렌더링 직후 `applyKatexToElement(el.querySelector('.dash-insight-list'))` 호출 추가 (다른 화면과 동일한 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)