### PR TITLE
chore(release): prepare v0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ EasyPaper의 변경 이력입니다. 이 프로젝트는 커밋 해시 기반 �
 
 ## 2026-08-10
 
+- ci: AppImage linuxdeploy 실패가 Linux deb·rpm 배포를 막지 않도록 번들 대상 분리 (#404)
 - ci: Linux Tauri 릴리스에서 필수 시스템 패키지 설치가 건너뛰어지던 조건 수정 (#402)
 - fix: PDF·AI 채팅 상호작용과 유휴 상태를 기준으로 읽기 시간 분류 정확도 개선 (#398)
 - fix: 의미 있는 페이지 방문·상호작용을 기준으로 Reading Score, EMA, 타임라인 정합성 보정 (#400)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.20"
+version = "0.1.21"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
Linux deb/rpm 배포 안정화가 반영된 v0.1.21 릴리스를 위해 버전을 동기화하고 CHANGELOG를 갱신.