### PR TITLE
fix(library): preserve renamed paper titles

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -5,7 +5,8 @@ from services.auth import get_current_user
 from services.library import (
     list_documents, search_documents, get_document, permanently_delete_document,
     soft_delete_document, restore_document, empty_trash,
-    get_translation, get_pdf_path, get_cover_path, update_document_metadata,
+    get_translation, get_pdf_path, get_cover_path,
+    patch_document_metadata,
     get_chat_quote_image_path, list_folders, create_folder, update_folder, delete_folder, move_documents_to_folder
 )
 from pydantic import BaseModel
@@ -462,9 +463,7 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         )
         db_save_user_reading_profile(current_user, new_ema, new_count)
 
-    metadata = dict((doc or {}).get("metadata") or {})
-    metadata["last_read_at"] = now_iso
-    update_document_metadata(doc_id, metadata)
+    patch_document_metadata(doc_id, {"last_read_at": now_iso})
 
     return res.model_dump()
 
@@ -961,8 +960,7 @@ async def get_library_bibliography(
     result = await resolve_paper_metadata(title)
 
     bibliography = result or {"venue": None, "doi": None, "arxiv_id": None, "citation_count": None}
-    meta["bibliography"] = bibliography
-    update_document_metadata(doc_id, meta)
+    patch_document_metadata(doc_id, {"bibliography": bibliography})
     return bibliography
 
 
@@ -1018,22 +1016,23 @@ async def update_doc_metadata(
             if not updated and ns not in combined:
                 combined.append(ns)
 
-        meta["read_sessions"] = combined[-100:]
         payload_copy = dict(payload)
-        payload_copy.pop("read_sessions")
-        meta.update(payload_copy)
+        payload_copy["read_sessions"] = combined[-100:]
+        updates = payload_copy
     else:
-        meta.update(payload)
-    
-    if "title" in payload and payload["title"] != old_title:
-        meta.pop("bibliography", None)
+        updates = payload
 
-    update_document_metadata(doc_id, meta)
-    
+    if "title" in payload and payload["title"] != old_title:
+        remove_keys = ("bibliography",)
+    else:
+        remove_keys = ()
+
+    persisted_meta = patch_document_metadata(doc_id, updates, remove_keys)
+
     # 활성 메모리 세션도 업데이트하여 정합성 유지
     from routers.upload import sessions
     if doc_id in sessions:
-        sessions[doc_id]["metadata"] = meta
-        
-    return {"status": "success", "metadata": meta}
+        sessions[doc_id]["metadata"] = persisted_meta
+
+    return {"status": "success", "metadata": persisted_meta}
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -890,6 +890,40 @@ def db_update_document_metadata(doc_id: str, metadata: dict) -> None:
         conn.commit()
 
 
+def db_patch_document_metadata(
+    doc_id: str,
+    updates: dict,
+    remove_keys: tuple[str, ...] = (),
+) -> Optional[dict]:
+    """Merge individual metadata fields without overwriting concurrent changes."""
+    with get_db() as conn:
+        # Keep the read/merge/write sequence inside one write transaction. Long
+        # running jobs often hold an old metadata snapshot, so callers that only
+        # changed one field must not replace the whole JSON document with it.
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT metadata FROM documents WHERE id = ?",
+            (doc_id,),
+        ).fetchone()
+        if row is None:
+            return None
+
+        try:
+            metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        metadata.update(updates)
+        for key in remove_keys:
+            metadata.pop(key, None)
+
+        conn.execute(
+            "UPDATE documents SET metadata = ? WHERE id = ?",
+            (json.dumps(metadata, ensure_ascii=False), doc_id),
+        )
+        conn.commit()
+        return metadata
+
+
 # ── 라이브러리 폴더 ───────────────────────────────────────────────────────────
 
 def db_list_folders(username: str) -> List[Dict[str, Any]]:

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -86,7 +86,7 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
     """번역 완료 직후 호출되어, 해당 문서의 개념을 추출하고 라이브러리 내
     다른 논문과의 인용 관계를 매칭해 DB에 저장한다. 실패해도 번역 파이프라인
     자체는 영향받지 않도록 호출부(translation_job.py)에서 try/except로 감싼다."""
-    from services.library import get_document, update_document_metadata
+    from services.library import get_document, patch_document_metadata
     doc = get_document(doc_id)
     if not doc:
         return
@@ -139,9 +139,7 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
     except Exception:
         pass  # 참고문헌 파싱/매칭 실패는 조용히 무시한다 (primer.py와 동일한 철학)
 
-    meta = doc.get("metadata", {})
-    meta["graph_synced_at"] = datetime.now(timezone.utc).isoformat()
-    update_document_metadata(doc_id, meta)
+    patch_document_metadata(doc_id, {"graph_synced_at": datetime.now(timezone.utc).isoformat()})
 
 
 async def sync_question_for_graph(chat_id: int, doc_id_or_compare_id: str, question_text: str) -> None:
@@ -1046,10 +1044,10 @@ def _resolve_ai_insight_title(doc: dict) -> str:
             filename.casefold(),
             filename_stem.casefold(),
         }:
-            from services.library import update_document_metadata
+            from services.library import patch_document_metadata
             updated_metadata = dict(metadata)
             updated_metadata["title"] = extracted_title
-            update_document_metadata(doc["id"], updated_metadata)
+            patch_document_metadata(doc["id"], {"title": extracted_title})
             doc["metadata"] = updated_metadata
             return extracted_title
 

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -22,6 +22,7 @@ from services.db import (
     db_clear_page_insights,
     db_delete_page_insight,
     db_update_document_metadata,
+    db_patch_document_metadata,
     db_bulk_translation_rows,
     db_list_folders, db_get_folder, db_create_folder, db_update_folder, db_delete_folder,
     db_get_document_folder_map, db_move_documents_to_folder,
@@ -420,6 +421,15 @@ def update_document_metadata(doc_id: str, metadata: dict) -> None:
     db_update_document_metadata(doc_id, metadata)
 
 
+def patch_document_metadata(
+    doc_id: str,
+    updates: dict,
+    remove_keys: tuple[str, ...] = (),
+) -> Optional[dict]:
+    """Atomically merge metadata fields and return the persisted metadata."""
+    return db_patch_document_metadata(doc_id, updates, remove_keys)
+
+
 def get_reference_start_page(doc: dict) -> Optional[int]:
     """문서에서 참고문헌 섹션이 시작하는 페이지 번호(1-based)를 반환합니다
     ("읽은 페이지 수"를 계산할 때 참고문헌 페이지를 본문에서 제외하는 데
@@ -451,7 +461,7 @@ def get_reference_start_page(doc: dict) -> Optional[int]:
     start_page = (idx + 1) if idx is not None else None  # 0-based 인덱스 -> 1-based 페이지 번호
 
     meta["reference_start_page"] = start_page
-    update_document_metadata(doc["id"], meta)
+    patch_document_metadata(doc["id"], {"reference_start_page": start_page})
     return start_page
 
 

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -264,15 +264,13 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
                 combined_text += p.get("text", "") + "\n"
             
             from services.llm_client import classify_paper_category
-            from services.library import update_document_metadata
+            from services.library import patch_document_metadata
             
             tags = await classify_paper_category(doc_title, combined_text, session_id=session_id)
             if tags:
                 doc = get_document(session_id)
                 if doc:
-                    meta = doc.get("metadata", {})
-                    meta["categories"] = tags
-                    update_document_metadata(session_id, meta)
+                    patch_document_metadata(session_id, {"categories": tags})
                     print(f"[Job {session_id}] Classified categories: {tags}")
         except Exception as ex:
             print(f"[Job {session_id}] Category classification failed: {ex}")

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -15,6 +15,30 @@ def test_document_crud_round_trip(isolated_dirs):
     assert db.db_get_document("nonexistent") is None
 
 
+def test_patch_document_metadata_preserves_unrelated_fields(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document(
+        "doc-patch",
+        "admin",
+        "paper.pdf",
+        "/x/paper.pdf",
+        10,
+        {"title": "Original", "bibliography": {"doi": "old"}, "read": True},
+    )
+
+    updated = db.db_patch_document_metadata(
+        "doc-patch", {"title": "Renamed"}, ("bibliography",),
+    )
+    assert updated == {"title": "Renamed", "read": True}
+
+    # A later background update must merge into the current metadata instead of
+    # restoring the title snapshot it started with.
+    db.db_patch_document_metadata("doc-patch", {"graph_synced_at": "now"})
+    assert db.db_get_document("doc-patch")["metadata"] == {
+        "title": "Renamed", "read": True, "graph_synced_at": "now",
+    }
+
+
 def test_list_documents_filters_by_username(isolated_dirs):
     db = isolated_dirs["db"]
     db.db_save_document("doc-a1", "alice", "a1.pdf", "/x", 1, {})

--- a/backend/tests/test_library_ownership_api.py
+++ b/backend/tests/test_library_ownership_api.py
@@ -60,6 +60,11 @@ def test_update_metadata_owned_by_self_succeeds(test_client, isolated_dirs):
     res = test_client.put("/api/library/doc-mine-2/metadata", json={"title": "My New Title"})
     assert res.status_code == 200
     assert res.json()["metadata"]["title"] == "My New Title"
+    assert isolated_dirs["db"].db_get_document("doc-mine-2")["metadata"]["title"] == "My New Title"
+
+    reloaded = test_client.get("/api/library/doc-mine-2")
+    assert reloaded.status_code == 200
+    assert reloaded.json()["metadata"]["title"] == "My New Title"
 
 
 def test_library_list_only_returns_own_documents(test_client, isolated_dirs):


### PR DESCRIPTION
# Summary
## 1. 논문 제목 영속성 수정
- 메타데이터 필드 단위 원자적 병합 기능을 추가해 동시 업데이트 시 변경된 제목이 유실되는 문제 수정함
- 서지정보 조회, 지식 그래프 동기화, 번역 카테고리 분석 및 열람 정보 저장이 오래된 메타데이터 전체를 덮어쓰지 않도록 수정함
## 2. 회귀 테스트 추가
- 제목 변경 결과가 DB와 문서 재조회 응답에 영구 저장되는지 검증 추가함
- 후속 백그라운드 메타데이터 갱신 이후에도 변경된 제목이 유지되는지 검증 추가함