### PR TITLE
fix: 작은 카드 퍼센트 표시 숨김

### DIFF
--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -287,7 +287,9 @@
 .library-grid.compact-view .lib-card-progress-bar-wrap {
   height: 3px;
 }
-.library-grid.compact-view .lib-card-progress-pct,
+.library-grid.compact-view .lib-card-progress-pct {
+  display: none;
+}
 .library-grid.compact-view .lib-card-progress-done .doc-meta-chip {
   font-size: 10px;
 }

--- a/frontend/tests/e2e/library-view-size.spec.js
+++ b/frontend/tests/e2e/library-view-size.spec.js
@@ -28,6 +28,7 @@ test('큰 카드, 작은 카드, 리스트 보기를 전환하고 마지막 선�
   await expect(grid.locator('.doc-card-tags')).toBeHidden()
   await expect(grid.locator('.doc-card-meta')).toBeHidden()
   await expect(grid.locator('.lib-card-progress')).toBeVisible()
+  await expect(grid.locator('.lib-card-progress-pct')).toBeHidden()
   await expect.poll(() => page.evaluate(() => localStorage.getItem('easypaper_library_view'))).toBe('compact')
 
   await page.reload()


### PR DESCRIPTION
# Summary
## 1. 작은 카드 진행률 표시 간소화
- 작은 카드에서 진행률 퍼센트 숫자를 숨김
- 진행률 바는 유지해 읽기 진행 상태를 시각적으로 확인 가능
## 2. 회귀 테스트 보강
- 작은 카드 모드에서 퍼센트 텍스트가 숨겨지는 E2E 검증을 추가