### PR TITLE
fix(library): preserve manual paper titles

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -983,7 +983,9 @@ async def update_doc_title(
         raise HTTPException(status_code=400, detail="제목은 500자 이하여야 합니다.")
 
     persisted_meta = patch_document_metadata(
-        doc_id, {"title": title}, remove_keys=("bibliography",),
+        doc_id,
+        {"title": title, "title_source": "manual"},
+        remove_keys=("bibliography",),
     )
 
     from routers.upload import sessions
@@ -1050,6 +1052,10 @@ async def update_doc_metadata(
         updates = payload_copy
     else:
         updates = payload
+
+    if "title" in payload:
+        updates = dict(updates)
+        updates["title_source"] = "manual"
 
     if "title" in payload and payload["title"] != old_title:
         remove_keys = ("bibliography",)

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -1023,6 +1023,9 @@ def _resolve_ai_insight_title(doc: dict) -> str:
     """
     metadata = doc.get("metadata") or {}
     title = (metadata.get("title") or "").strip()
+    if title and metadata.get("title_source") == "manual":
+        return title
+
     filename = (doc.get("filename") or "").strip()
     filename_stem = os.path.splitext(filename)[0]
     title_is_filename = bool(title and filename) and title.casefold() in {

--- a/backend/tests/test_knowledge_graph_v4.py
+++ b/backend/tests/test_knowledge_graph_v4.py
@@ -351,6 +351,49 @@ async def test_ai_insights_reextracts_filename_title_for_prompt(isolated_dirs, m
 
 
 @pytest.mark.asyncio
+async def test_ai_insights_preserves_manual_title_matching_filename(
+    test_client, isolated_dirs, monkeypatch, tmp_path,
+):
+    import services.llm_client as llm_client
+    import services.pdf_parser as pdf_parser
+    import services.knowledge_graph as knowledge_graph
+
+    db = isolated_dirs["db"]
+    pdf_path = tmp_path / "Muon is Scalable for LLM Training.pdf"
+    pdf_path.write_bytes(b"%PDF-test")
+    db.db_save_document(
+        "doc-manual-title",
+        "testuser",
+        pdf_path.name,
+        str(pdf_path),
+        1,
+        {"title": "Wrong Embedded PDF Title"},
+    )
+    res = test_client.put(
+        "/api/library/doc-manual-title/title",
+        json={"title": "Muon is Scalable for LLM Training"},
+    )
+    assert res.status_code == 200
+
+    monkeypatch.setattr(
+        pdf_parser,
+        "get_pdf_metadata",
+        lambda _path: {"title": "Wrong Embedded PDF Title"},
+    )
+
+    async def fake_generate_insights(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate_insights)
+
+    await knowledge_graph.get_ai_insights("testuser")
+
+    metadata = db.db_get_document("doc-manual-title")["metadata"]
+    assert metadata["title"] == "Muon is Scalable for LLM Training"
+    assert metadata["title_source"] == "manual"
+
+
+@pytest.mark.asyncio
 async def test_ai_insights_falls_back_to_rule_based_gaps_when_llm_empty(isolated_dirs, monkeypatch):
     import services.llm_client as llm_client
     import services.knowledge_graph as knowledge_graph

--- a/backend/tests/test_library_ownership_api.py
+++ b/backend/tests/test_library_ownership_api.py
@@ -60,6 +60,7 @@ def test_update_metadata_owned_by_self_succeeds(test_client, isolated_dirs):
     res = test_client.put("/api/library/doc-mine-2/metadata", json={"title": "My New Title"})
     assert res.status_code == 200
     assert res.json()["metadata"]["title"] == "My New Title"
+    assert res.json()["metadata"]["title_source"] == "manual"
     assert isolated_dirs["db"].db_get_document("doc-mine-2")["metadata"]["title"] == "My New Title"
 
     reloaded = test_client.get("/api/library/doc-mine-2")
@@ -81,11 +82,15 @@ def test_update_title_persists_and_preserves_metadata(test_client, isolated_dirs
     res = test_client.put("/api/library/doc-title/title", json={"title": "  Persisted title  "})
     assert res.status_code == 200
     assert res.json()["title"] == "Persisted title"
-    assert res.json()["metadata"] == {"title": "Persisted title", "read": True}
+    assert res.json()["metadata"] == {
+        "title": "Persisted title", "title_source": "manual", "read": True,
+    }
 
     reloaded = test_client.get("/api/library/doc-title")
     assert reloaded.status_code == 200
-    assert reloaded.json()["metadata"] == {"title": "Persisted title", "read": True}
+    assert reloaded.json()["metadata"] == {
+        "title": "Persisted title", "title_source": "manual", "read": True,
+    }
 
 
 def test_update_title_rejects_empty_title(test_client, isolated_dirs):


### PR DESCRIPTION
# Summary
## 1. 수동 제목 자동 덮어쓰기 방지
- 제목 수정 시 수동 편집 출처를 메타데이터에 함께 저장함
- AI 인사이트 생성 중 파일명과 같은 수동 제목을 PDF 내장 메타데이터로 덮어쓰지 않도록 수정함
## 2. 회귀 테스트 추가
- 실제 운영 사례와 동일한 파일명 기반 수동 제목 보존 테스트를 추가함
- 전용 제목 API와 기존 메타데이터 API의 수동 출처 저장을 검증함