### PR TITLE
perf: batch compare session documents

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -765,7 +765,11 @@ def db_get_compare_doc_ids(compare_id: str) -> List[str]:
 
 def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
     """사용자가 논문 비교 기능으로 대화한 채팅 세션 목록을, 최근 대화 시각
-    역순으로 반환합니다. 각 세션의 doc_ids에 연결된 문서 제목도 함께 담습니다."""
+    역순으로 반환합니다. 각 세션의 doc_ids에 연결된 문서 제목도 함께 담습니다.
+
+    compare_sessions와 사용자의 documents를 각각 한 번씩만 조회해, 세션별·문서별
+    SELECT가 반복되던 N+1 패턴을 피합니다.
+    """
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
@@ -774,6 +778,12 @@ def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
         )
         rows = cursor.fetchall()
 
+        cursor.execute(
+            "SELECT id, filename, metadata FROM documents WHERE username = ?",
+            (username,),
+        )
+        documents_by_id = {row["id"]: dict(row) for row in cursor.fetchall()}
+
         sessions = []
         for r in rows:
             row = dict(r)
@@ -781,15 +791,10 @@ def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
 
             titles = []
             for doc_id in doc_ids:
-                cursor.execute(
-                    "SELECT filename, metadata FROM documents WHERE id = ? AND username = ?",
-                    (doc_id, username)
-                )
-                doc_row = cursor.fetchone()
-                if not doc_row:
+                doc = documents_by_id.get(doc_id)
+                if not doc:
                     titles.append("(삭제된 논문)")
                     continue
-                doc = dict(doc_row)
                 metadata = json.loads(doc["metadata"]) if doc["metadata"] else {}
                 titles.append(metadata.get("title") or doc["filename"])
 
@@ -1709,4 +1714,3 @@ def db_get_all_reading_analytics_summary(username: str, since_days: Optional[int
         "total_active_reading_time": total_active_time,
         "paper_stats": paper_stats,
     }
-

--- a/backend/tests/test_chat_compare.py
+++ b/backend/tests/test_chat_compare.py
@@ -130,3 +130,30 @@ def test_compare_history_rejects_invalid_doc_count(test_client, isolated_dirs):
     _create_doc(isolated_dirs, "cmp-doc-1")
     res = test_client.get("/api/chat/compare/history", params={"doc_ids": "cmp-doc-1"})
     assert res.status_code == 400
+
+
+def test_list_compare_sessions_uses_two_queries_and_preserves_missing_titles(
+    isolated_dirs, monkeypatch
+):
+    db = isolated_dirs["db"]
+    db.db_save_document("batch-doc-1", "testuser", "one.pdf", "/x/one.pdf", 1, {"title": "One"})
+    db.db_save_document("batch-doc-2", "testuser", "two.pdf", "/x/two.pdf", 1, {})
+    db.db_upsert_compare_session("cmp_batch_1", "testuser", ["batch-doc-1", "batch-doc-2"])
+    db.db_upsert_compare_session("cmp_batch_2", "testuser", ["batch-doc-1", "missing-doc"])
+
+    original_get_db = db.get_db
+    statements = []
+
+    def traced_get_db():
+        conn = original_get_db()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(db, "get_db", traced_get_db)
+
+    sessions = db.db_list_compare_chat_sessions("testuser")
+
+    select_statements = [statement for statement in statements if statement.lstrip().upper().startswith("SELECT")]
+    assert len(select_statements) == 2
+    assert sessions[0]["titles"] == ["One", "(삭제된 논문)"]
+    assert sessions[1]["titles"] == ["One", "two.pdf"]


### PR DESCRIPTION
# Summary
## 1. 비교 세션 조회 N+1 제거
- 비교 세션과 문서 정보를 고정 2개 SELECT로 일괄 조회함
- SQLite 연결 풀링 대신 짧은 연결 구조를 유지해 잠금 복잡성을 방지함