### PR TITLE
fix: refine library folder drag interactions

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5178,6 +5178,7 @@ async function moveDocumentsWithUndo(docIds, folderId) {
   const entries = docIds.map(id => ({ id, folderId: currentLibraryDocs.find(doc => doc.id === id)?.folder_id || null }))
   await moveLibraryDocuments(docIds, folderId)
   if (entries.some(entry => entry.folderId !== folderId)) pushLibraryUndo({ kind: 'documents', entries })
+  clearDocSelection()
 }
 async function moveFolderWithUndo(folder, parentId) {
   await updateLibraryFolder(folder.id, { parent_id: parentId, move: true })
@@ -5354,7 +5355,7 @@ function createFolderCard(folder) {
   card.title = 'Enter/F2: 이름 변경 · Delete/Backspace: 삭제 · Ctrl/Cmd+X: 잘라내기'
   card.dataset.folderId = folder.id
   card.style.setProperty('--folder-color', folder.color)
-  card.innerHTML = `<div class="folder-card-icon">${icon('folder', 28)}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
+  card.innerHTML = `<div class="folder-card-icon">${icon('folder', 32, 'fill="currentColor" stroke="none"')}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
   card.addEventListener('click', e => { if (e.target.closest('.folder-card-menu')) return; navigateLibraryFolder(folder.id) })
   card.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: folder.id })); e.dataTransfer.effectAllowed = 'move' })
   setFolderDropTarget(card, folder.id)
@@ -6717,8 +6718,52 @@ function prepareDocItemHtml(doc) {
 }
 
 // 카드/리스트 뷰 공용: 위임 없이 각 아이템 컨테이너에 직접 붙는 이벤트 리스너를 등록한다.
+let activeLibraryDragPreview = null
+
+function removeLibraryDragPreview() {
+  activeLibraryDragPreview?.remove()
+  activeLibraryDragPreview = null
+}
+
+function createLibraryDragPreview(count) {
+  removeLibraryDragPreview()
+  const preview = document.createElement('div')
+  preview.className = 'library-multi-drag-preview'
+  preview.setAttribute('aria-hidden', 'true')
+  const stackDepth = Math.min(count - 1, 3)
+  preview.innerHTML = `${Array.from({ length: stackDepth }, (_, index) => `<span class="library-drag-stack-sheet" style="--stack-index:${index + 1}"></span>`).join('')}
+    <div class="library-drag-stack-card">
+      <span class="library-drag-stack-icon">${icon('fileText', 22)}</span>
+      <span class="library-drag-stack-copy"><strong>${count}개 논문</strong><small>선택 항목 이동</small></span>
+      <span class="library-drag-stack-count">${count}</span>
+    </div>`
+  document.body.appendChild(preview)
+  activeLibraryDragPreview = preview
+  return preview
+}
+
+function wireDocDragEvents(container, doc) {
+  if (state.currentLibraryTab === 'trash') return
+  container.draggable = true
+  container.addEventListener('dragstart', e => {
+    const ids = selectedDocIds.has(doc.id) ? Array.from(selectedDocIds) : [doc.id]
+    e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'document', ids }))
+    e.dataTransfer.effectAllowed = 'move'
+    container.classList.add('doc-dragging')
+    if (ids.length > 1) {
+      const preview = createLibraryDragPreview(ids.length)
+      e.dataTransfer.setDragImage(preview, 24, 24)
+    }
+  })
+  container.addEventListener('dragend', () => {
+    container.classList.remove('doc-dragging')
+    removeLibraryDragPreview()
+  })
+}
+
 // 클래스명(.doc-card-check-btn, .doc-open-btn 등)만 맞으면 어떤 레이아웃이든 동작한다.
 function wireDocItemEvents(container, doc, displayTitle) {
+  wireDocDragEvents(container, doc)
   if (selectedDocIds.has(doc.id)) {
     container.classList.add('doc-card-selected')
   }
@@ -6939,12 +6984,6 @@ function createDocCard(doc) {
   const card = document.createElement('div')
   card.className = 'doc-card'
   card.dataset.id = doc.id
-  card.draggable = state.currentLibraryTab !== 'trash'
-  card.addEventListener('dragstart', e => {
-    const ids = selectedDocIds.has(doc.id) ? Array.from(selectedDocIds) : [doc.id]
-    e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'document', ids }))
-    e.dataTransfer.effectAllowed = 'move'
-  })
   card.innerHTML = `
     ${d.compareCheckHtml}
     <div class="doc-card-zone">

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -554,7 +554,7 @@ body.light-theme .lib-detail-panel {
 .library-folder-card { position:relative; min-height:178px; padding:20px; border:1px solid var(--border); border-radius:var(--radius-lg); background:var(--bg-elevated); cursor:pointer; transition:transform .15s ease, border-color .15s ease, background .15s ease; }
 .library-folder-card:hover { transform:translateY(-2px); border-color:var(--folder-color); background:var(--bg-hover); }
 .library-folder-card:focus-visible { outline:2px solid var(--control-accent); outline-offset:2px; border-color:var(--folder-color); }
-.folder-card-icon { color:var(--folder-color); margin-bottom:22px; }
+.folder-card-icon { color:var(--folder-color); margin-bottom:22px; filter:drop-shadow(0 3px 7px color-mix(in srgb, var(--folder-color) 30%, transparent)); }
 .folder-card-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-primary); font-size:14px; font-weight:700; }
 .folder-card-meta { margin-top:6px; color:var(--text-muted); font-size:12px; }
 .folder-card-menu { position:absolute; top:12px; right:12px; padding:5px; border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-muted); cursor:pointer; }
@@ -563,7 +563,24 @@ body.light-theme .lib-detail-panel {
 .folder-dialog-label { display:grid; gap:8px; color:var(--text-secondary); font-size:13px; }
 .folder-dialog-input { width:100%; box-sizing:border-box; padding:9px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-sm); background:var(--bg-elevated); color:var(--text-primary); font:inherit; outline:none; }
 .folder-dialog-input:focus { border-color:var(--control-accent); }
-.doc-card[draggable=true] { cursor:grab; }
+.library-grid.list-view .library-folder-card { min-height:0; padding:12px 16px; display:flex; align-items:center; gap:16px; border-radius:14px; }
+.library-grid.list-view .library-folder-card:hover { transform:translateX(2px); }
+.library-grid.list-view .folder-card-icon { display:flex; flex:0 0 auto; margin:0; }
+.library-grid.list-view .folder-card-name { flex:1 1 240px; min-width:120px; font-size:14.5px; }
+.library-grid.list-view .folder-card-meta { flex:0 0 auto; margin:0 44px 0 0; }
+.library-grid.list-view .folder-card-menu { top:50%; right:16px; transform:translateY(-50%); }
+.library-grid.list-view .folder-card-actions { top:calc(50% + 20px); right:16px; }
+
+.doc-card[draggable=true], .doc-list-row[draggable=true] { cursor:grab; }
+.doc-dragging { opacity:.55; cursor:grabbing!important; }
+.library-multi-drag-preview { position:fixed; left:-10000px; top:0; z-index:99999; width:226px; height:74px; pointer-events:none; }
+.library-drag-stack-sheet { position:absolute; inset:0 8px 8px 0; transform:translate(calc(var(--stack-index) * 5px), calc(var(--stack-index) * 5px)); border:1px solid var(--control-accent); border-radius:12px; background:var(--bg-elevated); box-shadow:var(--shadow-sm); opacity:calc(1 - var(--stack-index) * .16); }
+.library-drag-stack-card { position:absolute; inset:0 12px 12px 0; display:flex; align-items:center; gap:10px; padding:12px 14px; border:2px solid var(--control-accent); border-radius:12px; background:var(--bg-surface); color:var(--text-primary); box-shadow:var(--shadow-lg); }
+.library-drag-stack-icon { display:grid; place-items:center; width:34px; height:34px; flex:0 0 auto; border-radius:9px; background:var(--control-accent-soft); color:var(--control-accent-text); }
+.library-drag-stack-copy { display:grid; min-width:0; gap:2px; }
+.library-drag-stack-copy strong { font-size:13px; white-space:nowrap; }
+.library-drag-stack-copy small { color:var(--text-muted); font-size:10.5px; white-space:nowrap; }
+.library-drag-stack-count { display:grid; place-items:center; min-width:27px; height:27px; margin-left:auto; padding:0 7px; border-radius:999px; background:var(--control-accent); color:#fff; font-size:12px; font-weight:800; }
 
 .folder-color-picker{display:flex;gap:12px;padding:6px}.folder-color-picker .color-dot{width:28px;height:28px;border:2px solid transparent;border-radius:50%;cursor:pointer}.folder-color-picker .color-dot.selected{outline:2px solid var(--text-primary);outline-offset:3px}
 


### PR DESCRIPTION
# Summary
## 1. 다중 선택 논문 드래그 피드백 개선
- 선택된 논문을 드래그할 때 겹친 카드 스택과 전체 선택 개수를 표시하는 전용 미리보기 추가
- 카드 및 리스트 레이아웃의 논문 항목에 동일한 드래그 동작 적용
- 폴더 이동 성공 후 다중 선택 상태와 선택 툴바 자동 해제
## 2. 폴더 카드 시각적 표현 개선
- 리스트 레이아웃의 폴더 카드를 기존 논문 행과 유사한 높이와 간격으로 축소
- 폴더 아이콘을 filled 형태로 변경하고 선택 색상 강조 효과 추가