### PR TITLE
fix: repair PDF title and translation startup

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -175,18 +175,29 @@ async def upload_pdf(
         "username": current_user,
     }
 
-    # 읽기 전 브리핑을 먼저 생성한 뒤 번역 잡을 시작한다. CLI(antigravity/claude_code/
-    # codex) provider는 문서(session_id)당 세션이 하나뿐이라 primer 생성과 번역이 그
-    # 세션을 동시에 쓸 수 없다 - primer를 완료한 뒤에만 번역이 세션을 점유하도록
-    # 순차 실행한다 (API 기반 provider는 세션 개념이 없어 이 순서가 지연을 조금
-    # 더할 뿐 문제가 되지 않는다).
-    #
     # translation_mode가 "auto"(기본값)가 아니면 - 번역 창을 펼칠 때(pane) 또는
     # 스크롤로 페이지를 볼 때(scroll)만 번역하길 원하는 사용자이므로 - 업로드
     # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다. 이후
     # 번역은 프런트엔드가 상황에 맞춰 /jobs/{id}/restart(pane) 또는
     # /translate/{id}/{page}(scroll) 를 호출해 트리거한다.
-    async def _run_primer_then_translate():
+    #
+    # auto 번역 잡은 선택 기능인 읽기 전 브리핑에 의존하지 않도록
+    # 업로드 응답 전에 즉시 등록한다. 이렇게 해야 primer LLM이 느리거나
+    # 멈춰도 job status가 404로 남지 않고 번역이 진행된다. 문서당 세션을
+    # 재사용하는 CLI provider의 실제 LLM 호출은 llm_client의 세션 락이
+    # 직렬화하므로 동시에 같은 세션을 쓰지 않는다.
+    if translation_mode == "auto":
+        start_job(
+            session_id,
+            pages,
+            target_lang=target_lang,
+            style=style,
+            ignore_math=ignore_math,
+            ignore_table=ignore_table,
+            ignore_refs=ignore_refs
+        )
+
+    async def _run_post_upload_insights():
         try:
             await generate_primer(
                 session_id,
@@ -199,16 +210,6 @@ async def upload_pdf(
             )
         except Exception as e:
             print(f"[Upload {session_id}] Primer 생성 실패: {e}")
-        if translation_mode == "auto":
-            start_job(
-                session_id,
-                pages,
-                target_lang=target_lang,
-                style=style,
-                ignore_math=ignore_math,
-                ignore_table=ignore_table,
-                ignore_refs=ignore_refs
-            )
 
         if keyword_mode == "auto":
             start_keyword_job(
@@ -226,7 +227,7 @@ async def upload_pdf(
                 metadata.get("title") or file.filename,
             )
 
-    asyncio.create_task(_run_primer_then_translate())
+    asyncio.create_task(_run_post_upload_insights())
 
     return UploadResponse(
         session_id=session_id,

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -468,6 +468,11 @@ def _extract_paper_title(doc: fitz.Document) -> str:
             r'\b(doi\s*:|issn\b|volume\s+\d|vol\.\s*\d|copyright|©|all rights reserved)\b',
             re.IGNORECASE,
         )
+        editor_watermark_re = re.compile(
+            r'\b(?:created|edited|generated)\s+(?:in|with|using|by)\s+'
+            r'(?:the\s+)?master\s+pdf\s+editor\b',
+            re.IGNORECASE,
+        )
 
         lines = []
         for line_spans in group_spans_into_lines(spans_info):
@@ -510,6 +515,11 @@ def _extract_paper_title(doc: fitz.Document) -> str:
             if section_header_re.match(line_text) or author_hint_re.search(line_text):
                 return False
             if publication_header_re.match(line_text) or bibliographic_header_re.search(line_text):
+                return False
+            # Master PDF Editor 등이 삽입한 대형 워터마크는 본문과 같은
+            # y 좌표의 한 행으로 합쳐지기도 한다. 글꼴 크기만 보면 이 행이
+            # 실제 제목보다 긴 제목 후보로 선택되므로 후보에서 제외한다.
+            if editor_watermark_re.search(line_text):
                 return False
             return line["size"] >= min_prominent_size
 

--- a/backend/tests/test_pdf_parser_title_extraction.py
+++ b/backend/tests/test_pdf_parser_title_extraction.py
@@ -4,7 +4,7 @@
 
 import fitz
 
-from services.pdf_parser import _extract_paper_title
+from services.pdf_parser import _extract_paper_title, get_pdf_metadata
 
 
 def test_numbered_section_header_not_included_in_title(tmp_path):
@@ -127,3 +127,35 @@ def test_large_journal_masthead_does_not_become_title(tmp_path):
 
     assert extracted_title == title
     assert "JOURNAL" not in extracted_title
+
+
+def test_pdf_editor_watermark_does_not_become_title(tmp_path):
+    """PDF 편집기 워터마크가 본문 문장과 한 행으로 합쳐져도
+    실제 제목 후보를 대신하지 않아야 한다."""
+    doc = fitz.open()
+    page = doc.new_page(width=700, height=842)
+
+    title = "Muon Optimizer Accelerates Grokking"
+    page.insert_text((50, 80), title, fontsize=18)
+    page.insert_text(
+        (25, 300),
+        "Created in Master PDF Editor checkpoints to support future research.",
+        fontsize=15,
+    )
+    page.insert_textbox(
+        fitz.Rect(50, 360, 650, 650),
+        "This paper investigates optimizer behavior and generalization. " * 20,
+        fontsize=10,
+    )
+    doc.set_metadata({"title": title})
+
+    path = tmp_path / "master_pdf_editor_watermark.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    result_doc = fitz.open(str(path))
+    extracted_title = _extract_paper_title(result_doc)
+    result_doc.close()
+
+    assert extracted_title == title
+    assert get_pdf_metadata(str(path))["title"] == title

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -40,7 +40,7 @@ def test_upload_accepts_file_within_size_limit(test_client, isolated_dirs, monke
     monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
 
     res = test_client.post(
-        "/api/upload",
+        "/api/upload?translation_mode=scroll",
         files={"file": ("small.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
@@ -48,3 +48,33 @@ def test_upload_accepts_file_within_size_limit(test_client, isolated_dirs, monke
     body = res.json()
     assert body["filename"] == "small.pdf"
     assert body["session_id"] in upload_module.sessions
+
+
+def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, monkeypatch):
+    """선택 기능인 primer가 느려도 auto 번역 job은 먼저 등록되어야 한다."""
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
+
+    events = []
+
+    def fake_start_job(*args, **kwargs):
+        events.append("translation")
+        return {"status": "running"}
+
+    async def fake_generate_primer(*args, **kwargs):
+        events.append("primer")
+        assert events[0] == "translation"
+        return {}
+
+    monkeypatch.setattr(upload_module, "start_job", fake_start_job)
+    monkeypatch.setattr(upload_module, "generate_primer", fake_generate_primer)
+
+    res = test_client.post(
+        "/api/upload?translation_mode=auto",
+        files={"file": ("paper.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert res.status_code == 200
+    assert events
+    assert events[0] == "translation"


### PR DESCRIPTION
# Summary
## 1. PDF 제목 추출 오류 수정
- Master PDF Editor 워터마크와 본문 문장이 결합된 행을 제목 후보에서 제외
- Muon Optimizer Accelerates Grokking 제목 추출 회귀 테스트 추가
## 2. 자동 번역 시작 오류 수정
- 읽기 전 브리핑 완료 여부와 무관하게 업로드 직후 자동 번역 작업을 등록
- 프라이머보다 번역 작업이 먼저 등록되는지 검증하는 회귀 테스트 추가