### PR TITLE
fix(auth): restrict system updates

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,6 +13,7 @@ from services.auth import (
     get_login_lockout_remaining,
     record_failed_login,
     reset_login_attempts,
+    require_admin_user,
 )
 from config import (
     get_app_username,
@@ -999,7 +1000,7 @@ async def _restart_server_process(project_dir: str):
 
 
 @router.post("/settings/update")
-async def system_update(current_user: str = Depends(get_current_user)):
+async def system_update(current_user: str = Depends(require_admin_user)):
     """깃허브 최신 커밋을 풀(pull) 받고, 프론트엔드를 빌드한 뒤 서버를 재기동합니다."""
     import subprocess
     import asyncio

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import os
 import time
-from fastapi import Request, HTTPException, status
+from fastapi import Depends, Request, HTTPException, status
 from config import get_app_password, get_app_username, get_skip_login, SECRET_KEY
 
 def verify_password(stored_password_hash: str, provided_password: str) -> bool:
@@ -121,3 +121,11 @@ async def get_current_user(request: Request) -> str:
             detail="로그인이 필요합니다.",
         )
     return token.split(':')[0]
+
+
+async def require_admin_user(current_user: str = Depends(get_current_user)) -> str:
+    """현재 단일 관리자 계정과 일치하는 인증 사용자만 반환합니다."""
+    configured_admin = get_app_username()
+    if not hmac.compare_digest(current_user.encode("utf-8"), configured_admin.encode("utf-8")):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="관리자 권한이 필요합니다.")
+    return current_user

--- a/backend/tests/test_system_update.py
+++ b/backend/tests/test_system_update.py
@@ -20,6 +20,12 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import config
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def configured_admin_matches_test_user(monkeypatch):
+    monkeypatch.setattr("services.auth.get_app_username", lambda: "testuser")
 
 
 def _make_subprocess_mock(returncode=0, stdout=b"", stderr=b""):
@@ -48,6 +54,15 @@ def test_system_update_runs_git_pull_in_actual_project_root(test_client):
     assert git_call["cwd"] == config.get_project_root()
     # 회귀 확인: cwd가 backend/backend나 backend/frontend처럼 backend가 중첩되면 안 된다
     assert not git_call["cwd"].rstrip(os.sep).endswith(f"backend{os.sep}backend")
+
+
+def test_system_update_rejects_non_admin_user(test_client, monkeypatch):
+    monkeypatch.setattr("services.auth.get_app_username", lambda: "admin")
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock()) as subprocess_mock:
+        res = test_client.post("/api/settings/update")
+    assert res.status_code == 403
+    assert res.json()["detail"] == "관리자 권한이 필요합니다."
+    subprocess_mock.assert_not_awaited()
 
 
 def test_system_update_builds_frontend_in_actual_frontend_dir_when_pull_has_changes(test_client):


### PR DESCRIPTION
# Summary
## 1. 시스템 업데이트 관리자 제한
- 현재 설정된 관리자 계정과 일치하는 세션만 업데이트 확인·실행 엔드포인트를 호출하도록 제한함
- 일반 인증 사용자 요청에 403을 반환하는 회귀 테스트를 추가함