### PR TITLE
feat: 대시보드 활동 요약 카드에 정독 비율/카테고리별 시간 분포/전주 대비 증감 추가

### DIFF
--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -7,10 +7,11 @@
 // (뷰어/비교 화면이 보이고 포커스된 동안 적립 → 서버 전송)가 쌓은 실측치를
 // fetchReadingTimeStats()로 가져온 것이다.
 import './../styles/dashboard.css'
+import '../styles/reading-history.css'
 import { fetchLibraryDashboard, fetchLibraryTimeline, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibrary, fetchLibraryGraph, fetchReadingTimeStats, fetchReadingAnalyticsSummary } from '../library.js'
 import { icon } from '../icons.js'
 import { readPageCount, lastActivityIso, hasReadActivity, computeStreakDays, todayKey, addDaysKey, isWithinDaysLocal } from '../readPages.js'
-import { periodStats, sumSecondsByDayRange, buildDailyActivityStats, formatDuration } from './readingHistoryPage.js'
+import { periodStats, sumSecondsByDayRange, buildDailyActivityStats, formatDuration, deltaDurationHtml, CATEGORY_LABEL, CATEGORY_COLOR_VAR, CATEGORY_ORDER } from './readingHistoryPage.js'
 import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
 function renderReadingAnalyticsCard(analyticsData) {
@@ -207,11 +208,47 @@ function renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, 
 }
 
 // ── 연구 성과 & Reading Score ──
-function renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary) {
+// 정독/스키밍 비율: paper_stats(논문별 최신 세션의 reading_depth)를 근거로 계산한다.
+// determine_reading_depth()가 검증 페이지 비율 20% 이상일 때부터 'Reading' 단계를
+// 부여하므로, 'Opened'/'Browsing'(검증 근거 부족)만 스키밍으로, 그 이상은 정독으로 분류한다.
+function computeDepthRatio(analyticsSummary) {
+  const paperStats = Object.values(analyticsSummary?.paper_stats || {})
+  const total = paperStats.length
+  if (total === 0) return null
+  const skimCount = paperStats.filter(p => p.reading_depth === 'Opened' || p.reading_depth === 'Browsing').length
+  const deepCount = total - skimCount
+  const deepPct = Math.round((deepCount / total) * 100)
+  return { deepCount, skimCount, deepPct, skimPct: 100 - deepPct }
+}
+
+function renderProgressSummaryCard(events, heatmap, weeklySeconds, prevWeeklySeconds, analyticsSummary, weeklyCategoryStats) {
   const streak = computeStreakDays(events)
   const focusTopic = heatmap[0]
   const score = analyticsSummary?.overall_avg_score || 0.0
   const scorePct = Math.max(0, Math.min(100, score))
+  const depthRatio = computeDepthRatio(analyticsSummary)
+
+  const catTotal = CATEGORY_ORDER.reduce((s, c) => s + (weeklyCategoryStats?.[c] || 0), 0)
+  const categoryMixHtml = catTotal === 0 ? '' : `
+      <div class="dash-category-mix">
+        <div class="dash-category-mix-head">활동 유형별 시간 분포</div>
+        <div class="rh-mix-bar">
+          ${CATEGORY_ORDER.map(c => {
+            const seconds = weeklyCategoryStats[c] || 0
+            const pct = catTotal ? (seconds / catTotal) * 100 : 0
+            if (pct <= 0) return ''
+            return `<div class="rh-mix-seg" style="width:${pct}%;background:var(${CATEGORY_COLOR_VAR[c]})" title="${escapeHtml(CATEGORY_LABEL[c])}: ${formatDuration(seconds)}"></div>`
+          }).join('')}
+        </div>
+        <div class="dash-category-mix-legend">
+          ${CATEGORY_ORDER.map(c => {
+            const seconds = weeklyCategoryStats[c] || 0
+            const pct = catTotal ? Math.round((seconds / catTotal) * 100) : 0
+            return `<span class="dash-category-mix-item"><i class="dash-mix-dot" style="background:var(${CATEGORY_COLOR_VAR[c]})"></i>${escapeHtml(CATEGORY_LABEL[c])} ${pct}%</span>`
+          }).join('')}
+        </div>
+      </div>
+  `
 
   return `
     <div class="dash-card">
@@ -239,6 +276,18 @@ function renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSumm
           <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 2px;">정독 패턴, verified pages & interaction 종합 평가</div>
         </div>
       </div>
+      ${depthRatio ? `
+      <div class="dash-depth-ratio">
+        <div class="dash-depth-ratio-bar">
+          <div class="dash-depth-ratio-seg is-deep" style="width:${depthRatio.deepPct}%" title="정독 ${depthRatio.deepCount}편"></div>
+          <div class="dash-depth-ratio-seg is-skim" style="width:${depthRatio.skimPct}%" title="스키밍 ${depthRatio.skimCount}편"></div>
+        </div>
+        <div class="dash-depth-ratio-legend">
+          <span><i class="dash-depth-dot is-deep"></i>정독 ${depthRatio.deepPct}% (${formatNumber(depthRatio.deepCount)}편)</span>
+          <span><i class="dash-depth-dot is-skim"></i>스키밍 ${depthRatio.skimPct}% (${formatNumber(depthRatio.skimCount)}편)</span>
+        </div>
+      </div>
+      ` : ''}
       <div class="dash-summary-grid">
         <div class="dash-summary-box">
           <div class="dash-summary-value">${formatNumber(streak)}<span class="dash-summary-unit">일</span></div>
@@ -247,12 +296,14 @@ function renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSumm
         <div class="dash-summary-box">
           <div class="dash-summary-value dash-summary-value-text">${formatDuration(weeklySeconds)}</div>
           <div class="dash-summary-label">주간 읽기 시간</div>
+          <div class="dash-summary-delta">${deltaDurationHtml(weeklySeconds, prevWeeklySeconds, '지난주 대비')}</div>
         </div>
         <div class="dash-summary-box">
           <div class="dash-summary-value dash-summary-value-text">${focusTopic ? escapeHtml(truncateLabel(focusTopic.name, 12)) : '—'}</div>
           <div class="dash-summary-label">집중 주제</div>
         </div>
       </div>
+      ${categoryMixHtml}
     </div>
   `
 }
@@ -646,7 +697,7 @@ export async function renderDashboardPage() {
 
   el.innerHTML = `<div class="dash-loading">${icon('refreshCw', 20)}<span>대시보드를 불러오는 중...</span></div>`
 
-  let dashboard, timelineData, libraryData, graphData, readingStats, cachedRecs, analyticsSummary
+  let dashboard, timelineData, libraryData, graphData, readingStats, cachedRecs, analyticsSummary, weeklyReadingStats
   try {
     const results = await Promise.all([
       fetchLibraryDashboard().catch(() => null),
@@ -656,6 +707,7 @@ export async function renderDashboardPage() {
       fetchReadingTimeStats().catch(() => null),
       fetchCachedReadingRecommendations().catch(() => ({ recommendations: null })),
       fetchReadingAnalyticsSummary().catch(() => null),
+      fetchReadingTimeStats(7).catch(() => null),
     ])
     dashboard = results[0]
     timelineData = results[1]
@@ -664,6 +716,7 @@ export async function renderDashboardPage() {
     readingStats = results[4]
     cachedRecs = results[5]
     analyticsSummary = results[6]
+    weeklyReadingStats = results[7]
   } catch (err) {
     console.error('대시보드 데이터 로드 실패:', err)
     el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
@@ -682,9 +735,12 @@ export async function renderDashboardPage() {
     const tKey = todayKey()
     const currStart7 = addDaysKey(tKey, -6)
     const currEnd7 = addDaysKey(tKey, 1)
+    const prevStart7 = addDaysKey(tKey, -13)
+    const prevEnd7 = currStart7
 
     const curr7 = periodStats(events, docsById, currStart7, currEnd7)
     const weeklySeconds = sumSecondsByDayRange(readingStats?.total_seconds_by_day, currStart7, currEnd7)
+    const prevWeeklySeconds = sumSecondsByDayRange(readingStats?.total_seconds_by_day, prevStart7, prevEnd7)
     const dailyStatsMap = buildDailyActivityStats(events, readingStats)
 
     let currEstPages7 = 0
@@ -701,7 +757,7 @@ export async function renderDashboardPage() {
         <div class="dash-row dash-row-3">
           ${renderInsightsCard(insights)}
           ${renderWeeklyActivityCard(curr7, weeklyPagesRead, weeklySeconds, stats, readingStats, docs)}
-          ${renderProgressSummaryCard(events, heatmap, weeklySeconds, analyticsSummary)}
+          ${renderProgressSummaryCard(events, heatmap, weeklySeconds, prevWeeklySeconds, analyticsSummary, weeklyReadingStats?.total_seconds_by_category)}
         </div>
         <div class="dash-row dash-row-recent">
           ${renderRecentPapersCard(docs)}

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -73,6 +73,12 @@ const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', browsed: 'activity', 
 const TYPE_COLOR_VAR = { read: '--rh-c1', browsed: '--rh-c5', question: '--rh-c2', note: '--rh-c3', uploaded: '--rh-c4' }
 const TYPE_ORDER = ['read', 'browsed', 'question', 'note', 'uploaded']
 
+// 읽기 시간 하트비트의 카테고리 3종(뷰어 기본/채팅 사이드바/논문 비교) - 대시보드
+// 활동 요약 카드의 "활동 유형별 시간 분포"에서도 동일 팔레트/라벨을 공유한다.
+export const CATEGORY_LABEL = { reading: '논문 읽기', chat: 'AI 채팅', compare: '논문 비교' }
+export const CATEGORY_COLOR_VAR = { reading: '--rh-c1', chat: '--rh-c2', compare: '--rh-c5' }
+export const CATEGORY_ORDER = ['reading', 'chat', 'compare']
+
 const DAY_MS = 86400000
 const WEEKDAY_LABELS = ['월', '', '수', '', '금', '', '일']
 
@@ -342,7 +348,7 @@ export function periodStats(events, docsById, startKey, endKeyExclusive) {
   return { activeDays, papersRead: completedDocIds.size, pagesRead, questions, notes, uploadedPapers }
 }
 
-function deltaHtml(curr, prev, unit = '', compareText = '이전 30일 대비') {
+export function deltaHtml(curr, prev, unit = '', compareText = '이전 30일 대비') {
   const c = curr || 0
   const p = prev || 0
   const diff = c - p
@@ -361,7 +367,7 @@ export function formatDuration(seconds) {
   if (m > 0) return `${m}m`
   return s > 0 ? `${s}s` : '0m'
 }
-function deltaDurationHtml(currSeconds, prevSeconds, compareText = '이전 30일 대비') {
+export function deltaDurationHtml(currSeconds, prevSeconds, compareText = '이전 30일 대비') {
   const diff = Math.round(currSeconds - prevSeconds)
   if (diff === 0) return `<span class="rh-stat-delta">±0m ${compareText}</span>`
   const cls = diff > 0 ? 'up' : 'down'
@@ -533,9 +539,6 @@ export async function renderReadingHistoryPage() {
       .map(([k, _]) => k)
   )
 
-  const CATEGORY_LABEL = { reading: '논문 읽기', chat: 'AI 채팅', compare: '논문 비교' }
-  const CATEGORY_COLOR_VAR = { reading: '--rh-c1', chat: '--rh-c2', compare: '--rh-c5' }
-  const CATEGORY_ORDER = ['reading', 'chat', 'compare']
   const byCategory = readingStats?.total_seconds_by_category || {}
   const mixTotalSeconds = CATEGORY_ORDER.reduce((s, c) => s + (byCategory[c] || 0), 0)
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -221,6 +221,34 @@
 .dash-summary-value-text { font-family: var(--font-body); font-size: 13.5px; word-break: keep-all; }
 .dash-summary-unit { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-left: 2px; }
 .dash-summary-label { font-size: 10.5px; font-weight: 600; color: var(--text-tertiary); }
+.dash-summary-delta { font-size: 10.5px; }
+.dash-summary-delta .rh-stat-delta { margin-top: 0; font-size: 10.5px; }
+
+/* ── 정독/스키밍 비율 ── */
+.dash-depth-ratio { margin-bottom: 12px; }
+.dash-depth-ratio-bar {
+  display: flex;
+  height: 8px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--border-strong);
+  margin-bottom: 8px;
+}
+.dash-depth-ratio-seg { height: 100%; }
+.dash-depth-ratio-seg.is-deep { background: linear-gradient(90deg, var(--accent-from), var(--accent-to)); }
+.dash-depth-ratio-seg.is-skim { background: var(--border-strong); }
+.dash-depth-ratio-legend { display: flex; align-items: center; gap: 14px; font-size: 11px; color: var(--text-tertiary); font-weight: 600; }
+.dash-depth-ratio-legend span { display: inline-flex; align-items: center; gap: 5px; }
+.dash-depth-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.dash-depth-dot.is-deep { background: var(--accent-to); }
+.dash-depth-dot.is-skim { background: var(--border-strong); }
+
+/* ── 활동 유형별 시간 분포 ── */
+.dash-category-mix { margin-top: 12px; }
+.dash-category-mix-head { font-size: 10.5px; font-weight: 600; color: var(--text-tertiary); margin-bottom: 8px; }
+.dash-category-mix-legend { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
+.dash-category-mix-item { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--text-secondary); font-weight: 600; }
+.dash-mix-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 
 /* ── 최근 읽은 논문 ── */
 .dash-paper-list {


### PR DESCRIPTION
# Summary
## 1. 정독/스키밍 비율 추가
- `renderProgressSummaryCard`의 Reading Score 게이지 바로 아래에 2단 세그먼트 바 추가
- `computeDepthRatio()` 함수로 `analyticsSummary.paper_stats`(전 논문 최신 세션의 `reading_depth`)를 집계
- `Opened`/`Browsing`(검증 페이지 비율 20% 미만)은 스키밍, `Reading`/`Deep Reading`/`Completed`는 정독으로 분류
- 이미 로드되어 있던 `analyticsSummary`를 재사용해 추가 API 호출 없음

## 2. 활동 유형별 시간 분포 추가
- 카드 하단에 "논문 읽기 / AI 채팅 / 논문 비교" 3단 세그먼트 바 + 범례 추가
- `fetchReadingTimeStats(7)`을 추가 호출해 최근 7일 `total_seconds_by_category`를 조회
- `readingHistoryPage.js`에 있던 `CATEGORY_LABEL`/`CATEGORY_COLOR_VAR`/`CATEGORY_ORDER`를 모듈 스코프로 옮기고 export해서 대시보드에서도 재사용

## 3. 전주 대비 증감 추가
- "주간 읽기 시간" 박스에 지난주(8~14일 전) 대비 증감을 나타내는 델타 배지 추가
- `sumSecondsByDayRange(readingStats?.total_seconds_by_day, prevStart7, prevEnd7)`로 지난주 합계를 클라이언트에서 계산(추가 API 호출 없음)
- `readingHistoryPage.js`의 기존 `deltaDurationHtml()`을 export해서 재사용

## 4. 기타
- `frontend/src/pages/dashboardPage.js`에서 `reading-history.css`를 import하여 `--rh-c1~c6` 팔레트 변수 및 `.rh-mix-*`/`.rh-stat-delta` 클래스를 공유
- `dashboard.css`에 정독/스키밍 바, 카테고리 분포 바 관련 스타일 추가

## Test plan
- [x] `vite build` 성공 확인
- [x] 정독/스키밍 비율 및 카테고리 분포 계산 로직 Node 단위 검증(빈 데이터/null 케이스 포함)
- [ ] 실제 로그인 후 대시보드 화면에서 육안 확인 (백엔드 인증 및 실제 읽기 세션 데이터 필요, 이번 작업에서는 미실시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)