### PR TITLE
feat: add Gemini 3.7 Flash to Antigravity

### DIFF
--- a/backend/routers/agy.py
+++ b/backend/routers/agy.py
@@ -45,6 +45,9 @@ async def get_agy_models():
         return {
             "ok": True,
             "models": [
+                "Gemini 3.7 Flash (Medium)",
+                "Gemini 3.7 Flash (High)",
+                "Gemini 3.7 Flash (Low)",
                 "Gemini 3.6 Flash (Medium)",
                 "Gemini 3.6 Flash (High)",
                 "Gemini 3.6 Flash (Low)",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1873,6 +1873,10 @@ const PROVIDER_CONFIG = [
   {
     id: 'antigravity', label: 'Antigravity', icon: icon('zap', 13),
     models: [
+      // Gemini 3.7 Flash
+      { value: 'Gemini 3.7 Flash (Low)',    label: 'Flash · Low',    group: 'Gemini 3.7 Flash' },
+      { value: 'Gemini 3.7 Flash (Medium)', label: 'Flash · Medium', group: 'Gemini 3.7 Flash' },
+      { value: 'Gemini 3.7 Flash (High)',   label: 'Flash · High',   group: 'Gemini 3.7 Flash' },
       // Gemini 3.6 Flash
       { value: 'Gemini 3.6 Flash (Low)',    label: 'Flash · Low',    group: 'Gemini 3.6 Flash' },
       { value: 'Gemini 3.6 Flash (Medium)', label: 'Flash · Medium', group: 'Gemini 3.6 Flash' },


### PR DESCRIPTION
# Summary
## 1. Antigravity Gemini 3.7 Flash 모델 추가
- CLI fallback 모델 목록에 Gemini 3.7 Flash Low/Medium/High 추가
- 번역/채팅 프로바이더 선택 목록에 Gemini 3.7 Flash 옵션 추가
- 기존 Gemini 3.5/3.6 Flash 모델 유지