### PR TITLE
feat: Notes 및 AI Chats Markdown·LaTeX 렌더링

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12993,7 +12993,7 @@ document.addEventListener('mouseup', () => {
 // KaTeX 로드 완료 후 페이지 내 pending 수식 전부 재처리
 document.addEventListener('katex-ready', () => {
   // 번역 패널의 모든 .math-pending 요소 처리
-  document.querySelectorAll('.trans-text, .message-bubble').forEach(el => {
+  document.querySelectorAll('.trans-text, .message-bubble, .notes-card-text, .aic-preview, .aic-card-preview').forEach(el => {
     applyKatexToElement(el)
   })
 })

--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -7,6 +7,7 @@
 import '../styles/ai-chats.css'
 import { icon } from '../icons.js'
 import { getChatSessionsAPI, getChatHistoryAPI } from '../api.js'
+import { formatMarkdownLatexHtml, applyKatexToElement } from '../textFormat.js'
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
@@ -40,12 +41,6 @@ function formatFullTime(isoString) {
   const date = new Date(isoString)
   if (Number.isNaN(date.getTime())) return ''
   return date.toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-function truncate(text, max) {
-  if (!text) return ''
-  const trimmed = text.replace(/\s+/g, ' ').trim()
-  return trimmed.length > max ? trimmed.slice(0, max) + '…' : trimmed
 }
 
 // items를 limit개씩 동시 실행하며 fn(item)을 적용한다 (세션이 많을 때 서버에 한 번에
@@ -177,7 +172,7 @@ export async function renderAiChatsPage() {
     const p = state.previews.get(session.doc_id)
     if (!p) return `<span class="aic-preview-loading">불러오는 중...</span>`
     if (p.error || !p.text) return `<span class="aic-preview-empty">-</span>`
-    return escapeHtml(truncate(p.text, 72))
+    return formatMarkdownLatexHtml(p.text)
   }
 
   function actionsHtml(session) {
@@ -302,6 +297,7 @@ export async function renderAiChatsPage() {
 
     bodyEl.innerHTML = state.viewMode === 'table' ? renderTable(pageItems) : renderCards(pageItems)
     bindActionButtons(bodyEl)
+    applyKatexToElement(bodyEl)
   }
 
   function renderPagination() {
@@ -353,6 +349,7 @@ export async function renderAiChatsPage() {
   function updatePreviewInDom(docId) {
     container.querySelectorAll(`[data-preview-doc="${CSS.escape(docId)}"]`).forEach(el => {
       el.innerHTML = previewCellHtml({ doc_id: docId })
+      applyKatexToElement(el)
     })
   }
 

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -15,7 +15,7 @@
 import '../styles/notes.css'
 import { fetchLibrary, fetchLibraryAnnotations, fetchLibraryMemos, fetchPrimer } from '../library.js'
 import { icon } from '../icons.js'
-import { formatTranslationHtml, applyKatexToElement } from '../textFormat.js'
+import { formatTranslationHtml, formatMarkdownLatexHtml, applyKatexToElement } from '../textFormat.js'
 
 let renderGeneration = 0
 
@@ -38,12 +38,6 @@ function toggleFavoriteDoc(docId) {
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
   return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-}
-
-function truncate(text, maxLen) {
-  if (!text) return ''
-  const trimmed = text.trim()
-  return trimmed.length > maxLen ? trimmed.substring(0, maxLen) + '...' : trimmed
 }
 
 // ── 모듈 상태 (페이지를 재방문해도 마지막 선택/탭/검색어를 기억한다) ──
@@ -396,17 +390,16 @@ function ensureSummaryLoaded(root, docId) {
 
 function renderAnnotationCard(item) {
   const iconName = item.kind === 'memo' ? 'edit3' : item.kind === 'highlight' ? 'highlighter' : 'underline'
-  const shortText = truncate(item.text, 220)
-  const canExpand = item.text.trim().length > shortText.replace(/\.\.\.$/, '').length
+  const canExpand = item.text.trim().length > 220
   const tsHtml = item.ts ? `<span class="notes-card-ts">${escapeHtml(formatTs(item.ts))}</span>` : ''
   const style = item.color ? ` style="--notes-item-accent:${escapeHtml(item.color)}"` : ''
   return `
-    <div class="notes-annotation-card notes-card-${item.kind}"${style} data-doc-id="${escapeHtml(item.docId)}">
+    <div class="notes-annotation-card notes-card-${item.kind} ${canExpand ? 'notes-card-collapsible' : ''}"${style} data-doc-id="${escapeHtml(item.docId)}">
       <div class="notes-card-top">
         <span class="notes-card-badge">${icon(iconName, 12)}p. ${item.page}</span>
         ${tsHtml}
       </div>
-      <p class="notes-card-text" data-full="${escapeHtml(item.text)}" data-short="${escapeHtml(shortText)}">${escapeHtml(shortText)}</p>
+      <div class="notes-card-text">${formatMarkdownLatexHtml(item.text)}</div>
       ${canExpand ? `<button type="button" class="notes-card-expand-btn">${icon('chevronDown', 12)}<span>더보기</span></button>` : ''}
     </div>
   `
@@ -468,6 +461,7 @@ function renderDetail(root) {
     <div class="notes-tab-content">${renderTabContent(entry)}</div>
   `
   bindThumbFallback(detailEl)
+  applyKatexToElement(detailEl)
 
   if (activeSubtab === 'summary') ensureSummaryLoaded(root, entry.doc.id)
 }
@@ -536,10 +530,8 @@ function attachListeners(root) {
     const expandBtn = e.target.closest('.notes-card-expand-btn')
     if (expandBtn) {
       const card = expandBtn.closest('.notes-annotation-card')
-      const textEl = card && card.querySelector('.notes-card-text')
-      if (!card || !textEl) return
+      if (!card) return
       const expanded = card.classList.toggle('expanded')
-      textEl.textContent = expanded ? textEl.dataset.full : textEl.dataset.short
       expandBtn.innerHTML = `${icon(expanded ? 'chevronUp' : 'chevronDown', 12)}<span>${expanded ? '접기' : '더보기'}</span>`
       return
     }

--- a/frontend/src/styles/ai-chats.css
+++ b/frontend/src/styles/ai-chats.css
@@ -267,6 +267,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.aic-preview > *,
+.aic-preview .katex-display-wrap,
+.aic-preview .katex-display { display: inline; margin: 0; }
+.aic-preview ul,
+.aic-preview ol { padding: 0; list-style: none; }
+
 .aic-preview-loading { color: var(--text-muted); font-style: italic; }
 .aic-preview-empty { color: var(--text-muted); }
 
@@ -340,6 +346,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.aic-card-preview > *,
+.aic-card-preview .katex-display-wrap,
+.aic-card-preview .katex-display { display: inline; margin: 0; }
+.aic-card-preview ul,
+.aic-card-preview ol { padding: 0; list-style: none; }
+
 .aic-card-actions { margin-top: 4px; }
 .aic-card-actions .aic-action-btn { flex: 1 1 auto; justify-content: center; }
 

--- a/frontend/src/styles/notes.css
+++ b/frontend/src/styles/notes.css
@@ -346,9 +346,23 @@
   font-size: 13px;
   line-height: 1.6;
   color: var(--text-primary);
-  white-space: pre-wrap;
   word-break: break-word;
 }
+.notes-card-collapsible:not(.expanded) .notes-card-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+}
+.notes-card-text > :first-child { margin-top: 0; }
+.notes-card-text > :last-child { margin-bottom: 0; }
+.notes-card-text p,
+.notes-card-text ul,
+.notes-card-text ol,
+.notes-card-text pre,
+.notes-card-text blockquote { margin: 0 0 0.55em; }
+.notes-card-text .katex-display { margin: 0.45em 0; overflow-x: auto; overflow-y: hidden; }
+.notes-card-text pre { overflow-x: auto; }
 .notes-card-expand-btn {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/textFormat.js
+++ b/frontend/src/textFormat.js
@@ -3,11 +3,69 @@
 // 옮겨온 것이다. 원래는 main.js 안에 있었는데, 읽기 전 브리핑(primer)
 // 텍스트도 같은 서식(LLM이 **볼드**나 $...$ 수식을 섞어 반환)을 쓰는
 // Notes 요약 탭에서도 그대로 재사용하려고 별도 모듈로 뺐다.
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
 const INDENT_MARK = String.fromCharCode(0xE000)
 
 function escapeHtml(str) {
   if (str === null || str === undefined) return ''
   return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/** Markdown과 LaTeX를 안전하게 렌더링한다. */
+export function formatMarkdownLatexHtml(text, options = {}) {
+  if (!text) return ''
+
+  const mathBlocks = []
+  let source = String(text)
+    .replace(/\$\$([\s\S]*?)\$\$/g, (_, formula) => {
+      const id = mathBlocks.push({ formula: formula.trim(), display: true }) - 1
+      return `EASYPAPERMATHBLOCK${id}END`
+    })
+    .replace(/\\\[([\s\S]*?)\\\]/g, (_, formula) => {
+      const id = mathBlocks.push({ formula: formula.trim(), display: true }) - 1
+      return `EASYPAPERMATHBLOCK${id}END`
+    })
+    .replace(/(?<!\$)\$([^\$\n]+?)\$(?!\$)/g, (_, formula) => {
+      const id = mathBlocks.push({ formula: formula.trim(), display: false }) - 1
+      return `EASYPAPERMATHBLOCK${id}END`
+    })
+    .replace(/\\\(([\s\S]*?)\\\)/g, (_, formula) => {
+      const id = mathBlocks.push({ formula: formula.trim(), display: false }) - 1
+      return `EASYPAPERMATHBLOCK${id}END`
+    })
+
+  source = source.replace(/\\+\*\*/g, '**').replace(/\\+__/g, '__')
+  let html = marked.parse(source)
+  const sanitize = options.sanitize || (value => {
+    if (typeof DOMPurify.sanitize === 'function') return DOMPurify.sanitize(value)
+    return escapeHtml(value)
+  })
+  html = sanitize(html)
+
+  const katex = options.katex === undefined ? globalThis.window?.katex : options.katex
+  return html.replace(/EASYPAPERMATHBLOCK(\d+)END/g, (placeholder, idText) => {
+    const item = mathBlocks[Number(idText)]
+    if (!item) return placeholder
+    const encodedFormula = encodeURIComponent(item.formula)
+    if (katex) {
+      try {
+        const rendered = katex.renderToString(item.formula, {
+          displayMode: item.display,
+          throwOnError: false,
+          output: 'htmlAndMathml',
+        })
+        const tag = item.display ? 'div' : 'span'
+        const className = item.display ? 'katex-display-wrap' : 'katex-inline-wrap'
+        return `<${tag} class="${className}" data-formula="${encodedFormula}" data-display="${item.display}">${rendered}</${tag}>`
+      } catch {
+        return `<code class="math-error" data-formula="${encodedFormula}" data-display="${item.display}">${escapeHtml(item.formula)}</code>`
+      }
+    }
+    const delimiter = item.display ? '$$' : '$'
+    return `<code class="math-pending" data-formula="${encodedFormula}" data-display="${item.display}">${escapeHtml(delimiter + item.formula + delimiter)}</code>`
+  })
 }
 
 export function formatTranslationHtml(text) {

--- a/frontend/tests/textFormat.test.js
+++ b/frontend/tests/textFormat.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { formatMarkdownLatexHtml } from '../src/textFormat.js'
+
+const passthrough = html => html
+
+test('Markdown과 인라인·블록 LaTeX를 함께 렌더링한다', () => {
+  const calls = []
+  const katex = {
+    renderToString(formula, options) {
+      calls.push({ formula, displayMode: options.displayMode })
+      return `<math>${formula}</math>`
+    },
+  }
+
+  const html = formatMarkdownLatexHtml(
+    '**핵심**은 $x_1$이고\n\n$$y = x^2$$',
+    { katex, sanitize: passthrough },
+  )
+
+  assert.match(html, /<strong>핵심<\/strong>/)
+  assert.match(html, /class="katex-inline-wrap"/)
+  assert.match(html, /class="katex-display-wrap"/)
+  assert.deepEqual(calls, [
+    { formula: 'x_1', displayMode: false },
+    { formula: 'y = x^2', displayMode: true },
+  ])
+})
+
+test('KaTeX가 아직 없으면 나중에 처리할 pending 수식을 만든다', () => {
+  const html = formatMarkdownLatexHtml('식: \\(a+b\\)', {
+    katex: null,
+    sanitize: passthrough,
+  })
+
+  assert.match(html, /class="math-pending"/)
+  assert.match(html, /data-formula="a%2Bb"/)
+})
+
+test('Markdown 결과를 수식 삽입 전에 sanitizer로 정제한다', () => {
+  const html = formatMarkdownLatexHtml('<img src=x onerror=alert(1)> **safe**', {
+    katex: null,
+    sanitize: value => value.replace(/<img[^>]*>/g, ''),
+  })
+
+  assert.doesNotMatch(html, /onerror/)
+  assert.match(html, /<strong>safe<\/strong>/)
+})


### PR DESCRIPTION
# Summary
## 1. Notes 주석 렌더링 지원
- 메모, 하이라이트, 언더라인 및 모든 주석 탭에 Markdown·LaTeX 렌더링 기능을 추가
- 긴 주석의 Markdown 문법을 보존하는 CSS 기반 접기 기능으로 수정함
## 2. AI Chats 최근 메시지 렌더링 지원
- 표 및 카드 보기의 최근 메시지에 Markdown·LaTeX 렌더링 기능을 추가
- KaTeX 지연 로딩 완료 시 미처리 수식을 다시 렌더링하도록 수정함
## 3. 안전성 및 검증
- marked 출력에 DOMPurify 정제를 적용함
- Markdown, 인라인·블록 LaTeX 및 지연 렌더링 단위 테스트를 추가