### PR TITLE
fix(reading): correct analytics evidence

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -273,7 +273,7 @@ async def start_reading_session_api(doc_id: str, body: Optional[StartSessionRequ
     latest = db_get_latest_reading_session(doc_id, current_user)
     now = datetime.now(timezone.utc)
 
-    if latest and latest.get("updated_at"):
+    if latest and latest.get("updated_at") and not latest.get("ended_at"):
         try:
             last_updated = datetime.fromisoformat(latest["updated_at"])
             diff_sec = (now - last_updated).total_seconds()
@@ -399,7 +399,9 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         db_save_reading_session,
         db_save_user_reading_profile,
     )
-    from services.reading_analytics import process_reading_analytics, update_user_ema
+    from services.reading_analytics import (
+        count_meaningful_page_sessions, process_reading_analytics, update_user_ema,
+    )
 
     doc = get_document(doc_id)
     doc_total_pages = doc.get("total_pages", 0) if doc else 0
@@ -446,11 +448,13 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
             user_ema,
             profile.get("session_count", 0),
             payload.activeReadingTime,
-            len({ps.page for ps in payload.pageSessions}),
+            count_meaningful_page_sessions(payload.pageSessions),
         )
         db_save_user_reading_profile(current_user, new_ema, new_count)
 
-    update_document_metadata(doc_id, {"last_read_at": now_iso})
+    metadata = dict((doc or {}).get("metadata") or {})
+    metadata["last_read_at"] = now_iso
+    update_document_metadata(doc_id, metadata)
 
     return res.model_dump()
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -303,6 +303,7 @@ def init_db():
             total_pages INTEGER DEFAULT 0,
             reading_activity TEXT DEFAULT 'unclassified',
             minimum_evidence_time REAL DEFAULT 90.0,
+            analytics_version INTEGER NOT NULL DEFAULT 2,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         )
@@ -369,6 +370,7 @@ def init_db():
             "ALTER TABLE reading_sessions ADD COLUMN reading_activity TEXT DEFAULT 'unclassified'",
             "ALTER TABLE reading_sessions ADD COLUMN minimum_evidence_time REAL DEFAULT 90.0",
             "ALTER TABLE reading_sessions ADD COLUMN verified_pages_json TEXT",
+            "ALTER TABLE reading_sessions ADD COLUMN analytics_version INTEGER NOT NULL DEFAULT 1",
         ):
             try:
                 cursor.execute(column_sql)
@@ -396,6 +398,9 @@ def init_db():
             )
             conn.commit()
             print(f"Default user '{default_user}' created in SQLite database.")
+
+    db_migrate_reading_analytics_v2()
+    db_backfill_document_titles()
 
 
 # ── 사용자 (Users) ───────────────────────────────────────────────────────────
@@ -1521,7 +1526,7 @@ def db_get_latest_reading_session(paper_id: str, username: str) -> Optional[Dict
                    page_sessions_json, interaction_summary_json, reading_depth,
                    reading_score, reading_confidence, verified_pages_count,
                    verified_pages_json, total_pages, reading_activity,
-                   minimum_evidence_time, created_at, updated_at
+                   minimum_evidence_time, analytics_version, created_at, updated_at
             FROM reading_sessions
             WHERE username = ? AND paper_id = ?
             ORDER BY updated_at DESC LIMIT 1
@@ -1544,7 +1549,7 @@ def db_get_reading_session(session_id: str, username: str) -> Optional[Dict[str,
                    page_sessions_json, interaction_summary_json, reading_depth,
                    reading_score, reading_confidence, verified_pages_count,
                    verified_pages_json, total_pages, reading_activity,
-                   minimum_evidence_time, created_at, updated_at
+                   minimum_evidence_time, analytics_version, created_at, updated_at
             FROM reading_sessions
             WHERE id = ? AND username = ?
             """,
@@ -1574,6 +1579,7 @@ def db_save_reading_session(
     reading_activity: str = "unclassified",
     minimum_evidence_time: float = 90.0,
     verified_pages_json: Optional[str] = None,
+    analytics_version: int = 2,
 ) -> bool:
     """Insert a session or replace it only with a newer heartbeat version."""
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -1586,8 +1592,8 @@ def db_save_reading_session(
                 page_sessions_json, interaction_summary_json, reading_depth,
                 reading_score, reading_confidence, verified_pages_count, total_pages,
                 reading_activity, minimum_evidence_time, verified_pages_json,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                analytics_version, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 ended_at = excluded.ended_at,
                 active_reading_time = excluded.active_reading_time,
@@ -1602,6 +1608,7 @@ def db_save_reading_session(
                 total_pages = excluded.total_pages,
                 reading_activity = excluded.reading_activity,
                 minimum_evidence_time = excluded.minimum_evidence_time,
+                analytics_version = excluded.analytics_version,
                 updated_at = excluded.updated_at
             WHERE excluded.version > reading_sessions.version
             """,
@@ -1623,6 +1630,7 @@ def db_save_reading_session(
                 reading_activity,
                 minimum_evidence_time,
                 verified_pages_json,
+                analytics_version,
                 now_iso,
                 now_iso,
             ),
@@ -1643,7 +1651,7 @@ def db_get_reading_sessions_for_user(username: str) -> List[Dict[str, Any]]:
                    rs.reading_depth, rs.reading_score, rs.reading_confidence,
                    rs.verified_pages_count, rs.verified_pages_json,
                    rs.total_pages, rs.reading_activity,
-                   rs.minimum_evidence_time, rs.updated_at,
+                   rs.minimum_evidence_time, rs.analytics_version, rs.updated_at,
                    titles.doc_title
             FROM reading_sessions AS rs
             LEFT JOIN (
@@ -1691,6 +1699,143 @@ def db_save_user_reading_profile(username: str, ema_seconds_per_page: float, ses
             (username, ema_seconds_per_page, session_count, now_iso),
         )
         conn.commit()
+
+
+def db_migrate_reading_analytics_v2() -> None:
+    """Recalculate legacy sessions and rebuild EMA from meaningful page visits."""
+    from services.reading_analytics import (
+        READING_ANALYTICS_VERSION, InteractionSummary, PageSession,
+        ReadingSessionPayload, count_meaningful_page_sessions,
+        process_reading_analytics, update_user_ema,
+    )
+
+    with get_db() as conn:
+        affected_rows = conn.execute(
+            "SELECT DISTINCT username FROM reading_sessions WHERE analytics_version < ?",
+            (READING_ANALYTICS_VERSION,),
+        ).fetchall()
+        affected_users = [row["username"] for row in affected_rows]
+        if not affected_users:
+            return
+
+        placeholders = ",".join("?" for _ in affected_users)
+        rows = conn.execute(
+            f"""
+            SELECT id, username, paper_id, version, active_reading_time, ended_at,
+                   page_sessions_json, interaction_summary_json, total_pages, analytics_version
+            FROM reading_sessions
+            WHERE username IN ({placeholders})
+            ORDER BY username, started_at, created_at
+            """,
+            affected_users,
+        ).fetchall()
+
+        profiles = {username: (600.0, 0) for username in affected_users}
+        for row in rows:
+            username = row["username"]
+            user_ema, session_count = profiles[username]
+            try:
+                raw_pages = json.loads(row["page_sessions_json"] or "[]")
+                raw_interaction = json.loads(row["interaction_summary_json"] or "{}")
+                page_sessions = [
+                    PageSession(**page) for page in raw_pages if isinstance(page, dict)
+                ]
+                interaction = InteractionSummary(**raw_interaction)
+                payload = ReadingSessionPayload(
+                    sessionId=row["id"],
+                    paperId=row["paper_id"],
+                    version=max(0, row["version"] or 0),
+                    currentPage=max([page.page for page in page_sessions], default=1),
+                    activeReadingTime=max(0, row["active_reading_time"] or 0),
+                    pageSessions=page_sessions,
+                    interactionSummary=interaction,
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                conn.execute(
+                    "UPDATE reading_sessions SET analytics_version = ? WHERE id = ?",
+                    (READING_ANALYTICS_VERSION, row["id"]),
+                )
+                continue
+
+            if (row["analytics_version"] < READING_ANALYTICS_VERSION):
+                result = process_reading_analytics(
+                    payload, max(0, row["total_pages"] or 0), user_ema,
+                )
+                verified_pages = sorted(
+                    page for page, score in result.pageScores.items() if score >= 50.0
+                )
+                conn.execute(
+                    """
+                    UPDATE reading_sessions
+                    SET reading_depth = ?, reading_score = ?, reading_confidence = ?,
+                        verified_pages_count = ?, verified_pages_json = ?, total_pages = ?,
+                        reading_activity = ?, minimum_evidence_time = ?, analytics_version = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        result.readingDepth, result.readingScore, result.readingConfidence,
+                        result.verifiedPagesCount, json.dumps(verified_pages), result.totalPages,
+                        result.readingActivity, result.minimumEvidenceTime,
+                        READING_ANALYTICS_VERSION, row["id"],
+                    ),
+                )
+
+            meaningful_pages = count_meaningful_page_sessions(page_sessions)
+            if row["ended_at"] and meaningful_pages > 0:
+                profiles[username] = update_user_ema(
+                    user_ema, session_count, payload.activeReadingTime, meaningful_pages,
+                )
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for username, (ema_seconds, session_count) in profiles.items():
+            conn.execute(
+                """
+                INSERT INTO user_reading_profiles
+                    (username, ema_seconds_per_page, session_count, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(username) DO UPDATE SET
+                    ema_seconds_per_page = excluded.ema_seconds_per_page,
+                    session_count = excluded.session_count,
+                    updated_at = excluded.updated_at
+                """,
+                (username, ema_seconds, session_count, now_iso),
+            )
+        conn.commit()
+
+
+def db_backfill_document_titles() -> None:
+    """Restore extracted paper titles lost by legacy metadata replacement."""
+    from services.pdf_parser import get_pdf_metadata
+
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT id, pdf_path, metadata FROM documents WHERE is_deleted = 0"
+        ).fetchall()
+
+    for row in rows:
+        try:
+            metadata = json.loads(row["metadata"] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if (metadata.get("title") or not os.path.isfile(row["pdf_path"] or "")):
+            continue
+        try:
+            title = (get_pdf_metadata(row["pdf_path"]).get("title") or "").strip()
+        except Exception:
+            continue
+        if not title:
+            continue
+        metadata["title"] = title
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE documents SET metadata = ? WHERE id = ?",
+                (json.dumps(metadata, ensure_ascii=False), row["id"]),
+            )
+            conn.execute(
+                "UPDATE reading_time SET doc_title = ? WHERE doc_id = ?",
+                (title, row["id"]),
+            )
+            conn.commit()
 
 
 def db_get_all_reading_analytics_summary(username: str, since_days: Optional[int] = None) -> Dict[str, Any]:

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -446,17 +446,22 @@ async def get_activity_timeline(username: str) -> List[dict]:
     docs = list_documents(username=username, include_deleted=True)
     titles_by_doc = {d["id"]: (d.get("metadata") or {}).get("title") or d["filename"] for d in docs}
     deleted_by_doc = {d["id"]: bool(d.get("is_deleted")) for d in docs}
+    manually_read_by_doc = {d["id"]: bool((d.get("metadata") or {}).get("read")) for d in docs}
 
     doc_ids_seen = set(titles_by_doc.keys())
     events = []
 
     from services.reading_analytics import (
         PageSession, analyze_page_sessions, classify_reading_activity,
+        is_meaningful_page_session,
     )
 
     analytics_rows = db_get_reading_sessions_for_user(username)
     user_ema = db_get_user_reading_profile(username).get("ema_seconds_per_page", 600.0)
     analytics_doc_ids = {row["paper_id"] for row in analytics_rows}
+    latest_session_by_doc = {}
+    for row in analytics_rows:
+        latest_session_by_doc.setdefault(row["paper_id"], row["id"])
     for row in analytics_rows:
         try:
             page_sessions = json.loads(row.get("page_sessions_json") or "[]")
@@ -470,7 +475,9 @@ async def get_activity_timeline(username: str) -> List[dict]:
                 page_models.append(PageSession(**page))
             except (TypeError, ValueError):
                 continue
-        pages = sorted({page.page for page in page_models})
+        pages = sorted({
+            page.page for page in page_models if is_meaningful_page_session(page)
+        })
         active_time = max(0, row.get("active_reading_time") or 0)
         verified_pages = max(0, row.get("verified_pages_count") or 0)
         verified_page_numbers = None
@@ -506,13 +513,15 @@ async def get_activity_timeline(username: str) -> List[dict]:
                 user_ema,
                 page_models,
             )
+        doc_id = row["paper_id"]
+        if manually_read_by_doc.get(doc_id) and latest_session_by_doc.get(doc_id) == row["id"]:
+            activity_type = "read"
         if activity_type == "ignored":
             continue
         start_ts = row.get("started_at") or row.get("updated_at")
         end_ts = row.get("ended_at")
         if end_ts == start_ts:
             end_ts = None
-        doc_id = row["paper_id"]
         events.append({
             "type": activity_type,
             "reading_activity": activity_type,

--- a/backend/services/reading_analytics.py
+++ b/backend/services/reading_analytics.py
@@ -2,6 +2,14 @@ from pydantic import BaseModel, Field
 from typing import Dict, List
 
 
+READING_ANALYTICS_VERSION = 2
+MIN_MEANINGFUL_PAGE_SECONDS = 10.0
+SEMANTIC_INTERACTION_FIELDS = (
+    "selection", "highlight", "underline", "memo", "question",
+    "citationClick", "figureClick", "tableClick", "equationClick",
+)
+
+
 class InteractionSummary(BaseModel):
     scroll: int = Field(default=0, ge=0)
     selection: int = Field(default=0, ge=0)
@@ -51,9 +59,9 @@ class ReadingAnalyticsResult(BaseModel):
 
 # --- 1. Interaction Quality Calculation ---
 def calculate_interaction_quality(interaction: InteractionSummary) -> float:
-    """Calculates weighted interaction quality score from raw counts."""
+    """Calculate interaction evidence without letting raw scroll events dominate."""
     return (
-        interaction.scroll * 0.1
+        min(interaction.scroll, 10) * 0.1
         + interaction.selection * 0.5
         + interaction.highlight * 3.0
         + interaction.underline * 3.0
@@ -64,6 +72,23 @@ def calculate_interaction_quality(interaction: InteractionSummary) -> float:
         + interaction.tableClick * 2.0
         + interaction.equationClick * 2.0
     )
+
+
+def has_semantic_interaction(interaction: InteractionSummary) -> bool:
+    """Return whether a page has an intentional research interaction."""
+    return any(getattr(interaction, field_name) > 0 for field_name in SEMANTIC_INTERACTION_FIELDS)
+
+
+def is_meaningful_page_session(page_session: PageSession) -> bool:
+    """Exclude pass-through pages while preserving short figure/reference visits."""
+    return (
+        page_session.activeTime >= MIN_MEANINGFUL_PAGE_SECONDS
+        or has_semantic_interaction(page_session.interaction)
+    )
+
+
+def count_meaningful_page_sessions(page_sessions: List[PageSession]) -> int:
+    return len({ps.page for ps in page_sessions if is_meaningful_page_session(ps)})
 
 
 def calculate_minimum_evidence_time(user_ema: float) -> float:
@@ -118,7 +143,8 @@ def analyze_page_sessions(
     """
     page_scores: Dict[int, float] = {}
     verified_count = 0
-    total_confidence_sum = 0.0
+    weighted_confidence_sum = 0.0
+    confidence_weight_sum = 0.0
 
     if not page_sessions:
         return {}, 0, 0.0
@@ -173,8 +199,9 @@ def analyze_page_sessions(
         if scroll_cov < 0.2 and iq < 1.0:
             final_score = min(final_score, 25.0)
 
-        # 2) Very short active time
-        if active_time < 10.0:
+        # 2) Retain pass-through pages for diagnostics without treating an
+        # intentional figure/table/reference visit as failed reading evidence.
+        if active_time < MIN_MEANINGFUL_PAGE_SECONDS and not has_semantic_interaction(ps.interaction):
             final_score = min(final_score, 15.0)
 
         # 3) AFK long time without interaction or scroll
@@ -186,9 +213,15 @@ def analyze_page_sessions(
 
         if final_score >= 50.0:
             verified_count += 1
-        total_confidence_sum += final_score
+        if is_meaningful_page_session(ps):
+            weight = max(
+                MIN_MEANINGFUL_PAGE_SECONDS,
+                min(active_time, max(MIN_MEANINGFUL_PAGE_SECONDS, expected_page_time)),
+            )
+            weighted_confidence_sum += final_score * weight
+            confidence_weight_sum += weight
 
-    avg_confidence = round(total_confidence_sum / len(consolidated), 1) if consolidated else 0.0
+    avg_confidence = round(weighted_confidence_sum / confidence_weight_sum, 1) if confidence_weight_sum else 0.0
     return page_scores, verified_count, avg_confidence
 
 
@@ -197,21 +230,24 @@ def determine_reading_depth(
     active_reading_time: float,
     verified_pages_count: int,
     total_pages: int,
-    reading_score: float
+    reading_score: float,
+    meaningful_pages_count: int | None = None,
 ) -> str:
     """
     Determines Reading Depth state: Opened -> Browsing -> Reading -> Deep Reading -> Completed
     """
     total_content = max(1, total_pages)
     verified_ratio = verified_pages_count / total_content
+    meaningful_total = max(1, meaningful_pages_count if meaningful_pages_count is not None else total_pages)
+    evidence_ratio = verified_pages_count / meaningful_total
 
     if active_reading_time < 30.0 and verified_pages_count == 0:
         return "Opened"
-    if verified_ratio >= 0.8 or reading_score >= 85.0:
+    if verified_ratio >= 0.8:
         return "Completed"
-    if verified_ratio >= 0.5 or (verified_pages_count >= 3 and reading_score >= 60.0):
+    if verified_ratio >= 0.5 or (verified_pages_count >= 3 and evidence_ratio >= 0.5):
         return "Deep Reading"
-    if verified_ratio >= 0.2 or (verified_pages_count >= 2 and reading_score >= 40.0):
+    if verified_ratio >= 0.2 or evidence_ratio >= 0.5 or (verified_pages_count >= 2 and reading_score >= 40.0):
         return "Reading"
     return "Browsing"
 
@@ -222,13 +258,16 @@ def calculate_reading_score(
     total_pages: int,
     reading_confidence: float,
     reading_depth: str,
-    total_interaction_quality: float
+    total_interaction_quality: float,
+    meaningful_pages_count: int | None = None,
 ) -> float:
     """
     Calculates final overall Reading Score (0~100) using rule-based feature weighting.
     """
     total_content = max(1, total_pages)
     verified_ratio = min(1.0, verified_pages_count / total_content)
+    meaningful_total = max(1, meaningful_pages_count if meaningful_pages_count is not None else total_pages)
+    evidence_ratio = min(1.0, verified_pages_count / meaningful_total)
 
     depth_weights = {
         "Opened": 10.0,
@@ -239,10 +278,11 @@ def calculate_reading_score(
     }
     depth_score = depth_weights.get(reading_depth, 10.0)
 
-    # 40% Verified ratio + 25% Confidence + 20% Depth + 15% Interaction Quality
+    # Whole-paper coverage and evidence quality are separate signals.
     score = (
-        0.40 * (verified_ratio * 100.0)
-        + 0.25 * reading_confidence
+        0.15 * (verified_ratio * 100.0)
+        + 0.20 * (evidence_ratio * 100.0)
+        + 0.30 * reading_confidence
         + 0.20 * depth_score
         + 0.15 * min(100.0, total_interaction_quality * 5.0)
     )
@@ -294,20 +334,32 @@ def process_reading_analytics(
         user_ema,
         total_pages
     )
+    meaningful_pages_count = count_meaningful_page_sessions(payload.pageSessions)
 
     summary_iq = calculate_interaction_quality(payload.interactionSummary)
-    page_iq = sum(calculate_interaction_quality(ps.interaction) for ps in payload.pageSessions)
+    page_iq = sum(
+        calculate_interaction_quality(ps.interaction)
+        for ps in payload.pageSessions if is_meaningful_page_session(ps)
+    )
     # Each frontend event is recorded in both representations; do not double count it.
     total_iq = max(summary_iq, page_iq)
 
-    depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, 0.0)
+    depth = determine_reading_depth(
+        payload.activeReadingTime, verified_count, total_pages, 0.0, meaningful_pages_count,
+    )
     for _ in range(3):
-        reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, depth, total_iq)
-        next_depth = determine_reading_depth(payload.activeReadingTime, verified_count, total_pages, reading_score)
+        reading_score = calculate_reading_score(
+            verified_count, total_pages, avg_confidence, depth, total_iq, meaningful_pages_count,
+        )
+        next_depth = determine_reading_depth(
+            payload.activeReadingTime, verified_count, total_pages, reading_score, meaningful_pages_count,
+        )
         if next_depth == depth:
             break
         depth = next_depth
-    reading_score = calculate_reading_score(verified_count, total_pages, avg_confidence, depth, total_iq)
+    reading_score = calculate_reading_score(
+        verified_count, total_pages, avg_confidence, depth, total_iq, meaningful_pages_count,
+    )
     reading_activity, minimum_evidence_time = classify_reading_activity(
         payload.activeReadingTime, verified_count, avg_confidence, user_ema, payload.pageSessions,
     )

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -1,5 +1,7 @@
 """services/db.py CRUD 및 app_meta 테스트 (격리된 임시 DB 사용)."""
 
+import json
+
 
 def test_document_crud_round_trip(isolated_dirs):
     db = isolated_dirs["db"]
@@ -214,3 +216,68 @@ def test_bulk_translation_rows_returns_empty_list_for_doc_without_translations(i
 def test_bulk_translation_rows_empty_doc_ids_returns_empty_dict(isolated_dirs):
     db = isolated_dirs["db"]
     assert db.db_bulk_translation_rows([]) == {}
+
+
+def test_reading_analytics_v2_migrates_legacy_sessions(isolated_dirs):
+    db = isolated_dirs["db"]
+    pages = [
+        {"page": page, "activeTime": 1, "scrollCoverage": 0.05, "interaction": {}}
+        for page in range(1, 7)
+    ] + [
+        {
+            "page": page, "activeTime": 600, "scrollCoverage": 0.8,
+            "interaction": {"scroll": 10, "highlight": 1},
+        }
+        for page in range(7, 10)
+    ]
+    db.db_save_reading_session(
+        session_id="legacy", username="admin", paper_id="paper",
+        started_at="2026-08-10T01:00:00+00:00",
+        ended_at="2026-08-10T02:00:00+00:00", active_reading_time=1806,
+        version=1, page_sessions_json=json.dumps(pages),
+        interaction_summary_json=json.dumps({"scroll": 30, "highlight": 3}),
+        reading_depth="Browsing", reading_score=37.9, reading_confidence=42.2,
+        verified_pages_count=3, total_pages=19, reading_activity="browsed",
+        analytics_version=1,
+    )
+
+    db.db_migrate_reading_analytics_v2()
+
+    migrated = db.db_get_reading_session("legacy", "admin")
+    assert migrated["analytics_version"] == 2
+    assert migrated["reading_activity"] == "read"
+    assert migrated["reading_confidence"] >= 90
+    assert migrated["reading_score"] >= 70
+    assert db.db_get_user_reading_profile("admin")["session_count"] == 1
+
+
+def test_backfill_document_title_preserves_metadata_and_snapshot(
+    isolated_dirs, tmp_path, monkeypatch,
+):
+    db = isolated_dirs["db"]
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"placeholder")
+    db.db_save_document(
+        "paper-title", "admin", "uploaded-name.pdf", str(pdf_path), 5,
+        {"last_read_at": "2026-08-10T00:00:00+00:00"},
+    )
+    db.db_add_reading_time("paper-title", "admin", "reading", 10)
+
+    import services.pdf_parser as pdf_parser
+    monkeypatch.setattr(
+        pdf_parser, "get_pdf_metadata",
+        lambda _path: {"title": "Extracted Research Title"},
+    )
+
+    db.db_backfill_document_titles()
+
+    metadata = db.db_get_document("paper-title")["metadata"]
+    assert metadata == {
+        "last_read_at": "2026-08-10T00:00:00+00:00",
+        "title": "Extracted Research Title",
+    }
+    with db.get_db() as conn:
+        snapshot = conn.execute(
+            "SELECT doc_title FROM reading_time WHERE doc_id = ?", ("paper-title",),
+        ).fetchone()["doc_title"]
+    assert snapshot == "Extracted Research Title"

--- a/backend/tests/test_knowledge_graph_v3.py
+++ b/backend/tests/test_knowledge_graph_v3.py
@@ -477,3 +477,35 @@ def test_reading_recommendations_endpoint_force_query_param(test_client, isolate
     res = test_client.get("/api/library/graph/recommendations?force=true")
     assert res.status_code == 200
     assert call_count["n"] == 2
+
+
+def test_timeline_manual_read_uses_meaningful_page_range(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    _create_doc_owned_by(
+        isolated_dirs, "doc-manual-read", "testuser",
+        {"title": "Extracted Timeline Title", "read": True},
+    )
+    db.db_save_reading_session(
+        session_id="manual-read", username="testuser", paper_id="doc-manual-read",
+        started_at="2026-08-10T01:00:00+00:00", ended_at=None,
+        active_reading_time=31, version=1,
+        page_sessions_json=json.dumps([
+            {"page": 1, "activeTime": 1, "scrollCoverage": 0.05},
+            {"page": 5, "activeTime": 30, "scrollCoverage": 0.4},
+            {
+                "page": 9, "activeTime": 2, "scrollCoverage": 0.1,
+                "interaction": {"figureClick": 1},
+            },
+        ]),
+        interaction_summary_json="{}", reading_depth="Browsing",
+        reading_score=20, reading_confidence=20, verified_pages_count=0,
+        total_pages=10, reading_activity="browsed",
+    )
+
+    events = test_client.get("/api/library/timeline").json()["events"]
+    event = next(item for item in events if item.get("reading_session_id") == "manual-read")
+
+    assert event["type"] == "read"
+    assert event["doc_title"] == "Extracted Timeline Title"
+    assert event["start_page"] == 5
+    assert event["end_page"] == 9

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -10,6 +10,7 @@ from services.reading_analytics import (
     calculate_reading_score,
     calculate_minimum_evidence_time,
     classify_reading_activity,
+    count_meaningful_page_sessions,
     update_user_ema,
 )
 
@@ -175,6 +176,48 @@ class TestReadingAnalytics(unittest.TestCase):
         self.assertEqual(res.minimumEvidenceTime, 90.0)
 
 
+    def test_brief_pass_through_pages_do_not_poison_confidence(self):
+        pages = [
+            PageSession(page=page, activeTime=1, scrollCoverage=0.05)
+            for page in range(1, 7)
+        ] + [
+            PageSession(
+                page=page, activeTime=600, scrollCoverage=0.8,
+                interaction=InteractionSummary(scroll=10, highlight=1),
+            )
+            for page in range(7, 10)
+        ]
+        payload = ReadingSessionPayload(
+            sessionId="targeted", paperId="paper", activeReadingTime=1806,
+            pageSessions=pages,
+            interactionSummary=InteractionSummary(scroll=30, highlight=3),
+        )
+
+        result = process_reading_analytics(payload, total_paper_pages=19, user_ema=600)
+
+        self.assertEqual(count_meaningful_page_sessions(pages), 3)
+        self.assertGreaterEqual(result.readingConfidence, 90.0)
+        self.assertEqual(result.readingActivity, "read")
+        self.assertEqual(result.readingDepth, "Deep Reading")
+        self.assertGreaterEqual(result.readingScore, 70.0)
+
+    def test_short_semantic_visit_remains_meaningful(self):
+        page = PageSession(
+            page=4, activeTime=3, scrollCoverage=0.1,
+            interaction=InteractionSummary(figureClick=2),
+        )
+        scores, _, confidence = analyze_page_sessions([page], 600, 10)
+
+        self.assertEqual(count_meaningful_page_sessions([page]), 1)
+        self.assertEqual(confidence, scores[4])
+        self.assertGreater(scores[4], 15.0)
+
+    def test_scroll_interaction_is_capped(self):
+        self.assertEqual(
+            calculate_interaction_quality(InteractionSummary(scroll=1000)),
+            calculate_interaction_quality(InteractionSummary(scroll=10)),
+        )
+
     def test_duplicate_page_entries_are_consolidated(self):
         page = PageSession(
             page=1, activeTime=180.0, scrollCoverage=0.8,
@@ -195,7 +238,7 @@ class TestReadingAnalytics(unittest.TestCase):
             interactionSummary=interaction,
         )
         result = process_reading_analytics(payload, total_paper_pages=10, user_ema=600)
-        self.assertEqual(result.readingScore, 28.2)
+        self.assertEqual(result.readingScore, 55.0)
 
 
 def _analytics_payload(session_id, paper_id, version, active_time=60):
@@ -218,7 +261,10 @@ def _analytics_payload(session_id, paper_id, version, active_time=60):
 
 def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
     db = isolated_dirs["db"]
-    db.db_save_document("paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5, {})
+    db.db_save_document(
+        "paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5,
+        {"title": "Extracted Paper Title"},
+    )
 
     started = test_client.post(
         "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
@@ -266,6 +312,7 @@ def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
     )
     assert ended.status_code == 200
     assert db.db_get_user_reading_profile("testuser")["session_count"] == 1
+    assert db.db_get_document("paper-1")["metadata"]["title"] == "Extracted Paper Title"
 
     repeated_end = test_client.post(
         "/api/library/paper-1/reading-session/end",
@@ -273,6 +320,12 @@ def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
     )
     assert repeated_end.json() == {"stale": True, "version": 2}
     assert db.db_get_user_reading_profile("testuser")["session_count"] == 1
+
+    restarted = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    ).json()
+    assert restarted["merged"] is False
+    assert restarted["sessionId"] != session_id
 
 
 def test_reading_session_rejects_mismatched_paper_id(test_client, isolated_dirs):

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -271,12 +271,13 @@ export async function fetchLibraryDashboard() {
 // 뷰어/비교 화면이 보이고 포커스된 동안 주기적으로 경과 초를 보고한다(main.js의
 // 읽기 시간 하트비트 타이머가 호출). 실패해도 다음 하트비트에서 다시 시도되므로
 // 조용히 무시한다 - 토스트 등으로 사용자에게 알릴 만한 오류가 아니다.
-export async function sendReadingHeartbeat(docId, seconds, category = 'reading') {
+export async function sendReadingHeartbeat(docId, seconds, category = 'reading', { keepalive = false } = {}) {
   try {
     const res = await fetch(`${API_BASE}/library/${docId}/reading-heartbeat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ seconds, category }),
+      keepalive,
     })
     if (res.ok) invalidateLibraryGetCache()
     return res.ok

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,7 +16,7 @@ import { renderNotesPage } from './pages/notesPage.js'
 import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
-import { createReadingTimeActivityTracker } from './readingTimeActivity.js'
+import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -700,6 +700,7 @@ async function initScrollViewer() {
   viewerScrollContainer.innerHTML = ''
 
   if (state.sessionId) {
+    readingTimeActivityTracker.reset('reading')
     globalAnalyticsTracker.startSession(state.sessionId, state.totalPages || 0)
   }
 
@@ -709,9 +710,19 @@ async function initScrollViewer() {
     viewerScrollContainer.addEventListener('scroll', () => {
       if (state.currentPage) {
         const curPageEl = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${state.currentPage}"]`)
-        globalAnalyticsTracker.trackScroll(state.currentPage, curPageEl, viewerScrollContainer, true)
+        globalAnalyticsTracker.trackScroll(state.currentPage, curPageEl, viewerScrollContainer, true, false)
       }
     }, { passive: true })
+
+    let lastAnalyticsScrollInteractionAt = 0
+    const trackUserScrollInteraction = () => {
+      const now = Date.now()
+      if (now - lastAnalyticsScrollInteractionAt < 1000 || !state.currentPage) return
+      lastAnalyticsScrollInteractionAt = now
+      globalAnalyticsTracker.trackInteraction('scroll', state.currentPage)
+    }
+    viewerScrollContainer.addEventListener('wheel', trackUserScrollInteraction, { passive: true })
+    viewerScrollContainer.addEventListener('touchmove', trackUserScrollInteraction, { passive: true })
 
     viewerScrollContainer.addEventListener('mouseup', () => {
       const sel = window.getSelection()
@@ -4138,7 +4149,7 @@ const READING_HEARTBEAT_TICK_SECONDS = 5
 const READING_HEARTBEAT_FLUSH_MS = 20000
 let readingHeartbeatBuffers = {} // `${docId}|${category}` -> 적립된 초
 let readingHeartbeatContextKey = null
-const readingTimeActivityTracker = createReadingTimeActivityTracker()
+const readingTimeActivityTracker = globalReadingTimeActivityTracker
 
 function recordReadingTimeInteraction(event) {
   if (!viewerScreen?.classList.contains('active')) return
@@ -4197,22 +4208,28 @@ function tickReadingHeartbeat() {
   }
 }
 
-async function flushReadingHeartbeat() {
+async function flushReadingHeartbeat({ keepalive = false } = {}) {
   const buffers = readingHeartbeatBuffers
   readingHeartbeatBuffers = {}
-  const entries = Object.entries(buffers).filter(([, s]) => s > 0)
+  const entries = Object.entries(buffers).filter(([, seconds]) => seconds > 0)
   if (entries.length === 0) return
-  await Promise.all(entries.map(([key, seconds]) => {
+
+  const results = await Promise.all(entries.map(async ([key, seconds]) => {
     const sep = key.lastIndexOf('|')
     const docId = key.slice(0, sep)
     const category = key.slice(sep + 1)
-    return sendReadingHeartbeat(docId, seconds, category)
+    const sent = await sendReadingHeartbeat(docId, seconds, category, { keepalive })
+    return { key, seconds, sent }
   }))
+
+  for (const { key, seconds, sent } of results) {
+    if (!sent) readingHeartbeatBuffers[key] = (readingHeartbeatBuffers[key] || 0) + seconds
+  }
 }
 
 setInterval(tickReadingHeartbeat, READING_HEARTBEAT_TICK_SECONDS * 1000)
 setInterval(flushReadingHeartbeat, READING_HEARTBEAT_FLUSH_MS)
-window.addEventListener('beforeunload', () => { flushReadingHeartbeat(); globalAnalyticsTracker.stopSession() })
+window.addEventListener('beforeunload', () => { flushReadingHeartbeat({ keepalive: true }); globalAnalyticsTracker.stopSession() })
 
 // ── 초기화 ────────────────────────────────────────
 checkAuthentication()

--- a/frontend/src/readingAnalytics.js
+++ b/frontend/src/readingAnalytics.js
@@ -1,3 +1,5 @@
+import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
+
 // Reading Analytics Tracker (Frontend)
 
 const HEARTBEAT_INTERVAL_MS = 20000 // 20 seconds
@@ -159,8 +161,11 @@ export class ReadingAnalyticsTracker {
 
   tickActiveReadingTime() {
     if (!this.isTracking || !this.paperId) return
-    // Active Reading Condition: tab visible & window focused
+    // Use the same PDF-vs-chat and idle state as Reading History heartbeats.
     if (document.visibilityState !== 'visible' || !document.hasFocus()) return
+    if (globalReadingTimeActivityTracker.getCategory({
+      chatAvailable: !document.getElementById('chat-sidebar')?.classList.contains('hidden'),
+    }) !== 'reading') return
 
     this.activeReadingTime += 1
     const ps = this.ensurePageSession(this.currentPage)

--- a/frontend/src/readingTimeActivity.js
+++ b/frontend/src/readingTimeActivity.js
@@ -29,3 +29,5 @@ export function createReadingTimeActivityTracker({
 
   return { record, reset, getCategory }
 }
+
+export const globalReadingTimeActivityTracker = createReadingTimeActivityTracker()


### PR DESCRIPTION
# Summary
## 1. 읽음 판정 및 Reading Score 보정
- 짧게 스쳐간 페이지를 평균 신뢰도와 EMA 계산에서 제외하고 의미 있는 페이지 기준 가중 평균 적용
- Figure, Table, Equation 등 의도적 상호작용은 짧은 방문이어도 읽기 증거로 유지
- 전체 논문 범위와 세션 내 검증 비율을 분리해 표적 읽기의 Reading Score 및 depth 보정
- 원시 스크롤 이벤트 상한 적용 및 프로그램 스크롤의 상호작용 집계 제외
## 2. 읽기 시간 추적 정합성 개선
- Reading Analytics와 Reading History가 동일한 PDF·채팅·유휴 상태를 공유하도록 수정
- 실패한 읽기 시간 heartbeat 재적립 및 페이지 종료 시 keepalive 전송 추가
- 종료된 세션 재병합 방지 및 의미 있는 페이지 기준 EMA 갱신 적용
## 3. 타임라인 및 기존 데이터 복구
- 타임라인 페이지 범위를 의미 있는 방문 기준으로 계산하고 수동 읽음 상태 반영
- 메타데이터 갱신 시 추출 논문 제목 보존 및 누락된 기존 제목 PDF 재추출
- 분석 버전 마이그레이션으로 기존 세션 판정·신뢰도·점수·EMA 재계산