### PR TITLE
fix: improve light theme muted contrast

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -82,7 +82,7 @@ body.light-theme {
   --text-primary:   #0f172a;
   --text-secondary: #475569;
   --text-tertiary:  #64748b;
-  --text-muted:     #94a3b8;
+  --text-muted:     #64748b;
 
   --control-accent-text: #1e40af;
 


### PR DESCRIPTION
# Summary
## 1. 라이트 테마 텍스트 대비 수정
- --text-muted 색상을 WCAG AA 권장 대비를 충족하는 #64748b로 수정함