### PR TITLE
fix: AI Chats 최근 메시지 미리보기 수정

### DIFF
--- a/frontend/src/pages/aiChatsPage.js
+++ b/frontend/src/pages/aiChatsPage.js
@@ -222,7 +222,7 @@ export async function renderAiChatsPage() {
                     <div class="aic-paper-title" title="${escapeHtml(session.title)}">${escapeHtml(session.title)}</div>
                   </div>
                 </td>
-                <td class="aic-col-message"><span class="aic-preview" data-preview-doc="${escapeHtml(session.doc_id)}">${previewCellHtml(session)}</span></td>
+                <td class="aic-col-message"><div class="aic-preview" data-preview-doc="${escapeHtml(session.doc_id)}">${previewCellHtml(session)}</div></td>
                 <td class="aic-col-updated" title="${escapeHtml(formatFullTime(session.last_message_at))}">${formatRelativeTime(session.last_message_at)}</td>
                 <td class="aic-col-actions"><div class="aic-actions">${actionsHtml(session)}</div></td>
               </tr>

--- a/frontend/src/styles/ai-chats.css
+++ b/frontend/src/styles/ai-chats.css
@@ -261,17 +261,40 @@
   white-space: nowrap;
   min-width: 0;
 }
-.aic-preview {
+.aic-preview,
+.aic-card-preview {
   display: block;
+  width: 100%;
+  max-width: 100%;
+  height: 1.5em;
+  line-height: 1.5;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.aic-preview > *,
+.aic-preview :is(p, h1, h2, h3, h4, h5, h6, blockquote, pre, ul, ol, li),
+.aic-card-preview :is(p, h1, h2, h3, h4, h5, h6, blockquote, pre, ul, ol, li),
 .aic-preview .katex-display-wrap,
-.aic-preview .katex-display { display: inline; margin: 0; }
-.aic-preview ul,
-.aic-preview ol { padding: 0; list-style: none; }
+.aic-preview .katex-display,
+.aic-card-preview .katex-display-wrap,
+.aic-card-preview .katex-display {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  white-space: nowrap;
+}
+.aic-preview :is(ul, ol),
+.aic-card-preview :is(ul, ol) { list-style: none; }
+.aic-preview :is(p, li, blockquote) + :is(p, li, blockquote)::before,
+.aic-card-preview :is(p, li, blockquote) + :is(p, li, blockquote)::before { content: ' · '; }
+.aic-preview br,
+.aic-card-preview br { display: none; }
+.aic-preview code,
+.aic-card-preview code { white-space: nowrap; }
+.aic-preview img,
+.aic-card-preview img { width: auto; max-width: 2em; height: 1em; vertical-align: -0.1em; }
 
 .aic-preview-loading { color: var(--text-muted); font-style: italic; }
 .aic-preview-empty { color: var(--text-muted); }
@@ -342,15 +365,7 @@
 .aic-card-preview {
   font-size: 12.5px;
   color: var(--text-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
-.aic-card-preview > *,
-.aic-card-preview .katex-display-wrap,
-.aic-card-preview .katex-display { display: inline; margin: 0; }
-.aic-card-preview ul,
-.aic-card-preview ol { padding: 0; list-style: none; }
 
 .aic-card-actions { margin-top: 4px; }
 .aic-card-actions .aic-action-btn { flex: 1 1 auto; justify-content: center; }

--- a/frontend/tests/textFormat.test.js
+++ b/frontend/tests/textFormat.test.js
@@ -47,3 +47,15 @@ test('Markdown 결과를 수식 삽입 전에 sanitizer로 정제한다', () => 
   assert.doesNotMatch(html, /onerror/)
   assert.match(html, /<strong>safe<\/strong>/)
 })
+
+test('미리보기에 쓰이는 블록 Markdown도 누락 없이 렌더링한다', () => {
+  const html = formatMarkdownLatexHtml(
+    '# 결론\n\n- **정확도** 향상\n- `지연시간` 감소',
+    { katex: null, sanitize: passthrough },
+  )
+
+  assert.match(html, /<h1>결론<\/h1>/)
+  assert.match(html, /<ul>/)
+  assert.match(html, /<strong>정확도<\/strong>/)
+  assert.match(html, /<code>지연시간<\/code>/)
+})


### PR DESCRIPTION
# Summary
## 1. 최근 메시지 노출 범위 수정
- AI Chats 표 및 카드 보기의 최근 메시지를 한 줄 높이로 제한함
- 긴 메시지에 말줄임 처리를 적용해 과도한 본문 노출을 방지함
## 2. Markdown 렌더링 수정
- 표 보기의 잘못된 인라인 컨테이너를 블록 컨테이너로 변경함
- 헤더, 목록, 인용, 코드 및 LaTeX 블록을 한 줄 안에서 렌더링하도록 스타일을 수정함
## 3. 회귀 테스트 추가
- 블록 Markdown의 헤더, 목록, 볼드 및 인라인 코드 렌더링 테스트를 추가