### PR TITLE
fix(library): keep card actions visible

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7133,8 +7133,11 @@ function prepareDocItemHtml(doc) {
   const categories = doc.metadata?.categories || []
   let tagsHtml = ''
   if (categories.length > 0) {
+    const shownCategories = categories.slice(0, 2)
+    const hiddenCategoryCount = categories.length - shownCategories.length
     tagsHtml = `<div class="doc-card-tags">` +
-      categories.map(cat => `<span class="doc-card-tag">${escapeHtml(cat)}</span>`).join('') +
+      shownCategories.map(cat => `<span class="doc-card-tag" title="${escapeHtml(cat)}">${escapeHtml(cat)}</span>`).join('') +
+      (hiddenCategoryCount > 0 ? `<span class="doc-card-tag doc-card-tag-count" title="태그 ${hiddenCategoryCount}개 더 보기">+${hiddenCategoryCount}</span>` : '') +
       `</div>`
   }
 
@@ -8118,8 +8121,7 @@ async function loadLibraryDetailRelated(doc) {
 function createDocListRow(doc) {
   const d = prepareDocItemHtml(doc)
 
-  // 리스트 뷰는 한 줄에 담아야 하므로, 태그가 CSS로 중간에 잘려 보이는 것을 막기 위해
-  // 최대 2개만 보여주고 나머지는 "+N"으로 요약한다 (카드 뷰의 전체 태그와는 별도로 계산).
+  // 리스트 뷰도 카드 뷰와 마찬가지로 최대 2개만 보여주고 나머지는 "+N"으로 요약한다.
   let listTagsHtml = ''
   if (d.categories.length > 0) {
     const shown = d.categories.slice(0, 2)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1227,6 +1227,9 @@ body.light-theme .toast.error { color: #dc2626; }
 .library-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(265px, 1fr));
+  grid-auto-rows: max-content;
+  align-content: start;
+  min-height: 0;
   gap: 16px;
   overflow-y: auto;
   padding-bottom: 30px;
@@ -1310,6 +1313,7 @@ body.light-theme .toast.error { color: #dc2626; }
   align-items: center;
   gap: 8px;
   margin-top: auto;
+  flex-shrink: 0;
 }
 
 .doc-card-meta {
@@ -3534,6 +3538,11 @@ body.light-theme .provider-picker-panel {
   gap: 6px;
   flex-wrap: wrap;
 }
+.doc-card .doc-card-tags {
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
 .doc-card-tag {
   font-size: 10.5px;
   font-weight: 700;
@@ -3542,6 +3551,15 @@ body.light-theme .provider-picker-panel {
   background: var(--control-accent-soft);
   color: var(--control-accent-text);
   border: 1px solid transparent;
+}
+.doc-card .doc-card-tag {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.doc-card .doc-card-tag-count {
+  flex-shrink: 0;
 }
 
 /* ── Google Drive Style Upload Popup ── */

--- a/frontend/tests/e2e/library-card-tags.spec.js
+++ b/frontend/tests/e2e/library-card-tags.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('many paper tags stay compact and keep card footer visible', async ({ page }) => {
+  const categories = [
+    'Large Language Models',
+    'Harness Engineering Methodology',
+    'Agentic Workflows',
+    'Evaluation and Benchmarking',
+    'Natural Language Processing',
+    'Software Engineering',
+    'Developer Tools',
+  ]
+  const doc = {
+    id: 'doc-many-tags',
+    filename: 'meta-harness.pdf',
+    total_pages: 18,
+    created_at: '2026-08-11T00:00:00Z',
+    metadata: { title: 'Meta-Harness', categories },
+    translated_pages: [],
+  }
+  await mockBaseRoutes(page, { documents: [doc] })
+
+  await gotoApp(page)
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+
+  const card = page.locator('.doc-card[data-id="doc-many-tags"]')
+  const tags = card.locator('.doc-card-tags')
+  await expect(card).toBeVisible()
+  await expect(tags.locator('.doc-card-tag')).toHaveCount(3)
+  await expect(tags.locator('.doc-card-tag')).toHaveText([
+    'Large Language Models',
+    'Harness Engineering Methodology',
+    '+5',
+  ])
+  await expect(card.locator('.doc-card-footer')).toBeVisible()
+
+  const [tagsBox, footerBox, cardBox] = await Promise.all([
+    tags.boundingBox(),
+    card.locator('.doc-card-footer').boundingBox(),
+    card.boundingBox(),
+  ])
+  expect(tagsBox.height).toBeLessThan(30)
+  expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(cardBox.y + cardBox.height)
+})


### PR DESCRIPTION
# Summary
## 1. 카드 태그 표시 방식 개선
- 카드뷰 태그를 대표 2개와 +N 형태로 한 줄 표시하도록 수정함
- 긴 태그 말줄임 처리 및 전체 태그 상세 패널 표시 유지
## 2. 하단 액션 영역 잘림 수정
- CSS Grid 자동 행을 콘텐츠 높이로 유지하도록 수정함
- 카드 푸터 축소를 방지해 열기·편집·더보기 버튼 노출 보장
## 3. 회귀 테스트 추가
- 태그 7개를 가진 카드에서 태그 축약과 푸터 경계 내 표시를 검증하는 Playwright 테스트 추가