### PR TITLE
fix: cascade nested folder deletion

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -903,14 +903,35 @@ def db_update_folder(folder_id: str, username: str, **updates: Any) -> bool:
 
 def db_delete_folder(folder_id: str, username: str, delete_papers: bool = False) -> bool:
     with get_db() as conn:
-        # 삭제를 선택한 경우 이 폴더의 직접 포함 논문은 휴지통으로 보낸다.
+        rows = conn.execute(
+            """
+            WITH RECURSIVE folder_tree(id) AS (
+                SELECT id FROM folders WHERE id = ? AND username = ?
+                UNION ALL
+                SELECT child.id
+                FROM folders child
+                JOIN folder_tree parent ON child.parent_id = parent.id
+                WHERE child.username = ?
+            )
+            SELECT id FROM folder_tree
+            """,
+            (folder_id, username, username),
+        ).fetchall()
+        folder_ids = [row["id"] for row in rows]
+        if not folder_ids:
+            return False
+
+        placeholders = ",".join("?" for _ in folder_ids)
+        # 삭제를 선택한 경우 하위 폴더를 포함한 트리 전체의 논문을 휴지통으로 보낸다.
         if delete_papers:
-            conn.execute("UPDATE documents SET is_deleted = 1 WHERE username = ? AND id IN (SELECT doc_id FROM document_folders WHERE folder_id = ?)", (username, folder_id))
-        conn.execute("UPDATE folders SET parent_id = NULL WHERE parent_id = ? AND username = ?", (folder_id, username))
-        conn.execute("UPDATE document_folders SET folder_id = NULL WHERE folder_id = ?", (folder_id,))
-        cursor = conn.execute("DELETE FROM folders WHERE id = ? AND username = ?", (folder_id, username))
+            conn.execute(
+                f"UPDATE documents SET is_deleted = 1 WHERE username = ? AND id IN (SELECT doc_id FROM document_folders WHERE folder_id IN ({placeholders}))",
+                (username, *folder_ids),
+            )
+        conn.execute(f"UPDATE document_folders SET folder_id = NULL WHERE folder_id IN ({placeholders})", folder_ids)
+        conn.execute(f"DELETE FROM folders WHERE username = ? AND id IN ({placeholders})", (username, *folder_ids))
         conn.commit()
-        return cursor.rowcount == 1
+        return True
 
 def db_get_document_folder_map(username: str) -> Dict[str, Optional[str]]:
     with get_db() as conn:

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -137,6 +137,41 @@ def test_app_meta_get_set_round_trip(isolated_dirs):
     assert db.db_get_meta("some_key") == "value2"
 
 
+def test_delete_folder_removes_nested_folders_and_keeps_their_documents(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_create_folder("parent", "admin", "Parent", None, "#64748b")
+    db.db_create_folder("child", "admin", "Child", "parent", "#64748b")
+    db.db_create_folder("grandchild", "admin", "Grandchild", "child", "#64748b")
+    db.db_create_folder("sibling", "admin", "Sibling", None, "#64748b")
+    db.db_save_document("nested-doc", "admin", "nested.pdf", "/x", 1, {})
+    db.db_move_documents_to_folder(["nested-doc"], "admin", "grandchild")
+
+    assert db.db_delete_folder("parent", "admin", delete_papers=False) is True
+
+    assert {folder["id"] for folder in db.db_list_folders("admin")} == {"sibling"}
+    assert db.db_get_document_folder_map("admin")["nested-doc"] is None
+    assert {doc["id"] for doc in db.db_list_documents("admin")} == {"nested-doc"}
+
+
+def test_delete_folder_trashes_documents_in_nested_folders(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_create_folder("parent", "admin", "Parent", None, "#64748b")
+    db.db_create_folder("child", "admin", "Child", "parent", "#64748b")
+    db.db_save_document("parent-doc", "admin", "parent.pdf", "/x", 1, {})
+    db.db_save_document("child-doc", "admin", "child.pdf", "/x", 1, {})
+    db.db_move_documents_to_folder(["parent-doc"], "admin", "parent")
+    db.db_move_documents_to_folder(["child-doc"], "admin", "child")
+
+    assert db.db_delete_folder("parent", "admin", delete_papers=True) is True
+
+    assert db.db_list_folders("admin") == []
+    assert db.db_list_documents("admin") == []
+    assert {doc["id"] for doc in db.db_list_documents("admin", only_trash=True)} == {
+        "parent-doc",
+        "child-doc",
+    }
+
+
 def test_bulk_translation_rows_groups_by_doc_id(isolated_dirs):
     """list_documents()의 N+1 쿼리를 대체하는 벌크 조회 함수 - 문서마다 새
     커넥션을 여는 대신 한 번의 커넥션으로 여러 문서의 번역 행을 모아온다."""

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5442,7 +5442,7 @@ function showFolderContentsDeleteDialog(paperCount) {
   return new Promise(resolve => {
     const modal = document.createElement('div')
     modal.className = 'custom-confirm-modal-wrapper'
-    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">폴더 안 논문 처리</span></div><div class="custom-confirm-modal-body">이 폴더에 논문 ${paperCount}개가 있습니다.<br>폴더 삭제 후 논문을 어떻게 처리할까요?</div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button><button class="custom-confirm-btn keep-btn">루트에 유지</button><button class="custom-confirm-btn confirm-btn">함께 휴지통으로 이동</button></div></div>`
+    modal.innerHTML = `<div class="custom-confirm-modal"><div class="custom-confirm-modal-header"><span class="custom-confirm-modal-title">폴더 안 논문 처리</span></div><div class="custom-confirm-modal-body">이 폴더와 하위 폴더에 논문 ${paperCount}개가 있습니다.<br>폴더 트리 삭제 후 논문을 어떻게 처리할까요?</div><div class="custom-confirm-modal-footer"><button class="custom-confirm-btn cancel-btn">취소</button><button class="custom-confirm-btn keep-btn">루트에 유지</button><button class="custom-confirm-btn confirm-btn">함께 휴지통으로 이동</button></div></div>`
     document.body.appendChild(modal)
     const close = value => { modal.classList.remove('active'); setTimeout(() => { modal.remove(); resolve(value) }, 200) }
     modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
@@ -5464,8 +5464,12 @@ async function requestRenameFolder(folder) {
   if (name && name !== folder.name) { await updateFolderWithUndo(folder, { name }); await renderLibrary() }
 }
 async function requestDeleteFolder(folder) {
-  const paperCount = currentLibraryDocs.filter(doc => doc.folder_id === folder.id).length
-  const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${paperCount ? '' : '\n비어 있는 폴더이며 논문에는 영향이 없습니다.'}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
+  const folderIds = folderDescendants(folder.id)
+  const childFolderCount = folderIds.size - 1
+  const paperCount = currentLibraryDocs.filter(doc => folderIds.has(doc.folder_id)).length
+  const childFolderNotice = childFolderCount > 0 ? `\n하위 폴더 ${childFolderCount}개도 함께 삭제됩니다.` : ''
+  const paperNotice = paperCount ? '' : '\n포함된 논문은 없으며 논문에는 영향이 없습니다.'
+  const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${childFolderNotice}${paperNotice}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
   if (!ok) return
   let deletePapers = false
   if (paperCount > 0) {


### PR DESCRIPTION
# Summary
## 1. 중첩 폴더 삭제 수정
- 상위 폴더 삭제 시 모든 하위 폴더를 재귀적으로 함께 삭제하도록 수정함
- 하위 폴더에 포함된 논문까지 삭제 대상 감지 및 처리하도록 수정함
## 2. 회귀 방지
- 중첩 폴더 및 하위 논문 삭제 시나리오에 대한 DB 서비스 테스트를 추가함