### PR TITLE
fix(ci): pin Tauri Linux release runner

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -30,7 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # AppImage linuxdeploy가 ubuntu-latest에서 반복 실패하므로 Tauri의
+          # 공식 tauri-action 릴리스 예시와 동일하게 22.04에 고정한다.
+          - os: ubuntu-22.04
             name: linux
           - os: windows-latest
             name: windows


### PR DESCRIPTION
# Summary
## 1. Linux AppImage 빌드 안정화
- ubuntu-latest에서 두 차례 반복 실패한 linuxdeploy 실행을 피하도록 Linux 릴리스 runner를 ubuntu-22.04로 고정함
- Tauri 공식 tauri-action 릴리스 예시와 동일한 runner 버전을 적용함