### PR TITLE
fix: improve library folder navigation

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5006,7 +5006,13 @@ document.addEventListener('keydown', async e => {
   if (state.currentWorkspacePage !== 'library' || /INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName || '')) return
   const mod = e.ctrlKey || e.metaKey
   const focusedFolder = getFocusedLibraryFolder()
-  if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+  if (mod && e.key === '[') {
+    e.preventDefault()
+    history.back()
+  } else if (mod && e.key === ']') {
+    e.preventDefault()
+    history.forward()
+  } else if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
     e.preventDefault()
     await undoLastLibraryAction()
   } else if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
@@ -5252,14 +5258,31 @@ function showCustomTextDialog({ title, label, value = '', confirmText = '확인'
     setTimeout(() => { modal.classList.add('active'); input.focus(); input.select() }, 10)
   })
 }
+
+function navigateLibraryFolder(folderId, { pushHistory = true } = {}) {
+  const nextFolderId = folderId || null
+  if (nextFolderId === activeLibraryFolderId && activeCategoryFilter === 'ALL') return
+  activeLibraryFolderId = nextFolderId
+  activeCategoryFilter = 'ALL'
+  if (pushHistory) {
+    history.pushState(
+      { ...(history.state || {}), screen: 'library', page: 'library', libraryFolderId: nextFolderId },
+      '',
+      location.href,
+    )
+  }
+  filterLibraryCards(currentLibraryDocs)
+  renderFolderNavigation(currentLibraryDocs)
+}
+
 function renderFolderNavigation(docs) {
   const crumb = $('library-breadcrumb')
   if (!crumb) return
   const path = folderPath(activeLibraryFolderId)
-  crumb.innerHTML = `<button data-folder-id="">전체 논문</button>${path.map(f => `<span>›</span><button data-folder-id="${escapeHtml(f.id)}">${escapeHtml(f.name)}</button>`).join('')}`
+  crumb.innerHTML = `<button data-folder-id="" class="library-breadcrumb-root">${icon('home', 14)}<span>전체 논문</span></button>${path.map((f, index) => `<span class="library-breadcrumb-separator">›</span><button data-folder-id="${escapeHtml(f.id)}" ${index === path.length - 1 ? 'aria-current="page"' : ''}>${icon('folder', 14)}<span>${escapeHtml(f.name)}</span></button>`).join('')}`
   crumb.querySelectorAll('button').forEach(el => {
     const id = el.dataset.folderId || null
-    el.addEventListener('click', () => { activeLibraryFolderId = id; filterLibraryCards(currentLibraryDocs); renderFolderNavigation(currentLibraryDocs) })
+    el.addEventListener('click', () => navigateLibraryFolder(id))
     setFolderDropTarget(el, id)
   })
 }
@@ -5332,7 +5355,7 @@ function createFolderCard(folder) {
   card.dataset.folderId = folder.id
   card.style.setProperty('--folder-color', folder.color)
   card.innerHTML = `<div class="folder-card-icon">${icon('folder', 28)}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
-  card.addEventListener('click', e => { if (e.target.closest('.folder-card-menu')) return; activeLibraryFolderId = folder.id; filterLibraryCards(currentLibraryDocs); renderFolderNavigation(currentLibraryDocs) })
+  card.addEventListener('click', e => { if (e.target.closest('.folder-card-menu')) return; navigateLibraryFolder(folder.id) })
   card.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: folder.id })); e.dataTransfer.effectAllowed = 'move' })
   setFolderDropTarget(card, folder.id)
   const menu = card.querySelector('.folder-card-actions')
@@ -6459,14 +6482,16 @@ function filterLibraryCards(docs) {
   document.querySelectorAll('.category-filter-btn').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.category === activeCategoryFilter)
   })
+  $('library-breadcrumb')?.classList.toggle('global-filter-active', activeCategoryFilter !== 'ALL')
 
-  // 현재 폴더(루트 포함)와 태그를 함께 적용한다.
-  let filteredDocs = state.currentLibraryTab === 'trash' ? docs : docs.filter(doc => (doc.folder_id || null) === activeLibraryFolderId)
+  // 카테고리 칩은 폴더 경계를 무시한 전역 필터다. '전체'일 때만 현재 폴더를 적용한다.
+  let filteredDocs = state.currentLibraryTab === 'trash' || activeCategoryFilter !== 'ALL'
+    ? docs
+    : docs.filter(doc => (doc.folder_id || null) === activeLibraryFolderId)
 
-  // Filter docs by category tag
-  filteredDocs = activeCategoryFilter === 'ALL'
-    ? filteredDocs
-    : filteredDocs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
+  if (activeCategoryFilter !== 'ALL') {
+    filteredDocs = filteredDocs.filter(doc => (doc.metadata?.categories || []).includes(activeCategoryFilter))
+  }
 
   // 상태 필터(전체/읽지 않음/읽는 중/완료/즐겨찾기) 적용 - 휴지통 탭에는 없는 개념이라 건너뛴다.
   if (state.currentLibraryTab !== 'trash' && activeStatusFilter !== 'all') {
@@ -6478,7 +6503,7 @@ function filterLibraryCards(docs) {
 
   filteredDocs = sortLibraryDocs(filteredDocs)
 
-  const childFolders = state.currentLibraryTab === 'trash'
+  const childFolders = state.currentLibraryTab === 'trash' || activeCategoryFilter !== 'ALL'
     ? []
     : libraryFolders.filter(folder => (folder.parent_id || null) === activeLibraryFolderId)
   if (filteredDocs.length === 0 && childFolders.length === 0) {
@@ -14516,6 +14541,10 @@ async function handleRouting() {
         sessionStorage.setItem('easypaper_graph_subview', subviewParam)
       }
       const pageId = rawPage
+      if (pageId === 'library' && history.state?.screen === 'library' && history.state?.page === 'library') {
+        activeLibraryFolderId = history.state.libraryFolderId || null
+        activeCategoryFilter = 'ALL'
+      }
       console.log("[Router] Routing to workspace page:", pageId, "Viewer active:", viewerScreen.classList.contains('active'), "Library active:", libraryScreen.classList.contains('active'))
       if (viewerScreen.classList.contains('active') || !libraryScreen.classList.contains('active')) {
         await showLibraryScreen(false, WORKSPACE_PAGES.includes(pageId) ? pageId : 'dashboard')
@@ -14530,6 +14559,16 @@ async function handleRouting() {
 
 window.addEventListener('popstate', (e) => {
   console.log("[Router] popstate fired. state:", e.state)
+  const isLibraryHistory = e.state?.screen === 'library' && e.state?.page === 'library'
+  const isLegacyLibraryRoot = !e.state && location.hash === '#library'
+  if (isLibraryHistory || isLegacyLibraryRoot) {
+    activeLibraryFolderId = e.state?.libraryFolderId || null
+    activeCategoryFilter = 'ALL'
+    if (state.currentWorkspacePage === 'library' && currentLibraryDocs.length) {
+      filterLibraryCards(currentLibraryDocs)
+      renderFolderNavigation(currentLibraryDocs)
+    }
+  }
   handleRouting()
 })
 

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -541,10 +541,14 @@ body.light-theme .lib-detail-panel {
 
 
 /* ── 라이브러리 내부 폴더 카드와 경로 ── */
-.library-folder-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:0 0 10px; }
-.library-breadcrumb { display:flex; align-items:center; min-width:0; gap:6px; overflow:auto; white-space:nowrap; color:var(--text-muted); font-size:13px; }
-.library-breadcrumb button { border:0; padding:4px 6px; background:transparent; color:var(--text-secondary); border-radius:var(--radius-sm); cursor:pointer; }
+.library-folder-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:0 0 14px; padding:10px 12px; border:1px solid var(--border-strong); border-left:3px solid var(--control-accent); border-radius:var(--radius-md); background:linear-gradient(90deg, var(--control-accent-soft), var(--bg-elevated) 58%); box-shadow:var(--shadow-sm); }
+.library-breadcrumb { display:flex; align-items:center; min-width:0; gap:5px; overflow:auto; white-space:nowrap; color:var(--text-muted); font-size:13px; font-weight:600; }
+.library-breadcrumb button { display:inline-flex; align-items:center; gap:6px; border:0; padding:6px 9px; background:transparent; color:var(--text-secondary); border-radius:var(--radius-sm); cursor:pointer; font:inherit; }
 .library-breadcrumb button:hover { background:var(--bg-hover); color:var(--text-primary); }
+.library-breadcrumb button[aria-current="page"] { background:var(--bg-surface); color:var(--control-accent-text); box-shadow:var(--shadow-sm); }
+.library-breadcrumb-root { color:var(--text-primary)!important; }
+.library-breadcrumb-separator { color:var(--text-muted); font-size:18px; font-weight:400; }
+.library-breadcrumb.global-filter-active::after { content:'전체 폴더에서 필터링 중'; margin-left:8px; padding:3px 8px; border-radius:999px; background:var(--control-accent); color:#fff; font-size:10.5px; font-weight:700; }
 .library-new-folder-btn { display:inline-flex; align-items:center; gap:6px; flex:0 0 auto; padding:7px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-md); background:var(--bg-elevated); color:var(--text-primary); cursor:pointer; font:inherit; font-size:12.5px; font-weight:600; }
 .library-new-folder-btn:hover { border-color:var(--control-accent); background:var(--control-accent-soft); }
 .library-folder-card { position:relative; min-height:178px; padding:20px; border:1px solid var(--border); border-radius:var(--radius-lg); background:var(--bg-elevated); cursor:pointer; transition:transform .15s ease, border-color .15s ease, background .15s ease; }


### PR DESCRIPTION
# Summary
## 1. Breadcrumb 가시성 및 디렉토리 탐색 개선
- Breadcrumb 강조 스타일과 폴더 경로 아이콘 추가
- 브라우저 뒤로가기·앞으로가기 및 Cmd/Ctrl + [, ] 단축키로 디렉토리 이동 기능 추가
## 2. 필터 칩의 전역 검색 동작 복원
- 필터 칩 선택 시 현재 폴더 범위를 무시하고 전체 논문에서 필터링하도록 수정
- 전역 필터 활성 상태 안내와 필터 해제 시 현재 폴더 복원 기능 추가