### PR TITLE
refactor: show library folders as cards

### DIFF
--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -6,6 +6,8 @@
 const PATHS = {
   fileText: '<path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/>',
   archive: '<rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/>',
+  folder: '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/>',
+  folderPlus: '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/><path d="M12 11v6"/><path d="M9 14h6"/>',
   clock: '<circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>',
   book: '<path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/>',
   bookOpen: '<path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>',

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5163,47 +5163,63 @@ function setFolderDropTarget(el, folderId) {
     } catch (err) { showToast(err.message || '이동 실패', 'error') }
   })
 }
-function renderFolderChrome(docs) {
-  const tree = $('library-folder-tree'), crumb = $('library-breadcrumb')
-  if (!tree || !crumb) return
-  const countByFolder = docs.reduce((m, d) => { const key = d.folder_id || 'root'; m[key] = (m[key] || 0) + 1; return m }, {})
-  const byParent = new Map()
-  libraryFolders.forEach(f => { const k = f.parent_id || 'root'; if (!byParent.has(k)) byParent.set(k, []); byParent.get(k).push(f) })
-  function nodes(parentId, depth = 0) {
-    return (byParent.get(parentId || 'root') || []).map(f => `<button class="library-folder-node ${activeLibraryFolderId === f.id ? 'active' : ''}" data-folder-id="${escapeHtml(f.id)}" draggable="true" style="--folder-depth:${depth};--folder-color:${escapeHtml(f.color)}"><span class="folder-color-dot"></span><span class="folder-node-name">${escapeHtml(f.name)}</span><span class="folder-node-count">${countByFolder[f.id] || 0}</span></button>${nodes(f.id, depth + 1)}`).join('')
-  }
-  tree.innerHTML = `<div class="folder-tree-head"><b>폴더</b><button id="library-new-folder-btn" title="새 폴더">+</button></div><button class="library-folder-node root ${!activeLibraryFolderId ? 'active' : ''}" data-folder-id="" style="--folder-depth:0"><span>전체 논문</span><span class="folder-node-count">${docs.length}</span></button>${nodes(null)}`
-  const path = folderPath(activeLibraryFolderId)
-  crumb.innerHTML = `<button data-folder-id="">전체 논문</button>${path.map(f => `<span>›</span><button data-folder-id="${escapeHtml(f.id)}">${escapeHtml(f.name)}</button>`).join('')}`
-  ;[...tree.querySelectorAll('.library-folder-node'), ...crumb.querySelectorAll('button')].forEach(el => {
-    const id = el.dataset.folderId || null
-    el.addEventListener('click', () => { activeLibraryFolderId = id; filterLibraryCards(currentLibraryDocs); renderFolderChrome(currentLibraryDocs) })
-    setFolderDropTarget(el, id)
-  })
-  tree.querySelectorAll('[draggable="true"]').forEach(el => {
-    el.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: el.dataset.folderId })); e.dataTransfer.effectAllowed = 'move' })
-    el.addEventListener('contextmenu', async e => {
-      e.preventDefault()
-      const folder = libraryFolders.find(f => f.id === el.dataset.folderId); if (!folder) return
-      const action = window.prompt('동작을 입력하세요: rename / color / delete')?.toLowerCase()
-      try {
-        if (action === 'rename') { const name = window.prompt('새 폴더 이름', folder.name)?.trim(); if (name) await updateLibraryFolder(folder.id, { name }) }
-        if (action === 'color') { const color = window.prompt(`색상 코드 (${FOLDER_COLORS.join(', ')})`, folder.color)?.trim(); if (color) await updateLibraryFolder(folder.id, { color }) }
-        if (action === 'delete' && window.confirm(`“${folder.name}” 폴더를 삭제할까요? 포함 논문과 하위 폴더는 루트로 이동합니다.`)) await deleteLibraryFolder(folder.id)
-        if (action) await renderLibrary()
-      } catch (err) { showToast(err.message || '폴더 변경 실패', 'error') }
-    })
-  })
-  $('library-new-folder-btn')?.addEventListener('click', async () => {
-    const name = window.prompt('새 폴더 이름')?.trim(); if (!name) return
-    try { await createLibraryFolder({ name, parent_id: activeLibraryFolderId, color: FOLDER_COLORS[0] }); await renderLibrary() } catch (err) { showToast(err.message, 'error') }
+function showCustomTextDialog({ title, label, value = '', confirmText = '확인' }) {
+  return new Promise(resolve => {
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">${escapeHtml(title)}</span></div><div class="custom-confirm-modal-body"><label class="folder-dialog-label">${escapeHtml(label)}<input class="folder-dialog-input" value="${escapeHtml(value)}" maxlength="120" /></label></div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button><button class="custom-confirm-btn confirm-btn primary-btn">${escapeHtml(confirmText)}</button></div></div>`
+    document.body.appendChild(modal)
+    const input = modal.querySelector('.folder-dialog-input')
+    const close = result => { modal.classList.remove('active'); setTimeout(() => { modal.remove(); resolve(result) }, 200) }
+    modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
+    modal.querySelector('.confirm-btn').addEventListener('click', () => close(input.value.trim() || null))
+    input.addEventListener('keydown', e => { if (e.key === 'Enter') close(input.value.trim() || null); if (e.key === 'Escape') close(null) })
+    modal.addEventListener('click', e => { if (e.target === modal) close(null) })
+    setTimeout(() => { modal.classList.add('active'); input.focus(); input.select() }, 10)
   })
 }
+function renderFolderNavigation(docs) {
+  const crumb = $('library-breadcrumb')
+  if (!crumb) return
+  const path = folderPath(activeLibraryFolderId)
+  crumb.innerHTML = `<button data-folder-id="">전체 논문</button>${path.map(f => `<span>›</span><button data-folder-id="${escapeHtml(f.id)}">${escapeHtml(f.name)}</button>`).join('')}`
+  crumb.querySelectorAll('button').forEach(el => {
+    const id = el.dataset.folderId || null
+    el.addEventListener('click', () => { activeLibraryFolderId = id; filterLibraryCards(currentLibraryDocs); renderFolderNavigation(currentLibraryDocs) })
+    setFolderDropTarget(el, id)
+  })
+}
+async function openCreateFolderDialog(parentId = activeLibraryFolderId) {
+  const name = await showCustomTextDialog({ title: '새 폴더', label: '폴더 이름', confirmText: '추가' })
+  if (!name) return
+  try { await createLibraryFolder({ name, parent_id: parentId, color: FOLDER_COLORS[0] }); await renderLibrary() } catch (err) { showToast(err.message || '폴더 생성 실패', 'error') }
+}
+function createFolderCard(folder) {
+  const card = document.createElement('article')
+  card.className = 'library-folder-card'
+  card.draggable = true
+  card.dataset.folderId = folder.id
+  card.style.setProperty('--folder-color', folder.color)
+  card.innerHTML = `<div class="folder-card-icon">${icon('folder', 28)}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button>`
+  card.addEventListener('click', e => { if (e.target.closest('.folder-card-menu')) return; activeLibraryFolderId = folder.id; filterLibraryCards(currentLibraryDocs); renderFolderNavigation(currentLibraryDocs) })
+  card.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: folder.id })); e.dataTransfer.effectAllowed = 'move' })
+  setFolderDropTarget(card, folder.id)
+  card.querySelector('.folder-card-menu').addEventListener('click', async e => {
+    e.stopPropagation()
+    const action = await showCustomTextDialog({ title: '폴더 관리', label: 'rename, color 또는 delete 입력', confirmText: '선택' })
+    try {
+      if (action === 'rename') { const name = await showCustomTextDialog({ title: '폴더 이름 변경', label: '폴더 이름', value: folder.name, confirmText: '저장' }); if (name) await updateLibraryFolder(folder.id, { name }) }
+      if (action === 'color') { const color = await showCustomTextDialog({ title: '폴더 색상 변경', label: `색상 코드 (${FOLDER_COLORS.join(', ')})`, value: folder.color, confirmText: '저장' }); if (color) await updateLibraryFolder(folder.id, { color }) }
+      if (action === 'delete' && await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요? 포함 항목은 루트로 이동합니다.`, { title: '폴더 삭제', confirmText: '삭제', danger: true })) await deleteLibraryFolder(folder.id)
+      if (action) await renderLibrary()
+    } catch (err) { showToast(err.message || '폴더 변경 실패', 'error') }
+  })
+  return card
+}
 function ensureLibraryFolderUI() {
-  if ($('library-folder-tree')) return
-  librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-layout"><aside id="library-folder-tree" class="library-folder-tree"></aside><div class="library-folder-main"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav></div></div>`)
-  const main = document.querySelector('.library-folder-main')
-  if (main && librarySearchBox) { main.appendChild(librarySearchBox); const status = $('library-search-status'); if (status) main.appendChild(status); const filters = $('library-filter-row'); if (filters) main.appendChild(filters); main.appendChild(libraryGrid) }
+  if ($('library-breadcrumb')) return
+  librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-header"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav><button id="library-new-folder-btn" class="library-new-folder-btn">${icon('folderPlus', 15)}<span>폴더 추가</span></button></div>`)
+  $('library-new-folder-btn')?.addEventListener('click', () => openCreateFolderDialog())
 }
 let libraryChromeReady = false
 function ensureLibraryChrome() {
@@ -5278,7 +5294,7 @@ async function renderLibrary() {
       const foldersData = await fetchLibraryFolders()
       libraryFolders = foldersData.folders || []
       if (activeLibraryFolderId && !libraryFolders.some(f => f.id === activeLibraryFolderId)) activeLibraryFolderId = null
-      renderFolderChrome(allDocs)
+      renderFolderNavigation(allDocs)
     }
 
     // 보관함 뱃지에는 안읽은 논문 개수 표시 (휴지통이 아닐 때만 적용하거나, archive 기준 개수 표시)
@@ -6332,13 +6348,17 @@ function filterLibraryCards(docs) {
 
   filteredDocs = sortLibraryDocs(filteredDocs)
 
-  if (filteredDocs.length === 0) {
+  const childFolders = state.currentLibraryTab === 'trash'
+    ? []
+    : libraryFolders.filter(folder => (folder.parent_id || null) === activeLibraryFolderId)
+  if (filteredDocs.length === 0 && childFolders.length === 0) {
     const variant = state.currentLibraryTab === 'trash'
       ? 'trash'
       : (activeStatusFilter !== 'all' ? activeStatusFilter : (docs.length > 0 ? 'filtered' : 'library'))
     libraryGrid.appendChild(createEmptyState(variant)); return
   }
 
+  childFolders.forEach(folder => libraryGrid.appendChild(createFolderCard(folder)))
   const createItem = libraryViewMode === 'list' ? createDocListRow : createDocCard
   filteredDocs.forEach(doc => libraryGrid.appendChild(createItem(doc)))
 }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -540,20 +540,22 @@ body.light-theme .lib-detail-panel {
 }
 
 
-/* ── 폴더 트리와 경로(Breadcrumb) ── */
-.library-folder-layout { display:grid; grid-template-columns:210px minmax(0,1fr); gap:22px; min-height:0; flex:1; overflow:hidden; }
-.library-folder-tree { padding:10px; background:var(--bg-elevated); border:1px solid var(--border); border-radius:var(--radius-lg); overflow:auto; align-self:stretch; }
-.folder-tree-head { display:flex; justify-content:space-between; align-items:center; padding:4px 6px 9px; color:var(--text-secondary); font-size:12px; }
-.folder-tree-head button { width:24px; height:24px; border:0; border-radius:var(--radius-sm); cursor:pointer; background:var(--control-accent-soft); color:var(--control-accent-text); font-size:18px; }
-.library-folder-main { min-width:0; display:flex; flex-direction:column; overflow:hidden; }
-.library-folder-node { width:100%; display:flex; align-items:center; gap:7px; min-height:32px; padding:5px 7px 5px calc(7px + var(--folder-depth) * 14px); border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-secondary); text-align:left; cursor:pointer; }
-.library-folder-node:hover,.library-folder-node.active { background:var(--bg-hover); color:var(--text-primary); }
-.folder-color-dot { width:9px; height:9px; flex:0 0 9px; border-radius:50%; background:var(--folder-color); }
-.folder-node-name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.folder-node-count { margin-left:auto; color:var(--text-muted); font-size:11px; }
-.folder-drop-target { outline:2px solid var(--control-accent); background:var(--control-accent-soft)!important; }
-.library-breadcrumb { display:flex; align-items:center; min-height:34px; gap:6px; margin:0 0 10px; overflow:auto; white-space:nowrap; color:var(--text-muted); font-size:13px; }
+/* ── 라이브러리 내부 폴더 카드와 경로 ── */
+.library-folder-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:0 0 10px; }
+.library-breadcrumb { display:flex; align-items:center; min-width:0; gap:6px; overflow:auto; white-space:nowrap; color:var(--text-muted); font-size:13px; }
 .library-breadcrumb button { border:0; padding:4px 6px; background:transparent; color:var(--text-secondary); border-radius:var(--radius-sm); cursor:pointer; }
 .library-breadcrumb button:hover { background:var(--bg-hover); color:var(--text-primary); }
+.library-new-folder-btn { display:inline-flex; align-items:center; gap:6px; flex:0 0 auto; padding:7px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-md); background:var(--bg-elevated); color:var(--text-primary); cursor:pointer; font:inherit; font-size:12.5px; font-weight:600; }
+.library-new-folder-btn:hover { border-color:var(--control-accent); background:var(--control-accent-soft); }
+.library-folder-card { position:relative; min-height:178px; padding:20px; border:1px solid var(--border); border-radius:var(--radius-lg); background:var(--bg-elevated); cursor:pointer; transition:transform .15s ease, border-color .15s ease, background .15s ease; }
+.library-folder-card:hover { transform:translateY(-2px); border-color:var(--folder-color); background:var(--bg-hover); }
+.folder-card-icon { color:var(--folder-color); margin-bottom:22px; }
+.folder-card-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-primary); font-size:14px; font-weight:700; }
+.folder-card-meta { margin-top:6px; color:var(--text-muted); font-size:12px; }
+.folder-card-menu { position:absolute; top:12px; right:12px; padding:5px; border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-muted); cursor:pointer; }
+.folder-card-menu:hover { color:var(--text-primary); background:var(--bg-surface); }
+.folder-drop-target { outline:2px solid var(--control-accent); background:var(--control-accent-soft)!important; }
+.folder-dialog-label { display:grid; gap:8px; color:var(--text-secondary); font-size:13px; }
+.folder-dialog-input { width:100%; box-sizing:border-box; padding:9px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-sm); background:var(--bg-elevated); color:var(--text-primary); font:inherit; outline:none; }
+.folder-dialog-input:focus { border-color:var(--control-accent); }
 .doc-card[draggable=true] { cursor:grab; }
-@media (max-width: 760px) { .library-folder-layout { grid-template-columns:1fr; overflow:visible; } .library-folder-tree { max-height:160px; } .library-folder-main { overflow:visible; } }


### PR DESCRIPTION
# Summary
## 1. 라이브러리 폴더 UI 개편
- 좌측 폴더 사이드바를 제거
- 폴더를 논문 카드와 동일한 라이브러리 그리드에서 표시하도록 수정
- 폴더 카드 클릭 시 하위 폴더와 해당 논문을 표시하도록 수정
## 2. 폴더 추가 다이얼로그 개선
- 폴더 추가 시 브라우저 prompt 대신 기존 커스텀 모달 스타일의 입력 다이얼로그를 적용
- 폴더 카드용 아이콘과 관리 메뉴를 추가