### PR TITLE
fix: disable Tauri drag-drop so HTML5 drag works on Windows

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
         "resizable": true,
         "fullscreen": false,
         "theme": "Dark",
-        "backgroundColor": "#06050a"
+        "backgroundColor": "#06050a",
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
- 윈도우 환경에서 Tauri 기본 드롭 핸들러와 HTML5 드래그 API는 Windows WebView2에서 충돌하는 문제가 발생하여, 드래그 앤 드롭이 동작하지 않는 문제가 발생하여, Tauri 창에 ``dragDropEnabled: false``를 설정해 동작하도록 수정
- Windows 앱에서 논문 카드 드래그앤드롭이 동작합니다.

<img width="360" height="258" alt="image" src="https://github.com/user-attachments/assets/054fefb9-e75f-4605-a57b-9daf75b632e9" />
