### PR TITLE
fix: Notes 카드에 주석 색상 반영

### DIFF
--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -19,6 +19,15 @@ import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
 
 let renderGeneration = 0
 
+// 뷰어의 플로팅 메모 색상 이름을 Notes 카드에서 사용하는 실제 accent 색상으로
+// 맞춘다. default는 사용자가 설정한 앱 accent를 그대로 사용한다.
+const MEMO_ACCENT_COLORS = {
+  yellow: '#eab308',
+  green: '#10b981',
+  blue: '#3b82f6',
+  red: '#f43f5e',
+}
+
 // 즐겨찾기는 서버에 저장되는 필드가 아니라 Library 페이지가 이미 쓰고 있는
 // 로컬 전용 상태다(백엔드에 star/favorite 필드가 없음 - Library 리스킨 때 같은
 // 이유로 로컬로 구현됨). 같은 localStorage 키를 그대로 읽고 써서 Library와
@@ -133,7 +142,8 @@ async function buildPaperEntry(doc) {
     ;(memosByPage[pageKey] || []).forEach(memo => {
       const ts = memoTimestamp(memo)
       const text = (memo.content && memo.content.trim()) || memo.sentenceText || '(내용 없음)'
-      memoItems.push({ kind: 'memo', docId: doc.id, page: pageNum, ts, text, color: null })
+      const color = MEMO_ACCENT_COLORS[memo.color] || null
+      memoItems.push({ kind: 'memo', docId: doc.id, page: pageNum, ts, text, color })
     })
   })
 

--- a/frontend/src/styles/notes.css
+++ b/frontend/src/styles/notes.css
@@ -311,13 +311,15 @@
   position: relative;
   padding: 12px 14px 12px 16px;
   border-radius: var(--radius-md);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--notes-item-accent) 10%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--notes-item-accent) 35%, var(--border));
   border-left: 3px solid var(--notes-item-accent);
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
-.notes-annotation-card:hover { background: var(--bg-hover); }
+.notes-annotation-card:hover {
+  background: color-mix(in srgb, var(--notes-item-accent) 16%, var(--bg-elevated));
+}
 .notes-card-memo { --notes-item-accent: var(--control-accent); }
 .notes-card-highlight { --notes-item-accent: #eab308; }
 .notes-card-underline { --notes-item-accent: #22c55e; }


### PR DESCRIPTION
# Summary
## 1. Notes 콘텐츠 카드 색상 반영
- 메모 색상명을 뷰어와 동일한 색상 코드로 매핑함
- 메모·하이라이트·언더라인 카드의 배경, 테두리, hover 색상을 항목별 accent에 맞춤
- 기본색 메모에 사용자 설정 앱 accent 적용