### PR TITLE
fix(ui): guard stale workspace renders

### DIFF
--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -17,6 +17,7 @@ const PAGE_SIZE = 8
 const RECENT_MS = 24 * 60 * 60 * 1000       // "최근 대화" 기준: 24시간 이내
 const ACTIVE_MS = 7 * 24 * 60 * 60 * 1000   // "활성" 기준: 7일 이내
 const PREVIEW_CONCURRENCY = 6
+let renderGeneration = 0
 
 function formatRelativeTime(isoString) {
   if (!isoString) return '-'
@@ -70,6 +71,8 @@ async function mapWithConcurrency(items, limit, fn) {
 export async function renderAiChatsPage() {
   const container = document.getElementById('page-chats')
   if (!container) return
+  const generation = ++renderGeneration
+  const isCurrent = () => generation === renderGeneration && container.classList.contains('active')
 
   container.innerHTML = `
     <div class="aic-page">
@@ -357,10 +360,12 @@ export async function renderAiChatsPage() {
     await mapWithConcurrency(sessions, PREVIEW_CONCURRENCY, async (session) => {
       try {
         const data = await getChatHistoryAPI(session.doc_id)
+        if (!isCurrent()) return
         const history = data.history || []
         const last = history.length ? history[history.length - 1] : null
         state.previews.set(session.doc_id, { text: last ? last.content : '', error: false })
       } catch {
+        if (!isCurrent()) return
         state.previews.set(session.doc_id, { text: '', error: true })
       }
       updatePreviewInDom(session.doc_id)
@@ -374,6 +379,7 @@ export async function renderAiChatsPage() {
     renderPagination()
     try {
       const data = await getChatSessionsAPI()
+      if (!isCurrent()) return
       state.sessions = data.sessions || []
       state.loading = false
       renderTabs()
@@ -383,6 +389,7 @@ export async function renderAiChatsPage() {
       // 표시된 행의 미리보기 텍스트만 점진적으로 채워 넣는다.
       loadPreviews(state.sessions)
     } catch (err) {
+      if (!isCurrent()) return
       console.error('AI 채팅 세션 목록 로드 실패:', err)
       state.loading = false
       state.loadError = err

--- a/frontend/src/pages/dashboardPage.js
+++ b/frontend/src/pages/dashboardPage.js
@@ -14,6 +14,8 @@ import { readPageCount, lastActivityIso, hasReadActivity, computeStreakDays, tod
 import { periodStats, sumSecondsByDayRange, formatDuration, deltaDurationHtml, CATEGORY_LABEL, CATEGORY_COLOR_VAR, CATEGORY_ORDER } from './readingHistoryPage.js'
 import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
+let renderGeneration = 0
+
 function renderReadingAnalyticsCard(analyticsData) {
   if (!analyticsData) return ''
 
@@ -694,6 +696,8 @@ function attachHandlers(root) {
 export async function renderDashboardPage() {
   const el = document.getElementById('page-dashboard')
   if (!el) return
+  const generation = ++renderGeneration
+  const isCurrent = () => generation === renderGeneration && el.classList.contains('active')
 
   el.innerHTML = `<div class="dash-loading">${icon('refreshCw', 20)}<span>대시보드를 불러오는 중...</span></div>`
 
@@ -719,9 +723,13 @@ export async function renderDashboardPage() {
     weeklyReadingStats = results[7]
   } catch (err) {
     console.error('대시보드 데이터 로드 실패:', err)
-    el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
+    if (isCurrent()) {
+      el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
+    }
     return
   }
+
+  if (!isCurrent()) return
 
   try {
     const events = (timelineData && Array.isArray(timelineData.events)) ? timelineData.events : []
@@ -768,6 +776,8 @@ export async function renderDashboardPage() {
     attachHandlers(el)
   } catch (renderErr) {
     console.error('대시보드 렌더링 예외 발생:', renderErr)
-    el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
+    if (isCurrent()) {
+      el.innerHTML = `<div class="dash-error">${icon('alertTriangle', 20)}<p>대시보드를 불러오지 못했습니다.</p></div>`
+    }
   }
 }

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -17,6 +17,8 @@ import { fetchLibrary, fetchLibraryAnnotations, fetchLibraryMemos, fetchPrimer }
 import { icon } from '../icons.js'
 import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
+let renderGeneration = 0
+
 // 즐겨찾기는 서버에 저장되는 필드가 아니라 Library 페이지가 이미 쓰고 있는
 // 로컬 전용 상태다(백엔드에 star/favorite 필드가 없음 - Library 리스킨 때 같은
 // 이유로 로컬로 구현됨). 같은 localStorage 키를 그대로 읽고 써서 Library와
@@ -594,6 +596,8 @@ function shellHtml() {
 export async function renderNotesPage() {
   const root = document.getElementById('page-notes')
   if (!root) return
+  const generation = ++renderGeneration
+  const isCurrent = () => generation === renderGeneration && root.classList.contains('active')
 
   root.innerHTML = shellHtml()
   attachListeners(root)
@@ -604,10 +608,14 @@ export async function renderNotesPage() {
     docs = data.documents || []
   } catch (err) {
     console.error('Notes 페이지: 라이브러리 조회 실패:', err)
-    const listEl = root.querySelector('.notes-paper-list-items')
-    if (listEl) listEl.innerHTML = `<div class="notes-empty"><p style="color:var(--error)">논문 목록을 불러오지 못했습니다</p></div>`
+    if (isCurrent()) {
+      const listEl = root.querySelector('.notes-paper-list-items')
+      if (listEl) listEl.innerHTML = `<div class="notes-empty"><p style="color:var(--error)">논문 목록을 불러오지 못했습니다</p></div>`
+    }
     return
   }
+
+  if (!isCurrent()) return
 
   if (docs.length === 0) {
     allPapers = []
@@ -618,6 +626,7 @@ export async function renderNotesPage() {
   }
 
   allPapers = await Promise.all(docs.map(buildPaperEntry))
+  if (!isCurrent()) return
 
   if (!selectedDocId || !allPapers.some(e => e.doc.id === selectedDocId)) {
     selectedDocId = allPapers[0].doc.id

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -625,8 +625,9 @@ export async function renderNotesPage() {
     return
   }
 
-  allPapers = await Promise.all(docs.map(buildPaperEntry))
+  const loadedPapers = await Promise.all(docs.map(buildPaperEntry))
   if (!isCurrent()) return
+  allPapers = loadedPapers
 
   if (!selectedDocId || !allPapers.some(e => e.doc.id === selectedDocId)) {
     selectedDocId = allPapers[0].doc.id

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -15,6 +15,8 @@ import { countUniqueVerifiedPages, readPageCount, lastActivityIso, lastActivityD
 import '../styles/reading-history.css'
 import '../styles/dashboard.css'
 
+let renderGeneration = 0
+
 function renderReadingAnalyticsSummaryCard(analyticsSummary) {
   if (!analyticsSummary) return ''
 
@@ -367,6 +369,8 @@ function hideRhTooltip() {
 export async function renderReadingHistoryPage() {
   const el = document.getElementById('page-history')
   if (!el) return
+  const generation = ++renderGeneration
+  const isCurrent = () => generation === renderGeneration && el.classList.contains('active')
 
   hideRhTooltip() // 다른 페이지로 이동한 뒤에도 뜬 채로 남아있지 않도록
   el.innerHTML = '<div class="rh-page"><div class="rh-empty">읽기 기록을 불러오는 중...</div></div>'
@@ -391,11 +395,13 @@ export async function renderReadingHistoryPage() {
     analyticsSummary = analyticsSummaryRes
   } catch (err) {
     console.error('Reading History 로드 실패:', err)
-    el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">읽기 기록을 불러오지 못했습니다.</div></div>'
+    if (isCurrent()) {
+      el.innerHTML = '<div class="rh-page"><div class="rh-empty" style="color:var(--error)">읽기 기록을 불러오지 못했습니다.</div></div>'
+    }
     return
   }
 
-  if (document.getElementById('page-history') !== el) return // 페이지 전환됨
+  if (!isCurrent()) return
 
   const docsById = new Map(libraryDocs.map(d => [d.id, d]))
   // readingStats.title_by_doc: 하트비트 시 스냅샷된 doc별 제목 (영구 삭제 후에도 복원 가능)


### PR DESCRIPTION
# Summary
## 1. 워크스페이스 stale render 차단
- Dashboard·History·AI Chats·Notes에 generation 및 활성 페이지 가드를 추가함
- 늦게 완료된 이전 요청이 최신 DOM과 Notes 전역 상태를 덮어쓰지 않도록 수정함