### PR TITLE
fix: prevent reading score regression

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -352,7 +352,12 @@ async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessio
     profile = db_get_user_reading_profile(current_user)
     user_ema = profile.get("ema_seconds_per_page", 600.0)
 
-    res = process_reading_analytics(payload, doc_total_pages, user_ema)
+    res = process_reading_analytics(
+        payload,
+        doc_total_pages,
+        user_ema,
+        previous_reading_score=existing["reading_score"] if existing else 0.0,
+    )
 
     started_at = existing["started_at"] if existing else datetime.now(timezone.utc).isoformat()
 
@@ -413,7 +418,12 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
 
     profile = db_get_user_reading_profile(current_user)
     user_ema = profile.get("ema_seconds_per_page", 600.0)
-    res = process_reading_analytics(payload, doc_total_pages, user_ema)
+    res = process_reading_analytics(
+        payload,
+        doc_total_pages,
+        user_ema,
+        previous_reading_score=existing["reading_score"] if existing else 0.0,
+    )
     started_at = existing["started_at"] if existing else datetime.now(timezone.utc).isoformat()
     now_iso = datetime.now(timezone.utc).isoformat()
 

--- a/backend/services/reading_analytics.py
+++ b/backend/services/reading_analytics.py
@@ -325,7 +325,8 @@ def update_user_ema(
 def process_reading_analytics(
     payload: ReadingSessionPayload,
     total_paper_pages: int,
-    user_ema: float
+    user_ema: float,
+    previous_reading_score: float = 0.0,
 ) -> ReadingAnalyticsResult:
     total_pages = max(total_paper_pages, max([ps.page for ps in payload.pageSessions], default=1))
 
@@ -360,6 +361,10 @@ def process_reading_analytics(
     reading_score = calculate_reading_score(
         verified_count, total_pages, avg_confidence, depth, total_iq, meaningful_pages_count,
     )
+    # Reading Score represents cumulative achievement within a session. A newly
+    # opened page can temporarily lower confidence while it is still being read,
+    # but it must not erase evidence already earned earlier in the same session.
+    reading_score = round(max(previous_reading_score, reading_score), 1)
     reading_activity, minimum_evidence_time = classify_reading_activity(
         payload.activeReadingTime, verified_count, avg_confidence, user_ema, payload.pageSessions,
     )

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -240,6 +240,37 @@ class TestReadingAnalytics(unittest.TestCase):
         result = process_reading_analytics(payload, total_paper_pages=10, user_ema=600)
         self.assertEqual(result.readingScore, 55.0)
 
+    def test_previous_score_is_preserved_while_new_page_is_in_progress(self):
+        established_payload = ReadingSessionPayload(
+            sessionId="session", paperId="paper", activeReadingTime=600,
+            pageSessions=[PageSession(
+                page=1,
+                activeTime=600,
+                scrollCoverage=0.8,
+                interaction=InteractionSummary(highlight=1),
+            )],
+            interactionSummary=InteractionSummary(highlight=1),
+        )
+        established = process_reading_analytics(
+            established_payload, total_paper_pages=10, user_ema=600,
+        )
+
+        in_progress_payload = established_payload.model_copy(deep=True)
+        in_progress_payload.activeReadingTime += 10
+        in_progress_payload.pageSessions.append(PageSession(page=2, activeTime=10))
+        recalculated = process_reading_analytics(
+            in_progress_payload, total_paper_pages=10, user_ema=600,
+        )
+        preserved = process_reading_analytics(
+            in_progress_payload,
+            total_paper_pages=10,
+            user_ema=600,
+            previous_reading_score=established.readingScore,
+        )
+
+        self.assertLess(recalculated.readingScore, established.readingScore)
+        self.assertEqual(preserved.readingScore, established.readingScore)
+
 
 def _analytics_payload(session_id, paper_id, version, active_time=60):
     return {
@@ -326,6 +357,42 @@ def test_reading_session_merge_versioning_and_ema(test_client, isolated_dirs):
     ).json()
     assert restarted["merged"] is False
     assert restarted["sessionId"] != session_id
+
+
+def test_heartbeat_preserves_the_session_high_score(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document(
+        "paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5, {},
+    )
+    started = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    )
+    session_id = started.json()["sessionId"]
+
+    established = _analytics_payload(session_id, "paper-1", 1, active_time=600)
+    first = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat", json=established,
+    )
+    assert first.status_code == 200
+
+    in_progress = _analytics_payload(session_id, "paper-1", 2, active_time=610)
+    in_progress["currentPage"] = 2
+    in_progress["pageSessions"].append({
+        "page": 2,
+        "activeTime": 10,
+        "visibleTime": 10,
+        "scrollCoverage": 0.0,
+        "interaction": {},
+    })
+    second = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat", json=in_progress,
+    )
+
+    assert second.status_code == 200
+    assert second.json()["readingScore"] == first.json()["readingScore"]
+    assert db.db_get_reading_session(
+        session_id, "testuser",
+    )["reading_score"] == first.json()["readingScore"]
 
 
 def test_reading_session_rejects_mismatched_paper_id(test_client, isolated_dirs):


### PR DESCRIPTION
# Summary
## 1. Reading Score 하락 방지
- 새 페이지를 읽기 시작할 때 낮은 중간 점수가 기존 누적 점수를 낮추지 않도록 세션 최고 점수 보존 로직 추가
- heartbeat 및 세션 종료 처리에서 저장된 기존 점수를 계산 하한값으로 적용
## 2. 회귀 테스트 추가
- 진행 중인 새 페이지가 원시 계산 점수를 낮추는 상황과 기존 점수 보존 동작 검증 추가
- heartbeat API 응답 및 데이터베이스 저장 점수의 비하락 검증 추가