### PR TITLE
fix(auth): secure PDF parser management

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -430,7 +430,10 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
 
 
 @router.get("/settings/install-pdf-parser")
-async def install_pdf_parser_stream(parser_id: str):
+async def install_pdf_parser_stream(
+    parser_id: str,
+    current_user: str = Depends(get_current_user),
+):
     import asyncio
 
     package_map = {
@@ -508,7 +511,10 @@ async def install_pdf_parser_stream(parser_id: str):
     )
 
 @router.post("/settings/uninstall-pdf-parser")
-async def uninstall_pdf_parser(request: Request):
+async def uninstall_pdf_parser(
+    request: Request,
+    current_user: str = Depends(get_current_user),
+):
     import subprocess
     import config as cfg
 

--- a/backend/tests/test_pdf_parser_install_auth.py
+++ b/backend/tests/test_pdf_parser_install_auth.py
@@ -1,0 +1,34 @@
+"""PDF parser package-management endpoints must require authentication."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        (
+            "get",
+            "/api/settings/install-pdf-parser",
+            {"params": {"parser_id": "unsupported"}},
+        ),
+        (
+            "post",
+            "/api/settings/uninstall-pdf-parser",
+            {"json": {"parser_id": "unsupported"}},
+        ),
+    ],
+)
+def test_pdf_parser_package_management_rejects_unauthenticated_requests(
+    test_client, monkeypatch, method, path, kwargs
+):
+    """Authentication must run before parser validation or package operations."""
+    from main import app
+    import services.auth as auth_service
+
+    app.dependency_overrides.pop(auth_service.get_current_user, None)
+    monkeypatch.setattr(auth_service, "get_skip_login", lambda: False)
+
+    response = getattr(test_client, method)(path, **kwargs)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "로그인이 필요합니다."}


### PR DESCRIPTION
# Summary
## 1. PDF 파서 패키지 관리 API 인증 복구
- 설치·삭제 엔드포인트에 `get_current_user` 인증 의존성을 다시 적용함
## 2. 인증 회귀 테스트 추가
- 미인증 요청을 패키지 검증 및 프로세스 실행 전에 401로 차단하는 테스트를 추가함