### PR TITLE
perf: parallelize OpenAlex validation

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -43,6 +43,10 @@ READING_RECOMMENDATIONS_CACHE_DAYS = 7
 # 한 번은 그날의 최신 활동(질문/메모/읽은 논문)을 반영해 새로 생성되게 한다.
 AI_INSIGHTS_CACHE_HOURS = 24
 
+# OpenAlex에 짧은 시간 동안 과도한 요청을 보내지 않으면서 직렬 네트워크
+# 왕복은 피하기 위한 추천 논문 검증 동시성 상한.
+OPENALEX_RECOMMENDATION_CONCURRENCY = 4
+
 # 그래프 조회 시점에 아직 개념/인용 동기화가 안 된(graph_synced_at 없는) 문서를
 # 백그라운드로 백필한다. 같은 문서에 대해 중복으로 백필 태스크가 여러 개
 # 뜨는 것을 막기 위한 in-flight 집합.
@@ -718,20 +722,25 @@ async def get_reading_recommendations(username: str, force: bool = False) -> Lis
     raw = await generate_reading_recommendations(titles, categories, session_id=username)
     exclude_word_sets = [w for w in (_normalize_words(t) for t in titles) if w]
 
-    results = []
-    for r in raw:
+    semaphore = asyncio.Semaphore(OPENALEX_RECOMMENDATION_CONCURRENCY)
+
+    async def resolve_recommendation(r: dict) -> Optional[dict]:
         title = (r.get("title") or "").strip()
         if not title:
-            continue
-        resolved = await resolve_reference(title)
+            return None
+        async with semaphore:
+            resolved = await resolve_reference(title)
         if not resolved or not _is_plausible_match(title, resolved):
-            continue
+            return None
         result_words = _normalize_words(resolved.get("title", ""))
         if not result_words:
-            continue
+            return None
         if any(len(result_words & seen) / len(result_words) >= 0.6 for seen in exclude_word_sets):
-            continue  # 이미 읽은 논문과 같은 논문이면 제외
-        results.append({**resolved, "reason": r.get("reason", "")})
+            return None  # 이미 읽은 논문과 같은 논문이면 제외
+        return {**resolved, "reason": r.get("reason", "")}
+
+    resolved_results = await asyncio.gather(*(resolve_recommendation(r) for r in raw))
+    results = [result for result in resolved_results if result is not None]
 
     db_set_meta(_reading_recommendations_cache_key(username), json.dumps({
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -355,6 +355,47 @@ async def test_reading_recommendations_filters_implausible_and_duplicate(isolate
     assert any(r["reason"] == "자기지도학습 확장" for r in results)
 
 
+@pytest.mark.asyncio
+async def test_reading_recommendations_resolve_references_with_bounded_concurrency(
+    isolated_dirs, monkeypatch
+):
+    import asyncio
+    import services.llm_client as llm_client
+    import services.reference_linker as reference_linker
+    import services.knowledge_graph as knowledge_graph
+
+    _create_doc_owned_by(isolated_dirs, "doc-rec-concurrent-1", "testuser", {"title": "Read One"})
+    _create_doc_owned_by(isolated_dirs, "doc-rec-concurrent-2", "testuser", {"title": "Read Two"})
+    recommendation_count = knowledge_graph.OPENALEX_RECOMMENDATION_CONCURRENCY + 3
+
+    async def fake_generate(titles, categories, session_id=None):
+        return [
+            {"title": f"Recommended Paper {index}", "reason": f"reason {index}"}
+            for index in range(recommendation_count)
+        ]
+
+    active = 0
+    max_active = 0
+
+    async def fake_resolve(query_text):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return {"title": query_text, "url": f"https://example.com/{query_text}"}
+
+    monkeypatch.setattr(llm_client, "generate_reading_recommendations", fake_generate)
+    monkeypatch.setattr(reference_linker, "resolve_reference", fake_resolve)
+
+    results = await knowledge_graph.get_reading_recommendations("testuser")
+
+    assert max_active == knowledge_graph.OPENALEX_RECOMMENDATION_CONCURRENCY
+    assert [result["title"] for result in results] == [
+        f"Recommended Paper {index}" for index in range(recommendation_count)
+    ]
+
+
 def test_reading_recommendations_endpoint(test_client, isolated_dirs, monkeypatch):
     import services.llm_client as llm_client
     import services.reference_linker as reference_linker


### PR DESCRIPTION
# Summary
## 1. OpenAlex 참고문헌 검증 병렬화
- 최대 4개 제한 동시성으로 참고문헌 검증을 병렬 처리함
- 입력 순서와 실패 격리 동작을 보존함