### PR TITLE
fix: harden library folder workflows

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -342,6 +342,18 @@ def init_db():
         """)
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_folders_user_parent ON folders(username, parent_id, sort_order)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_folders_folder ON document_folders(folder_id)")
+        # foreign_keys 설정이 꺼진 기존 설치에서 영구 삭제된 논문이나 폴더를
+        # 가리키는 매핑이 남을 수 있으므로 시작 시 기존 데이터도 정리한다.
+        cursor.execute("DELETE FROM document_folders WHERE doc_id NOT IN (SELECT id FROM documents)")
+        cursor.execute(
+            "UPDATE document_folders SET folder_id = NULL "
+            "WHERE folder_id IS NOT NULL AND folder_id NOT IN (SELECT id FROM folders)"
+        )
+        cursor.execute(
+            "UPDATE folders AS child SET parent_id = NULL WHERE parent_id IS NOT NULL "
+            "AND NOT EXISTS (SELECT 1 FROM folders AS parent "
+            "WHERE parent.id = child.parent_id AND parent.username = child.username)"
+        )
 
         conn.commit()
 
@@ -564,6 +576,7 @@ def db_delete_document(doc_id: str) -> bool:
         if not cursor.fetchone():
             return False
         cursor.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+        cursor.execute("DELETE FROM document_folders WHERE doc_id = ?", (doc_id,))
         conn.commit()
         return True
 

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -172,6 +172,21 @@ def test_delete_folder_trashes_documents_in_nested_folders(isolated_dirs):
     }
 
 
+def test_permanent_document_delete_removes_folder_mapping(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_create_folder("folder", "admin", "Folder", None, "#64748b")
+    db.db_save_document("doc", "admin", "paper.pdf", "/x", 1, {})
+    db.db_move_documents_to_folder(["doc"], "admin", "folder")
+
+    assert db.db_delete_document("doc") is True
+
+    with db.get_db() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM document_folders WHERE doc_id = ?",
+            ("doc",),
+        ).fetchone()[0] == 0
+
+
 def test_bulk_translation_rows_groups_by_doc_id(isolated_dirs):
     """list_documents()의 N+1 쿼리를 대체하는 벌크 조회 함수 - 문서마다 새
     커넥션을 여는 대신 한 번의 커넥션으로 여러 문서의 번역 행을 모아온다."""

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -539,7 +539,8 @@ if (libraryScreen) {
 }
 fileInput.addEventListener('change', (e) => {
   if (e.target.files && e.target.files.length > 0) {
-    handleFiles(e.target.files)
+    const targetFolderId = state.currentWorkspacePage === 'library' ? activeLibraryFolderId : null
+    handleFiles(e.target.files, targetFolderId)
   }
 })
 
@@ -4449,7 +4450,8 @@ let activeCategoryFilter = 'ALL'
 const selectedDocIds = new Set()
 
 function getVisibleDocIds() {
-  return currentLibraryDocs.map(d => d.id)
+  if (!libraryGrid) return []
+  return Array.from(libraryGrid.querySelectorAll('.doc-card[data-id], .doc-list-row[data-id]'), el => el.dataset.id)
 }
 
 function toggleDocSelection(docId) {
@@ -5146,10 +5148,14 @@ document.addEventListener('keydown', async e => {
   } else if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
     e.preventDefault()
     await undoLastLibraryAction()
-  } else if (mod && ['c', 'x'].includes(e.key.toLowerCase()) && selectedDocIds.size) {
+  } else if (mod && e.key.toLowerCase() === 'x' && selectedDocIds.size) {
     e.preventDefault()
-    libraryClipboard = { kind: 'documents', mode: e.key.toLowerCase() === 'x' ? 'cut' : 'copy', ids: Array.from(selectedDocIds) }
-    showToast(`${selectedDocIds.size}개 논문을 ${libraryClipboard.mode === 'cut' ? '잘라냈습니다' : '복사했습니다'}.`, 'info')
+    libraryClipboard = { kind: 'documents', mode: 'cut', ids: Array.from(selectedDocIds) }
+    showToast(`${selectedDocIds.size}개 논문을 잘라냈습니다.`, 'info')
+  } else if (mod && e.key.toLowerCase() === 'c' && selectedDocIds.size) {
+    e.preventDefault()
+    libraryClipboard = null
+    showToast('논문은 한 폴더에만 둘 수 있습니다. 이동하려면 Ctrl/Cmd+X를 사용하세요.', 'info')
   } else if (mod && e.key.toLowerCase() === 'x' && focusedFolder) {
     e.preventDefault()
     libraryClipboard = { kind: 'folder', mode: 'cut', id: focusedFolder.id }
@@ -5157,6 +5163,7 @@ document.addEventListener('keydown', async e => {
   } else if (mod && e.key.toLowerCase() === 'v' && libraryClipboard) {
     e.preventDefault()
     try {
+      if (libraryClipboard.mode === 'copy') throw new Error('논문 복사는 지원되지 않습니다. 이동하려면 잘라내기를 사용하세요.')
       if (libraryClipboard.kind === 'folder') {
         const folder = libraryFolders.find(candidate => candidate.id === libraryClipboard.id)
         if (!folder) throw new Error('잘라낸 폴더를 찾을 수 없습니다.')
@@ -5305,6 +5312,24 @@ function pushLibraryUndo(action) {
   libraryUndoStack.push(action)
   if (libraryUndoStack.length > 30) libraryUndoStack.shift()
 }
+
+function discardUndoActionsForDeletedItems(folderIds, paperIds) {
+  for (let index = libraryUndoStack.length - 1; index >= 0; index--) {
+    const action = libraryUndoStack[index]
+    if (action.kind === 'documents') {
+      action.entries = action.entries.filter(entry => (
+        !paperIds.has(entry.id) && !folderIds.has(entry.folderId)
+      ))
+      if (action.entries.length === 0) libraryUndoStack.splice(index, 1)
+    } else if (
+      (action.kind === 'folderMove' && (folderIds.has(action.id) || folderIds.has(action.parentId))) ||
+      (action.kind === 'folderUpdate' && folderIds.has(action.id))
+    ) {
+      libraryUndoStack.splice(index, 1)
+    }
+  }
+}
+
 async function moveDocumentsWithUndo(docIds, folderId) {
   const entries = docIds.map(id => ({ id, folderId: currentLibraryDocs.find(doc => doc.id === id)?.folder_id || null }))
   await moveLibraryDocuments(docIds, folderId)
@@ -5335,8 +5360,13 @@ async function undoLastLibraryAction() {
     showToast('마지막 작업을 되돌렸습니다.', 'success')
     await renderLibrary()
   } catch (err) {
-    libraryUndoStack.push(action)
-    showToast(err.message || '실행 취소 실패', 'error')
+    const message = err.message || '실행 취소 실패'
+    if (/찾을 수 없습니다/.test(message)) {
+      showToast('삭제된 항목을 참조하는 실행 취소 기록을 건너뛰었습니다.', 'warning')
+    } else {
+      libraryUndoStack.push(action)
+      showToast(message, 'error')
+    }
   }
 }
 
@@ -5394,6 +5424,7 @@ function showCustomTextDialog({ title, label, value = '', confirmText = '확인'
 function navigateLibraryFolder(folderId, { pushHistory = true } = {}) {
   const nextFolderId = folderId || null
   if (nextFolderId === activeLibraryFolderId && activeCategoryFilter === 'ALL') return
+  clearDocSelection()
   activeLibraryFolderId = nextFolderId
   activeCategoryFilter = 'ALL'
   if (pushHistory) {
@@ -5465,8 +5496,9 @@ async function requestRenameFolder(folder) {
 }
 async function requestDeleteFolder(folder) {
   const folderIds = folderDescendants(folder.id)
+  const papersInTree = currentLibraryDocs.filter(doc => folderIds.has(doc.folder_id))
   const childFolderCount = folderIds.size - 1
-  const paperCount = currentLibraryDocs.filter(doc => folderIds.has(doc.folder_id)).length
+  const paperCount = papersInTree.length
   const childFolderNotice = childFolderCount > 0 ? `\n하위 폴더 ${childFolderCount}개도 함께 삭제됩니다.` : ''
   const paperNotice = paperCount ? '' : '\n포함된 논문은 없으며 논문에는 영향이 없습니다.'
   const ok = await showCustomConfirm(`“${folder.name}” 폴더를 삭제할까요?${childFolderNotice}${paperNotice}`, { title: '폴더 삭제', confirmText: '삭제', danger: true })
@@ -5478,6 +5510,7 @@ async function requestDeleteFolder(folder) {
     deletePapers = choice
   }
   await deleteLibraryFolder(folder.id, deletePapers)
+  discardUndoActionsForDeletedItems(folderIds, deletePapers ? new Set(papersInTree.map(doc => doc.id)) : new Set())
   await renderLibrary()
 }
 
@@ -5582,7 +5615,12 @@ async function renderLibrary() {
     if (state.currentLibraryTab !== 'trash') {
       const foldersData = await fetchLibraryFolders()
       libraryFolders = foldersData.folders || []
-      if (activeLibraryFolderId && !libraryFolders.some(f => f.id === activeLibraryFolderId)) activeLibraryFolderId = null
+      if (activeLibraryFolderId && !libraryFolders.some(f => f.id === activeLibraryFolderId)) {
+        activeLibraryFolderId = null
+        if (history.state?.screen === 'library' && history.state?.page === 'library') {
+          history.replaceState({ ...history.state, libraryFolderId: null }, '', location.href)
+        }
+      }
       renderFolderNavigation(allDocs)
     }
 
@@ -14736,9 +14774,16 @@ window.addEventListener('popstate', (e) => {
   const isLibraryHistory = e.state?.screen === 'library' && e.state?.page === 'library'
   const isLegacyLibraryRoot = !e.state && location.hash === '#library'
   if (isLibraryHistory || isLegacyLibraryRoot) {
-    activeLibraryFolderId = e.state?.libraryFolderId || null
+    const requestedFolderId = e.state?.libraryFolderId || null
+    const canValidateFolder = state.currentWorkspacePage === 'library'
+    const folderExists = !requestedFolderId || !canValidateFolder || libraryFolders.some(folder => folder.id === requestedFolderId)
+    activeLibraryFolderId = folderExists ? requestedFolderId : null
+    if (requestedFolderId && !folderExists) {
+      history.replaceState({ ...(e.state || {}), screen: 'library', page: 'library', libraryFolderId: null }, '', location.href)
+    }
     activeCategoryFilter = 'ALL'
-    if (state.currentWorkspacePage === 'library' && currentLibraryDocs.length) {
+    clearDocSelection()
+    if (state.currentWorkspacePage === 'library') {
       filterLibraryCards(currentLibraryDocs)
       renderFolderNavigation(currentLibraryDocs)
     }


### PR DESCRIPTION
# Summary
## 1. 폴더 탐색 및 선택 상태 수정
- 현재 디렉토리에 표시된 논문만 전체 선택하도록 범위를 수정함
- 폴더 이동 및 브라우저 탐색 시 다중 선택을 초기화하고 삭제된 경로를 루트로 복구하도록 수정함
## 2. 논문 이동·추가·단축키 동작 수정
- 현재 폴더에서 추가한 논문이 해당 폴더에 저장되도록 수정함
- 복사 단축키가 단일 폴더 데이터 모델에서 논문을 예기치 않게 이동시키지 않도록 수정함
- 삭제된 폴더·논문을 참조하는 실행 취소 기록을 정리하도록 수정함
## 3. 폴더 연결 데이터 정합성 보강
- 고아 폴더 연결과 유효하지 않은 부모 폴더 참조를 초기화 시 정리하도록 수정함
- 논문 영구 삭제 시 폴더 연결 레코드도 제거하고 회귀 테스트를 추가함