### PR TITLE
fix(library): add durable title endpoint

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -33,6 +33,10 @@ class DocumentMoveRequest(BaseModel):
     doc_ids: list[str]
     folder_id: Optional[str] = None
 
+class DocumentTitleUpdateRequest(BaseModel):
+    title: str
+
+
 @router.get("/library/folders")
 async def get_library_folders(current_user: str = Depends(get_current_user)):
     return {"folders": list_folders(current_user)}
@@ -962,6 +966,31 @@ async def get_library_bibliography(
     bibliography = result or {"venue": None, "doi": None, "arxiv_id": None, "citation_count": None}
     patch_document_metadata(doc_id, {"bibliography": bibliography})
     return bibliography
+
+
+@router.put("/library/{doc_id}/title")
+async def update_doc_title(
+    doc_id: str,
+    body: DocumentTitleUpdateRequest,
+    current_user: str = Depends(get_current_user),
+):
+    """Update a document title through an explicit, persistent write path."""
+    require_owned_document(doc_id, current_user)
+    title = body.title.strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="제목을 입력해주세요.")
+    if len(title) > 500:
+        raise HTTPException(status_code=400, detail="제목은 500자 이하여야 합니다.")
+
+    persisted_meta = patch_document_metadata(
+        doc_id, {"title": title}, remove_keys=("bibliography",),
+    )
+
+    from routers.upload import sessions
+    if doc_id in sessions:
+        sessions[doc_id]["metadata"] = persisted_meta
+
+    return {"status": "success", "title": title, "metadata": persisted_meta}
 
 
 @router.put("/library/{doc_id}/metadata")

--- a/backend/tests/test_library_ownership_api.py
+++ b/backend/tests/test_library_ownership_api.py
@@ -67,6 +67,39 @@ def test_update_metadata_owned_by_self_succeeds(test_client, isolated_dirs):
     assert reloaded.json()["metadata"]["title"] == "My New Title"
 
 
+def test_update_title_persists_and_preserves_metadata(test_client, isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_save_document(
+        "doc-title",
+        "testuser",
+        "paper.pdf",
+        "/x/paper.pdf",
+        3,
+        {"title": "Original", "read": True, "bibliography": {"doi": "old"}},
+    )
+
+    res = test_client.put("/api/library/doc-title/title", json={"title": "  Persisted title  "})
+    assert res.status_code == 200
+    assert res.json()["title"] == "Persisted title"
+    assert res.json()["metadata"] == {"title": "Persisted title", "read": True}
+
+    reloaded = test_client.get("/api/library/doc-title")
+    assert reloaded.status_code == 200
+    assert reloaded.json()["metadata"] == {"title": "Persisted title", "read": True}
+
+
+def test_update_title_rejects_empty_title(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-title-empty", "testuser")
+    res = test_client.put("/api/library/doc-title-empty/title", json={"title": "   "})
+    assert res.status_code == 400
+
+
+def test_update_title_owned_by_other_user_returns_404(test_client, isolated_dirs):
+    _create_doc_owned_by(isolated_dirs, "doc-title-other", "otheruser")
+    res = test_client.put("/api/library/doc-title-other/title", json={"title": "Hijacked"})
+    assert res.status_code == 404
+
+
 def test_library_list_only_returns_own_documents(test_client, isolated_dirs):
     _create_doc_owned_by(isolated_dirs, "doc-mine-3", "testuser")
     _create_doc_owned_by(isolated_dirs, "doc-other-6", "otheruser")

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -101,6 +101,22 @@ export async function updateLibraryDocMetadata(docId, payload) {
   return res.json()
 }
 
+export async function updateLibraryDocTitle(docId, title) {
+  const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/title`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ title })
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.detail || '제목 변경 실패')
+  }
+  invalidateLibraryGetCache()
+  return res.json()
+}
+
 export async function updateLibraryTranslation(docId, pageNum, payload, options = {}) {
   const res = await fetch(`${API_BASE}/library/${docId}/translation/${pageNum}${buildQuery(options)}`, {
     method: 'PUT',

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,7 +6,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat } from './library.js'
 import { icon } from './icons.js'
 import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
 import { renderDashboardPage } from './pages/dashboardPage.js'
@@ -1705,9 +1705,10 @@ if (docTitleEditBtn) {
       const newTitle = input.value.trim()
       if (newTitle && newTitle !== oldTitle) {
         try {
-          await updateLibraryDocMetadata(state.sessionId, { title: newTitle })
+          await updateLibraryDocTitle(state.sessionId, newTitle)
           state.title = newTitle
           docTitle.textContent = newTitle
+          state.currentDocMetadata.title = newTitle
           showToast('제목이 변경되었습니다.', 'success')
         } catch (err) {
           showToast('제목 변경 실패: ' + err.message, 'error')
@@ -7400,7 +7401,7 @@ function wireDocItemEvents(container, doc, displayTitle) {
       const newTitle = input.value.trim()
       if (newTitle && newTitle !== oldTitle) {
         try {
-          await updateLibraryDocMetadata(doc.id, { title: newTitle })
+          await updateLibraryDocTitle(doc.id, newTitle)
           showToast('제목이 변경되었습니다.', 'success')
           await renderLibrary()
         } catch (err) {
@@ -7788,7 +7789,7 @@ function startLibraryDetailTitleEdit(doc) {
     const newTitle = input.value.trim()
     if (newTitle && newTitle !== oldTitle) {
       try {
-        await updateLibraryDocMetadata(doc.id, { title: newTitle })
+        await updateLibraryDocTitle(doc.id, newTitle)
         showToast('제목이 변경되었습니다.', 'success')
         titleEl.textContent = newTitle
         await renderLibrary()

--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -44,6 +44,9 @@ export async function mockBaseRoutes(page, { documents = [] } = {}) {
     if (url.includes('/api/settings/post-update-notice')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ show: false, version: 'test0000', version_date: '2026-01-01', changelog: [] }) })
     }
+    if (url.includes('/api/library/folders')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders: [] }) })
+    }
     if (url.includes('/api/library/trash')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents: [], total: 0 }) })
     }

--- a/frontend/tests/e2e/library-title-edit.spec.js
+++ b/frontend/tests/e2e/library-title-edit.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('card title edit persists after reload', async ({ page }) => {
+  const doc = {
+    id: 'doc-title',
+    filename: 'paper.pdf',
+    total_pages: 3,
+    created_at: '2026-08-11T00:00:00Z',
+    metadata: { title: 'Original title' },
+    translated_pages: [],
+  }
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-title/title', async route => {
+    expect(route.request().method()).toBe('PUT')
+    const payload = route.request().postDataJSON()
+    doc.metadata = { ...doc.metadata, title: payload.title }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'success', title: payload.title, metadata: doc.metadata }),
+    })
+  })
+
+  await gotoApp(page)
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+  await expect(page.locator('#library-screen')).toHaveClass(/active/)
+  const card = page.locator('.doc-card[data-id="doc-title"]')
+  await expect(card.locator('.doc-card-title')).toHaveText('Original title')
+
+  await card.locator('.doc-edit-btn').click()
+  const input = card.locator('.doc-card-title input')
+  await input.fill('Persisted title')
+  await input.press('Enter')
+  await expect(card.locator('.doc-card-title')).toHaveText('Persisted title')
+
+  await page.reload()
+  await page.waitForTimeout(600)
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+  await expect(page.locator('#library-screen')).toHaveClass(/active/)
+  await expect(page.locator('.doc-card[data-id="doc-title"] .doc-card-title'))
+    .toHaveText('Persisted title')
+})


### PR DESCRIPTION
# Summary
## 1. 논문 제목 전용 저장 경로 추가
- 논문 제목만 검증하고 DB에 영구 저장하는 `PUT /api/library/{doc_id}/title` API를 추가함
- 카드, 상세 패널, 뷰어의 제목 변경 동작을 제목 전용 API로 통일함
- 제목 변경 시 서지정보 캐시 초기화 및 활성 세션 메타데이터 동기화 기능을 유지함
## 2. 제목 저장 회귀 테스트 추가
- 제목 변경 후 DB 및 문서 재조회 결과에 변경값이 유지되는지 검증 추가함
- 빈 제목과 타 사용자 문서 변경을 거부하는 검증 추가함
- 브라우저에서 카드 제목 변경 후 새로고침해도 변경값이 유지되는 E2E 테스트 추가함