### PR TITLE
fix: improve library folder controls

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -158,7 +158,11 @@
                 <p class="library-header-subtitle">보관함에 저장된 모든 논문을 한 곳에서 관리하세요</p>
               </div>
               <div>
-                <div class="lib-add-fab-wrap"><button id="lib-upload-btn" class="file-btn">+ 추가</button><button id="lib-add-paper-btn" class="lib-add-sub-btn">논문 추가</button><button id="lib-add-folder-btn" class="lib-add-sub-btn">폴더 추가</button></div>
+                <div class="lib-add-fab-wrap">
+                  <button id="lib-upload-btn" class="file-btn lib-add-main-btn" aria-expanded="false" aria-label="추가 메뉴 열기"><span aria-hidden="true">+</span></button>
+                  <button id="lib-add-paper-btn" class="lib-add-sub-btn"><span class="lib-add-label">논문 추가</span><span class="lib-add-circle" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8l6 6v12a2 2 0 0 1-2 2z"/><path d="M14 2v6h6"/></svg></span></button>
+                  <button id="lib-add-folder-btn" class="lib-add-sub-btn"><span class="lib-add-label">폴더 추가</span><span class="lib-add-circle" aria-hidden="true"><svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/><path d="M12 11v6M9 14h6"/></svg></span></button>
+                </div>
               </div>
             </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5005,18 +5005,47 @@ if (chatDrawerViewerBtn) {
 document.addEventListener('keydown', async e => {
   if (state.currentWorkspacePage !== 'library' || /INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName || '')) return
   const mod = e.ctrlKey || e.metaKey
+  const focusedFolder = getFocusedLibraryFolder()
   if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
     e.preventDefault()
     await undoLastLibraryAction()
   } else if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
-    e.preventDefault(); libraryClipboard = { mode: e.key.toLowerCase() === 'x' ? 'cut' : 'copy', ids: Array.from(selectedDocIds) }; showToast(`${selectedDocIds.size}개 논문을 ${libraryClipboard.mode === 'cut' ? '잘라냈습니다' : '복사했습니다'}.`, 'info')
-  } else if (mod && e.key.toLowerCase() === 'v' && libraryClipboard?.ids?.length) {
     e.preventDefault()
-    // 논문 파일/캐시를 중복 복제하지 않기 위해 붙여넣기는 이동으로 동작한다.
-    try { await moveDocumentsWithUndo(libraryClipboard.ids, activeLibraryFolderId); showToast('현재 폴더로 이동했습니다.', 'success'); if (libraryClipboard.mode === 'cut') libraryClipboard = null; await renderLibrary() } catch (err) { showToast(err.message || '붙여넣기 실패', 'error') }
-  } else if (e.key === 'Delete' && selectedDocIds.size) {
-    e.preventDefault(); document.querySelector('#lib-select-delete-btn')?.click()
-  } else if (e.key === 'Escape') { clearDocSelection(); libraryClipboard = null }
+    libraryClipboard = { kind: 'documents', mode: e.key.toLowerCase() === 'x' ? 'cut' : 'copy', ids: Array.from(selectedDocIds) }
+    showToast(`${selectedDocIds.size}개 논문을 ${libraryClipboard.mode === 'cut' ? '잘라냈습니다' : '복사했습니다'}.`, 'info')
+  } else if (mod && e.key.toLowerCase() === 'x' && focusedFolder) {
+    e.preventDefault()
+    libraryClipboard = { kind: 'folder', mode: 'cut', id: focusedFolder.id }
+    showToast(`“${focusedFolder.name}” 폴더를 잘라냈습니다.`, 'info')
+  } else if (mod && e.key.toLowerCase() === 'v' && libraryClipboard) {
+    e.preventDefault()
+    try {
+      if (libraryClipboard.kind === 'folder') {
+        const folder = libraryFolders.find(candidate => candidate.id === libraryClipboard.id)
+        if (!folder) throw new Error('잘라낸 폴더를 찾을 수 없습니다.')
+        if (folder.id === activeLibraryFolderId || folderDescendants(folder.id).has(activeLibraryFolderId)) throw new Error('폴더를 자기 자신 또는 하위 폴더에 붙여넣을 수 없습니다.')
+        await moveFolderWithUndo(folder, activeLibraryFolderId)
+      } else if (libraryClipboard.ids?.length) {
+        await moveDocumentsWithUndo(libraryClipboard.ids, activeLibraryFolderId)
+      }
+      showToast('현재 폴더로 이동했습니다.', 'success')
+      if (libraryClipboard.mode === 'cut') libraryClipboard = null
+      await renderLibrary()
+    } catch (err) { showToast(err.message || '붙여넣기 실패', 'error') }
+  } else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedDocIds.size) {
+    e.preventDefault()
+    document.querySelector('#lib-select-delete-btn')?.click()
+  } else if ((e.key === 'Delete' || e.key === 'Backspace') && focusedFolder) {
+    e.preventDefault()
+    await requestDeleteFolder(focusedFolder)
+  } else if ((e.key === 'F2' || e.key === 'Enter') && focusedFolder) {
+    e.preventDefault()
+    await requestRenameFolder(focusedFolder)
+  } else if (e.key === 'Escape') {
+    clearDocSelection()
+    libraryClipboard = null
+    setLibraryAddMenuOpen(false)
+  }
 })
 
 // ── Library 재설계: 상태 필터 탭(전체/읽지 않음/읽는 중/완료/즐겨찾기) + 정렬 + 즐겨찾기 ──
@@ -5269,10 +5298,37 @@ function showFolderContentsDeleteDialog(paperCount) {
   })
 }
 
+
+function getFocusedLibraryFolder() {
+  const card = document.activeElement
+  if (!card?.classList?.contains('library-folder-card')) return null
+  return libraryFolders.find(folder => folder.id === card.dataset.folderId) || null
+}
+async function requestRenameFolder(folder) {
+  const name = await showCustomTextDialog({ title: '폴더 이름 변경', label: '폴더 이름', value: folder.name, confirmText: '저장' })
+  if (name && name !== folder.name) { await updateFolderWithUndo(folder, { name }); await renderLibrary() }
+}
+async function requestDeleteFolder(folder) {
+  const paperCount = currentLibraryDocs.filter(doc => doc.folder_id === folder.id).length
+  const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${paperCount ? '' : '\n비어 있는 폴더이며 논문에는 영향이 없습니다.'}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
+  if (!ok) return
+  let deletePapers = false
+  if (paperCount > 0) {
+    const choice = await showFolderContentsDeleteDialog(paperCount)
+    if (choice === null) return
+    deletePapers = choice
+  }
+  await deleteLibraryFolder(folder.id, deletePapers)
+  await renderLibrary()
+}
+
 function createFolderCard(folder) {
   const card = document.createElement('article')
   card.className = 'library-folder-card'
   card.draggable = true
+  card.tabIndex = 0
+  card.setAttribute('aria-label', `${folder.name} 폴더`)
+  card.title = 'Enter/F2: 이름 변경 · Delete/Backspace: 삭제 · Ctrl/Cmd+X: 잘라내기'
   card.dataset.folderId = folder.id
   card.style.setProperty('--folder-color', folder.color)
   card.innerHTML = `<div class="folder-card-icon">${icon('folder', 28)}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
@@ -5284,21 +5340,9 @@ function createFolderCard(folder) {
   menu.addEventListener('click', async e => {
     e.stopPropagation(); const action = e.target.dataset.action; if (!action) return
     try {
-      if (action === 'rename') { const name = await showCustomTextDialog({ title: '폴더 이름 변경', label: '폴더 이름', value: folder.name, confirmText: '저장' }); if (name && name !== folder.name) await updateFolderWithUndo(folder, { name }) }
-      if (action === 'color') { const color = await showFolderColorDialog(folder.color); if (color && color !== folder.color) await updateFolderWithUndo(folder, { color }) }
-      if (action === 'delete') {
-        const paperCount = currentLibraryDocs.filter(doc => doc.folder_id === folder.id).length
-        const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${paperCount ? '' : '\n비어 있는 폴더이며 논문에는 영향이 없습니다.'}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
-        if (!ok) return
-        let deletePapers = false
-        if (paperCount > 0) {
-          const choice = await showFolderContentsDeleteDialog(paperCount)
-          if (choice === null) return
-          deletePapers = choice
-        }
-        await deleteLibraryFolder(folder.id, deletePapers)
-      }
-      await renderLibrary()
+      if (action === 'rename') await requestRenameFolder(folder)
+      if (action === 'color') { const color = await showFolderColorDialog(folder.color); if (color && color !== folder.color) { await updateFolderWithUndo(folder, { color }); await renderLibrary() } }
+      if (action === 'delete') await requestDeleteFolder(folder)
     } catch (err) { showToast(err.message || '폴더 변경 실패', 'error') }
   })
   return card
@@ -8103,9 +8147,16 @@ function sanitizeMarkedHtml(html) {
   return DOMPurify.sanitize(html)
 }
 
-libUploadBtn.addEventListener('click', () => { document.querySelector('.lib-add-fab-wrap')?.classList.toggle('open') })
-$('lib-add-paper-btn')?.addEventListener('click', () => fileInput.click())
-$('lib-add-folder-btn')?.addEventListener('click', () => openCreateFolderDialog())
+function setLibraryAddMenuOpen(open) {
+  const wrap = document.querySelector('.lib-add-fab-wrap')
+  if (!wrap) return
+  wrap.classList.toggle('open', open)
+  libUploadBtn.setAttribute('aria-expanded', String(open))
+  libUploadBtn.setAttribute('aria-label', open ? '추가 메뉴 닫기' : '추가 메뉴 열기')
+}
+libUploadBtn.addEventListener('click', () => setLibraryAddMenuOpen(!document.querySelector('.lib-add-fab-wrap')?.classList.contains('open')))
+$('lib-add-paper-btn')?.addEventListener('click', () => { setLibraryAddMenuOpen(false); fileInput.click() })
+$('lib-add-folder-btn')?.addEventListener('click', () => { setLibraryAddMenuOpen(false); openCreateFolderDialog() })
 
 // ── 테마 토글 기능 ──────────────────────────────
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5005,12 +5005,15 @@ if (chatDrawerViewerBtn) {
 document.addEventListener('keydown', async e => {
   if (state.currentWorkspacePage !== 'library' || /INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName || '')) return
   const mod = e.ctrlKey || e.metaKey
-  if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
+  if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+    e.preventDefault()
+    await undoLastLibraryAction()
+  } else if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
     e.preventDefault(); libraryClipboard = { mode: e.key.toLowerCase() === 'x' ? 'cut' : 'copy', ids: Array.from(selectedDocIds) }; showToast(`${selectedDocIds.size}개 논문을 ${libraryClipboard.mode === 'cut' ? '잘라냈습니다' : '복사했습니다'}.`, 'info')
   } else if (mod && e.key.toLowerCase() === 'v' && libraryClipboard?.ids?.length) {
     e.preventDefault()
     // 논문 파일/캐시를 중복 복제하지 않기 위해 붙여넣기는 이동으로 동작한다.
-    try { await moveLibraryDocuments(libraryClipboard.ids, activeLibraryFolderId); showToast('현재 폴더로 이동했습니다.', 'success'); if (libraryClipboard.mode === 'cut') libraryClipboard = null; await renderLibrary() } catch (err) { showToast(err.message || '붙여넣기 실패', 'error') }
+    try { await moveDocumentsWithUndo(libraryClipboard.ids, activeLibraryFolderId); showToast('현재 폴더로 이동했습니다.', 'success'); if (libraryClipboard.mode === 'cut') libraryClipboard = null; await renderLibrary() } catch (err) { showToast(err.message || '붙여넣기 실패', 'error') }
   } else if (e.key === 'Delete' && selectedDocIds.size) {
     e.preventDefault(); document.querySelector('#lib-select-delete-btn')?.click()
   } else if (e.key === 'Escape') { clearDocSelection(); libraryClipboard = null }
@@ -5128,7 +5131,47 @@ function sortLibraryDocs(docs) {
 let libraryFolders = []
 let activeLibraryFolderId = null
 let libraryClipboard = null
+const libraryUndoStack = []
 const FOLDER_COLORS = ['#6b7280', '#4f8ef7', '#8b5cf6', '#ec4899', '#f59e0b', '#10b981']
+
+
+function pushLibraryUndo(action) {
+  libraryUndoStack.push(action)
+  if (libraryUndoStack.length > 30) libraryUndoStack.shift()
+}
+async function moveDocumentsWithUndo(docIds, folderId) {
+  const entries = docIds.map(id => ({ id, folderId: currentLibraryDocs.find(doc => doc.id === id)?.folder_id || null }))
+  await moveLibraryDocuments(docIds, folderId)
+  if (entries.some(entry => entry.folderId !== folderId)) pushLibraryUndo({ kind: 'documents', entries })
+}
+async function moveFolderWithUndo(folder, parentId) {
+  await updateLibraryFolder(folder.id, { parent_id: parentId, move: true })
+  if ((folder.parent_id || null) !== parentId) pushLibraryUndo({ kind: 'folderMove', id: folder.id, parentId: folder.parent_id || null })
+}
+async function updateFolderWithUndo(folder, payload) {
+  await updateLibraryFolder(folder.id, payload)
+  const previous = {}
+  if (payload.name !== undefined) previous.name = folder.name
+  if (payload.color !== undefined) previous.color = folder.color
+  pushLibraryUndo({ kind: 'folderUpdate', id: folder.id, payload: previous })
+}
+async function undoLastLibraryAction() {
+  const action = libraryUndoStack.pop()
+  if (!action) { showToast('되돌릴 작업이 없습니다.', 'info'); return }
+  try {
+    if (action.kind === 'documents') {
+      const groups = new Map()
+      action.entries.forEach(entry => { const key = entry.folderId || ''; if (!groups.has(key)) groups.set(key, []); groups.get(key).push(entry.id) })
+      for (const [folderId, ids] of groups) await moveLibraryDocuments(ids, folderId || null)
+    } else if (action.kind === 'folderMove') await updateLibraryFolder(action.id, { parent_id: action.parentId, move: true })
+    else if (action.kind === 'folderUpdate') await updateLibraryFolder(action.id, action.payload)
+    showToast('마지막 작업을 되돌렸습니다.', 'success')
+    await renderLibrary()
+  } catch (err) {
+    libraryUndoStack.push(action)
+    showToast(err.message || '실행 취소 실패', 'error')
+  }
+}
 
 function folderPath(folderId) {
   const byId = new Map(libraryFolders.map(f => [f.id, f]))
@@ -5154,10 +5197,12 @@ function setFolderDropTarget(el, folderId) {
         return
       }
       const item = JSON.parse(raw)
-      if (item.kind === 'document') await moveLibraryDocuments(item.ids, folderId)
+      if (item.kind === 'document') await moveDocumentsWithUndo(item.ids, folderId)
       if (item.kind === 'folder') {
         if (item.id === folderId || folderDescendants(item.id).has(folderId)) throw new Error('폴더를 자기 자신 또는 하위 폴더로 옮길 수 없습니다.')
-        await updateLibraryFolder(item.id, { parent_id: folderId, move: true })
+        const folder = libraryFolders.find(candidate => candidate.id === item.id)
+        if (!folder) throw new Error('폴더를 찾을 수 없습니다.')
+        await moveFolderWithUndo(folder, folderId)
       }
       showToast('이동했습니다.', 'success'); await renderLibrary()
     } catch (err) { showToast(err.message || '이동 실패', 'error') }
@@ -5198,15 +5243,32 @@ function showFolderColorDialog(currentColor) {
   return new Promise(resolve => {
     const modal = document.createElement('div')
     modal.className = 'custom-confirm-modal-wrapper'
-    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">폴더 색상</span></div><div class="custom-confirm-modal-body"><div class="folder-color-picker">${FOLDER_COLORS.map(color => `<button class="color-dot ${color === currentColor ? 'selected' : ''}" data-color="${color}" style="background:${color}" title="${color}"></button>`).join('')}</div></div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button></div></div>`
+    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">폴더 색상</span></div><div class="custom-confirm-modal-body"><div class="folder-color-picker">${FOLDER_COLORS.map(color => `<button class="color-dot ${color === currentColor ? 'selected' : ''}" data-color="${color}" style="background:${color}" title="${color}"></button>`).join('')}<label class="folder-native-color" title="직접 색상 선택"><input type="color" value="${currentColor}"><span>+</span></label></div></div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button></div></div>`
     document.body.appendChild(modal)
     const close = value => { modal.classList.remove('active'); setTimeout(() => { modal.remove(); resolve(value) }, 200) }
     modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
     modal.querySelectorAll('[data-color]').forEach(btn => btn.addEventListener('click', () => close(btn.dataset.color)))
+    modal.querySelector('input[type="color"]').addEventListener('change', e => close(e.target.value))
     modal.addEventListener('click', e => { if (e.target === modal) close(null) })
     setTimeout(() => modal.classList.add('active'), 10)
   })
 }
+
+function showFolderContentsDeleteDialog(paperCount) {
+  return new Promise(resolve => {
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">폴더 안 논문 처리</span></div><div class="custom-confirm-modal-body">이 폴더에 논문 ${paperCount}개가 있습니다.<br>폴더 삭제 후 논문을 어떻게 처리할까요?</div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button><button class="custom-confirm-btn keep-btn">루트에 유지</button><button class="custom-confirm-btn confirm-btn">함께 휴지통으로 이동</button></div></div>`
+    document.body.appendChild(modal)
+    const close = value => { modal.classList.remove('active'); setTimeout(() => { modal.remove(); resolve(value) }, 200) }
+    modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
+    modal.querySelector('.keep-btn').addEventListener('click', () => close(false))
+    modal.querySelector('.confirm-btn').addEventListener('click', () => close(true))
+    modal.addEventListener('click', e => { if (e.target === modal) close(null) })
+    setTimeout(() => modal.classList.add('active'), 10)
+  })
+}
+
 function createFolderCard(folder) {
   const card = document.createElement('article')
   card.className = 'library-folder-card'
@@ -5222,9 +5284,20 @@ function createFolderCard(folder) {
   menu.addEventListener('click', async e => {
     e.stopPropagation(); const action = e.target.dataset.action; if (!action) return
     try {
-      if (action === 'rename') { const name = await showCustomTextDialog({ title: '폴더 이름 변경', label: '폴더 이름', value: folder.name, confirmText: '저장' }); if (name) await updateLibraryFolder(folder.id, { name }) }
-      if (action === 'color') { const color = await showFolderColorDialog(folder.color); if (color) await updateLibraryFolder(folder.id, { color }) }
-      if (action === 'delete') { const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요? 내부 논문을 휴지통으로 이동할지 다음 단계에서 선택합니다.`, { title: '폴더 삭제', confirmText: '계속', danger: true }); if (ok) { const deletePapers = await showCustomConfirm('폴더 내부 논문도 휴지통으로 이동할까요?', { title: '논문 처리', confirmText: '휴지통으로 이동', cancelText: '루트에 유지', danger: true }); await deleteLibraryFolder(folder.id, deletePapers) } }
+      if (action === 'rename') { const name = await showCustomTextDialog({ title: '폴더 이름 변경', label: '폴더 이름', value: folder.name, confirmText: '저장' }); if (name && name !== folder.name) await updateFolderWithUndo(folder, { name }) }
+      if (action === 'color') { const color = await showFolderColorDialog(folder.color); if (color && color !== folder.color) await updateFolderWithUndo(folder, { color }) }
+      if (action === 'delete') {
+        const paperCount = currentLibraryDocs.filter(doc => doc.folder_id === folder.id).length
+        const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${paperCount ? '' : '\n비어 있는 폴더이며 논문에는 영향이 없습니다.'}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
+        if (!ok) return
+        let deletePapers = false
+        if (paperCount > 0) {
+          const choice = await showFolderContentsDeleteDialog(paperCount)
+          if (choice === null) return
+          deletePapers = choice
+        }
+        await deleteLibraryFolder(folder.id, deletePapers)
+      }
       await renderLibrary()
     } catch (err) { showToast(err.message || '폴더 변경 실패', 'error') }
   })
@@ -5232,8 +5305,7 @@ function createFolderCard(folder) {
 }
 function ensureLibraryFolderUI() {
   if ($('library-breadcrumb')) return
-  librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-header"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav><button id="library-new-folder-btn" class="library-new-folder-btn">${icon('folderPlus', 15)}<span>폴더 추가</span></button></div>`)
-  $('library-new-folder-btn')?.addEventListener('click', () => openCreateFolderDialog())
+  librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-header"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav></div>`)
 }
 let libraryChromeReady = false
 function ensureLibraryChrome() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6807,4 +6807,12 @@ body.light-theme .chat-drawer {
 }
 
 
-.lib-add-fab-wrap{position:fixed;bottom:40px;right:40px;z-index:999;display:flex;flex-direction:column-reverse;align-items:flex-end;gap:9px}.lib-add-sub-btn{display:none;padding:10px 16px;border:0;border-radius:22px;background:var(--bg-elevated);color:var(--text-primary);box-shadow:var(--shadow-md);cursor:pointer}.lib-add-fab-wrap.open .lib-add-sub-btn{display:block}.lib-add-fab-wrap #lib-upload-btn{position:static}
+.lib-add-fab-wrap { position:fixed; bottom:40px; right:40px; z-index:999; display:flex; flex-direction:column-reverse; align-items:flex-end; gap:12px; }
+.lib-add-fab-wrap #lib-upload-btn.lib-add-main-btn { position:static; width:58px; height:58px; padding:0; border-radius:50%; display:grid; place-items:center; background:var(--control-accent); box-shadow:0 8px 24px rgba(0,0,0,.22); }
+.lib-add-main-btn > span { font-size:30px; line-height:1; font-weight:300; transition:transform .2s ease; }
+.lib-add-fab-wrap.open .lib-add-main-btn > span { transform:rotate(45deg); }
+.lib-add-sub-btn { display:flex; align-items:center; justify-content:flex-end; gap:12px; padding:0; border:0; background:transparent; color:var(--text-primary); cursor:pointer; opacity:0; visibility:hidden; transform:translateY(12px) scale(.94); transition:opacity .18s ease, transform .18s ease, visibility .18s; }
+.lib-add-fab-wrap.open .lib-add-sub-btn { opacity:1; visibility:visible; transform:translateY(0) scale(1); }
+.lib-add-label { padding:5px 9px; border-radius:7px; background:var(--bg-surface); box-shadow:var(--shadow-sm); font-size:12.5px; font-weight:650; white-space:nowrap; }
+.lib-add-circle { width:50px; height:50px; border-radius:50%; display:grid; place-items:center; background:var(--bg-surface); color:var(--text-primary); box-shadow:0 5px 16px rgba(0,0,0,.18); }
+.lib-add-sub-btn:hover .lib-add-circle { color:var(--control-accent-text); transform:translateY(-1px); }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -549,6 +549,7 @@ body.light-theme .lib-detail-panel {
 .library-new-folder-btn:hover { border-color:var(--control-accent); background:var(--control-accent-soft); }
 .library-folder-card { position:relative; min-height:178px; padding:20px; border:1px solid var(--border); border-radius:var(--radius-lg); background:var(--bg-elevated); cursor:pointer; transition:transform .15s ease, border-color .15s ease, background .15s ease; }
 .library-folder-card:hover { transform:translateY(-2px); border-color:var(--folder-color); background:var(--bg-hover); }
+.library-folder-card:focus-visible { outline:2px solid var(--control-accent); outline-offset:2px; border-color:var(--folder-color); }
 .folder-card-icon { color:var(--folder-color); margin-bottom:22px; }
 .folder-card-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-primary); font-size:14px; font-weight:700; }
 .folder-card-meta { margin-top:6px; color:var(--text-muted); font-size:12px; }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -563,3 +563,9 @@ body.light-theme .lib-detail-panel {
 .folder-color-picker{display:flex;gap:12px;padding:6px}.folder-color-picker .color-dot{width:28px;height:28px;border:2px solid transparent;border-radius:50%;cursor:pointer}.folder-color-picker .color-dot.selected{outline:2px solid var(--text-primary);outline-offset:3px}
 
 .folder-card-actions{position:absolute;right:10px;top:40px;z-index:4;display:grid;padding:5px;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-sm);box-shadow:var(--shadow-md)}.folder-card-actions button{border:0;background:transparent;color:var(--text-primary);padding:7px 10px;text-align:left;cursor:pointer}.folder-card-actions button:hover{background:var(--bg-hover)}
+
+.folder-native-color { position:relative; width:28px; height:28px; border:1px dashed var(--border-strong); border-radius:50%; display:grid; place-items:center; color:var(--text-secondary); cursor:pointer; overflow:hidden; flex:0 0 auto; }
+.folder-native-color:hover { border-color:var(--control-accent); color:var(--control-accent-text); }
+.folder-native-color input { position:absolute; inset:0; width:100%; height:100%; opacity:0; cursor:pointer; }
+.folder-native-color span { font-size:18px; line-height:1; }
+.folder-color-picker { align-items:center; }


### PR DESCRIPTION
# Summary
## 1. 폴더 색상 및 삭제 다이얼로그 개선
- 폴더 색상 팔레트에 직접 색상을 선택할 수 있는 컬러 피커를 추가
- 폴더에 실제 논문이 있을 때만 논문 처리 다이얼로그를 표시하도록 수정
- 논문 유지, 휴지통 이동, 취소 선택지를 구분하도록 안내 및 동작을 수정
## 2. 라이브러리 폴더 단축키 지원
- Ctrl/Cmd + Z로 논문 이동, 폴더 이동, 이름 및 색상 변경을 실행 취소하는 기능을 추가
- Ctrl/Cmd + X 및 V로 선택 논문과 포커스된 폴더를 이동하는 기능을 추가
- Delete/Backspace로 폴더 삭제, F2/Enter로 폴더 이름 변경 기능을 추가
## 3. 통합 추가 플로팅 버튼 개선
- 참고 이미지 기반 원형 스피드 다이얼 UI로 변경
- 논문 추가와 폴더 추가 버튼이 라벨과 함께 위로 펼쳐지도록 수정