### PR TITLE
feat: add library folder tree management

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -5,10 +5,11 @@ from services.library import (
     list_documents, search_documents, get_document, permanently_delete_document,
     soft_delete_document, restore_document, empty_trash,
     get_translation, get_pdf_path, get_cover_path, update_document_metadata,
-    get_chat_quote_image_path
+    get_chat_quote_image_path, list_folders, create_folder, update_folder, delete_folder, move_documents_to_folder
 )
 from pydantic import BaseModel
 import json
+import re
 
 router = APIRouter()
 
@@ -28,6 +29,66 @@ def _require_owned_document(doc_id: str, current_user: str, doc: Optional[dict] 
     if not doc or doc.get("username") != current_user:
         raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
     return doc
+
+class FolderCreateRequest(BaseModel):
+    name: str
+    parent_id: Optional[str] = None
+    color: str = "#6b7280"
+
+class FolderUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    color: Optional[str] = None
+    parent_id: Optional[str] = None
+    move: bool = False
+
+class DocumentMoveRequest(BaseModel):
+    doc_ids: list[str]
+    folder_id: Optional[str] = None
+
+@router.get("/library/folders")
+async def get_library_folders(current_user: str = Depends(get_current_user)):
+    return {"folders": list_folders(current_user)}
+
+@router.post("/library/folders")
+async def create_library_folder(body: FolderCreateRequest, current_user: str = Depends(get_current_user)):
+    import uuid
+    name = body.name.strip()
+    if not name or len(name) > 120:
+        raise HTTPException(status_code=400, detail="폴더 이름은 1~120자여야 합니다.")
+    if not re.fullmatch(r"#[0-9a-fA-F]{6}", body.color):
+        raise HTTPException(status_code=400, detail="폴더 색상 형식이 올바르지 않습니다.")
+    try:
+        return create_folder(current_user, str(uuid.uuid4()), name, body.parent_id, body.color)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+@router.patch("/library/folders/{folder_id}")
+async def patch_library_folder(folder_id: str, body: FolderUpdateRequest, current_user: str = Depends(get_current_user)):
+    if body.name is not None and (not body.name.strip() or len(body.name.strip()) > 120):
+        raise HTTPException(status_code=400, detail="폴더 이름은 1~120자여야 합니다.")
+    if body.color is not None and not re.fullmatch(r"#[0-9a-fA-F]{6}", body.color):
+        raise HTTPException(status_code=400, detail="폴더 색상 형식이 올바르지 않습니다.")
+    try:
+        ok = update_folder(current_user, folder_id, name=body.name.strip() if body.name is not None else None, color=body.color, parent_id=body.parent_id, move=body.move)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not ok: raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
+    return {"ok": True}
+
+@router.delete("/library/folders/{folder_id}")
+async def delete_library_folder(folder_id: str, current_user: str = Depends(get_current_user)):
+    if not delete_folder(current_user, folder_id): raise HTTPException(status_code=404, detail="폴더를 찾을 수 없습니다.")
+    return {"ok": True}
+
+@router.post("/library/documents/move")
+async def move_library_documents(body: DocumentMoveRequest, current_user: str = Depends(get_current_user)):
+    try:
+        moved = move_documents_to_folder(current_user, body.doc_ids, body.folder_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if moved != len(set(body.doc_ids)): raise HTTPException(status_code=404, detail="일부 논문을 찾을 수 없습니다.")
+    return {"moved": moved}
+
 
 @router.get("/library")
 async def get_library(

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -323,6 +323,26 @@ def init_db():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_time_username_day ON reading_time(username, day)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_time_doc ON reading_time(doc_id, username)")
 
+        # UI의 폴더 구조는 실제 PDF 디렉터리와 분리해 관리한다.
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS folders (
+            id TEXT PRIMARY KEY, username TEXT NOT NULL, parent_id TEXT,
+            name TEXT NOT NULL, color TEXT NOT NULL DEFAULT '#6b7280',
+            sort_order INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            FOREIGN KEY (username) REFERENCES users(username) ON DELETE CASCADE,
+            FOREIGN KEY (parent_id) REFERENCES folders(id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS document_folders (
+            doc_id TEXT PRIMARY KEY, folder_id TEXT,
+            FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE,
+            FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE SET NULL
+        )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_folders_user_parent ON folders(username, parent_id, sort_order)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_folders_folder ON document_folders(folder_id)")
+
         conn.commit()
 
         # reading_time 테이블 동적 스키마 마이그레이션: doc_title 컬럼 추가
@@ -841,6 +861,61 @@ def db_update_document_metadata(doc_id: str, metadata: dict) -> None:
             (meta_str, doc_id)
         )
         conn.commit()
+
+
+# ── 라이브러리 폴더 ───────────────────────────────────────────────────────────
+
+def db_list_folders(username: str) -> List[Dict[str, Any]]:
+    with get_db() as conn:
+        rows = conn.execute("SELECT id, username, parent_id, name, color, sort_order, created_at, updated_at FROM folders WHERE username = ? ORDER BY sort_order, name COLLATE NOCASE", (username,)).fetchall()
+        return [dict(row) for row in rows]
+
+def db_get_folder(folder_id: str, username: str) -> Optional[Dict[str, Any]]:
+    with get_db() as conn:
+        row = conn.execute("SELECT id, username, parent_id, name, color, sort_order, created_at, updated_at FROM folders WHERE id = ? AND username = ?", (folder_id, username)).fetchone()
+        return dict(row) if row else None
+
+def db_create_folder(folder_id: str, username: str, name: str, parent_id: Optional[str], color: str) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        conn.execute("INSERT INTO folders (id, username, parent_id, name, color, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)", (folder_id, username, parent_id, name, color, now, now))
+        conn.commit()
+    return {"id": folder_id, "username": username, "parent_id": parent_id, "name": name, "color": color, "created_at": now, "updated_at": now}
+
+def db_update_folder(folder_id: str, username: str, **updates: Any) -> bool:
+    allowed = {key: value for key, value in updates.items() if key in {"name", "color", "parent_id"}}
+    if not allowed: return False
+    allowed["updated_at"] = datetime.now(timezone.utc).isoformat()
+    set_sql = ", ".join(f"{key} = ?" for key in allowed)
+    with get_db() as conn:
+        cursor = conn.execute(f"UPDATE folders SET {set_sql} WHERE id = ? AND username = ?", (*allowed.values(), folder_id, username))
+        conn.commit()
+        return cursor.rowcount == 1
+
+def db_delete_folder(folder_id: str, username: str) -> bool:
+    with get_db() as conn:
+        # 하위 폴더와 포함 문서는 루트로 올린 뒤 폴더만 제거한다.
+        conn.execute("UPDATE folders SET parent_id = NULL WHERE parent_id = ? AND username = ?", (folder_id, username))
+        conn.execute("UPDATE document_folders SET folder_id = NULL WHERE folder_id = ?", (folder_id,))
+        cursor = conn.execute("DELETE FROM folders WHERE id = ? AND username = ?", (folder_id, username))
+        conn.commit()
+        return cursor.rowcount == 1
+
+def db_get_document_folder_map(username: str) -> Dict[str, Optional[str]]:
+    with get_db() as conn:
+        rows = conn.execute("SELECT df.doc_id, df.folder_id FROM document_folders df JOIN documents d ON d.id = df.doc_id WHERE d.username = ?", (username,)).fetchall()
+        return {row["doc_id"]: row["folder_id"] for row in rows}
+
+def db_move_documents_to_folder(doc_ids: List[str], username: str, folder_id: Optional[str]) -> int:
+    if not doc_ids: return 0
+    placeholders = ",".join("?" for _ in doc_ids)
+    with get_db() as conn:
+        rows = conn.execute(f"SELECT id FROM documents WHERE username = ? AND id IN ({placeholders})", (username, *doc_ids)).fetchall()
+        owned_ids = [row["id"] for row in rows]
+        for doc_id in owned_ids:
+            conn.execute("INSERT INTO document_folders (doc_id, folder_id) VALUES (?, ?) ON CONFLICT(doc_id) DO UPDATE SET folder_id = excluded.folder_id", (doc_id, folder_id))
+        conn.commit()
+        return len(owned_ids)
 
 
 # ── 앱 내부 상태 (app_meta) ───────────────────────────────────────────────────

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -23,6 +23,8 @@ from services.db import (
     db_delete_page_insight,
     db_update_document_metadata,
     db_bulk_translation_rows,
+    db_list_folders, db_get_folder, db_create_folder, db_update_folder, db_delete_folder,
+    db_get_document_folder_map, db_move_documents_to_folder,
 )
 
 
@@ -124,8 +126,10 @@ def list_documents(
         suffix = f"{target_lang}_{style}_math{int(ignore_math)}_table{int(ignore_table)}_refs{int(ignore_refs)}"
 
     rows_by_doc = db_bulk_translation_rows([doc["id"] for doc in docs])
+    folder_map = db_get_document_folder_map(username) if username else {}
     for doc in docs:
         doc["translated_pages"] = _resolve_translated_pages(rows_by_doc.get(doc["id"], []), suffix)
+        doc["folder_id"] = folder_map.get(doc["id"])
     return docs
 
 
@@ -140,10 +144,55 @@ def search_documents(username: str, query: str, only_trash: bool = False) -> lis
         return docs
 
     rows_by_doc = db_bulk_translation_rows([doc["id"] for doc in docs])
+    folder_map = db_get_document_folder_map(username) if username else {}
     for doc in docs:
+        doc["folder_id"] = folder_map.get(doc["id"])
         pages = sorted({r[0] for r in rows_by_doc.get(doc["id"], [])})
         doc["translated_pages"] = pages
     return docs
+
+
+# ── 라이브러리 폴더 ───────────────────────────────────────────────────────────
+
+def list_folders(username: str) -> list:
+    return db_list_folders(username)
+
+def create_folder(username: str, folder_id: str, name: str, parent_id: Optional[str], color: str) -> dict:
+    if parent_id and not db_get_folder(parent_id, username):
+        raise ValueError("상위 폴더를 찾을 수 없습니다.")
+    return db_create_folder(folder_id, username, name, parent_id, color)
+
+def _is_descendant(folder_id: str, parent_id: Optional[str], username: str) -> bool:
+    current = parent_id
+    while current:
+        if current == folder_id:
+            return True
+        folder = db_get_folder(current, username)
+        current = folder.get("parent_id") if folder else None
+    return False
+
+def update_folder(username: str, folder_id: str, name: Optional[str] = None, color: Optional[str] = None, parent_id: Optional[str] = None, move: bool = False) -> bool:
+    folder = db_get_folder(folder_id, username)
+    if not folder:
+        raise ValueError("폴더를 찾을 수 없습니다.")
+    updates = {}
+    if name is not None: updates["name"] = name
+    if color is not None: updates["color"] = color
+    if move:
+        if parent_id and not db_get_folder(parent_id, username):
+            raise ValueError("대상 폴더를 찾을 수 없습니다.")
+        if parent_id == folder_id or _is_descendant(folder_id, parent_id, username):
+            raise ValueError("폴더를 자기 자신 또는 하위 폴더로 옮길 수 없습니다.")
+        updates["parent_id"] = parent_id
+    return db_update_folder(folder_id, username, **updates)
+
+def delete_folder(username: str, folder_id: str) -> bool:
+    return db_delete_folder(folder_id, username)
+
+def move_documents_to_folder(username: str, doc_ids: List[str], folder_id: Optional[str]) -> int:
+    if folder_id and not db_get_folder(folder_id, username):
+        raise ValueError("대상 폴더를 찾을 수 없습니다.")
+    return db_move_documents_to_folder(doc_ids, username, folder_id)
 
 
 def delete_chat_sessions(doc_id: str) -> None:

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -12,6 +12,33 @@ export async function fetchLibrary(options = {}) {
   return res.json()
 }
 
+
+export async function fetchLibraryFolders() {
+  const res = await fetch(`${API_BASE}/library/folders`)
+  if (!res.ok) throw new Error('폴더 조회 실패')
+  return res.json()
+}
+export async function createLibraryFolder(payload) {
+  const res = await fetch(`${API_BASE}/library/folders`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+  if (!res.ok) throw new Error((await res.json()).detail || '폴더 생성 실패')
+  return res.json()
+}
+export async function updateLibraryFolder(folderId, payload) {
+  const res = await fetch(`${API_BASE}/library/folders/${encodeURIComponent(folderId)}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+  if (!res.ok) throw new Error((await res.json()).detail || '폴더 수정 실패')
+  return res.json()
+}
+export async function deleteLibraryFolder(folderId) {
+  const res = await fetch(`${API_BASE}/library/folders/${encodeURIComponent(folderId)}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error((await res.json()).detail || '폴더 삭제 실패')
+  return res.json()
+}
+export async function moveLibraryDocuments(docIds, folderId) {
+  const res = await fetch(`${API_BASE}/library/documents/move`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ doc_ids: docIds, folder_id: folderId }) })
+  if (!res.ok) throw new Error((await res.json()).detail || '논문 이동 실패')
+  return res.json()
+}
+
 export async function fetchLibraryDoc(docId, options = {}) {
   const res = await fetch(`${API_BASE}/library/${docId}${buildQuery(options)}`)
   if (!res.ok) throw new Error('문서 조회 실패')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,7 +6,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, checkForUpdateAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 import { renderDashboardPage } from './pages/dashboardPage.js'
@@ -495,7 +495,7 @@ if (libraryScreen) {
   libraryScreen.addEventListener('drop', (e) => {
     e.preventDefault(); libraryScreen.classList.remove('drag-over')
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-      handleFiles(e.dataTransfer.files)
+      handleFiles(e.dataTransfer.files, activeLibraryFolderId)
     }
   })
 }
@@ -506,7 +506,7 @@ fileInput.addEventListener('change', (e) => {
 })
 
 // ── 파일 처리 ─────────────────────────────────────
-async function handleFiles(files) {
+async function handleFiles(files, targetFolderId = null) {
   const pdfFiles = Array.from(files).filter(file => file.name.toLowerCase().endsWith('.pdf'))
   
   if (pdfFiles.length === 0) {
@@ -550,6 +550,7 @@ async function handleFiles(files) {
       lastTotalPages = result.total_pages
       lastTitle = (result.metadata && result.metadata.title) ? result.metadata.title : result.filename
       successCount++
+      if (targetFolderId) await moveLibraryDocuments([result.session_id], targetFolderId)
 
       if (isLibraryActive) {
         await renderLibrary()
@@ -4961,6 +4962,21 @@ if (chatDrawerViewerBtn) {
   })
 }
 
+// 라이브러리 전용 키보드 단축키. 텍스트 입력 중에는 브라우저 기본 동작을 보존한다.
+document.addEventListener('keydown', async e => {
+  if (state.currentWorkspacePage !== 'library' || /INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName || '')) return
+  const mod = e.ctrlKey || e.metaKey
+  if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
+    e.preventDefault(); libraryClipboard = { mode: e.key.toLowerCase() === 'x' ? 'cut' : 'copy', ids: Array.from(selectedDocIds) }; showToast(`${selectedDocIds.size}개 논문을 ${libraryClipboard.mode === 'cut' ? '잘라냈습니다' : '복사했습니다'}.`, 'info')
+  } else if (mod && e.key.toLowerCase() === 'v' && libraryClipboard?.ids?.length) {
+    e.preventDefault()
+    // 논문 파일/캐시를 중복 복제하지 않기 위해 붙여넣기는 이동으로 동작한다.
+    try { await moveLibraryDocuments(libraryClipboard.ids, activeLibraryFolderId); showToast('현재 폴더로 이동했습니다.', 'success'); if (libraryClipboard.mode === 'cut') libraryClipboard = null; await renderLibrary() } catch (err) { showToast(err.message || '붙여넣기 실패', 'error') }
+  } else if (e.key === 'Delete' && selectedDocIds.size) {
+    e.preventDefault(); document.querySelector('#lib-select-delete-btn')?.click()
+  } else if (e.key === 'Escape') { clearDocSelection(); libraryClipboard = null }
+})
+
 // ── Library 재설계: 상태 필터 탭(전체/읽지 않음/읽는 중/완료/즐겨찾기) + 정렬 + 즐겨찾기 ──
 // 즐겨찾기는 documents.metadata에 아직 star/favorite 개념이 없어(백엔드 스키마에
 // 없음) 새 필드를 추가하지 않고 로컬 전용 편의 기능으로만 제공한다 - localStorage에만
@@ -5069,6 +5085,87 @@ function sortLibraryDocs(docs) {
 // Library 페이지의 새 UI 조각(상태 탭 / 정렬 드롭다운 / 상세 패널)은 index.html을
 // 건드리지 않고 여기서 필요할 때 한 번만 삽입한다. renderLibrary()가 탭 전환/새로고침마다
 // 다시 호출되므로 반드시 멱등이어야 한다(이미 삽입돼 있으면 아무것도 하지 않음).
+// ── 폴더 트리 / Breadcrumb ───────────────────────────────────────────────────
+let libraryFolders = []
+let activeLibraryFolderId = null
+let libraryClipboard = null
+const FOLDER_COLORS = ['#6b7280', '#4f8ef7', '#8b5cf6', '#ec4899', '#f59e0b', '#10b981']
+
+function folderPath(folderId) {
+  const byId = new Map(libraryFolders.map(f => [f.id, f]))
+  const path = []
+  let current = folderId ? byId.get(folderId) : null
+  while (current) { path.unshift(current); current = current.parent_id ? byId.get(current.parent_id) : null }
+  return path
+}
+function folderDescendants(folderId) {
+  const result = new Set([folderId]); let changed = true
+  while (changed) { changed = false; for (const f of libraryFolders) if (f.parent_id && result.has(f.parent_id) && !result.has(f.id)) { result.add(f.id); changed = true } }
+  return result
+}
+function setFolderDropTarget(el, folderId) {
+  el.addEventListener('dragover', e => { e.preventDefault(); el.classList.add('folder-drop-target') })
+  el.addEventListener('dragleave', () => el.classList.remove('folder-drop-target'))
+  el.addEventListener('drop', async e => {
+    e.preventDefault(); el.classList.remove('folder-drop-target')
+    try {
+      const raw = e.dataTransfer.getData('application/x-easypaper-item')
+      if (!raw) {
+        if (e.dataTransfer.files?.length) handleFiles(e.dataTransfer.files, folderId)
+        return
+      }
+      const item = JSON.parse(raw)
+      if (item.kind === 'document') await moveLibraryDocuments(item.ids, folderId)
+      if (item.kind === 'folder') {
+        if (item.id === folderId || folderDescendants(item.id).has(folderId)) throw new Error('폴더를 자기 자신 또는 하위 폴더로 옮길 수 없습니다.')
+        await updateLibraryFolder(item.id, { parent_id: folderId, move: true })
+      }
+      showToast('이동했습니다.', 'success'); await renderLibrary()
+    } catch (err) { showToast(err.message || '이동 실패', 'error') }
+  })
+}
+function renderFolderChrome(docs) {
+  const tree = $('library-folder-tree'), crumb = $('library-breadcrumb')
+  if (!tree || !crumb) return
+  const countByFolder = docs.reduce((m, d) => { const key = d.folder_id || 'root'; m[key] = (m[key] || 0) + 1; return m }, {})
+  const byParent = new Map()
+  libraryFolders.forEach(f => { const k = f.parent_id || 'root'; if (!byParent.has(k)) byParent.set(k, []); byParent.get(k).push(f) })
+  function nodes(parentId, depth = 0) {
+    return (byParent.get(parentId || 'root') || []).map(f => `<button class="library-folder-node ${activeLibraryFolderId === f.id ? 'active' : ''}" data-folder-id="${escapeHtml(f.id)}" draggable="true" style="--folder-depth:${depth};--folder-color:${escapeHtml(f.color)}"><span class="folder-color-dot"></span><span class="folder-node-name">${escapeHtml(f.name)}</span><span class="folder-node-count">${countByFolder[f.id] || 0}</span></button>${nodes(f.id, depth + 1)}`).join('')
+  }
+  tree.innerHTML = `<div class="folder-tree-head"><b>폴더</b><button id="library-new-folder-btn" title="새 폴더">+</button></div><button class="library-folder-node root ${!activeLibraryFolderId ? 'active' : ''}" data-folder-id="" style="--folder-depth:0"><span>전체 논문</span><span class="folder-node-count">${docs.length}</span></button>${nodes(null)}`
+  const path = folderPath(activeLibraryFolderId)
+  crumb.innerHTML = `<button data-folder-id="">전체 논문</button>${path.map(f => `<span>›</span><button data-folder-id="${escapeHtml(f.id)}">${escapeHtml(f.name)}</button>`).join('')}`
+  ;[...tree.querySelectorAll('.library-folder-node'), ...crumb.querySelectorAll('button')].forEach(el => {
+    const id = el.dataset.folderId || null
+    el.addEventListener('click', () => { activeLibraryFolderId = id; filterLibraryCards(currentLibraryDocs); renderFolderChrome(currentLibraryDocs) })
+    setFolderDropTarget(el, id)
+  })
+  tree.querySelectorAll('[draggable="true"]').forEach(el => {
+    el.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: el.dataset.folderId })); e.dataTransfer.effectAllowed = 'move' })
+    el.addEventListener('contextmenu', async e => {
+      e.preventDefault()
+      const folder = libraryFolders.find(f => f.id === el.dataset.folderId); if (!folder) return
+      const action = window.prompt('동작을 입력하세요: rename / color / delete')?.toLowerCase()
+      try {
+        if (action === 'rename') { const name = window.prompt('새 폴더 이름', folder.name)?.trim(); if (name) await updateLibraryFolder(folder.id, { name }) }
+        if (action === 'color') { const color = window.prompt(`색상 코드 (${FOLDER_COLORS.join(', ')})`, folder.color)?.trim(); if (color) await updateLibraryFolder(folder.id, { color }) }
+        if (action === 'delete' && window.confirm(`“${folder.name}” 폴더를 삭제할까요? 포함 논문과 하위 폴더는 루트로 이동합니다.`)) await deleteLibraryFolder(folder.id)
+        if (action) await renderLibrary()
+      } catch (err) { showToast(err.message || '폴더 변경 실패', 'error') }
+    })
+  })
+  $('library-new-folder-btn')?.addEventListener('click', async () => {
+    const name = window.prompt('새 폴더 이름')?.trim(); if (!name) return
+    try { await createLibraryFolder({ name, parent_id: activeLibraryFolderId, color: FOLDER_COLORS[0] }); await renderLibrary() } catch (err) { showToast(err.message, 'error') }
+  })
+}
+function ensureLibraryFolderUI() {
+  if ($('library-folder-tree')) return
+  librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-layout"><aside id="library-folder-tree" class="library-folder-tree"></aside><div class="library-folder-main"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav></div></div>`)
+  const main = document.querySelector('.library-folder-main')
+  if (main && librarySearchBox) { main.appendChild(librarySearchBox); const status = $('library-search-status'); if (status) main.appendChild(status); const filters = $('library-filter-row'); if (filters) main.appendChild(filters); main.appendChild(libraryGrid) }
+}
 let libraryChromeReady = false
 function ensureLibraryChrome() {
   if (libraryChromeReady) return
@@ -5111,6 +5208,7 @@ function ensureLibraryChrome() {
 async function renderLibrary() {
   // Library 페이지의 새 UI 조각(상태 탭/정렬 드롭다운/상세 패널)이 아직 없으면 삽입한다.
   ensureLibraryChrome()
+  ensureLibraryFolderUI()
   closeLibraryDetailPanel()
   // 상세 패널의 "관련 자료" 탭이 쓰는 지식 그래프 캐시도 목록을 새로 불러올 때 함께 무효화한다.
   libraryGraphCacheForDetail = null
@@ -5137,6 +5235,12 @@ async function renderLibrary() {
       data = await fetchLibrary(getTranslationOptions())
     }
     const allDocs = data.documents || []
+    if (state.currentLibraryTab !== 'trash') {
+      const foldersData = await fetchLibraryFolders()
+      libraryFolders = foldersData.folders || []
+      if (activeLibraryFolderId && !libraryFolders.some(f => f.id === activeLibraryFolderId)) activeLibraryFolderId = null
+      renderFolderChrome(allDocs)
+    }
 
     // 보관함 뱃지에는 안읽은 논문 개수 표시 (휴지통이 아닐 때만 적용하거나, archive 기준 개수 표시)
     updateUnreadBadge(allDocs)
@@ -6171,10 +6275,13 @@ function filterLibraryCards(docs) {
     btn.classList.toggle('active', btn.dataset.category === activeCategoryFilter)
   })
 
+  // 현재 폴더(루트 포함)와 태그를 함께 적용한다.
+  let filteredDocs = state.currentLibraryTab === 'trash' || !activeLibraryFolderId ? docs : docs.filter(doc => (doc.folder_id || null) === activeLibraryFolderId)
+
   // Filter docs by category tag
-  let filteredDocs = activeCategoryFilter === 'ALL'
-    ? docs
-    : docs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
+  filteredDocs = activeCategoryFilter === 'ALL'
+    ? filteredDocs
+    : filteredDocs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
 
   // 상태 필터(전체/읽지 않음/읽는 중/완료/즐겨찾기) 적용 - 휴지통 탭에는 없는 개념이라 건너뛴다.
   if (state.currentLibraryTab !== 'trash' && activeStatusFilter !== 'all') {
@@ -6618,6 +6725,12 @@ function createDocCard(doc) {
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.dataset.id = doc.id
+  card.draggable = state.currentLibraryTab !== 'trash'
+  card.addEventListener('dragstart', e => {
+    const ids = selectedDocIds.has(doc.id) ? Array.from(selectedDocIds) : [doc.id]
+    e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'document', ids }))
+    e.dataTransfer.effectAllowed = 'move'
+  })
   card.innerHTML = `
     ${d.compareCheckHtml}
     <div class="doc-card-zone">

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -538,3 +538,22 @@ body.light-theme .lib-detail-panel {
 @media (max-width: 640px) {
   .lib-detail-panel { width: 100vw; max-width: 100vw; }
 }
+
+
+/* ── 폴더 트리와 경로(Breadcrumb) ── */
+.library-folder-layout { display:grid; grid-template-columns:210px minmax(0,1fr); gap:22px; min-height:0; flex:1; overflow:hidden; }
+.library-folder-tree { padding:10px; background:var(--bg-elevated); border:1px solid var(--border); border-radius:var(--radius-lg); overflow:auto; align-self:stretch; }
+.folder-tree-head { display:flex; justify-content:space-between; align-items:center; padding:4px 6px 9px; color:var(--text-secondary); font-size:12px; }
+.folder-tree-head button { width:24px; height:24px; border:0; border-radius:var(--radius-sm); cursor:pointer; background:var(--control-accent-soft); color:var(--control-accent-text); font-size:18px; }
+.library-folder-main { min-width:0; display:flex; flex-direction:column; overflow:hidden; }
+.library-folder-node { width:100%; display:flex; align-items:center; gap:7px; min-height:32px; padding:5px 7px 5px calc(7px + var(--folder-depth) * 14px); border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-secondary); text-align:left; cursor:pointer; }
+.library-folder-node:hover,.library-folder-node.active { background:var(--bg-hover); color:var(--text-primary); }
+.folder-color-dot { width:9px; height:9px; flex:0 0 9px; border-radius:50%; background:var(--folder-color); }
+.folder-node-name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.folder-node-count { margin-left:auto; color:var(--text-muted); font-size:11px; }
+.folder-drop-target { outline:2px solid var(--control-accent); background:var(--control-accent-soft)!important; }
+.library-breadcrumb { display:flex; align-items:center; min-height:34px; gap:6px; margin:0 0 10px; overflow:auto; white-space:nowrap; color:var(--text-muted); font-size:13px; }
+.library-breadcrumb button { border:0; padding:4px 6px; background:transparent; color:var(--text-secondary); border-radius:var(--radius-sm); cursor:pointer; }
+.library-breadcrumb button:hover { background:var(--bg-hover); color:var(--text-primary); }
+.doc-card[draggable=true] { cursor:grab; }
+@media (max-width: 760px) { .library-folder-layout { grid-template-columns:1fr; overflow:visible; } .library-folder-tree { max-height:160px; } .library-folder-main { overflow:visible; } }


### PR DESCRIPTION
# Summary
## 1. 라이브러리 폴더 트리 기능 추가
- SQLite 기반 가상 폴더 트리 및 논문-폴더 연결 구조를 추가
- 폴더 생성, 이름 변경, 색상 변경, 삭제 및 하위 폴더 이동 기능을 추가
- 폴더 순환 이동과 사용자 소유권 검증을 추가
## 2. 라이브러리 경로 및 드래그 앤 드롭 지원
- 폴더 트리와 Breadcrumb 경로 UI를 추가
- 논문·폴더를 트리 또는 경로 항목에 드롭해 이동하는 기능을 추가
- 폴더 또는 경로에 PDF를 드롭하면 해당 폴더로 업로드하도록 수정
## 3. 키보드 조작 지원
- Ctrl/Cmd + C, X, V, Delete, Escape 단축키를 추가