### PR TITLE
feat(library): add recently read sorting

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17,6 +17,7 @@ import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
 import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
+import { compareDocsByLastRead } from './readPages.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -5359,7 +5360,7 @@ document.addEventListener('keydown', async e => {
 // 없음) 새 필드를 추가하지 않고 로컬 전용 편의 기능으로만 제공한다 - localStorage에만
 // 저장되며 기기 간 동기화되거나 서버에 반영되지 않는다.
 let activeStatusFilter = 'all' // 'all' | 'unread' | 'reading' | 'finished' | 'favorites'
-let librarySortMode = localStorage.getItem('easypaper_library_sort') || 'recent' // 'recent' | 'title' | 'progress'
+let librarySortMode = localStorage.getItem('easypaper_library_sort') || 'recent' // 'recent' | 'last-read' | 'title' | 'progress'
 
 const LIBRARY_FAVORITES_KEY = 'easypaper_library_favorites'
 function getFavoriteIds() {
@@ -5440,6 +5441,8 @@ function sortDocsByMode(docs) {
     })
   } else if (librarySortMode === 'progress') {
     sorted.sort((a, b) => getLibraryReadProgress(b) - getLibraryReadProgress(a))
+  } else if (librarySortMode === 'last-read') {
+    sorted.sort(compareDocsByLastRead)
   } else {
     sorted.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
   }
@@ -5885,6 +5888,7 @@ function ensureLibraryChrome() {
       <div class="lib-sort-dropdown">
         <select id="library-sort-select" class="lib-sort-select" title="정렬 기준">
           <option value="recent">최근 추가순</option>
+          <option value="last-read">최근 읽은 순</option>
           <option value="title">제목순</option>
           <option value="progress">번역 진행률순</option>
         </select>

--- a/frontend/src/readPages.js
+++ b/frontend/src/readPages.js
@@ -55,6 +55,28 @@ export function hasReadActivity(meta) {
   return Boolean(meta?.last_read_at || meta?.read_at)
 }
 
+// Library의 "최근 읽은 순"은 업로드 시각을 읽기 활동으로 간주하지 않는다.
+// last_read_at/read_at 중 유효한 최신 시각을 사용하고, 읽은 기록이 없는 문서는
+// -Infinity로 두어 목록 뒤로 보낸다.
+export function lastReadTimestamp(meta) {
+  const timestamps = [meta?.last_read_at, meta?.read_at]
+    .map(value => Date.parse(value))
+    .filter(Number.isFinite)
+  return timestamps.length > 0 ? Math.max(...timestamps) : -Infinity
+}
+
+export function compareDocsByLastRead(a, b) {
+  const aReadAt = lastReadTimestamp(a?.metadata)
+  const bReadAt = lastReadTimestamp(b?.metadata)
+  if (aReadAt !== bReadAt) return bReadAt > aReadAt ? 1 : -1
+
+  const createdTimestamp = doc => {
+    const value = Date.parse(doc?.created_at)
+    return Number.isFinite(value) ? value : -Infinity
+  }
+  return createdTimestamp(b) - createdTimestamp(a)
+}
+
 // ISO 타임스탬프 문자열을 사용자 로컬 시간대 자정 기준 "YYYY-MM-DD" 날짜 키로 변환한다.
 // 단순 .slice(0, 10)을 하면 UTC 날짜가 잘려 나와 한국 시간(KST) 등에서 9시간 시차
 // 어긋남이 발생하므로, local Date 객체의 연/월/일을 사용한다.

--- a/frontend/tests/readPages.test.js
+++ b/frontend/tests/readPages.test.js
@@ -3,10 +3,12 @@ import test from 'node:test'
 
 import {
   addDaysKey,
+  compareDocsByLastRead,
   computeStreakDays,
   countUniqueVerifiedPages,
   hasReadActivity,
   lastActivityIso,
+  lastReadTimestamp,
   readPageCount,
   todayKey,
   uniqueVerifiedPageKeys,
@@ -57,6 +59,31 @@ test('마지막 활동 시각과 실제 읽기 활동 여부를 구분한다', (
   assert.equal(lastActivityIso(meta, createdAt), meta.last_read_at)
   assert.equal(hasReadActivity(meta), true)
   assert.equal(hasReadActivity({}), false)
+})
+
+test('최근 읽은 시각은 읽기 기록만 사용하고 두 기록 중 최신값을 고른다', () => {
+  assert.equal(lastReadTimestamp({
+    last_read_at: '2026-08-02T00:00:00Z',
+    read_at: '2026-08-03T00:00:00Z',
+  }), Date.parse('2026-08-03T00:00:00Z'))
+  assert.equal(lastReadTimestamp({ last_read_at: 'invalid' }), -Infinity)
+  assert.equal(lastReadTimestamp({}), -Infinity)
+})
+
+test('최근 읽은 순은 최신 읽기 활동을 우선하고 미열람 논문은 최근 추가순으로 뒤에 둔다', () => {
+  const docs = [
+    { id: 'unread-new', created_at: '2026-08-05T00:00:00Z', metadata: {} },
+    { id: 'read-old', created_at: '2026-08-04T00:00:00Z', metadata: { last_read_at: '2026-08-06T00:00:00Z' } },
+    { id: 'unread-old', created_at: '2026-08-01T00:00:00Z', metadata: {} },
+    { id: 'read-new', created_at: '2026-08-02T00:00:00Z', metadata: { read_at: '2026-08-07T00:00:00Z' } },
+  ]
+
+  assert.deepEqual(docs.sort(compareDocsByLastRead).map(doc => doc.id), [
+    'read-new',
+    'read-old',
+    'unread-new',
+    'unread-old',
+  ])
 })
 
 test('날짜 키 덧셈은 월·연도 경계를 넘는다', () => {


### PR DESCRIPTION
# Summary
## 1. 최근 읽은 순 정렬 추가
- Library 정렬 드롭다운에 `최근 읽은 순` 옵션 추가
- `last_read_at`과 `read_at` 중 최신 읽기 시각을 기준으로 정렬하는 로직 추가
- 미열람 논문을 최근 추가순으로 목록 뒤에 배치
## 2. 정렬 동작 검증 추가
- 최신 읽기 시각 선택 및 잘못된 시각 처리 단위 테스트 추가
- 읽은 논문 우선순위와 미열람 논문 정렬 단위 테스트 추가