### PR TITLE
fix(auth): migrate user data on rename

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -429,6 +429,7 @@ def update_user_credentials(old_username: str, new_username: str, new_password_h
                     "reading_sessions",
                     "user_reading_profiles",
                     "compare_sessions",
+                    "folders",
                 ):
                     cursor.execute(
                         f"UPDATE {table} SET username = ? WHERE username = ?",

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -418,19 +418,22 @@ def update_user_credentials(old_username: str, new_username: str, new_password_h
                 "UPDATE users SET username = ?, password_hash = ? WHERE username = ?",
                 (new_username, new_password_hash, old_username)
             )
-            # documents.username은 users.username을 참조하는 외래키로 선언돼
-            # 있지만, SQLite는 연결마다 별도로 PRAGMA foreign_keys를 켜주지
-            # 않는 한 이 외래키 제약(및 ON UPDATE CASCADE)을 전혀 강제하지
-            # 않는다. 이 프로젝트는 그 PRAGMA를 켜지 않으므로, 아이디를
-            # 바꾸면 documents 테이블은 예전 아이디를 그대로 가리킨 채 남아
-            # 라이브러리 목록 조회(WHERE username = 새 아이디)에서 전부
-            # 빠져버려 문서가 사라진 것처럼 보이는 문제가 있었다. 같은
-            # 트랜잭션 안에서 명시적으로 함께 갱신한다.
+            # 사용자별 데이터 테이블은 SQLite의 ON UPDATE CASCADE에 의존하지
+            # 않고 같은 트랜잭션에서 명시적으로 함께 갱신한다. 그렇지 않으면
+            # 아이디 변경 후 문서, 읽기 기록, EMA 프로필, 비교 세션이 예전
+            # 아이디에 남아 새 아이디로 조회되지 않는다.
             if new_username != old_username:
-                cursor.execute(
-                    "UPDATE documents SET username = ? WHERE username = ?",
-                    (new_username, old_username)
-                )
+                for table in (
+                    "documents",
+                    "reading_time",
+                    "reading_sessions",
+                    "user_reading_profiles",
+                    "compare_sessions",
+                ):
+                    cursor.execute(
+                        f"UPDATE {table} SET username = ? WHERE username = ?",
+                        (new_username, old_username),
+                    )
             conn.commit()
             return True
     except Exception:

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -90,6 +90,12 @@ def test_update_user_credentials_propagates_username_to_user_data(isolated_dirs)
                VALUES (?, ?, ?, ?, ?)""",
             ("compare-1", "admin", '["doc-1", "doc-2"]', now, now),
         )
+        conn.execute(
+            """INSERT INTO folders
+               (id, username, name, color, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("folder-1", "admin", "읽을 논문", "#64748b", now, now),
+        )
         conn.commit()
 
     assert db.update_user_credentials("admin", "newname", "newhash:abcd") is True
@@ -100,6 +106,7 @@ def test_update_user_credentials_propagates_username_to_user_data(isolated_dirs)
             "reading_sessions",
             "user_reading_profiles",
             "compare_sessions",
+            "folders",
         ):
             assert conn.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE username = ?", ("newname",)

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -59,6 +59,56 @@ def test_update_user_credentials_propagates_username_to_documents(isolated_dirs)
         "예전 아이디로는 더 이상 문서가 조회되지 않아야 한다"
 
 
+def test_update_user_credentials_propagates_username_to_user_data(isolated_dirs):
+    """아이디 변경 시 사용자별 리딩/비교 데이터도 함께 이전한다."""
+    db = isolated_dirs["db"]
+    now = "2026-08-09T00:00:00+00:00"
+
+    with db.get_db() as conn:
+        conn.execute(
+            """INSERT INTO reading_time
+               (doc_id, username, day, category, seconds, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("doc-1", "admin", "2026-08-09", "reading", 120, now),
+        )
+        conn.execute(
+            """INSERT INTO reading_sessions
+               (id, username, paper_id, started_at, active_reading_time,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            ("session-1", "admin", "doc-1", now, 120, now, now),
+        )
+        conn.execute(
+            """INSERT INTO user_reading_profiles
+               (username, ema_seconds_per_page, session_count, updated_at)
+               VALUES (?, ?, ?, ?)""",
+            ("admin", 300.0, 1, now),
+        )
+        conn.execute(
+            """INSERT INTO compare_sessions
+               (id, username, doc_ids, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("compare-1", "admin", '["doc-1", "doc-2"]', now, now),
+        )
+        conn.commit()
+
+    assert db.update_user_credentials("admin", "newname", "newhash:abcd") is True
+
+    with db.get_db() as conn:
+        for table in (
+            "reading_time",
+            "reading_sessions",
+            "user_reading_profiles",
+            "compare_sessions",
+        ):
+            assert conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE username = ?", ("newname",)
+            ).fetchone()[0] == 1
+            assert conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE username = ?", ("admin",)
+            ).fetchone()[0] == 0
+
+
 def test_update_user_credentials_same_username_is_noop_for_documents(isolated_dirs):
     """비밀번호만 바꾸고 아이디는 그대로인 경우, 불필요한 UPDATE가 안전하게 스킵된다."""
     db = isolated_dirs["db"]


### PR DESCRIPTION
# Summary
## 1. 아이디 변경 데이터 마이그레이션 보완
- 읽기 시간·세션·EMA 프로필·비교 세션·폴더 사용자명을 동일 트랜잭션에서 갱신함
- 아이디 변경 후 기존 사용자 데이터와 폴더가 유지되도록 회귀 테스트를 추가함