### PR TITLE
feat: add library drag selection

### DIFF
--- a/frontend/src/library-selection.js
+++ b/frontend/src/library-selection.js
@@ -1,0 +1,36 @@
+export function createSelectionRect(startX, startY, endX, endY) {
+  const left = Math.min(startX, endX)
+  const top = Math.min(startY, endY)
+  const right = Math.max(startX, endX)
+  const bottom = Math.max(startY, endY)
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+  }
+}
+
+export function selectionRectsIntersect(first, second) {
+  return !(
+    first.right < second.left ||
+    first.left > second.right ||
+    first.bottom < second.top ||
+    first.top > second.bottom
+  )
+}
+
+export function resolveDragSelection(baseIds, items, selectionRect, toggle = false) {
+  const selected = toggle ? new Set(baseIds) : new Set()
+  for (const item of items) {
+    if (!selectionRectsIntersect(selectionRect, item.rect)) continue
+    if (toggle && selected.has(item.id)) {
+      selected.delete(item.id)
+    } else {
+      selected.add(item.id)
+    }
+  }
+  return selected
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -14,6 +14,7 @@ import { renderReadingHistoryPage } from './pages/readingHistoryPage.js'
 import { renderAiChatsPage } from './pages/aiChatsPage.js'
 import { renderNotesPage } from './pages/notesPage.js'
 import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
+import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
 
 
@@ -4487,6 +4488,14 @@ function clearDocSelection() {
   updateSelectToolbarUI()
 }
 
+function replaceDocSelection(nextIds) {
+  const affectedIds = new Set([...selectedDocIds, ...nextIds])
+  selectedDocIds.clear()
+  nextIds.forEach(id => selectedDocIds.add(id))
+  affectedIds.forEach(id => updateDocCardSelectionVisuals(id))
+  updateSelectToolbarUI()
+}
+
 function updateSelectToolbarUI() {
   const count = selectedDocIds.size
   const toolbar = $('lib-select-toolbar')
@@ -4606,7 +4615,106 @@ function initSelectToolbarEvents() {
   }
 }
 
+function initLibraryDragSelection() {
+  if (!libraryGrid) return
+  let dragState = null
+  let marquee = null
+
+  const removeMarquee = () => {
+    marquee?.remove()
+    marquee = null
+    document.body.classList.remove('library-marquee-selecting')
+  }
+
+  const finishDragSelection = (event, cancelled = false) => {
+    if (!dragState || event.pointerId !== dragState.pointerId) return
+    if (cancelled) replaceDocSelection(dragState.baseIds)
+    if (libraryGrid.hasPointerCapture?.(event.pointerId)) {
+      libraryGrid.releasePointerCapture(event.pointerId)
+    }
+    dragState = null
+    removeMarquee()
+  }
+
+  libraryGrid.addEventListener('pointerdown', event => {
+    if (
+      event.button !== 0 ||
+      event.isPrimary === false ||
+      (event.pointerType && event.pointerType !== 'mouse') ||
+      state.currentWorkspacePage !== 'library' ||
+      state.currentLibraryTab === 'trash' ||
+      event.target.closest('.doc-card, .doc-list-row, .library-folder-card, button, a, input, textarea, select')
+    ) return
+
+    const toggle = event.ctrlKey || event.metaKey
+    const baseIds = new Set(selectedDocIds)
+    if (!toggle) replaceDocSelection(new Set())
+    dragState = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      baseIds,
+      toggle,
+      active: false,
+    }
+    libraryGrid.setPointerCapture?.(event.pointerId)
+    event.preventDefault()
+  })
+
+  libraryGrid.addEventListener('pointermove', event => {
+    if (!dragState || event.pointerId !== dragState.pointerId) return
+    const distance = Math.hypot(event.clientX - dragState.startX, event.clientY - dragState.startY)
+    if (!dragState.active && distance < 4) return
+    if (!dragState.active) {
+      dragState.active = true
+      marquee = document.createElement('div')
+      marquee.className = 'library-selection-marquee'
+      marquee.setAttribute('aria-hidden', 'true')
+      document.body.appendChild(marquee)
+      document.body.classList.add('library-marquee-selecting')
+    }
+
+    const selectionRect = createSelectionRect(
+      dragState.startX,
+      dragState.startY,
+      event.clientX,
+      event.clientY,
+    )
+    Object.assign(marquee.style, {
+      left: `${selectionRect.left}px`,
+      top: `${selectionRect.top}px`,
+      width: `${selectionRect.width}px`,
+      height: `${selectionRect.height}px`,
+    })
+
+    const items = Array.from(
+      libraryGrid.querySelectorAll('.doc-card[data-id], .doc-list-row[data-id]'),
+      element => ({ id: element.dataset.id, rect: element.getBoundingClientRect() }),
+    )
+    replaceDocSelection(resolveDragSelection(
+      dragState.baseIds,
+      items,
+      selectionRect,
+      dragState.toggle,
+    ))
+    event.preventDefault()
+  })
+
+  libraryGrid.addEventListener('pointerup', event => finishDragSelection(event))
+  libraryGrid.addEventListener('pointercancel', event => finishDragSelection(event, true))
+  window.addEventListener('blur', () => {
+    if (!dragState) return
+    if (libraryGrid.hasPointerCapture?.(dragState.pointerId)) {
+      libraryGrid.releasePointerCapture(dragState.pointerId)
+    }
+    replaceDocSelection(dragState.baseIds)
+    dragState = null
+    removeMarquee()
+  })
+}
+
 initSelectToolbarEvents()
+initLibraryDragSelection()
 
 
 // ── 여러 논문 비교 채팅 화면 ────────────────────────────

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -581,6 +581,10 @@ body.light-theme .lib-detail-panel {
 .library-drag-stack-copy strong { font-size:13px; white-space:nowrap; }
 .library-drag-stack-copy small { color:var(--text-muted); font-size:10.5px; white-space:nowrap; }
 .library-drag-stack-count { display:grid; place-items:center; min-width:27px; height:27px; margin-left:auto; padding:0 7px; border-radius:999px; background:var(--control-accent); color:#fff; font-size:12px; font-weight:800; }
+.library-grid { cursor:crosshair; }
+.library-selection-marquee { position:fixed; z-index:99998; pointer-events:none; box-sizing:border-box; border:1px solid var(--control-accent); border-radius:5px; background:color-mix(in srgb, var(--control-accent) 14%, transparent); box-shadow:0 0 0 1px color-mix(in srgb, var(--control-accent) 18%, transparent); }
+body.library-marquee-selecting, body.library-marquee-selecting * { user-select:none!important; }
+body.library-marquee-selecting { cursor:crosshair!important; }
 
 .folder-color-picker{display:flex;gap:12px;padding:6px}.folder-color-picker .color-dot{width:28px;height:28px;border:2px solid transparent;border-radius:50%;cursor:pointer}.folder-color-picker .color-dot.selected{outline:2px solid var(--text-primary);outline-offset:3px}
 

--- a/frontend/tests/librarySelection.test.js
+++ b/frontend/tests/librarySelection.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createSelectionRect,
+  resolveDragSelection,
+  selectionRectsIntersect,
+} from '../src/library-selection.js'
+
+test('어느 방향으로 드래그해도 정규화된 선택 영역을 만든다', () => {
+  assert.deepEqual(createSelectionRect(80, 70, 20, 10), {
+    left: 20,
+    top: 10,
+    right: 80,
+    bottom: 70,
+    width: 60,
+    height: 60,
+  })
+})
+
+test('선택 사각형과 겹치는 논문만 선택한다', () => {
+  const selection = createSelectionRect(0, 0, 100, 100)
+  const items = [
+    { id: 'inside', rect: { left: 10, top: 10, right: 40, bottom: 40 } },
+    { id: 'edge', rect: { left: 100, top: 20, right: 130, bottom: 50 } },
+    { id: 'outside', rect: { left: 110, top: 110, right: 140, bottom: 140 } },
+  ]
+
+  assert.equal(selectionRectsIntersect(selection, items[0].rect), true)
+  assert.deepEqual([...resolveDragSelection([], items, selection)], ['inside', 'edge'])
+})
+
+test('Cmd/Ctrl 드래그는 기존 선택을 기준으로 겹친 항목을 토글한다', () => {
+  const selection = createSelectionRect(0, 0, 100, 100)
+  const items = [
+    { id: 'selected', rect: { left: 10, top: 10, right: 40, bottom: 40 } },
+    { id: 'added', rect: { left: 50, top: 50, right: 80, bottom: 80 } },
+    { id: 'untouched', rect: { left: 150, top: 150, right: 180, bottom: 180 } },
+  ]
+
+  const result = resolveDragSelection(
+    ['selected', 'untouched'],
+    items,
+    selection,
+    true,
+  )
+
+  assert.deepEqual([...result].sort(), ['added', 'untouched'])
+})


### PR DESCRIPTION
# Summary
## 1. 드래그 영역 선택 기능 추가
- 라이브러리 빈 영역에서 마우스 드래그로 여러 논문을 선택하는 기능을 추가함
- 그리드 및 리스트 레이아웃의 논문 항목을 선택 영역 교차 기준으로 처리함
## 2. 선택 조작 및 충돌 방지
- Ctrl/Cmd 조합 드래그로 기존 선택 항목을 토글하는 기능을 추가함
- 논문·폴더 드래그 앤 드롭 및 버튼 조작과 영역 선택이 충돌하지 않도록 처리함
- 포인터 취소와 창 포커스 이탈 시 기존 선택 상태를 복원하도록 처리함
## 3. 회귀 테스트 추가
- 역방향 선택 영역, 교차 판정, Ctrl/Cmd 토글 동작 단위 테스트를 추가함