### PR TITLE
feat: 라이브러리 필터 접힘 상태 유지

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -193,7 +193,10 @@
 
             <!-- 카테고리 필터 + 보기 방식 전환 영역 -->
             <div id="library-filter-row" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 20px;">
-              <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
+              <div class="library-category-filter-group">
+                <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
+                <button type="button" id="library-category-filter-toggle" class="library-category-filter-toggle hidden" aria-controls="library-category-filters" aria-expanded="true"></button>
+              </div>
               <div id="library-view-toggle" class="library-view-toggle" role="group" aria-label="논문 보기 방식">
                 <button type="button" class="view-toggle-btn" data-view="card" title="큰 카드 보기" aria-label="큰 카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>
                 <button type="button" class="view-toggle-btn" data-view="compact" title="작은 카드 보기" aria-label="작은 카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="5" height="5" x="3" y="3" rx="1"/><rect width="5" height="5" x="10" y="3" rx="1"/><rect width="5" height="5" x="17" y="3" rx="1"/><rect width="5" height="5" x="3" y="10" rx="1"/><rect width="5" height="5" x="10" y="10" rx="1"/><rect width="5" height="5" x="17" y="10" rx="1"/><rect width="5" height="5" x="3" y="17" rx="1"/><rect width="5" height="5" x="10" y="17" rx="1"/><rect width="5" height="5" x="17" y="17" rx="1"/></svg></button>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -249,6 +249,7 @@ const fileInput         = $('file-input')
 const libUploadBtn      = $('lib-upload-btn')
 const libraryGrid       = $('library-grid')
 const libraryCategoryFilters = $('library-category-filters')
+const libraryCategoryFilterToggle = $('library-category-filter-toggle')
 const librarySearchInput = $('library-search-input')
 const librarySearchClearBtn = $('library-search-clear-btn')
 const librarySearchStatus = $('library-search-status')
@@ -4501,8 +4502,19 @@ if (workspaceSearchInput) {
   })
 }
 
-
 let activeCategoryFilter = 'ALL'
+const LIBRARY_FILTERS_COLLAPSED_KEY = 'easypaper_library_category_filters_collapsed'
+let libraryCategoryFiltersCollapsed = localStorage.getItem(LIBRARY_FILTERS_COLLAPSED_KEY) === 'true'
+
+function updateLibraryCategoryFilterVisibility(hasCategories = libraryCategoryFilters?.childElementCount > 0) {
+  if (!libraryCategoryFilters || !libraryCategoryFilterToggle) return
+  libraryCategoryFilterToggle.classList.toggle('hidden', !hasCategories)
+  libraryCategoryFilters.classList.toggle('hidden', hasCategories && libraryCategoryFiltersCollapsed)
+  libraryCategoryFilterToggle.setAttribute('aria-expanded', String(!libraryCategoryFiltersCollapsed))
+  libraryCategoryFilterToggle.setAttribute('aria-label', libraryCategoryFiltersCollapsed ? '카테고리 필터 펼치기' : '카테고리 필터 접기')
+  libraryCategoryFilterToggle.title = libraryCategoryFiltersCollapsed ? '카테고리 필터 펼치기' : '카테고리 필터 접기'
+  libraryCategoryFilterToggle.innerHTML = `${icon(libraryCategoryFiltersCollapsed ? 'chevronDown' : 'chevronUp', 13)}<span>${libraryCategoryFiltersCollapsed ? '필터 펼치기' : '필터 접기'}</span>`
+}
 
 // ── 여러 논문 비교 채팅: 라이브러리 선택 모드 ──────────────
 // ── 라이브러리 논문 선택 모드 & 하단 플로팅 알약 툴바 ──
@@ -5881,6 +5893,12 @@ function ensureLibraryChrome() {
   if (libraryChromeReady) return
   libraryChromeReady = true
 
+  libraryCategoryFilterToggle?.addEventListener('click', () => {
+    libraryCategoryFiltersCollapsed = !libraryCategoryFiltersCollapsed
+    localStorage.setItem(LIBRARY_FILTERS_COLLAPSED_KEY, String(libraryCategoryFiltersCollapsed))
+    updateLibraryCategoryFilterVisibility()
+  })
+
   if (librarySearchBox && !$('library-status-tabs')) {
     librarySearchBox.insertAdjacentHTML('beforebegin', `
       <div class="library-toolbar-row">
@@ -5938,6 +5956,7 @@ async function renderLibrary() {
 
   libraryGrid.innerHTML = ''
   libraryCategoryFilters.innerHTML = ''
+  updateLibraryCategoryFilterVisibility(false)
   try {
     let data
     if (state.currentLibraryTab === 'trash') {
@@ -6017,6 +6036,7 @@ async function renderLibrary() {
         libraryCategoryFilters.appendChild(btn)
       })
     }
+    updateLibraryCategoryFilterVisibility(uniqueCategories.length > 0)
 
     // Initial card rendering
     filterLibraryCards(docs)

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -31,6 +31,42 @@
   margin-left: auto;
 }
 
+/* ── 카테고리 필터 접기/펼치기 ── */
+.library-category-filter-group {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.library-category-filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+.library-category-filter-toggle:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-glow);
+  color: var(--text-primary);
+}
+.library-category-filter-toggle:focus-visible {
+  outline: 2px solid var(--control-accent);
+  outline-offset: 2px;
+}
+
 /* ── 상태 필터 탭 (전체 / 읽지 않음 / 읽는 중 / 완료 / 즐겨찾기) ── */
 .lib-status-tabs {
   display: flex;

--- a/frontend/tests/e2e/library-filter-collapse.spec.js
+++ b/frontend/tests/e2e/library-filter-collapse.spec.js
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('category filter chips stay collapsed after reload', async ({ page }) => {
+  const doc = {
+    id: 'doc-filter-collapse',
+    filename: 'filter-collapse.pdf',
+    total_pages: 5,
+    created_at: '2026-08-14T00:00:00Z',
+    metadata: { title: 'Filter Collapse', categories: ['Machine Learning'] },
+    translated_pages: [],
+  }
+  await mockBaseRoutes(page, { documents: [doc] })
+  await gotoApp(page)
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+
+  const filters = page.locator('#library-category-filters')
+  const toggle = page.locator('#library-category-filter-toggle')
+  await expect(filters).toBeVisible()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+  await toggle.click()
+  await expect(filters).toBeHidden()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('easypaper_library_category_filters_collapsed'))).toBe('true')
+
+  await page.reload()
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+  await expect(filters).toBeHidden()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+  await toggle.click()
+  await expect(filters).toBeVisible()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+})


### PR DESCRIPTION
# Summary
## 1. 카테고리 필터 접기 기능 추가
- 라이브러리 filter chips를 접고 펼칠 수 있는 토글 버튼 추가
- 토글 상태에 따른 아이콘, 레이블, 접근성 속성 갱신
## 2. 숨김 상태 유지
- 접힘 여부를 localStorage에 저장해 페이지 재진입 및 새로고침 후 복원
- 접힘 상태 유지와 재펼침 동작을 검증하는 Playwright 테스트 추가