### PR TITLE
perf: cache shared page data briefly

### DIFF
--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -1,4 +1,26 @@
 const API_BASE = '/api'
+const SHARED_GET_TTL_MS = 5000
+const sharedGetCache = new Map()
+
+async function fetchJsonWithSharedTtl(url, errorMessage) {
+  const now = Date.now()
+  const cached = sharedGetCache.get(url)
+  if (cached && now - cached.createdAt < SHARED_GET_TTL_MS) return cached.promise
+
+  const promise = fetch(url).then(async res => {
+    if (!res.ok) throw new Error(errorMessage)
+    return res.json()
+  })
+  sharedGetCache.set(url, { createdAt: now, promise })
+  promise.catch(() => {
+    if (sharedGetCache.get(url)?.promise === promise) sharedGetCache.delete(url)
+  })
+  return promise
+}
+
+export function invalidateLibraryGetCache() {
+  sharedGetCache.clear()
+}
 
 function buildQuery(options) {
   if (!options || !options.targetLang) return ''
@@ -7,9 +29,7 @@ function buildQuery(options) {
 }
 
 export async function fetchLibrary(options = {}) {
-  const res = await fetch(`${API_BASE}/library${buildQuery(options)}`)
-  if (!res.ok) throw new Error('라이브러리 조회 실패')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library${buildQuery(options)}`, '라이브러리 조회 실패')
 }
 
 
@@ -197,9 +217,7 @@ export async function resolveLibraryReference(docId, refNum) {
 }
 
 export async function fetchLibraryGraph() {
-  const res = await fetch(`${API_BASE}/library/graph`)
-  if (!res.ok) throw new Error('지식 그래프 조회 실패')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library/graph`, '지식 그래프 조회 실패')
 }
 
 export async function fetchGraphNodeQuestions(nodeId) {
@@ -215,9 +233,7 @@ export async function searchGraphNodes(query) {
 }
 
 export async function fetchLibraryTimeline() {
-  const res = await fetch(`${API_BASE}/library/timeline`)
-  if (!res.ok) throw new Error('타임라인 조회 실패')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library/timeline`, '타임라인 조회 실패')
 }
 
 export async function fetchLibraryHeatmap() {
@@ -240,9 +256,7 @@ export async function fetchLibraryGaps() {
 }
 
 export async function fetchLibraryDashboard() {
-  const res = await fetch(`${API_BASE}/library/dashboard`)
-  if (!res.ok) throw new Error('대시보드 조회 실패')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library/dashboard`, '대시보드 조회 실패')
 }
 
 // 뷰어/비교 화면이 보이고 포커스된 동안 주기적으로 경과 초를 보고한다(main.js의
@@ -265,16 +279,12 @@ export async function sendReadingHeartbeat(docId, seconds, category = 'reading')
 // 랭킹에 쓰이는 실측 집계. sinceDays를 주면 최근 N일로 제한한다.
 export async function fetchReadingTimeStats(sinceDays) {
   const query = sinceDays ? `?since_days=${sinceDays}` : ''
-  const res = await fetch(`${API_BASE}/library/reading-stats${query}`)
-  if (!res.ok) throw new Error('읽기 시간 통계 조회 실패')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library/reading-stats${query}`, '읽기 시간 통계 조회 실패')
 }
 
 export async function fetchReadingAnalyticsSummary(sinceDays) {
   const query = sinceDays ? `?since_days=${sinceDays}` : ''
-  const res = await fetch(`${API_BASE}/library/reading-analytics-summary${query}`)
-  if (!res.ok) throw new Error('Reading Analytics summary fetch failed')
-  return res.json()
+  return fetchJsonWithSharedTtl(`${API_BASE}/library/reading-analytics-summary${query}`, 'Reading Analytics summary fetch failed')
 }
 
 export async function fetchPaperReadingAnalytics(docId) {

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -41,21 +41,25 @@ export async function fetchLibraryFolders() {
 export async function createLibraryFolder(payload) {
   const res = await fetch(`${API_BASE}/library/folders`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
   if (!res.ok) throw new Error((await res.json()).detail || '폴더 생성 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 export async function updateLibraryFolder(folderId, payload) {
   const res = await fetch(`${API_BASE}/library/folders/${encodeURIComponent(folderId)}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
   if (!res.ok) throw new Error((await res.json()).detail || '폴더 수정 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 export async function deleteLibraryFolder(folderId, deletePapers = false) {
   const res = await fetch(`${API_BASE}/library/folders/${encodeURIComponent(folderId)}?delete_papers=${deletePapers}`, { method: 'DELETE' })
   if (!res.ok) throw new Error((await res.json()).detail || '폴더 삭제 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 export async function moveLibraryDocuments(docIds, folderId) {
   const res = await fetch(`${API_BASE}/library/documents/move`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ doc_ids: docIds, folder_id: folderId }) })
   if (!res.ok) throw new Error((await res.json()).detail || '논문 이동 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 
@@ -74,6 +78,7 @@ export async function fetchLibraryTranslation(docId, pageNum, options = {}) {
 export async function deleteLibraryDoc(docId) {
   const res = await fetch(`${API_BASE}/library/${docId}`, { method: 'DELETE' })
   if (!res.ok) throw new Error('삭제 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 
@@ -92,6 +97,7 @@ export async function updateLibraryDocMetadata(docId, payload) {
     body: JSON.stringify(payload)
   })
   if (!res.ok) throw new Error('메타데이터 업데이트 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 
@@ -104,6 +110,7 @@ export async function updateLibraryTranslation(docId, pageNum, payload, options 
     body: JSON.stringify(payload)
   })
   if (!res.ok) throw new Error('번역 수정 저장 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 export async function exportAnnotatedPdf(docId, payload) {
@@ -158,6 +165,7 @@ export async function putLibraryAnnotations(docId, data) {
     }
     throw new Error(message)
   }
+  invalidateLibraryGetCache()
   return res.json()
 }
 
@@ -192,6 +200,7 @@ export async function putLibraryMemos(docId, data) {
     }
     throw new Error(message)
   }
+  invalidateLibraryGetCache()
   return res.json()
 }
 
@@ -269,6 +278,7 @@ export async function sendReadingHeartbeat(docId, seconds, category = 'reading')
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ seconds, category }),
     })
+    if (res.ok) invalidateLibraryGetCache()
     return res.ok
   } catch {
     return false
@@ -317,18 +327,21 @@ export async function fetchLibraryTrash(options = {}) {
 export async function restoreLibraryDoc(docId) {
   const res = await fetch(`${API_BASE}/library/${docId}/restore`, { method: 'POST' })
   if (!res.ok) throw new Error('복원 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 
 export async function emptyLibraryTrash() {
   const res = await fetch(`${API_BASE}/library/trash/empty`, { method: 'DELETE' })
   if (!res.ok) throw new Error('휴지통 비우기 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 
 export async function deleteLibraryDocPermanently(docId) {
   const res = await fetch(`${API_BASE}/library/${docId}/permanent`, { method: 'DELETE' })
   if (!res.ok) throw new Error('영구 삭제 실패')
+  invalidateLibraryGetCache()
   return res.json()
 }
 

--- a/frontend/tests/libraryCache.test.js
+++ b/frontend/tests/libraryCache.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { deleteLibraryDoc, fetchLibrary, invalidateLibraryGetCache } from '../src/library.js'
+
+test('성공한 mutation 뒤 공유 GET 캐시를 무효화한다', async () => {
+  const originalFetch = globalThis.fetch
+  let calls = 0
+  globalThis.fetch = async () => {
+    calls += 1
+    return {
+      ok: true,
+      async json() {
+        return { documents: [{ id: `call-${calls}` }] }
+      },
+    }
+  }
+
+  try {
+    invalidateLibraryGetCache()
+    const first = await fetchLibrary()
+    const second = await fetchLibrary()
+    assert.equal(calls, 1)
+    assert.deepEqual(second, first)
+
+    await deleteLibraryDoc('doc-1')
+    const refreshed = await fetchLibrary()
+    assert.equal(calls, 3)
+    assert.equal(refreshed.documents[0].id, 'call-3')
+  } finally {
+    globalThis.fetch = originalFetch
+    invalidateLibraryGetCache()
+  }
+})


### PR DESCRIPTION
# Summary
## 1. 워크스페이스 공유 GET 캐시 추가
- 라이브러리·대시보드·타임라인·리딩 통계 요청에 5초 TTL과 in-flight Promise 공유를 적용함
## 2. Mutation 캐시 무효화 추가
- 삭제·복원·메타데이터·폴더·하트비트 등 성공한 변경 직후 공유 캐시를 초기화함
- 캐시 재사용과 무효화 단위테스트를 추가함