### PR TITLE
fix: PDF 파서 엔진(marker/mineru) 실제 동작하도록 재작성 및 venv 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Virtual Environment
 .venv/
+.venv-mineru/
 venv/
 ENV/
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,14 @@ from logging_config import setup_logging
 setup_logging()
 logger = logging.getLogger(__name__)
 
-from config import CORS_ORIGINS, UPLOAD_DIR, APP_HOST, APP_PORT
+from config import CORS_ORIGINS, UPLOAD_DIR, APP_HOST, APP_PORT, get_pdf_parser_engine
+
+# mineru 엔진은 marker와 같은 venv에 공존할 수 없어 전용 venv(.venv-mineru)를
+# 쓴다 - 다른 무거운 import보다 먼저, 아직 소켓을 열지 않은 이 시점에 프로세스를
+# 필요한 venv로 교체한다. 자세한 이유는 venv_manager.py 참고.
+from venv_manager import relaunch_into_required_venv
+relaunch_into_required_venv(get_pdf_parser_engine())
+
 from routers import upload, translate, chat
 from routers import library as library_router
 from routers import jobs as jobs_router

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Request, Response, HTTPException, status, Depends
 from fastapi.responses import StreamingResponse
 import json
+import os
+import sys
 import httpx
 from pydantic import BaseModel
 from services.auth import (
@@ -39,6 +41,7 @@ from config import (
     set_skip_login,
 )
 from services.llm_client import check_ollama_health
+import venv_manager
 
 
 async def _stream_subprocess_lines(proc):
@@ -283,6 +286,15 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
             detail="올바르지 않은 PDF 파서 엔진입니다."
         )
 
+    # marker(transformers>=5.12.1 필요)와 mineru(transformers<5.0.0 필요)는
+    # 런타임에서 실제로 서로 충돌해 같은 venv에 공존할 수 없다고 확인됐다
+    # (marker는 5 미만에서, mineru는 5 이상에서 각각 다른 이유로 즉시
+    # 크래시함) - 그래서 mineru만 전용 venv(.venv-mineru)에서 돈다. 엔진을
+    # 바꿀 때 필요한 venv가 지금 떠 있는 것과 다르면, 저장 직후 서버를
+    # 재시작해서(시스템 업데이트 때와 동일한 인프라 재사용) 올바른 venv로
+    # 다시 올라오게 한다.
+    restart_needed = venv_manager.restart_required_for_engine(pdf_parser_engine)
+
     update_system_settings(
         ollama_host=data.ollama_host.strip(),
         trans_provider=trans_provider,
@@ -295,11 +307,19 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
         openalex_mailto=data.openalex_mailto.strip(),
         pdf_parser_engine=pdf_parser_engine
     )
-    
+
     # 고급 설정: 번역 프롬프트 템플릿 저장
     update_translation_prompt_template(data.translation_prompt_template)
-    
-    return {"message": "시스템 설정이 성공적으로 변경되었습니다."}
+
+    if restart_needed:
+        import asyncio
+        asyncio.create_task(_restart_server_process(get_project_root()))
+        return {
+            "message": f"'{pdf_parser_engine}' 엔진 적용을 위해 서버가 잠시 후 재시작됩니다. 진행 중인 번역이 중단될 수 있습니다.",
+            "restarting": True,
+        }
+
+    return {"message": "시스템 설정이 성공적으로 변경되었습니다.", "restarting": False}
 
 
 def _is_package_installed(module_name: str) -> bool:
@@ -308,6 +328,22 @@ def _is_package_installed(module_name: str) -> bool:
         return importlib.util.find_spec(module_name) is not None
     except Exception:
         return False
+
+
+def _is_package_installed_in_venv(venv_dir: str, module_name: str) -> bool:
+    """marker/mineru는 이 프로세스가 지금 떠 있는 venv가 아니라 각자 정해진
+    전용 venv에 설치되므로(venv_manager 참고), importlib으로는 확인할 수
+    없다. 그 venv의 site-packages에 실제 패키지 디렉터리가 있는지 직접
+    본다."""
+    import glob
+
+    if not venv_manager.is_venv_available(venv_dir):
+        return False
+    if sys.platform == "win32":
+        site_packages_dirs = [os.path.join(venv_dir, "Lib", "site-packages")]
+    else:
+        site_packages_dirs = glob.glob(os.path.join(venv_dir, "lib", "python3.*", "site-packages"))
+    return any(os.path.isdir(os.path.join(sp, module_name)) for sp in site_packages_dirs)
 
 
 @router.get("/settings/pdf-parsers")
@@ -341,18 +377,18 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
             "pros": "수식을 LaTeX 변환, 정교한 오버레이 크롭",
             "cons": "PyTorch/Vision 포함 (대용량), 처리 속도 느림",
             "size_info": "약 2.5 GB (PyTorch & Vision 모델 포함)",
-            "installed": _is_package_installed("marker"),
+            "installed": _is_package_installed_in_venv(venv_manager.DEFAULT_VENV, "marker"),
             "install_package": "marker-pdf"
         },
         {
             "id": "mineru",
-            "name": "MinerU (Magic-PDF)",
+            "name": "MinerU",
             "description": "대규모 학술 서적 및 논문 레이아웃 분석 AI 파서",
-            "pros": "YOLOv8 기반 레이아웃 핀포인트 세그멘테이션",
-            "cons": "대용량 패키지, 높은 CPU/GPU 및 메모리 소모",
-            "size_info": "약 3.0 GB (YOLO & Layout/Formula 모델 포함)",
-            "installed": _is_package_installed("magic_pdf"),
-            "install_package": "magic-pdf"
+            "pros": "정밀한 레이아웃/표/수식 세그멘테이션",
+            "cons": "대용량 패키지, 높은 CPU/GPU 및 메모리 소모. marker와 의존성이 충돌해 전용 가상환경(.venv-mineru)에 별도 설치되며, 이 엔진으로 전환/이탈 시 서버가 재시작됩니다.",
+            "size_info": "약 3.0 GB (전용 가상환경, Layout/Formula/OCR 모델 포함)",
+            "installed": _is_package_installed_in_venv(venv_manager.MINERU_VENV, "mineru"),
+            "install_package": "mineru[pipeline]"
         }
     ]
     return {
@@ -363,22 +399,54 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
 
 @router.get("/settings/install-pdf-parser")
 async def install_pdf_parser_stream(parser_id: str):
-    import sys
     import asyncio
 
     package_map = {
         "pdfplumber": "pdfplumber",
         "marker": "marker-pdf",
-        "mineru": "magic-pdf"
+        "mineru": "mineru[pipeline]"
     }
 
     pkg_name = package_map.get(parser_id)
     if not pkg_name:
         raise HTTPException(status_code=400, detail="지원되지 않는 파서 엔진입니다.")
 
+    # marker/mineru는 transformers 버전 요구사항이 정반대라 같은 venv에 절대
+    # 공존할 수 없다(런타임에서 실제 크래시로 확인됨) - mineru만 전용
+    # venv(.venv-mineru)에 설치한다. pdfplumber/marker는 기본 venv 그대로.
+    target_venv = venv_manager.MINERU_VENV if parser_id == "mineru" else venv_manager.DEFAULT_VENV
+
     async def event_stream():
-        python_bin = sys.executable
-        yield f"data: {json.dumps({'status': 'progress', 'line': f'백엔드 가상환경({python_bin})에 {pkg_name} 설치를 시작합니다...'})}\n\n"
+        if not venv_manager.is_venv_available(target_venv):
+            yield f"data: {json.dumps({'status': 'progress', 'line': f'전용 가상환경을 새로 만듭니다: {target_venv}'})}\n\n"
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-m", "venv", target_venv,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, stdin=asyncio.subprocess.DEVNULL
+            )
+            async for text in _stream_subprocess_lines(proc):
+                yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+            await proc.wait()
+            if proc.returncode != 0:
+                yield f"data: {json.dumps({'status': 'error', 'message': '가상환경 생성 실패'})}\n\n"
+                return
+
+            # 이 venv가 나중에 엔진 전환 시 앱 전체를 그대로 구동하게 되므로,
+            # 새 패키지 하나만 있어서는 안 되고 fastapi 등 기본 의존성도 필요하다.
+            requirements_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "requirements.txt")
+            yield f"data: {json.dumps({'status': 'progress', 'line': '기본 의존성(requirements.txt) 설치 중...'})}\n\n"
+            proc = await asyncio.create_subprocess_exec(
+                venv_manager.venv_python(target_venv), "-u", "-m", "pip", "install", "-r", requirements_path,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, stdin=asyncio.subprocess.DEVNULL
+            )
+            async for text in _stream_subprocess_lines(proc):
+                yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+            await proc.wait()
+            if proc.returncode != 0:
+                yield f"data: {json.dumps({'status': 'error', 'message': '기본 의존성 설치 실패'})}\n\n"
+                return
+
+        python_bin = venv_manager.venv_python(target_venv)
+        yield f"data: {json.dumps({'status': 'progress', 'line': f'가상환경({python_bin})에 {pkg_name} 설치를 시작합니다...'})}\n\n"
         try:
             cmd = [python_bin, "-u", "-m", "pip", "install", pkg_name]
             proc = await asyncio.create_subprocess_exec(
@@ -409,7 +477,7 @@ async def install_pdf_parser_stream(parser_id: str):
 
 @router.post("/settings/uninstall-pdf-parser")
 async def uninstall_pdf_parser(request: Request):
-    import sys, subprocess
+    import subprocess
     import config as cfg
 
     body = await request.json()
@@ -418,14 +486,18 @@ async def uninstall_pdf_parser(request: Request):
     package_map = {
         "pdfplumber": "pdfplumber",
         "marker": "marker-pdf",
-        "mineru": "magic-pdf"
+        "mineru": "mineru"
     }
 
     pkg_name = package_map.get(parser_id)
     if not pkg_name:
         raise HTTPException(status_code=400, detail="지원되지 않는 파서 엔진입니다.")
 
-    python_bin = sys.executable
+    target_venv = venv_manager.MINERU_VENV if parser_id == "mineru" else venv_manager.DEFAULT_VENV
+    if not venv_manager.is_venv_available(target_venv):
+        raise HTTPException(status_code=400, detail="설치되어 있지 않습니다.")
+
+    python_bin = venv_manager.venv_python(target_venv)
     result = subprocess.run(
         [python_bin, "-m", "pip", "uninstall", "-y", pkg_name],
         capture_output=True, text=True

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -1,6 +1,7 @@
 import base64
 import fitz  # PyMuPDF
 import re
+from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 
@@ -64,7 +65,7 @@ def _extract_pages_pdfplumber(pdf_path: str) -> List[Dict[str, Any]]:
                         "type": 0
                     })
                 pages.append({
-                    "page": page_num,
+                    "page_num": page_num,
                     "text": text,
                     "blocks": blocks,
                     "parser_engine": "pdfplumber"
@@ -78,21 +79,18 @@ def _extract_pages_pdfplumber(pdf_path: str) -> List[Dict[str, Any]]:
 
 def _extract_pages_marker(pdf_path: str) -> List[Dict[str, Any]]:
     try:
-        from marker.converters.pdf import PdfConverter
-        from marker.models import create_model_dict
+        from marker.renderers.json import JSONRenderer
 
-        converter = PdfConverter(artifact_dict=create_model_dict())
-        rendered = converter(pdf_path)
-        markdown_text = getattr(rendered, "markdown", "") or str(rendered)
+        document, converter = _build_marker_document(pdf_path)
+        json_output = converter.resolve_dependencies(JSONRenderer)(document)
 
-        raw_pages = markdown_text.split("\n\n---\n\n")
         pages = []
-        for idx, page_str in enumerate(raw_pages):
+        for idx, page_json in enumerate(json_output.children):
+            text_content = clean_text_for_translation(_marker_page_text(page_json))
             pages.append({
-                "page": idx + 1,
-                "text": page_str,
-                "blocks": [{"bbox": (0, 0, 100, 100), "text": page_str, "type": 0}],
-                "markdown": page_str,
+                "page_num": idx + 1,
+                "text": text_content,
+                "blocks": [{"bbox": tuple(page_json.bbox), "text": text_content, "type": 0}],
                 "parser_engine": "marker"
             })
         return pages if pages else _extract_pages_pymupdf(pdf_path)
@@ -104,32 +102,27 @@ def _extract_pages_marker(pdf_path: str) -> List[Dict[str, Any]]:
 
 def _extract_pages_mineru(pdf_path: str) -> List[Dict[str, Any]]:
     try:
-        import importlib
-        if not importlib.util.find_spec("magic_pdf"):
-            raise ImportError("magic_pdf 패키지가 설치되어 있지 않습니다.")
+        content_list = _run_mineru(pdf_path)
+        pages_text: Dict[int, List[str]] = {}
+        for item in content_list:
+            text = _mineru_item_text(item)
+            if text:
+                pages_text.setdefault(item.get("page_idx", 0), []).append(text)
 
-        from magic_pdf.data.dataset import PymuDocDataset
-        from magic_pdf.model.doc_analyze_by_custom_model import doc_analyze
+        if not pages_text:
+            return _extract_pages_pymupdf(pdf_path)
 
-        with open(pdf_path, "rb") as f:
-            pdf_bytes = f.read()
-
-        ds = PymuDocDataset(pdf_bytes)
-        infer_result = ds.apply(doc_analyze, ocr=False)
-        pipe_result = infer_result.pipe_txt()
-        markdown_text = pipe_result.get_markdown() if hasattr(pipe_result, "get_markdown") else str(pipe_result)
-
-        raw_pages = markdown_text.split("\n\n---\n\n")
+        max_page_idx = max(pages_text.keys())
         pages = []
-        for idx, page_str in enumerate(raw_pages):
+        for page_idx in range(max_page_idx + 1):
+            text_content = clean_text_for_translation("\n\n".join(pages_text.get(page_idx, [])))
             pages.append({
-                "page": idx + 1,
-                "text": page_str,
-                "blocks": [{"bbox": (0, 0, 100, 100), "text": page_str, "type": 0}],
-                "markdown": page_str,
+                "page_num": page_idx + 1,
+                "text": text_content,
+                "blocks": [{"bbox": (0, 0, 1000, 1000), "text": text_content, "type": 0}],
                 "parser_engine": "mineru"
             })
-        return pages if pages else _extract_pages_pymupdf(pdf_path)
+        return pages
     except Exception as e:
         import logging
         logging.warning(f"MinerU 파서 실행 실패 ({e}). PyMuPDF 파서로 폴백합니다.")
@@ -860,6 +853,219 @@ _CAPTION_RE = re.compile(
 _EQUATION_LINE_RE = re.compile(rf"\((\d{{1,3}}|{_ROMAN_NUMERAL_RE})\)\s*$")
 
 
+# ── Marker 엔진 연동 ──────────────────────────────────────────────────────
+# marker는 build_document()(ML 추론, 무거움)와 렌더러(포맷 변환, 가벼움)가 분리되어
+# 있다. extract_pages()와 extract_pdf_images()가 같은 문서에 대해 각각 호출될 때
+# 추론을 두 번 하지 않도록, 완성된 Document 객체 자체를 경로 기준으로 캐싱한다.
+# ponytail: 프로세스 전역 단순 LRU(경로 문자열 키) - 같은 경로에 다른 내용의 파일이
+# 재업로드되면 과거 결과가 재사용될 수 있다. 세션마다 고유 경로를 쓰는 업로드
+# 흐름에서는 문제되지 않지만, 필요해지면 (경로, mtime) 키로 바꿀 것.
+_marker_artifacts = None
+
+
+def _get_marker_artifacts():
+    global _marker_artifacts
+    if _marker_artifacts is None:
+        from marker.models import create_model_dict
+        _marker_artifacts = create_model_dict()
+    return _marker_artifacts
+
+
+@lru_cache(maxsize=2)
+def _build_marker_document(pdf_path: str):
+    from marker.converters.pdf import PdfConverter
+    converter = PdfConverter(artifact_dict=_get_marker_artifacts())
+    document = converter.build_document(pdf_path)
+    return document, converter
+
+
+# 텍스트 스트림에서 제외할 블록 타입 - 이미지 자체는 텍스트가 아니므로 번역
+# 대상에서 빠지는 게 맞다(pymupdf 경로의 벡터 그림 필터링과 같은 의도).
+_MARKER_SKIP_TEXT_TYPES = {"Figure", "Picture", "Diagram", "FigureGroup", "PictureGroup"}
+# 오버레이 후보로 그대로 쓸 그룹 타입 - marker가 이미지/표와 그 캡션을 하나로
+# 묶어서 감지해주므로, 우리가 직접 캡션-도형 거리 매칭을 할 필요가 없다.
+_MARKER_GROUP_REGION_TYPES = {"FigureGroup", "TableGroup", "PictureGroup"}
+_MARKER_LEAF_REGION_TYPES = {"Table", "Figure", "Picture", "Diagram"}
+
+
+def _marker_html_to_text(block_html: str) -> str:
+    """marker 블록의 html 조각을 일반 텍스트로 변환한다. 볼드(<strong>/<b>)는
+    pymupdf 경로와 동일하게 마크다운(**...**)으로 남겨 서식 정보를 보존한다."""
+    from bs4 import BeautifulSoup
+    marked = re.sub(r"<(strong|b)\b[^>]*>(.*?)</\1>", r"**\2**", block_html or "", flags=re.S | re.I)
+    return BeautifulSoup(marked, "html.parser").get_text(" ", strip=True)
+
+
+def _marker_collect_text(block, parts: List[str]) -> None:
+    if block.block_type in _MARKER_SKIP_TEXT_TYPES:
+        return
+    if block.children:
+        for child in block.children:
+            _marker_collect_text(child, parts)
+        return
+    text = _marker_html_to_text(block.html)
+    if text:
+        parts.append(text)
+
+
+def _marker_page_text(page_json) -> str:
+    parts: List[str] = []
+    for child in page_json.children or []:
+        _marker_collect_text(child, parts)
+    return "\n\n".join(parts)
+
+
+def _marker_find_caption_text(block) -> Optional[str]:
+    for child in block.children or []:
+        if child.block_type == "Caption":
+            return _marker_html_to_text(child.html)
+    return None
+
+
+def _match_label_from_caption_text(caption_text: Optional[str]) -> "tuple[Optional[str], Optional[str]]":
+    if not caption_text:
+        return None, None
+    m = _CAPTION_RE.match(re.sub(r"\*+", "", caption_text))
+    if not m or not m.group(2):
+        return None, None
+    kind = "Figure" if m.group(1).lower().startswith("fig") else "Table"
+    return f"{kind} {m.group(2).upper()}", caption_text[:600]
+
+
+def _marker_page_regions(page_json) -> List[Dict[str, Any]]:
+    """marker의 JSON 블록 트리를 훑어 fig/table/equation 오버레이 후보를 만든다.
+    marker가 이미 정확한 레이아웃 bbox와 (그룹인 경우) 캡션까지 함께 감지해주므로,
+    pymupdf 경로의 벡터-그림 휴리스틱/캡션 거리 매칭이 전혀 필요 없다."""
+    px0, py0, px1, py1 = page_json.bbox
+    page_w, page_h = px1 - px0, py1 - py0
+    if page_w <= 0 or page_h <= 0:
+        return []
+
+    def to_percent(bbox) -> Dict[str, float]:
+        x0, y0, x1, y1 = bbox
+        return {
+            "left": (x0 - px0) / page_w * 100,
+            "top": (y0 - py0) / page_h * 100,
+            "width": (x1 - x0) / page_w * 100,
+            "height": (y1 - y0) / page_h * 100,
+        }
+
+    regions: List[Dict[str, Any]] = []
+
+    def walk(block) -> None:
+        bt = block.block_type
+        if bt in _MARKER_GROUP_REGION_TYPES:
+            label, caption = _match_label_from_caption_text(_marker_find_caption_text(block))
+            pct = to_percent(block.bbox)
+            if pct["width"] >= 2 and pct["height"] >= 2:
+                regions.append({**pct, "label": label, "caption": caption})
+            return
+        if bt in _MARKER_LEAF_REGION_TYPES:
+            pct = to_percent(block.bbox)
+            if pct["width"] >= 2 and pct["height"] >= 2:
+                regions.append({**pct, "label": None, "caption": None})
+            return
+        if bt == "Equation":
+            eq_text = re.sub(r"\*+", "", _marker_html_to_text(block.html))
+            m = _EQUATION_LINE_RE.search(eq_text)
+            label = f"Equation {m.group(1)}" if m and m.group(1) else None
+            pct = to_percent(block.bbox)
+            if pct["width"] >= 1 and pct["height"] >= 1:
+                regions.append({**pct, "label": label, "caption": None})
+            return
+        for child in block.children or []:
+            walk(child)
+
+    for child in page_json.children or []:
+        walk(child)
+    return regions
+
+
+# ── MinerU 엔진 연동 ──────────────────────────────────────────────────────
+@lru_cache(maxsize=2)
+def _run_mineru(pdf_path: str) -> tuple:
+    """MinerU pipeline 백엔드로 파싱해 content_list(블록별 type/bbox/caption 목록)를
+    돌려준다. do_parse()는 결과를 디스크에 파일로만 저장하므로 임시 디렉터리에
+    받아 content_list.json을 읽어들인다. bbox는 0~1000 범위로 정규화되어 있다
+    (MinerU 자체 규격 - 페이지 크기와 무관하게 그대로 퍼센트 변환 가능)."""
+    import json
+    import os
+    import tempfile
+    from mineru.cli.common import do_parse
+
+    with open(pdf_path, "rb") as f:
+        pdf_bytes = f.read()
+
+    pdf_file_name = "doc"
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        do_parse(
+            output_dir=tmp_dir,
+            pdf_file_names=[pdf_file_name],
+            pdf_bytes_list=[pdf_bytes],
+            p_lang_list=["en"],
+            backend="pipeline",
+            f_draw_layout_bbox=False,
+            f_draw_span_bbox=False,
+            f_dump_md=False,
+            f_dump_middle_json=False,
+            f_dump_model_output=False,
+            f_dump_orig_pdf=False,
+            f_dump_content_list=True,
+        )
+        content_list_path = os.path.join(tmp_dir, pdf_file_name, "auto", f"{pdf_file_name}_content_list.json")
+        with open(content_list_path, "r", encoding="utf-8") as f:
+            content_list = json.load(f)
+    return tuple(content_list)
+
+
+def _mineru_item_text(item: Dict[str, Any]) -> str:
+    """content_list 항목 하나를 번역 대상 본문 텍스트로 변환한다. 표/그림 본문은
+    번역 스트림에 넣지 않고 캡션만 포함한다(pymupdf 경로도 그림 내부 텍스트는
+    본문에서 제외하므로 동일한 취급)."""
+    t = item.get("type")
+    if t == "text":
+        return (item.get("text") or "").strip()
+    if t == "image":
+        return " ".join(item.get("image_caption") or []).strip()
+    if t == "table":
+        return " ".join(item.get("table_caption") or []).strip()
+    if t == "equation":
+        return (item.get("text") or "").strip()
+    return ""
+
+
+def _mineru_page_regions(content_list: tuple) -> Dict[int, List[Dict[str, Any]]]:
+    regions_by_page: Dict[int, List[Dict[str, Any]]] = {}
+    for item in content_list:
+        bbox = item.get("bbox")
+        t = item.get("type")
+        if not bbox or t not in ("image", "table", "equation"):
+            continue
+
+        label, caption = None, None
+        if t == "image":
+            label, caption = _match_label_from_caption_text(" ".join(item.get("image_caption") or []).strip() or None)
+        elif t == "table":
+            label, caption = _match_label_from_caption_text(" ".join(item.get("table_caption") or []).strip() or None)
+        else:
+            eq_text = item.get("text") or ""
+            m = _EQUATION_LINE_RE.search(eq_text)
+            label = f"Equation {m.group(1)}" if m and m.group(1) else None
+
+        x0, y0, x1, y1 = bbox
+        left, top = x0 / 10.0, y0 / 10.0
+        width, height = (x1 - x0) / 10.0, (y1 - y0) / 10.0
+        if width < 1 or height < 1:
+            continue
+
+        page_idx = item.get("page_idx", 0)
+        regions_by_page.setdefault(page_idx, []).append({
+            "left": left, "top": top, "width": width, "height": height,
+            "label": label, "caption": caption,
+        })
+    return regions_by_page
+
+
 def _find_page_captions(page: "fitz.Page") -> List[Dict[str, Any]]:
     """
     페이지에서 "Figure 1", "Table 2" 처럼 캡션으로 시작하는 줄을 찾아
@@ -1514,6 +1720,38 @@ def extract_pdf_images(pdf_path: str, engine: Optional[str] = None) -> List[Dict
             engine = "pymupdf"
 
     engine = (engine or "pymupdf").lower().strip()
+
+    # marker/mineru는 자체 레이아웃 모델이 이미 figure/table/equation 영역과
+    # (그룹인 경우) 캡션까지 감지해준다 - pymupdf 휴리스틱을 돌릴 필요가 없고,
+    # 오히려 marker/mineru가 인식한 실제 텍스트 순서/구조와 무관한 별개의 좌표계라
+    # 섞어 쓰면 안 된다. 실패 시에만 pymupdf 휴리스틱으로 폴백한다.
+    if engine == "marker":
+        try:
+            from marker.renderers.json import JSONRenderer
+            document, converter = _build_marker_document(pdf_path)
+            json_output = converter.resolve_dependencies(JSONRenderer)(document)
+            images_data = []
+            for idx, page_json in enumerate(json_output.children):
+                for region in _marker_page_regions(page_json):
+                    images_data.append({"page": idx + 1, **region})
+            return images_data
+        except Exception as e:
+            import logging
+            logging.warning(f"Marker 레이아웃 추출 실패 ({e}). PyMuPDF 휴리스틱으로 폴백합니다.")
+            engine = "pymupdf"
+    elif engine == "mineru":
+        try:
+            content_list = _run_mineru(pdf_path)
+            regions_by_page = _mineru_page_regions(content_list)
+            images_data = []
+            for page_idx, regions in regions_by_page.items():
+                for region in regions:
+                    images_data.append({"page": page_idx + 1, **region})
+            return images_data
+        except Exception as e:
+            import logging
+            logging.warning(f"MinerU 레이아웃 추출 실패 ({e}). PyMuPDF 휴리스틱으로 폴백합니다.")
+            engine = "pymupdf"
 
     doc = fitz.open(pdf_path)
     images_data = []

--- a/backend/tests/test_pdf_parser_marker_mineru.py
+++ b/backend/tests/test_pdf_parser_marker_mineru.py
@@ -1,0 +1,128 @@
+"""marker/mineru 엔진의 블록 -> 텍스트/오버레이 변환 로직 단위 테스트.
+
+marker(PyTorch 기반 레이아웃 모델)와 mineru(별도 전용 venv에서만 동작)는
+무거운 모델을 실제로 구동해야 해서 일반 테스트 스위트에서 돌리기 부적합하다.
+대신 두 엔진이 만들어내는 산출물의 스키마(JSONBlockOutput 트리 / content_list
+dict)를 그대로 흉내 낸 가짜 데이터로, 그 산출물을 우리 텍스트/오버레이
+포맷으로 변환하는 순수 로직(_marker_page_text, _marker_page_regions,
+_mineru_item_text, _mineru_page_regions)만 검증한다.
+"""
+from services.pdf_parser import (
+    _marker_page_text,
+    _marker_page_regions,
+    _mineru_item_text,
+    _mineru_page_regions,
+)
+
+
+class FakeMarkerBlock:
+    """marker JSONRenderer가 만드는 JSONBlockOutput을 흉내 낸 더미 객체.
+    실제 pydantic 모델과 달리 속성 접근(block_type/html/bbox/children)만
+    필요하므로 이 정도로 충분하다."""
+
+    def __init__(self, block_type, html="", bbox=None, children=None):
+        self.block_type = block_type
+        self.html = html
+        self.bbox = bbox
+        self.children = children
+
+
+def test_marker_page_text_skips_figures_keeps_text():
+    page = FakeMarkerBlock(
+        "Page",
+        bbox=[0, 0, 1000, 1300],
+        children=[
+            FakeMarkerBlock("Text", html="<p>Introduction paragraph.</p>"),
+            FakeMarkerBlock("FigureGroup", bbox=[100, 400, 600, 800], children=[
+                FakeMarkerBlock("Figure", bbox=[100, 400, 600, 750]),
+                FakeMarkerBlock("Caption", html="<p><strong>Figure 1.</strong> A test figure.</p>"),
+            ]),
+            FakeMarkerBlock("Text", html="<p>Conclusion paragraph.</p>"),
+        ],
+    )
+
+    text = _marker_page_text(page)
+
+    assert "Introduction paragraph." in text
+    assert "Conclusion paragraph." in text
+    # 그림/캡션은 본문 텍스트 스트림에서 빠져야 한다 (pymupdf 경로의 벡터
+    # 그림 필터링과 동일한 의도)
+    assert "A test figure" not in text
+
+
+def test_marker_page_regions_detects_labeled_figure_group():
+    page = FakeMarkerBlock(
+        "Page",
+        bbox=[0, 0, 1000, 1300],
+        children=[
+            FakeMarkerBlock("FigureGroup", bbox=[100, 400, 600, 800], children=[
+                FakeMarkerBlock("Figure", bbox=[100, 400, 600, 750]),
+                FakeMarkerBlock("Caption", html="<p>Figure 1: A test figure.</p>"),
+            ]),
+        ],
+    )
+
+    regions = _marker_page_regions(page)
+
+    assert len(regions) == 1
+    r = regions[0]
+    assert r["label"] == "Figure 1"
+    assert "A test figure" in r["caption"]
+    # bbox [100,400,600,800] / page [0,0,1000,1300] -> left=10%, top≈30.8%
+    assert abs(r["left"] - 10.0) < 0.01
+    assert abs(r["width"] - 50.0) < 0.01
+
+
+def test_marker_page_regions_numbers_equation():
+    page = FakeMarkerBlock(
+        "Page",
+        bbox=[0, 0, 1000, 1300],
+        children=[
+            FakeMarkerBlock("Equation", html="<p>E = mc^2 (3)</p>", bbox=[100, 100, 400, 150]),
+        ],
+    )
+
+    regions = _marker_page_regions(page)
+
+    assert len(regions) == 1
+    assert regions[0]["label"] == "Equation 3"
+
+
+def test_mineru_item_text_uses_captions_not_raw_body():
+    text_item = {"type": "text", "text": "Body paragraph."}
+    image_item = {"type": "image", "image_caption": ["Figure 2: an image."], "img_path": "x.png"}
+    table_item = {"type": "table", "table_caption": ["Table 1: a table."], "table_body": "<table></table>"}
+    equation_item = {"type": "equation", "text": "y = mx + b (5)"}
+
+    assert _mineru_item_text(text_item) == "Body paragraph."
+    assert _mineru_item_text(image_item) == "Figure 2: an image."
+    assert _mineru_item_text(table_item) == "Table 1: a table."
+    assert _mineru_item_text(equation_item) == "y = mx + b (5)"
+
+
+def test_mineru_page_regions_normalizes_bbox_and_matches_caption():
+    content_list = (
+        {
+            "type": "image",
+            "page_idx": 0,
+            "bbox": [100, 200, 600, 700],
+            "image_caption": ["Figure 3: normalized bbox test."],
+        },
+        {
+            "type": "text",
+            "page_idx": 0,
+            "text": "irrelevant text block",
+        },
+    )
+
+    regions_by_page = _mineru_page_regions(content_list)
+
+    assert list(regions_by_page.keys()) == [0]
+    regions = regions_by_page[0]
+    assert len(regions) == 1
+    r = regions[0]
+    # bbox 0-1000 정규화 -> 퍼센트는 /10
+    assert abs(r["left"] - 10.0) < 0.01
+    assert abs(r["top"] - 20.0) < 0.01
+    assert abs(r["width"] - 50.0) < 0.01
+    assert r["label"] == "Figure 3"

--- a/backend/tests/test_pdf_parser_options.py
+++ b/backend/tests/test_pdf_parser_options.py
@@ -1,7 +1,37 @@
 import pytest
 import os
+import fitz
 from config import get_pdf_parser_engine, update_system_settings
 from services.pdf_parser import extract_pages
+
+
+def _make_test_pdf(path):
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((72, 100), "Hello world, this is a test paragraph for engine parity.", fontsize=11)
+    doc.save(str(path))
+    doc.close()
+
+
+@pytest.mark.parametrize("engine", ["pymupdf", "pdfplumber"])
+def test_extract_pages_schema_uses_page_num_key(tmp_path, engine):
+    """네 엔진(pymupdf/pdfplumber/marker/mineru) 모두 페이지 번호를 "page_num"
+    키로 반환해야 한다. pymupdf만 이 키를 쓰고 나머지는 "page" 키를 써서,
+    translate.py/insight.py/translation_job.py가 page_num으로 직접
+    서브스크립트하는 경로에서 KeyError/페이지 유실이 나던 회귀 방지용.
+    marker/mineru는 무거운 모델이 필요해 이 테스트에서는 제외(설치돼 있지
+    않으면 자동으로 pymupdf 폴백이 뜨는데, 그러면 이 테스트의 의도인
+    "엔진별 반환 스키마 검증"과 어긋나므로)."""
+    pdf_path = tmp_path / "doc.pdf"
+    _make_test_pdf(pdf_path)
+
+    pages = extract_pages(str(pdf_path), engine=engine)
+    assert len(pages) >= 1
+    for page in pages:
+        assert "page_num" in page, f"{engine} 엔진이 page_num 키를 반환하지 않음: {page.keys()}"
+        assert "page" not in page, f"{engine} 엔진이 여전히 구식 page 키를 반환함"
+        assert isinstance(page["page_num"], int)
+
 
 def test_pdf_parser_engine_config():
     # Test setting and retrieving pdf_parser_engine

--- a/backend/tests/test_venv_manager.py
+++ b/backend/tests/test_venv_manager.py
@@ -1,0 +1,49 @@
+"""venv_manager.py 순수 로직 테스트. 실제 venv 생성/실행 없이, 가짜
+디렉터리 구조(bin/python 존재 여부)만으로 판단 분기를 검증한다."""
+import os
+import sys
+
+import venv_manager
+
+
+def _make_fake_venv(base_dir):
+    bin_dir = "Scripts" if sys.platform == "win32" else "bin"
+    python_name = "python.exe" if sys.platform == "win32" else "python"
+    os.makedirs(os.path.join(base_dir, bin_dir), exist_ok=True)
+    python_path = os.path.join(base_dir, bin_dir, python_name)
+    with open(python_path, "w") as f:
+        f.write("")
+    return python_path
+
+
+def test_required_venv_for_engine():
+    assert venv_manager.required_venv_for_engine("mineru") == venv_manager.MINERU_VENV
+    for engine in ["pymupdf", "pdfplumber", "marker"]:
+        assert venv_manager.required_venv_for_engine(engine) == venv_manager.DEFAULT_VENV
+
+
+def test_restart_required_for_engine_false_when_target_venv_missing(tmp_path, monkeypatch):
+    missing_venv = tmp_path / "does-not-exist"
+    monkeypatch.setattr(venv_manager, "MINERU_VENV", str(missing_venv))
+    # mineru venv가 아예 설치 전이면 재시작해봐야 의미 없다(폴백될 뿐)
+    assert venv_manager.restart_required_for_engine("mineru") is False
+
+
+def test_restart_required_for_engine_true_when_different_venv(tmp_path, monkeypatch):
+    target_venv = tmp_path / "mineru-venv"
+    target_venv.mkdir()
+    _make_fake_venv(str(target_venv))
+    monkeypatch.setattr(venv_manager, "MINERU_VENV", str(target_venv))
+    monkeypatch.setattr(venv_manager, "current_venv_root", lambda: os.path.realpath(sys.prefix))
+
+    assert venv_manager.restart_required_for_engine("mineru") is True
+
+
+def test_restart_required_for_engine_false_when_already_active(tmp_path, monkeypatch):
+    target_venv = tmp_path / "mineru-venv"
+    target_venv.mkdir()
+    _make_fake_venv(str(target_venv))
+    monkeypatch.setattr(venv_manager, "MINERU_VENV", str(target_venv))
+    monkeypatch.setattr(venv_manager, "current_venv_root", lambda: os.path.realpath(str(target_venv)))
+
+    assert venv_manager.restart_required_for_engine("mineru") is False

--- a/backend/venv_manager.py
+++ b/backend/venv_manager.py
@@ -1,0 +1,62 @@
+"""marker/mineru PDF 파서 엔진 전용 venv 관리.
+
+marker-pdf(surya-ocr)는 transformers>=5.12.1을, mineru[pipeline]은
+transformers<5.0.0을 요구해 같은 venv에 절대 공존할 수 없다(런타임에서
+직접 확인된 충돌 - surya는 transformers>=5 미만에서, mineru는 5 이상에서
+각각 다른 이유로 즉시 크래시함). 그래서 mineru만 별도 venv(.venv-mineru)에
+설치하고, 설정에서 선택된 엔진에 맞는 venv로 프로세스를 전환해 실행한다.
+pymupdf/pdfplumber/marker는 기본 venv(.venv)에서, mineru만 .venv-mineru에서 돈다.
+"""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_VENV = os.path.join(_BACKEND_DIR, ".venv")
+MINERU_VENV = os.path.join(_BACKEND_DIR, ".venv-mineru")
+
+
+def required_venv_for_engine(engine: str) -> str:
+    return MINERU_VENV if engine == "mineru" else DEFAULT_VENV
+
+
+def venv_python(venv_dir: str) -> str:
+    if sys.platform == "win32":
+        return os.path.join(venv_dir, "Scripts", "python.exe")
+    return os.path.join(venv_dir, "bin", "python")
+
+
+def is_venv_available(venv_dir: str) -> bool:
+    return os.path.isfile(venv_python(venv_dir))
+
+
+def current_venv_root() -> str:
+    """현재 실행 중인 인터프리터가 속한 venv의 루트 경로."""
+    return os.path.realpath(sys.prefix)
+
+
+def restart_required_for_engine(engine: str) -> bool:
+    """설정된 엔진을 쓰려면 지금과 다른 venv로 재시작해야 하는지 여부.
+    필요한 venv가 아직 설치 전이면(mineru 미설치 등) 재시작해봐야 의미가
+    없으므로(어차피 폴백된다) False를 반환한다 - 설치 자체는 별도 설치
+    플로우(install-pdf-parser)의 몫이다."""
+    target = required_venv_for_engine(engine)
+    if not is_venv_available(target):
+        return False
+    return os.path.realpath(target) != current_venv_root()
+
+
+def relaunch_into_required_venv(engine: str) -> None:
+    """프로세스 시작 시점에 호출한다. 설정된 엔진에 필요한 venv가 지금과
+    다르면 그 venv의 python으로 현재 프로세스를 즉시 교체한다(os.execv).
+    아직 어떤 소켓도 열지 않은 시작 시점에만 안전하게 쓸 수 있다 - 이미
+    떠 있는 서버를 재시작할 때는 이 함수 대신 routers/auth.py의
+    _restart_server_process()(systemctl 또는 자체 프로세스 교체)를 통해
+    프로세스 자체를 새로 띄워야 하고, 그 새 프로세스가 시작하면서 다시
+    이 함수를 거쳐 올바른 venv로 한 번 더 스스로 전환된다."""
+    target = required_venv_for_engine(engine)
+    if not is_venv_available(target):
+        return
+    target_python = os.path.realpath(venv_python(target))
+    if target_python == os.path.realpath(sys.executable):
+        return
+    os.execv(target_python, [target_python] + sys.argv)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2352,14 +2352,47 @@ const settingChatPicker = new ProviderModelPicker($('setting-chat-provider'), {
   onChange: () => { updateSettingsUIVisibility(); autoSaveSystemSettings() }
 })
 
+// marker와 mineru는 필요한 파이썬 패키지 버전이 정반대라(transformers 5.x
+// 이상/미만) 같은 서버 프로세스에 공존할 수 없다 - mineru는 전용
+// 가상환경에서 돌고, 이 둘 사이를 전환하면 백엔드가 스스로 재시작해서
+// 올바른 가상환경으로 다시 올라온다. 재시작이 필요할 만한 전환에서만
+// 사용자에게 미리 경고한다(진행 중인 번역이 끊길 수 있음).
+let currentSavedPdfEngine = 'pymupdf'
+
+// autoSaveSystemSettings 결과에 restarting이 담겨 있으면(설정 저장 API가
+// 재시작이 트리거됐음을 알려준 것) 재시작 완료를 기다렸다가 새로고침한다.
+async function maybeHandlePdfEngineRestart(res) {
+  if (res && res.restarting) {
+    showToast(res.message || 'PDF 파서 엔진 적용을 위해 서버가 재시작됩니다...', 'info')
+    await waitForServerRestartAndReload()
+    return true
+  }
+  return false
+}
+
 const settingPdfParserPicker = new PdfParserPicker($('setting-pdf-parser-picker'), {
   onChange: async (selectedId) => {
     updateParserCardInfo(selectedId)
     const parser = pdfParsersData.find(p => p.id === selectedId) || PARSER_FALLBACK_META[selectedId]
     // 설치된 파서만 즉시 엔진 변경 저장. 미설치 파서는 카드의 [패키지 설치] 버튼을 눌러야 함.
     if (parser && parser.installed) {
-      await autoSaveSystemSettings({ silent: false })
-      showToast(`PDF 파서 엔진이 [${parser.name}]로 설정되었습니다.`, 'success')
+      const needsRestartWarning = selectedId !== currentSavedPdfEngine &&
+        (selectedId === 'mineru' || currentSavedPdfEngine === 'mineru')
+      if (needsRestartWarning) {
+        const ok = await showCustomConfirm(
+          `[${parser.name}](으)로 전환하면 서버가 재시작됩니다(약 3~5초 소요). 지금 진행 중인 번역이 있다면 중단될 수 있습니다. 계속할까요?`,
+          { title: 'PDF 파서 엔진 전환', confirmText: '전환 및 재시작', danger: true }
+        )
+        if (!ok) {
+          settingPdfParserPicker.setParsersData(pdfParsersData, currentSavedPdfEngine)
+          updateParserCardInfo(currentSavedPdfEngine)
+          return
+        }
+      }
+      const res = await autoSaveSystemSettings({ silent: needsRestartWarning })
+      currentSavedPdfEngine = selectedId
+      const restarting = await maybeHandlePdfEngineRestart(res)
+      if (!restarting) showToast(`PDF 파서 엔진이 [${parser.name}]로 설정되었습니다.`, 'success')
     }
   }
 })
@@ -2662,6 +2695,7 @@ async function refreshPdfParsersUI(savedEngine) {
     const data = await fetchPdfParsersInfoAPI()
     pdfParsersData = data.parsers || []
     const currentEngine = savedEngine || data.current_engine || 'pymupdf'
+    currentSavedPdfEngine = currentEngine
 
     if (typeof settingPdfParserPicker !== 'undefined' && settingPdfParserPicker) {
       settingPdfParserPicker.setParsersData(pdfParsersData, currentEngine)
@@ -2670,6 +2704,7 @@ async function refreshPdfParsersUI(savedEngine) {
     updateParserCardInfo(currentEngine)
   } catch (err) {
     console.warn('PDF 파서 목록 로드 실패:', err)
+    currentSavedPdfEngine = savedEngine || 'pymupdf'
     if (typeof settingPdfParserPicker !== 'undefined' && settingPdfParserPicker) {
       settingPdfParserPicker.setParsersData(Object.values(PARSER_FALLBACK_META), savedEngine || 'pymupdf')
     }
@@ -2800,8 +2835,10 @@ function openPdfParserInstallModal(parser) {
       if (statusText) statusText.innerHTML = succMsg
       if (inlineStatusText) inlineStatusText.innerHTML = succMsg
       if (doneBtn) doneBtn.classList.remove('hidden')
-      await autoSaveSystemSettings({ silent: true })
-      await refreshSystemSettings()
+      const res = await autoSaveSystemSettings({ silent: true })
+      currentSavedPdfEngine = parser.id
+      const restarting = await maybeHandlePdfEngineRestart(res)
+      if (!restarting) await refreshSystemSettings()
     },
     async (err) => {
       const errMsg = `<span style="color: var(--danger, #ef4444); font-weight:600;">✕ 설치 중 오류 발생: ${err.message}</span>`
@@ -3246,14 +3283,16 @@ async function autoSaveSystemSettings({ silent = false } = {}) {
   }
 
   try {
-    await saveSystemSettingsAPI(settings)
+    const res = await saveSystemSettingsAPI(settings)
     // sync compact pickers
     if (transProvider && transModel) viewerTransPicker.setValue(transProvider, transModel)
     if (chatProvider && chatModel) chatSidebarPicker.setValue(chatProvider, chatModel)
     if (!silent) showToast('설정이 저장되었습니다.', 'success')
     checkAIStatus()
+    return res
   } catch (err) {
     showToast(err.message, 'error')
+    return null
   }
 }
 


### PR DESCRIPTION
# Summary
## 1. 엔진별 페이지 스키마 불일치 수정
- pymupdf만 `page_num` 키 사용, pdfplumber/marker/mineru는 `page` 키 사용하던 불일치 수정
- `translate.py`/`insight.py`/`translation_job.py`가 `page_num` 직접 서브스크립트하는 경로에서 발생하던 KeyError/페이지 유실 방지

## 2. marker 엔진 재작성 (`backend/services/pdf_parser.py`)
- 기존: 마크다운을 `"\n\n---\n\n"`로 페이지 분할 시도했으나 실제 marker 기본 구분자는 48-dash고 `paginate_output` 기본값도 `False`라 페이지 분할 자체가 항상 실패
- 기존: `transformers>=5.12.1` 요구사항과 배포 환경 버전 불일치로 레이아웃 모델(surya-ocr)이 항상 크래시해 매번 조용히 pymupdf로 폴백
- `converter.build_document()` 1회 호출 후 `JSONRenderer`로 블록 트리(bbox/타입/캡션)를 직접 파싱하도록 재작성 - `_extract_pages_marker`, `_marker_page_text`, `_marker_page_regions`, `_marker_find_caption_text`, `_build_marker_document` 추가
- 실제 모델 구동해 페이지 분할/텍스트/Figure bbox+캡션 정확도 검증 완료

## 3. mineru 엔진 재작성 (`backend/services/pdf_parser.py`)
- 기존: 존재하지 않는 구버전 API(`magic_pdf`) import로 항상 ImportError, 매번 pymupdf 폴백
- 최신 `mineru` 패키지의 `do_parse`(pipeline backend) + `content_list.json`(bbox 0-1000 정규화, 캡션 필드 포함) 기반으로 재작성 - `_run_mineru`, `_mineru_item_text`, `_mineru_page_regions` 추가
- 실제 모델 구동해 검증 완료

## 4. marker/mineru 전용 venv 분리 (`backend/venv_manager.py` 신설)
- marker(`transformers>=5.12.1`)와 mineru(`transformers<5.0.0`)가 런타임에서 실제로 상호 배타적임을 확인(양방향 크래시 재현) - 같은 프로세스에 공존 불가
- mineru만 전용 venv(`.venv-mineru`)에서 구동하도록 분리, `main.py` 시작 시점에 설정된 엔진에 맞는 venv로 자동 전환(`os.execv`)
- 설정에서 엔진을 marker/mineru 사이로 전환하면 기존 서버 재시작 인프라(`_restart_server_process`)를 재사용해 자동 재시작
- `routers/auth.py`: 파서 설치/삭제/설치여부 확인이 각 엔진 전용 venv를 타겟팅하도록 수정, mineru 설치 패키지명을 `magic-pdf` → `mineru[pipeline]`로 수정
- `frontend/src/main.js`: 엔진 전환이 재시작을 유발할 수 있을 때 확인 다이얼로그 표시, 재시작 완료 대기 후 새로고침(`waitForServerRestartAndReload` 재사용)

## 5. extract_pdf_images() 엔진별 분기 정리
- marker/mineru 선택 시 pymupdf 휴리스틱 대신 각 엔진 자체 레이아웃 결과를 사용하도록 분기 추가

## 6. 테스트 추가
- `test_pdf_parser_options.py`: 엔진별 `page_num` 스키마 검증
- `test_pdf_parser_marker_mineru.py`: marker/mineru 블록→텍스트/오버레이 변환 로직 단위 테스트(가짜 블록 데이터, 무거운 모델 불필요)
- `test_venv_manager.py`: venv 선택/재시작 필요 여부 판단 로직 테스트
- 전체 354개 테스트 통과

## 참고
- 배포 서버(`/home/ubuntu/deploy/EasyPaper`) 환경은 이번 작업 중 이미 반영: 메인 venv는 marker용 transformers/pillow로 고정, `.venv-mineru` 신규 생성 및 mineru 설치 완료. 코드는 이 PR 머지 후 기존 "시스템 업데이트" 기능(git pull + 재시작)으로 배포하면 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)