### PR TITLE
feat: 라이브러리 상호작용 개선

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4665,7 +4665,9 @@ function initSelectToolbarEvents() {
 }
 
 function initLibraryDragSelection() {
-  if (!libraryGrid) return
+  const dragSurface = $('page-outlet')
+  const filterRow = $('library-filter-row')
+  if (!libraryGrid || !dragSurface || !filterRow) return
   let dragState = null
   let marquee = null
 
@@ -4678,20 +4680,22 @@ function initLibraryDragSelection() {
   const finishDragSelection = (event, cancelled = false) => {
     if (!dragState || event.pointerId !== dragState.pointerId) return
     if (cancelled) replaceDocSelection(dragState.baseIds)
-    if (libraryGrid.hasPointerCapture?.(event.pointerId)) {
-      libraryGrid.releasePointerCapture(event.pointerId)
+    if (dragSurface.hasPointerCapture?.(event.pointerId)) {
+      dragSurface.releasePointerCapture(event.pointerId)
     }
     dragState = null
     removeMarquee()
   }
 
-  libraryGrid.addEventListener('pointerdown', event => {
+  dragSurface.addEventListener('pointerdown', event => {
+    const selectionTop = filterRow.getBoundingClientRect().bottom
     if (
       event.button !== 0 ||
       event.isPrimary === false ||
       (event.pointerType && event.pointerType !== 'mouse') ||
       state.currentWorkspacePage !== 'library' ||
       state.currentLibraryTab === 'trash' ||
+      event.clientY < selectionTop ||
       event.target.closest('.doc-card, .doc-list-row, .library-folder-card, button, a, input, textarea, select')
     ) return
 
@@ -4706,11 +4710,11 @@ function initLibraryDragSelection() {
       toggle,
       active: false,
     }
-    libraryGrid.setPointerCapture?.(event.pointerId)
+    dragSurface.setPointerCapture?.(event.pointerId)
     event.preventDefault()
   })
 
-  libraryGrid.addEventListener('pointermove', event => {
+  dragSurface.addEventListener('pointermove', event => {
     if (!dragState || event.pointerId !== dragState.pointerId) return
     const distance = Math.hypot(event.clientX - dragState.startX, event.clientY - dragState.startY)
     if (!dragState.active && distance < 4) return
@@ -4749,12 +4753,12 @@ function initLibraryDragSelection() {
     event.preventDefault()
   })
 
-  libraryGrid.addEventListener('pointerup', event => finishDragSelection(event))
-  libraryGrid.addEventListener('pointercancel', event => finishDragSelection(event, true))
+  dragSurface.addEventListener('pointerup', event => finishDragSelection(event))
+  dragSurface.addEventListener('pointercancel', event => finishDragSelection(event, true))
   window.addEventListener('blur', () => {
     if (!dragState) return
-    if (libraryGrid.hasPointerCapture?.(dragState.pointerId)) {
-      libraryGrid.releasePointerCapture(dragState.pointerId)
+    if (dragSurface.hasPointerCapture?.(dragState.pointerId)) {
+      dragSurface.releasePointerCapture(dragState.pointerId)
     }
     replaceDocSelection(dragState.baseIds)
     dragState = null
@@ -5696,6 +5700,167 @@ function createFolderCard(folder) {
   })
   return card
 }
+// ── 라이브러리 우클릭 메뉴 ────────────────────────────────────────────────
+let libraryContextMenu = null
+
+function closeLibraryContextMenu() {
+  libraryContextMenu?.remove()
+  libraryContextMenu = null
+}
+
+function libraryContextMenuItem(action, label, iconName, { danger = false } = {}) {
+  return `<button type="button" class="library-context-menu-item${danger ? ' danger' : ''}" role="menuitem" data-action="${action}">${icon(iconName, 15)}<span>${label}</span></button>`
+}
+
+function positionLibraryContextMenu(menu, clientX, clientY) {
+  const margin = 8
+  const rect = menu.getBoundingClientRect()
+  menu.style.left = `${Math.max(margin, Math.min(clientX, window.innerWidth - rect.width - margin))}px`
+  menu.style.top = `${Math.max(margin, Math.min(clientY, window.innerHeight - rect.height - margin))}px`
+}
+
+async function deleteDocFromContextMenu(doc) {
+  const displayTitle = doc.metadata?.title || doc.filename
+  const ok = await showCustomConfirm(`"${displayTitle}"을 삭제할까요? (휴지통으로 이동합니다)`, { title: '논문 삭제', confirmText: '삭제', danger: true })
+  if (!ok) return
+  await deleteLibraryDoc(doc.id)
+  showToast('휴지통으로 이동되었습니다.', 'success')
+  await renderLibrary()
+}
+
+async function clearDocCacheFromContextMenu(doc) {
+  const displayTitle = doc.metadata?.title || doc.filename
+  const ok = await showCustomConfirm(`"${displayTitle}"의 PDF 추출 캐시를 삭제할까요?\n(다음 열람 시 PDF를 다시 파싱하게 됩니다.)`, { title: 'PDF 캐시 삭제', confirmText: '캐시 삭제' })
+  if (!ok) return
+  await clearSingleDocCacheAPI(doc.id)
+  showToast('PDF 추출 캐시가 삭제되었습니다.', 'success')
+}
+
+function showLibraryContextMenu(event, { doc = null, folder = null } = {}) {
+  closeLibraryContextMenu()
+  const menu = document.createElement('div')
+  menu.className = 'library-context-menu'
+  menu.setAttribute('role', 'menu')
+
+  if (doc && state.currentLibraryTab === 'trash') {
+    menu.innerHTML = [
+      libraryContextMenuItem('restore', '복원', 'refreshCw'),
+      '<div class="library-context-menu-separator" role="separator"></div>',
+      libraryContextMenuItem('permanent-delete', '영구 삭제', 'trash2', { danger: true }),
+    ].join('')
+  } else if (doc) {
+    menu.innerHTML = [
+      libraryContextMenuItem('open', '논문 열기', 'externalLink'),
+      libraryContextMenuItem('details', '상세 정보', 'info'),
+      '<div class="library-context-menu-separator" role="separator"></div>',
+      libraryContextMenuItem('select', selectedDocIds.has(doc.id) ? '선택 해제' : '선택', 'checkCircle'),
+      libraryContextMenuItem('read', doc.metadata?.read === true ? '읽음 표시 해제' : '읽음으로 표시', 'bookOpen'),
+      libraryContextMenuItem('favorite', isFavoriteDoc(doc.id) ? '즐겨찾기 해제' : '즐겨찾기', 'star'),
+      '<div class="library-context-menu-separator" role="separator"></div>',
+      libraryContextMenuItem('clear-cache', 'PDF 캐시 삭제', 'refreshCw'),
+      libraryContextMenuItem('delete', '휴지통으로 이동', 'trash2', { danger: true }),
+    ].join('')
+  } else if (folder) {
+    menu.innerHTML = [
+      libraryContextMenuItem('open-folder', '폴더 열기', 'folder'),
+      '<div class="library-context-menu-separator" role="separator"></div>',
+      libraryContextMenuItem('rename-folder', '이름 변경', 'edit3'),
+      libraryContextMenuItem('color-folder', '폴더 색상', 'edit3'),
+      libraryContextMenuItem('delete-folder', '폴더 삭제', 'trash2', { danger: true }),
+    ].join('')
+  } else if (state.currentLibraryTab === 'trash') {
+    menu.innerHTML = libraryContextMenuItem('empty-trash', '휴지통 비우기', 'trash2', { danger: true })
+  } else {
+    menu.innerHTML = [
+      libraryContextMenuItem('add-paper', '논문 추가', 'fileText'),
+      libraryContextMenuItem('add-folder', '폴더 추가', 'folder'),
+      '<div class="library-context-menu-separator" role="separator"></div>',
+      libraryContextMenuItem('select-all', '전체 선택', 'checkCircle'),
+    ].join('')
+  }
+
+  document.body.appendChild(menu)
+  libraryContextMenu = menu
+  positionLibraryContextMenu(menu, event.clientX, event.clientY)
+  menu.querySelector('[role="menuitem"]')?.focus()
+
+  menu.addEventListener('click', async clickEvent => {
+    const action = clickEvent.target.closest('[data-action]')?.dataset.action
+    if (!action) return
+    closeLibraryContextMenu()
+    try {
+      if (action === 'open') await openFromLibrary(doc)
+      else if (action === 'details') openLibraryDetailPanel(doc)
+      else if (action === 'select') toggleDocSelection(doc.id)
+      else if (action === 'read') {
+        const nextRead = doc.metadata?.read !== true
+        await updateLibraryDocMetadata(doc.id, { read: nextRead, read_at: nextRead ? new Date().toISOString() : null })
+        await renderLibrary()
+      } else if (action === 'favorite') {
+        toggleFavoriteDoc(doc.id)
+        await renderLibrary()
+      } else if (action === 'clear-cache') await clearDocCacheFromContextMenu(doc)
+      else if (action === 'delete') await deleteDocFromContextMenu(doc)
+      else if (action === 'restore') {
+        await restoreLibraryDoc(doc.id)
+        showToast('논문을 복원했습니다.', 'success')
+        await renderLibrary()
+      } else if (action === 'permanent-delete') {
+        const ok = await showCustomConfirm('이 논문을 영구 삭제할까요? 이 작업은 되돌릴 수 없습니다.', { title: '논문 영구 삭제', confirmText: '영구 삭제', danger: true })
+        if (ok) {
+          await deleteLibraryDocPermanently(doc.id)
+          await renderLibrary()
+        }
+      } else if (action === 'open-folder') navigateLibraryFolder(folder.id)
+      else if (action === 'rename-folder') await requestRenameFolder(folder)
+      else if (action === 'color-folder') {
+        const color = await showFolderColorDialog(folder.color)
+        if (color && color !== folder.color) {
+          await updateFolderWithUndo(folder, { color })
+          await renderLibrary()
+        }
+      } else if (action === 'delete-folder') await requestDeleteFolder(folder)
+      else if (action === 'add-paper') fileInput.click()
+      else if (action === 'add-folder') await openCreateFolderDialog()
+      else if (action === 'select-all') {
+        const visibleIds = getVisibleDocIds()
+        visibleIds.forEach(id => selectedDocIds.add(id))
+        visibleIds.forEach(id => updateDocCardSelectionVisuals(id))
+        updateSelectToolbarUI()
+      } else if (action === 'empty-trash') $('lib-empty-trash-btn')?.click()
+    } catch (err) {
+      showToast(err.message || '작업에 실패했습니다.', 'error')
+    }
+  })
+}
+
+function initLibraryContextMenu() {
+  const surface = $('page-outlet')
+  if (!surface) return
+  surface.addEventListener('contextmenu', event => {
+    if (state.currentWorkspacePage !== 'library') return
+    const docElement = event.target.closest('.doc-card[data-id], .doc-list-row[data-id]')
+    const folderElement = event.target.closest('.library-folder-card[data-folder-id]')
+    const isLibraryArea = event.target === surface || event.target.closest('#page-library')
+    if (!docElement && !folderElement && (!isLibraryArea || event.target.closest('input, textarea, select'))) return
+
+    const doc = docElement ? currentLibraryDocs.find(item => item.id === docElement.dataset.id) : null
+    const folder = folderElement ? libraryFolders.find(item => item.id === folderElement.dataset.folderId) : null
+    event.preventDefault()
+    showLibraryContextMenu(event, { doc, folder })
+  })
+  document.addEventListener('pointerdown', event => {
+    if (libraryContextMenu && !event.target.closest('.library-context-menu')) closeLibraryContextMenu()
+  })
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closeLibraryContextMenu()
+  })
+  surface.addEventListener('scroll', closeLibraryContextMenu)
+  window.addEventListener('resize', closeLibraryContextMenu)
+}
+
+initLibraryContextMenu()
+
 function ensureLibraryFolderUI() {
   if ($('library-breadcrumb')) return
   librarySearchBox?.insertAdjacentHTML('beforebegin', `<div class="library-folder-header"><nav id="library-breadcrumb" class="library-breadcrumb" aria-label="폴더 경로"></nav></div>`)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6815,4 +6815,8 @@ body.light-theme .chat-drawer {
 .lib-add-fab-wrap.open .lib-add-sub-btn { opacity:1; visibility:visible; transform:translateY(0) scale(1); }
 .lib-add-label { padding:5px 9px; border-radius:7px; background:var(--bg-surface); box-shadow:var(--shadow-sm); font-size:12.5px; font-weight:650; white-space:nowrap; }
 .lib-add-circle { width:50px; height:50px; border-radius:50%; display:grid; place-items:center; background:var(--bg-surface); color:var(--text-primary); box-shadow:0 5px 16px rgba(0,0,0,.18); }
-.lib-add-sub-btn:hover .lib-add-circle { color:var(--control-accent-text); transform:translateY(-1px); }
+.lib-add-sub-btn:hover .lib-add-circle { transform:translateY(-1px); filter:brightness(1.06); }
+#lib-add-paper-btn .lib-add-circle { background:#4f8ef7; color:#fff; }
+#lib-add-folder-btn .lib-add-circle { background:#f59e0b; color:#fff; }
+#lib-add-paper-btn .lib-add-label { color:#4f8ef7; }
+#lib-add-folder-btn .lib-add-label { color:#d97706; }

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -586,6 +586,14 @@ body.light-theme .lib-detail-panel {
 body.library-marquee-selecting, body.library-marquee-selecting * { user-select:none!important; }
 body.library-marquee-selecting { cursor:crosshair!important; }
 
+.library-context-menu { position:fixed; z-index:100002; min-width:208px; padding:6px; border:1px solid var(--border-strong); border-radius:var(--radius-md); background:var(--bg-surface); box-shadow:var(--shadow-lg); }
+.library-context-menu-item { display:flex; align-items:center; gap:10px; width:100%; padding:9px 10px; border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-primary); cursor:pointer; font:inherit; font-size:12.5px; text-align:left; }
+.library-context-menu-item:hover, .library-context-menu-item:focus-visible { background:var(--bg-hover); outline:none; }
+.library-context-menu-item svg { flex:0 0 auto; color:var(--text-muted); }
+.library-context-menu-item.danger { color:var(--error); }
+.library-context-menu-item.danger svg { color:currentColor; }
+.library-context-menu-separator { height:1px; margin:5px 4px; background:var(--border); }
+
 .folder-color-picker{display:flex;gap:12px;padding:6px}.folder-color-picker .color-dot{width:28px;height:28px;border:2px solid transparent;border-radius:50%;cursor:pointer}.folder-color-picker .color-dot.selected{outline:2px solid var(--text-primary);outline-offset:3px}
 
 .folder-card-actions{position:absolute;right:10px;top:40px;z-index:4;display:grid;padding:5px;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-sm);box-shadow:var(--shadow-md)}.folder-card-actions button{border:0;background:transparent;color:var(--text-primary);padding:7px 10px;text-align:left;cursor:pointer}.folder-card-actions button:hover{background:var(--bg-hover)}


### PR DESCRIPTION
# Summary
## 1. 드래그 선택 영역 확장
- 필터 칩 하단부터 사이드바 경계까지 빈 영역에서 드래그 선택 가능하도록 선택 표면 확장
- 기존 논문 카드 교차 판정과 Ctrl/Cmd 토글 선택 동작 유지
## 2. 추가 플로팅 버튼 색상 구분
- 논문 추가 버튼에 파란색, 폴더 추가 버튼에 주황색 적용
- 라이트·다크 테마에서 레이블과 아이콘 구분 강화
## 3. 라이브러리 우클릭 메뉴 추가
- 빈 영역에 논문 추가, 폴더 추가, 전체 선택 기능 추가
- 논문에 열기, 상세 정보, 선택, 읽음, 즐겨찾기, 캐시 삭제, 휴지통 이동 기능 추가
- 폴더 및 휴지통 항목에 기존 관리 기능을 연결한 상황별 메뉴 추가