### PR TITLE
fix(llm): protect Gemini API credentials

### DIFF
--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -426,6 +426,10 @@ async def stream_translation(
         raise RuntimeError(f"Ollama HTTP 오류: {e.response.status_code}")
 
 
+class _ProviderResponseError(RuntimeError):
+    pass
+
+
 async def _ensure_provider_response_ok(
     response: httpx.Response, provider: str, include_body: bool = True
 ) -> None:
@@ -434,7 +438,7 @@ async def _ensure_provider_response_ok(
         return
     body = await response.aread()
     detail = f": {body.decode()[:200]}" if include_body else ""
-    raise RuntimeError(f"{provider} API 오류 (HTTP {response.status_code}){detail}")
+    raise _ProviderResponseError(f"{provider} API 오류 (HTTP {response.status_code}){detail}")
 
 
 def _raise_provider_transport_error(provider: str, exc: Exception) -> None:
@@ -606,7 +610,7 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
 
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         _raise_provider_transport_error("Gemini", exc)
-    except RuntimeError:
+    except _ProviderResponseError:
         raise
     except Exception:
         raise RuntimeError("Gemini 요청 처리 중 오류가 발생했습니다.")

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -615,8 +615,6 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
         raise RuntimeError("Gemini 서버에 연결할 수 없습니다.")
     except httpx.TimeoutException:
         raise RuntimeError("Gemini 요청 시간이 초과되었습니다.")
-    except RuntimeError:
-        raise
     except Exception:
         raise RuntimeError("Gemini 요청 처리 중 오류가 발생했습니다.")
 >>>>>>> f151740 (fix(llm): protect Gemini API key)

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -497,7 +497,8 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
         raise RuntimeError("Gemini API Key가 설정되지 않았습니다. 설정에서 입력해 주세요.")
 
     headers = {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "x-goog-api-key": api_key,
     }
 
     gemini_contents = []
@@ -531,7 +532,7 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
     if system_instruction:
         payload["systemInstruction"] = system_instruction
         
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent?key={api_key}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent"
     
     try:
         async with httpx.AsyncClient(timeout=360.0) as client:
@@ -541,7 +542,13 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
                 headers=headers,
                 json=payload
             ) as response:
+<<<<<<< HEAD
                 await _ensure_provider_response_ok(response, "Gemini")
+=======
+                if response.status_code != 200:
+                    await response.aread()
+                    raise RuntimeError(f"Gemini API 오류 (HTTP {response.status_code})")
+>>>>>>> f151740 (fix(llm): protect Gemini API key)
 
                 # Gemini streamGenerateContent는 JSON 배열을 스트리밍함:
                 # [ {chunk1},\n {chunk2}, ... ]
@@ -600,8 +607,19 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
                         except json.JSONDecodeError:
                             continue
 
+<<<<<<< HEAD
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         _raise_provider_transport_error("Gemini", exc)
+=======
+    except httpx.ConnectError:
+        raise RuntimeError("Gemini 서버에 연결할 수 없습니다.")
+    except httpx.TimeoutException:
+        raise RuntimeError("Gemini 요청 시간이 초과되었습니다.")
+    except RuntimeError:
+        raise
+    except Exception:
+        raise RuntimeError("Gemini 요청 처리 중 오류가 발생했습니다.")
+>>>>>>> f151740 (fix(llm): protect Gemini API key)
 
 
 async def stream_claude(messages: list, model: str, temperature: float = 0.5) -> AsyncGenerator[str, None]:

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -426,12 +426,15 @@ async def stream_translation(
         raise RuntimeError(f"Ollama HTTP 오류: {e.response.status_code}")
 
 
-async def _ensure_provider_response_ok(response: httpx.Response, provider: str) -> None:
+async def _ensure_provider_response_ok(
+    response: httpx.Response, provider: str, include_body: bool = True
+) -> None:
     """원격 provider의 비정상 응답을 기존 RuntimeError 계약으로 변환한다."""
     if response.status_code == 200:
         return
     body = await response.aread()
-    raise RuntimeError(f"{provider} API 오류 (HTTP {response.status_code}): {body.decode()[:200]}")
+    detail = f": {body.decode()[:200]}" if include_body else ""
+    raise RuntimeError(f"{provider} API 오류 (HTTP {response.status_code}){detail}")
 
 
 def _raise_provider_transport_error(provider: str, exc: Exception) -> None:
@@ -542,13 +545,7 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
                 headers=headers,
                 json=payload
             ) as response:
-<<<<<<< HEAD
-                await _ensure_provider_response_ok(response, "Gemini")
-=======
-                if response.status_code != 200:
-                    await response.aread()
-                    raise RuntimeError(f"Gemini API 오류 (HTTP {response.status_code})")
->>>>>>> f151740 (fix(llm): protect Gemini API key)
+                await _ensure_provider_response_ok(response, "Gemini", include_body=False)
 
                 # Gemini streamGenerateContent는 JSON 배열을 스트리밍함:
                 # [ {chunk1},\n {chunk2}, ... ]
@@ -607,17 +604,12 @@ async def stream_gemini(messages: list, model: str, temperature: float = 0.5, im
                         except json.JSONDecodeError:
                             continue
 
-<<<<<<< HEAD
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         _raise_provider_transport_error("Gemini", exc)
-=======
-    except httpx.ConnectError:
-        raise RuntimeError("Gemini 서버에 연결할 수 없습니다.")
-    except httpx.TimeoutException:
-        raise RuntimeError("Gemini 요청 시간이 초과되었습니다.")
+    except RuntimeError:
+        raise
     except Exception:
         raise RuntimeError("Gemini 요청 처리 중 오류가 발생했습니다.")
->>>>>>> f151740 (fix(llm): protect Gemini API key)
 
 
 async def stream_claude(messages: list, model: str, temperature: float = 0.5) -> AsyncGenerator[str, None]:

--- a/backend/tests/test_gemini_security.py
+++ b/backend/tests/test_gemini_security.py
@@ -28,7 +28,7 @@ async def test_gemini_uses_header_for_api_key(monkeypatch):
 async def test_gemini_redacts_unexpected_exception(monkeypatch):
     class FailingClient:
         async def __aenter__(self):
-            raise ValueError("secret-key https://example.test/?key=secret-key")
+            raise RuntimeError("secret-key https://example.test/?key=secret-key")
         async def __aexit__(self, *args):
             return False
     monkeypatch.setattr(llm_client, "get_gemini_api_key", lambda: "secret-key")

--- a/backend/tests/test_gemini_security.py
+++ b/backend/tests/test_gemini_security.py
@@ -1,0 +1,39 @@
+import httpx
+import pytest
+
+from services import llm_client
+
+
+async def _collect(generator):
+    return [token async for token in generator]
+
+
+@pytest.mark.asyncio
+async def test_gemini_uses_header_for_api_key(monkeypatch):
+    seen = None
+    def handler(request):
+        nonlocal seen
+        seen = request
+        return httpx.Response(200, content=b'[{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}]')
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+    monkeypatch.setattr(llm_client, "get_gemini_api_key", lambda: "secret-key")
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", lambda **kw: real_client(transport=transport, **kw))
+    assert await _collect(llm_client.stream_gemini([{"role": "user", "content": "hello"}], "gemini-test")) == ["ok"]
+    assert seen.url.query == b""
+    assert seen.headers["x-goog-api-key"] == "secret-key"
+
+
+@pytest.mark.asyncio
+async def test_gemini_redacts_unexpected_exception(monkeypatch):
+    class FailingClient:
+        async def __aenter__(self):
+            raise ValueError("secret-key https://example.test/?key=secret-key")
+        async def __aexit__(self, *args):
+            return False
+    monkeypatch.setattr(llm_client, "get_gemini_api_key", lambda: "secret-key")
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", lambda **kw: FailingClient())
+    with pytest.raises(RuntimeError) as exc:
+        await _collect(llm_client.stream_gemini([{"role": "user", "content": "hello"}], "gemini-test"))
+    assert str(exc.value) == "Gemini 요청 처리 중 오류가 발생했습니다."
+    assert "secret-key" not in str(exc.value)


### PR DESCRIPTION
# Summary
## 1. Gemini API 키 전송 방식 보호
- API 키를 URL query에서 제거하고 x-goog-api-key header로 전송함
## 2. Gemini 오류 정보 노출 차단
- HTTP 응답 본문과 예상치 못한 예외 원문을 사용자 메시지에서 제거함
- 공통 provider 오류 helper와 안전한 고정 메시지 계약을 함께 유지함