### PR TITLE
fix(db): clean document orphan records

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -575,11 +575,41 @@ def db_search_documents(username: str, query: str, only_trash: bool = False) -> 
 
 
 def db_delete_document(doc_id: str) -> bool:
+    # documents FK들은 전부 ON DELETE CASCADE로 선언돼 있지만, SQLite는
+    # 커넥션마다 PRAGMA foreign_keys=ON을 켜야 실제로 CASCADE가 동작하는데
+    # 이 프로젝트는 그 PRAGMA를 켜지 않는다(update_user_credentials 참고).
+    # 그래서 documents 삭제만으로는 연관 레코드가 전혀 지워지지 않아
+    # translations/chats/... 가 고아로 영구히 남는다. 여기서 명시적으로
+    # 정리한다. reading_time/reading_sessions/compare_sessions은 "삭제된
+    # 논문도 제목/기록을 보존해서 보여준다"는 의도된 설계라 대상에서
+    # 제외한다(reading_time.doc_title 컬럼 참고). concepts/concept_edges는
+    # 문서가 아니라 개념 간 전역 관계라 문서 삭제와 무관하다.
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute("SELECT id FROM documents WHERE id = ?", (doc_id,))
         if not cursor.fetchone():
             return False
+
+        cursor.execute("SELECT id FROM chats WHERE doc_id = ?", (doc_id,))
+        chat_ids = [row["id"] for row in cursor.fetchall()]
+        if chat_ids:
+            placeholders = ",".join("?" for _ in chat_ids)
+            cursor.execute(
+                f"DELETE FROM question_concepts WHERE chat_id IN ({placeholders})",
+                chat_ids,
+            )
+
+        cursor.execute("DELETE FROM question_papers WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM paper_concepts WHERE doc_id = ?", (doc_id,))
+        cursor.execute(
+            "DELETE FROM paper_edges WHERE doc_id_a = ? OR doc_id_b = ?",
+            (doc_id, doc_id),
+        )
+        cursor.execute("DELETE FROM annotations WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM memos WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM page_insights WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM translations WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM chats WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
         cursor.execute("DELETE FROM document_folders WHERE doc_id = ?", (doc_id,))
         conn.commit()

--- a/backend/tests/test_document_delete_cascade.py
+++ b/backend/tests/test_document_delete_cascade.py
@@ -1,0 +1,96 @@
+"""db_delete_document이 SQLite의 PRAGMA foreign_keys 미설정으로 인해
+FK ON DELETE CASCADE가 실제로는 동작하지 않는 문제를 우회해, 연관 테이블을
+명시적으로 정리하는지 검증하는 회귀 테스트."""
+
+from datetime import datetime, timezone
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _seed_related_rows(db, doc_id):
+    """9개 연관 테이블에 doc_id를 참조하는 행을 하나씩 심는다."""
+    with db.get_db() as conn:
+        cur = conn.cursor()
+        now = _now()
+
+        cur.execute(
+            "INSERT INTO translations (doc_id, page_num, suffix, translation, saved_at) VALUES (?, 1, '', 'x', ?)",
+            (doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO chats (doc_id, role, content, created_at) VALUES (?, 'user', 'hi', ?)",
+            (doc_id, now),
+        )
+        chat_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO page_insights (doc_id, page_num, kind, suffix, content, saved_at) VALUES (?, 1, 'summary', '', 'x', ?)",
+            (doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO concepts (name, normalized_name, kind, created_at) VALUES ('Concept A', 'concept a', 'topic', ?)",
+            (now,),
+        )
+        concept_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO paper_concepts (doc_id, concept_id, created_at) VALUES (?, ?, ?)",
+            (doc_id, concept_id, now),
+        )
+        cur.execute(
+            "INSERT INTO paper_edges (doc_id_a, doc_id_b, edge_type, detail, created_at) VALUES (?, 'other-doc', 'citation', NULL, ?)",
+            (doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO annotations (doc_id, data, updated_at) VALUES (?, '{}', ?)",
+            (doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO memos (doc_id, data, updated_at) VALUES (?, '{}', ?)",
+            (doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO question_papers (chat_id, doc_id, created_at) VALUES (?, ?, ?)",
+            (chat_id, doc_id, now),
+        )
+        cur.execute(
+            "INSERT INTO question_concepts (chat_id, concept_id, created_at) VALUES (?, ?, ?)",
+            (chat_id, concept_id, now),
+        )
+        conn.commit()
+        return concept_id
+
+
+def _count(db, table, where, params):
+    with db.get_db() as conn:
+        cur = conn.cursor()
+        cur.execute(f"SELECT COUNT(*) AS c FROM {table} WHERE {where}", params)
+        return cur.fetchone()["c"]
+
+
+def test_delete_document_removes_orphan_rows_in_related_tables(isolated_dirs):
+    db = isolated_dirs["db"]
+    doc_id = "doc-with-related-rows"
+    db.db_save_document(doc_id, "admin", "p.pdf", "/x", 1, {})
+    concept_id = _seed_related_rows(db, doc_id)
+
+    assert db.db_delete_document(doc_id) is True
+
+    assert _count(db, "translations", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "chats", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "page_insights", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "paper_concepts", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "paper_edges", "doc_id_a = ? OR doc_id_b = ?", (doc_id, doc_id)) == 0
+    assert _count(db, "annotations", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "memos", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "question_papers", "doc_id = ?", (doc_id,)) == 0
+    assert _count(db, "question_concepts", "concept_id = ?", (concept_id,)) == 0
+    assert db.db_get_document(doc_id) is None
+
+    # concepts 자체는 문서와 무관한 전역 노드라 삭제 대상이 아니다.
+    assert _count(db, "concepts", "id = ?", (concept_id,)) == 1
+
+
+def test_delete_document_returns_false_for_nonexistent_doc(isolated_dirs):
+    db = isolated_dirs["db"]
+    assert db.db_delete_document("does-not-exist") is False


### PR DESCRIPTION
# Summary
## 1. 문서 연관 데이터 정리 보강
- 문서 영구 삭제 시 종속된 번역·채팅·분석·그래프·주석·메모 데이터를 같은 트랜잭션에서 정리함
## 2. 데이터 무결성 회귀 테스트 추가
- 9개 연관 테이블의 고아 레코드 제거와 읽기 기록 보존을 검증하는 테스트를 추가함