### PR TITLE
fix: track AI chat time by interaction

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -698,8 +698,8 @@ async def delete_library_document(doc_id: str, current_user: str = Depends(get_c
 @router.post("/library/{doc_id}/reading-heartbeat")
 async def post_reading_heartbeat(doc_id: str, body: ReadingHeartbeatRequest, current_user: str = Depends(get_current_user)):
     """뷰어/비교 화면이 보이고 포커스된 동안 프론트가 주기적으로 보내는 경과
-    시간(초)을 누적합니다. category는 'reading'(뷰어 기본) / 'chat'(채팅
-    사이드바가 열려있는 동안) / 'compare'(논문 비교 채팅 화면) 중 하나입니다.
+    시간(초)을 누적합니다. category는 'reading'(PDF 영역 상호작용) / 'chat'(채팅
+    영역 상호작용) / 'compare'(논문 비교 채팅 화면) 중 하나입니다.
     한 번의 하트비트 간격(예: 20초) 이상을 보내는 조작을 막기 위해 상한을 둡니다."""
     require_owned_document(doc_id, current_user)
     if body.category not in ("reading", "chat", "compare"):

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -247,7 +247,7 @@ def init_db():
         # 13. reading_time 테이블 (Reading History의 "읽은 시간" 실측치). 뷰어/비교
         #     화면이 화면에 보이고 포커스된 동안 프런트가 일정 간격(하트비트)으로
         #     경과 초를 보내오면 (doc_id, username, day, category) 단위로 누적한다.
-        #     category는 'reading'(뷰어 기본)/'chat'(채팅 사이드바가 열려있는 동안)/
+        #     category는 'reading'(PDF 영역 상호작용)/'chat'(채팅 영역 상호작용)/
         #     'compare'(논문 비교 채팅 화면) 중 하나 - 실제로 구분 가능한 화면
         #     상태만 카테고리로 쓰고, 근거 없는 세부 항목(예: "메모 작성 시간")은
         #     만들지 않는다.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,7 @@ import { renderNotesPage } from './pages/notesPage.js'
 import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
+import { createReadingTimeActivityTracker } from './readingTimeActivity.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -4130,12 +4131,31 @@ if (settingSkipLoginCheckbox) {
 // ── 읽기 시간 하트비트 (Reading History의 "읽은 시간" 실측) ──────────────
 // 뷰어/비교 화면이 화면에 보이고(Page Visibility) 창이 포커스된 동안만 5초
 // 간격으로 "현재 컨텍스트"(문서 id + reading/chat/compare 카테고리)에 초를
-// 적립하고, 20초마다 적립분을 서버로 보낸다. 5초 tick 시점의 컨텍스트를 그때
-// 그때 버킷에 더하므로, 20초 사이에 채팅 사이드바를 열고 닫는 등 컨텍스트가
-// 바뀌어도 각 구간이 올바른 카테고리로 집계된다.
+// 적립하고, 20초마다 적립분을 서버로 보낸다. 단일 논문 뷰어에서는 사이드바의
+// 열림 여부가 아니라 PDF/채팅 영역 중 사용자가 마지막으로 상호작용한 영역으로
+// 분류하며, 60초 동안 상호작용이 없으면 유휴 상태로 보고 적립하지 않는다.
 const READING_HEARTBEAT_TICK_SECONDS = 5
 const READING_HEARTBEAT_FLUSH_MS = 20000
 let readingHeartbeatBuffers = {} // `${docId}|${category}` -> 적립된 초
+let readingHeartbeatContextKey = null
+const readingTimeActivityTracker = createReadingTimeActivityTracker()
+
+function recordReadingTimeInteraction(event) {
+  if (!viewerScreen?.classList.contains('active')) return
+  const target = event.target
+  const isChatInteraction = chatSidebar
+    && !chatSidebar.classList.contains('hidden')
+    && chatSidebar.contains(target)
+    && !target.closest?.('#chat-close-btn')
+  readingTimeActivityTracker.record(isChatInteraction ? 'chat' : 'reading')
+}
+
+// pointerdown은 클릭·선택·스크롤바 드래그·터치를, wheel/keydown/input은 각각
+// 휠 스크롤·키보드 탐색·채팅 입력을 포착한다. scroll 이벤트는 답변 렌더링이나
+// 페이지 복원 코드가 일으킨 자동 스크롤도 포함하므로 활동 근거로 사용하지 않는다.
+for (const eventName of ['pointerdown', 'wheel', 'keydown', 'input']) {
+  viewerScreen?.addEventListener(eventName, recordReadingTimeInteraction, { capture: true, passive: eventName === 'wheel' })
+}
 
 function isReadingTimeActive() {
   if (document.visibilityState !== 'visible' || !document.hasFocus()) return false
@@ -4146,17 +4166,29 @@ function isReadingTimeActive() {
 
 function currentReadingContext() {
   if (viewerScreen && viewerScreen.classList.contains('active') && state.sessionId) {
-    const category = (chatSidebar && !chatSidebar.classList.contains('hidden')) ? 'chat' : 'reading'
+    const contextKey = `viewer|${state.sessionId}`
+    if (readingHeartbeatContextKey !== contextKey) {
+      readingHeartbeatContextKey = contextKey
+      readingTimeActivityTracker.reset('reading')
+    }
+    const category = readingTimeActivityTracker.getCategory({
+      chatAvailable: Boolean(chatSidebar && !chatSidebar.classList.contains('hidden')),
+    })
+    if (!category) return null
     return { docIds: [state.sessionId], category }
   }
   if (compareScreen && compareScreen.classList.contains('active') && compareChatState.docIds.length > 0) {
+    readingHeartbeatContextKey = `compare|${compareChatState.docIds.join(',')}`
     return { docIds: compareChatState.docIds, category: 'compare' }
   }
   return null
 }
 
 function tickReadingHeartbeat() {
-  if (!isReadingTimeActive()) return
+  if (!isReadingTimeActive()) {
+    readingHeartbeatContextKey = null
+    return
+  }
   const ctx = currentReadingContext()
   if (!ctx) return
   for (const docId of ctx.docIds) {

--- a/frontend/src/pages/readingHistoryPage.js
+++ b/frontend/src/pages/readingHistoryPage.js
@@ -4,7 +4,7 @@
 // 동안 5초 tick으로 현재 문서+카테고리에 적립 → 20초마다 서버로 flush,
 // POST /library/{doc_id}/reading-heartbeat)가 쌓은 실측치를
 // fetchReadingTimeStats()로 집계해서 쓴다. 카테고리는 실제로 구분 가능한 화면
-// 상태 3가지뿐이다: reading(뷰어 기본) / chat(채팅 사이드바 열림) /
+// 상태 3가지뿐이다: reading(최근 PDF 상호작용) / chat(최근 채팅 상호작용) /
 // compare(논문 비교 채팅). 이 기능을 도입하기 전에 만든 페이지라 이 시점
 // 이전의 활동에는 시간 데이터가 없을 수 있다 - 그런 경우 위젯은 "아직 기록된
 // 읽기 시간이 없습니다"로 정직하게 표시한다.
@@ -75,7 +75,7 @@ const TYPE_ICON = { uploaded: 'archive', read: 'bookOpen', browsed: 'activity', 
 const TYPE_COLOR_VAR = { read: '--rh-c1', browsed: '--rh-c5', question: '--rh-c2', note: '--rh-c3', uploaded: '--rh-c4' }
 const TYPE_ORDER = ['read', 'browsed', 'question', 'note', 'uploaded']
 
-// 읽기 시간 하트비트의 카테고리 3종(뷰어 기본/채팅 사이드바/논문 비교) - 대시보드
+// 읽기 시간 하트비트의 카테고리 3종(PDF 상호작용/채팅 상호작용/논문 비교) - 대시보드
 // 활동 요약 카드의 "활동 유형별 시간 분포"에서도 동일 팔레트/라벨을 공유한다.
 export const CATEGORY_LABEL = { reading: '논문 읽기', chat: 'AI 채팅', compare: '논문 비교' }
 export const CATEGORY_COLOR_VAR = { reading: '--rh-c1', chat: '--rh-c2', compare: '--rh-c5' }
@@ -670,7 +670,7 @@ export async function renderReadingHistoryPage() {
 
   // ── Reading Time Distribution (part-to-whole, 전체 기간 실측치) ──
   // 카테고리는 main.js 하트비트가 실제로 구분하는 화면 상태 3가지뿐이다:
-  // reading(뷰어에서 읽는 중) / chat(채팅 사이드바 사용 중) / compare(논문 비교).
+  // reading(최근 PDF 상호작용) / chat(최근 채팅 상호작용) / compare(논문 비교).
   const mixBarHtml = CATEGORY_ORDER.map(c => {
     const seconds = byCategory[c] || 0
     const pct = mixTotalSeconds ? (seconds / mixTotalSeconds) * 100 : 0

--- a/frontend/src/readingTimeActivity.js
+++ b/frontend/src/readingTimeActivity.js
@@ -1,0 +1,31 @@
+export const READING_TIME_IDLE_MS = 60_000
+
+export function createReadingTimeActivityTracker({
+  idleMs = READING_TIME_IDLE_MS,
+  now = () => Date.now(),
+} = {}) {
+  let activityAt = { reading: 0, chat: 0 }
+
+  function record(category, at = now()) {
+    if (category !== 'reading' && category !== 'chat') return
+    activityAt[category] = at
+  }
+
+  function reset(category = 'reading', at = now()) {
+    activityAt = { reading: 0, chat: 0 }
+    record(category, at)
+  }
+
+  function getCategory({ chatAvailable = true, at = now() } = {}) {
+    const candidates = [
+      ['reading', activityAt.reading],
+      ...(chatAvailable ? [['chat', activityAt.chat]] : []),
+    ].filter(([, timestamp]) => timestamp > 0)
+
+    if (candidates.length === 0) return null
+    const [category, timestamp] = candidates.reduce((latest, item) => item[1] > latest[1] ? item : latest)
+    return at - timestamp <= idleMs ? category : null
+  }
+
+  return { record, reset, getCategory }
+}

--- a/frontend/tests/readingTimeActivity.test.js
+++ b/frontend/tests/readingTimeActivity.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createReadingTimeActivityTracker } from '../src/readingTimeActivity.js'
+
+test('사이드바가 열려 있어도 마지막 PDF 상호작용을 읽기 시간으로 분류한다', () => {
+  let now = 1_000
+  const tracker = createReadingTimeActivityTracker({ now: () => now })
+
+  tracker.reset('reading')
+  assert.equal(tracker.getCategory({ chatAvailable: true }), 'reading')
+})
+
+test('채팅 영역과 PDF 영역의 마지막 상호작용에 따라 분류를 전환한다', () => {
+  let now = 1_000
+  const tracker = createReadingTimeActivityTracker({ now: () => now })
+
+  tracker.reset('reading')
+  now = 2_000
+  tracker.record('chat')
+  assert.equal(tracker.getCategory({ chatAvailable: true }), 'chat')
+
+  now = 3_000
+  tracker.record('reading')
+  assert.equal(tracker.getCategory({ chatAvailable: true }), 'reading')
+})
+
+test('유휴 제한을 넘으면 시간을 분류하지 않는다', () => {
+  let now = 1_000
+  const tracker = createReadingTimeActivityTracker({ idleMs: 60_000, now: () => now })
+
+  tracker.reset('reading')
+  now = 61_001
+  assert.equal(tracker.getCategory(), null)
+})
+
+test('닫힌 채팅 사이드바의 과거 상호작용을 채팅 시간으로 분류하지 않는다', () => {
+  let now = 1_000
+  const tracker = createReadingTimeActivityTracker({ now: () => now })
+
+  tracker.reset('reading')
+  now = 2_000
+  tracker.record('chat')
+  assert.equal(tracker.getCategory({ chatAvailable: false }), 'reading')
+})


### PR DESCRIPTION
# Summary
## 1. AI 채팅 시간 분류 기준 개선
- 채팅 사이드바 표시 여부 대신 PDF와 채팅 영역의 최근 사용자 상호작용을 기준으로 시간을 분류하도록 수정함
- 60초 동안 상호작용이 없으면 시간 적립을 중지하고 자동 스크롤을 활동에서 제외함
## 2. 활동 분류 검증 추가
- PDF 및 채팅 간 분류 전환, 유휴 처리, 닫힌 사이드바 처리를 검증하는 단위 테스트를 추가함