### PR TITLE
fix(ci): install Linux Tauri dependencies

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux Tauri build deps
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file \


### PR DESCRIPTION
Tauri 릴리스의 Linux 매트릭스가 ubuntu-22.04를 사용하면서 ubuntu-latest 조건으로 필수 패키지 설치를 건너뛰던 문제 수정.