### PR TITLE
fix(api): require POST for CLI installs

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -588,7 +588,7 @@ async def ollama_status(current_user: str = Depends(get_current_user)):
     }
 
 
-@router.get("/settings/install-ollama")
+@router.post("/settings/install-ollama")
 async def install_ollama_stream(current_user: str = Depends(get_current_user)):
     """이 서버의 운영체제에 맞는 방법으로 Ollama를 설치하고 진행 상황을 스트리밍합니다.
     Linux는 공식 설치 스크립트, macOS는 Homebrew(있는 경우), Windows는 공식 설치
@@ -819,7 +819,7 @@ router.add_api_route(
         get_claude_code_path,
         "Claude Code CLI가 이미 설치되어 있습니다.",
     ),
-    methods=["GET"],
+    methods=["POST"],
 )
 
 router.add_api_route(
@@ -830,7 +830,7 @@ router.add_api_route(
         get_codex_path,
         "Codex CLI가 이미 설치되어 있습니다.",
     ),
-    methods=["GET"],
+    methods=["POST"],
 )
 
 
@@ -845,7 +845,7 @@ router.add_api_route(
         path_aliases=("agy",),
         exit_error_message="설치 스크립트가 오류 코드 {returncode}로 종료되었습니다.",
     ),
-    methods=["GET"],
+    methods=["POST"],
 )
 
 

--- a/backend/tests/test_install_endpoint_methods.py
+++ b/backend/tests/test_install_endpoint_methods.py
@@ -1,0 +1,14 @@
+from main import app
+
+
+def test_install_endpoints_only_allow_post():
+    expected = {
+        "/api/settings/install-ollama",
+        "/api/settings/install-claude-code",
+        "/api/settings/install-codex",
+        "/api/settings/install-antigravity",
+    }
+    routes = {route.path: route.methods for route in app.routes if route.path in expected}
+
+    assert routes.keys() == expected
+    assert all(methods == {"POST"} for methods in routes.values())

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -389,17 +389,16 @@ export async function getOllamaStatusAPI() {
  * CLI 엔진 설치 SSE 스트림을 구독하는 공통 헬퍼.
  */
 function _streamInstallCliAPI(endpoint, defaultErrorMessage, onProgress, onDone, onError) {
-  const eventSource = new EventSource(`${API_BASE}${endpoint}`)
-
-  eventSource.onmessage = (event) => {
+  const controller = new AbortController()
+  const handleMessage = (rawData) => {
     try {
-      const data = JSON.parse(event.data)
+      const data = JSON.parse(rawData)
       if (data.status === 'error') {
         onError(new Error(data.message || defaultErrorMessage))
-        eventSource.close()
+        controller.abort()
       } else if (data.status === 'success') {
         onDone()
-        eventSource.close()
+        controller.abort()
       } else {
         onProgress(data)
       }
@@ -408,12 +407,39 @@ function _streamInstallCliAPI(endpoint, defaultErrorMessage, onProgress, onDone,
     }
   }
 
-  eventSource.onerror = () => {
-    onError(new Error('네트워크 연결 끊김 또는 설치 실패'))
-    eventSource.close()
-  }
+  ;(async () => {
+    try {
+      const response = await fetch(`${API_BASE}${endpoint}`, {
+        method: 'POST',
+        signal: controller.signal,
+      })
+      if (!response.ok || !response.body) throw new Error(defaultErrorMessage)
 
-  return () => eventSource.close()
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      while (true) {
+        const { value, done } = await reader.read()
+        buffer += decoder.decode(value || new Uint8Array(), { stream: !done })
+        const events = buffer.split(/\r?\n\r?\n/)
+        buffer = events.pop() || ''
+        for (const event of events) {
+          const data = event.split(/\r?\n/)
+            .filter(line => line.startsWith('data:'))
+            .map(line => line.slice(5).trimStart())
+            .join('\n')
+          if (data) handleMessage(data)
+        }
+        if (done) break
+      }
+    } catch (err) {
+      if (err?.name !== 'AbortError') {
+        onError(err instanceof Error ? err : new Error('네트워크 연결 끊김 또는 설치 실패'))
+      }
+    }
+  })()
+
+  return () => controller.abort()
 }
 
 /**

--- a/frontend/tests/api-install-stream.test.js
+++ b/frontend/tests/api-install-stream.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { streamInstallOllamaAPI } from '../src/api.js'
+
+test('CLI install stream uses POST and parses SSE events', async () => {
+  const requests = []
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options })
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          'data: {"status":"progress","line":"installing"}\n\n' +
+          'data: {"status":"success"}\n\n'
+        ))
+        controller.close()
+      },
+    })
+    return new Response(body, { status: 200 })
+  }
+
+  const progress = []
+  await new Promise((resolve, reject) => {
+    streamInstallOllamaAPI(data => progress.push(data.line), resolve, reject)
+  })
+
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].url, '/api/settings/install-ollama')
+  assert.equal(requests[0].options.method, 'POST')
+  assert.deepEqual(progress, ['installing'])
+})


### PR DESCRIPTION
# Summary
## 1. CLI 설치 엔드포인트 CSRF 방어
- Ollama·Claude Code·Codex·Antigravity 설치 라우트를 GET에서 POST로 전환함
## 2. POST 기반 SSE 클라이언트 적용
- EventSource 대신 fetch stream parser를 사용해 POST 응답을 처리함
- 공통 설치 팩토리와 네 라우트의 POST 계약 테스트를 추가함