### PR TITLE
fix(library): unify folder list styling

### DIFF
--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -576,12 +576,59 @@ body.light-theme .lib-detail-panel {
 .folder-dialog-label { display:grid; gap:8px; color:var(--text-secondary); font-size:13px; }
 .folder-dialog-input { width:100%; box-sizing:border-box; padding:9px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-sm); background:var(--bg-elevated); color:var(--text-primary); font:inherit; outline:none; }
 .folder-dialog-input:focus { border-color:var(--control-accent); }
-.library-grid.list-view .library-folder-card { min-height:0; padding:12px 16px; display:flex; align-items:center; gap:16px; border-radius:14px; }
-.library-grid.list-view .library-folder-card:hover { transform:translateX(2px); }
-.library-grid.list-view .folder-card-icon { display:flex; flex:0 0 auto; margin:0; }
-.library-grid.list-view .folder-card-name { flex:1 1 240px; min-width:120px; font-size:14.5px; }
-.library-grid.list-view .folder-card-meta { flex:0 0 auto; margin:0 44px 0 0; }
-.library-grid.list-view .folder-card-menu { top:50%; right:16px; transform:translateY(-50%); }
+.library-grid.list-view .library-folder-card {
+  min-height:0;
+  padding:12px 16px;
+  display:flex;
+  align-items:center;
+  gap:16px;
+  border-radius:14px;
+  background:var(--bg-card);
+  transition:background .2s ease, border-color .2s ease, transform .2s ease;
+}
+.library-grid.list-view .library-folder-card:hover {
+  transform:translateX(2px);
+  border-color:var(--border-strong);
+  background:var(--bg-card-hover);
+}
+.library-grid.list-view .library-folder-card:focus-visible {
+  border-color:var(--control-accent);
+  background:var(--bg-card-hover);
+}
+.library-grid.list-view .folder-card-icon {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:22px;
+  height:22px;
+  flex:0 0 22px;
+  margin:0;
+  filter:none;
+}
+.library-grid.list-view .folder-card-icon svg { width:22px; height:22px; }
+.library-grid.list-view .folder-card-name {
+  flex:1 1 240px;
+  min-width:120px;
+  font-size:14.5px;
+  letter-spacing:-.01em;
+}
+.library-grid.list-view .folder-card-meta { flex:0 0 auto; margin:0; font-size:11px; font-weight:500; }
+.library-grid.list-view .folder-card-menu {
+  position:static;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:28px;
+  height:28px;
+  flex:0 0 28px;
+  padding:0;
+  border:1px solid var(--border);
+  border-radius:8px;
+}
+.library-grid.list-view .folder-card-menu:hover {
+  border-color:var(--border-strong);
+  background:var(--bg-hover);
+}
 .library-grid.list-view .folder-card-actions { top:calc(50% + 20px); right:16px; }
 
 .doc-card[draggable=true], .doc-list-row[draggable=true] { cursor:grab; }


### PR DESCRIPTION
# Summary
## 1. 폴더 리스트 아이템 디자인 통일
- 폴더 행의 배경, 테두리, hover 및 포커스 상태를 논문 리스트 아이템과 동일한 스타일로 수정함
- 폴더 아이콘 크기와 제목 타이포그래피를 논문 리스트 아이템의 정렬 기준에 맞춤
- 폴더 메타 정보와 관리 메뉴 버튼의 크기 및 배치를 논문 리스트 액션 영역과 통일함