### PR TITLE
feat: rate limit costly API requests

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@ OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=gemma4:e4b
 MAX_FILE_SIZE_MB=50
 SESSION_TTL_HOURS=24
+# 인증 사용자별 고비용 API 제한(프로세스별 슬라이딩 윈도우)
+CHAT_RATE_LIMIT_REQUESTS=30
+TRANSLATE_RATE_LIMIT_REQUESTS=120
+UPLOAD_RATE_LIMIT_REQUESTS=10
 UPLOAD_DIR=./uploads
 CACHE_DIR=./cache
 CORS_ORIGINS=http://localhost:5173,http://localhost:4173
@@ -44,4 +48,3 @@ APP_PORT=8000
 
 # 프로젝트 루트 절대 경로 설정 (선택 사항 - 비워두면 자동으로 감지됨)
 # PROJECT_ROOT=/path/to/EasyPaper
-

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -18,6 +18,7 @@ from services.db import (
 )
 from services.library import save_chat_quote_image
 from services.auth import get_current_user
+from services.rate_limiter import enforce_rate_limit
 
 # 프론트가 이미지 인용 메시지에 붙이는 "[인용된 이미지 (Page N)|quoteId]" 마커에서
 # quoteId만 뽑아낸다 - main.js의 sendChatMessage()가 만드는 placeholder 형식과 맞춰야 한다.
@@ -63,6 +64,7 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
     """
     논문 내용을 기반으로 AI 전문가와 챗을 진행하고 실시간 스트리밍 답변을 반환합니다.
     """
+    enforce_rate_limit("chat", current_user)
     session_id = data.session_id
     session = require_session_owner(session_id, current_user)
 
@@ -157,6 +159,7 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
 async def chat_suggestions(data: ChatRequest, current_user: str = Depends(get_current_user)):
     """직전 어시스턴트 답변과 논문 본문을 참고해 후속 질문 3개를 추천합니다. 채팅
     기록(chats 테이블)에는 남기지 않는 보조 UI(추천 질문 칩) 전용 엔드포인트입니다."""
+    enforce_rate_limit("chat", current_user)
     session_id = data.session_id
     session = require_session_owner(session_id, current_user)
 
@@ -190,6 +193,7 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
     """여러 논문을 함께 컨텍스트로 제공해, 논문 간 비교/종합 질문에 답하는
     스트리밍 채팅입니다.
     """
+    enforce_rate_limit("chat", current_user)
     doc_ids = _dedupe_preserve_order(data.doc_ids)
     if len(doc_ids) < MIN_COMPARE_DOCS or len(doc_ids) > MAX_COMPARE_DOCS:
         raise HTTPException(

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -11,6 +11,7 @@ from services.llm_client import stream_translation, check_ollama_health
 from services.cache import get_cached_translation, save_translation_cache, get_cached_translation_full
 from services.library import save_translation as lib_save_translation, get_translation as lib_get_translation, get_translation_full as lib_get_translation_full, clear_translations as lib_clear_translations
 from services.pdf_parser import render_page_image_base64
+from services.rate_limiter import enforce_rate_limit
 
 # 수식(LaTeX) 번역 정확도를 위해 페이지 이미지를 함께 첨부할 수 있는 provider
 # (translation_job.py의 배치 번역 잡과 동일한 기준).
@@ -34,6 +35,7 @@ async def translate_page(
     특정 페이지를 번역하고 SSE 스트리밍으로 반환합니다.
     이미 동일한 옵션으로 번역된 페이지는 캐시에서 즉시 반환합니다.
     """
+    enforce_rate_limit("translate", current_user)
     session = require_session_owner(session_id, current_user)
     total_pages = session["total_pages"]
 
@@ -305,4 +307,3 @@ async def clear_translation_cache(session_id: str, current_user: str = Depends(g
             pass
             
     return {"message": "번역 캐시와 잡이 성공적으로 초기화되었습니다."}
-

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -13,6 +13,7 @@ from services.library import save_document, get_document, get_pdf_path as lib_pd
 from services.translation_job import start_job, resume_incomplete_jobs, get_job_status
 from services.insight_job import start_keyword_job, start_summary_job
 from services.primer import generate_primer
+from services.rate_limiter import enforce_rate_limit
 from models.schemas import UploadResponse
 
 router = APIRouter()
@@ -113,6 +114,8 @@ async def upload_pdf(
     current_user: str = Depends(get_current_user)
 ):
     """PDF 파일을 업로드하고 텍스트를 추출합니다."""
+    enforce_rate_limit("upload", current_user)
+
     # 파일 검증
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="PDF 파일만 업로드 가능합니다.")

--- a/backend/services/rate_limiter.py
+++ b/backend/services/rate_limiter.py
@@ -1,0 +1,72 @@
+"""인증 사용자별 고비용 API 슬라이딩 윈도우 레이트리밋."""
+
+import math
+import os
+import threading
+import time
+from collections import defaultdict, deque
+from typing import Callable, Dict, Tuple
+
+from fastapi import HTTPException, status
+
+
+RatePolicy = Tuple[int, float]
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+DEFAULT_RATE_POLICIES: Dict[str, RatePolicy] = {
+    "chat": (_positive_int_env("CHAT_RATE_LIMIT_REQUESTS", 30), 60.0),
+    "translate": (_positive_int_env("TRANSLATE_RATE_LIMIT_REQUESTS", 120), 60.0),
+    "upload": (_positive_int_env("UPLOAD_RATE_LIMIT_REQUESTS", 10), 3600.0),
+}
+
+
+class SlidingWindowRateLimiter:
+    def __init__(
+        self,
+        policies: Dict[str, RatePolicy],
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._policies = policies
+        self._clock = clock
+        self._requests = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(self, scope: str, identity: str) -> None:
+        limit, window_seconds = self._policies[scope]
+        now = self._clock()
+        cutoff = now - window_seconds
+        key = (scope, identity)
+
+        with self._lock:
+            timestamps = self._requests[key]
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
+
+            if len(timestamps) >= limit:
+                retry_after = max(1, math.ceil(timestamps[0] + window_seconds - now))
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            timestamps.append(now)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._requests.clear()
+
+
+request_rate_limiter = SlidingWindowRateLimiter(DEFAULT_RATE_POLICIES)
+
+
+def enforce_rate_limit(scope: str, username: str) -> None:
+    request_rate_limiter.check(scope, username)

--- a/backend/services/rate_limiter.py
+++ b/backend/services/rate_limiter.py
@@ -38,6 +38,20 @@ class SlidingWindowRateLimiter:
         self._clock = clock
         self._requests = defaultdict(deque)
         self._lock = threading.Lock()
+        self._cleanup_interval = min(window for _, window in policies.values())
+        self._next_cleanup_at = 0.0
+
+    def _evict_stale_identities(self, now: float) -> None:
+        if now < self._next_cleanup_at:
+            return
+        for key, timestamps in list(self._requests.items()):
+            _, window_seconds = self._policies[key[0]]
+            cutoff = now - window_seconds
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
+            if not timestamps:
+                del self._requests[key]
+        self._next_cleanup_at = now + self._cleanup_interval
 
     def check(self, scope: str, identity: str) -> None:
         limit, window_seconds = self._policies[scope]
@@ -46,6 +60,7 @@ class SlidingWindowRateLimiter:
         key = (scope, identity)
 
         with self._lock:
+            self._evict_stale_identities(now)
             timestamps = self._requests[key]
             while timestamps and timestamps[0] <= cutoff:
                 timestamps.popleft()

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import HTTPException
+
+from services.rate_limiter import SlidingWindowRateLimiter
+
+
+def test_sliding_window_rate_limiter_returns_retry_after_and_isolates_users():
+    now = [100.0]
+    limiter = SlidingWindowRateLimiter({"chat": (2, 10.0)}, clock=lambda: now[0])
+
+    limiter.check("chat", "alice")
+    limiter.check("chat", "alice")
+    limiter.check("chat", "bob")
+
+    with pytest.raises(HTTPException) as exc_info:
+        limiter.check("chat", "alice")
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers == {"Retry-After": "10"}
+
+    now[0] = 110.0
+    limiter.check("chat", "alice")
+
+
+def test_upload_endpoint_enforces_configured_limit(test_client, monkeypatch):
+    import services.rate_limiter as rate_limiter
+
+    limiter = SlidingWindowRateLimiter({"upload": (1, 60.0)})
+    monkeypatch.setattr(rate_limiter, "request_rate_limiter", limiter)
+
+    first = test_client.post(
+        "/api/upload",
+        files={"file": ("invalid.txt", b"not a pdf", "text/plain")},
+    )
+    second = test_client.post(
+        "/api/upload",
+        files={"file": ("invalid.txt", b"not a pdf", "text/plain")},
+    )
+
+    assert first.status_code == 400
+    assert second.status_code == 429
+    assert second.headers["Retry-After"] == "60"

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -22,6 +22,20 @@ def test_sliding_window_rate_limiter_returns_retry_after_and_isolates_users():
     limiter.check("chat", "alice")
 
 
+def test_sliding_window_rate_limiter_evicts_retired_identities():
+    now = [100.0]
+    limiter = SlidingWindowRateLimiter({"chat": (2, 10.0)}, clock=lambda: now[0])
+
+    limiter.check("chat", "old-name")
+    limiter.check("chat", "other-user")
+    assert len(limiter._requests) == 2
+
+    now[0] = 110.0
+    limiter.check("chat", "active-user")
+
+    assert set(limiter._requests) == {("chat", "active-user")}
+
+
 def test_upload_endpoint_enforces_configured_limit(test_client, monkeypatch):
     import services.rate_limiter as rate_limiter
 


### PR DESCRIPTION
# Summary
## 1. 고비용 API 레이트리밋 추가
- 사용자별 chat 30회/분, translate 120회/분, upload 10회/시간 제한을 적용함
- 제한 초과 시 429와 Retry-After를 반환함
## 2. 레이트리미터 메모리 정리
- 만료된 사용자별 윈도우를 주기적으로 제거해 stale identity 누적을 방지함