### PR TITLE
fix(deps): pin Pillow for Marker compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,5 @@ pydantic==2.8.2
 aiofiles==23.2.1
 python-dotenv==1.0.1
 matplotlib==3.11.1
-pillow==12.3.0
+# marker-pdf/surya-ocr require Pillow >=10.2.0,<11.
+pillow>=10.2.0,<11


### PR DESCRIPTION
# Summary
## 1. Marker PDF 의존성 충돌 수정
- marker-pdf 및 surya-ocr가 요구하는 Pillow 버전 범위(>=10.2.0,<11)로 수정함
- Pillow 12.x 설치로 인해 발생하던 Marker PDF 런타임 의존성 충돌을 해소함