### PR TITLE
fix(auth): support colons in usernames

### DIFF
--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -97,7 +97,7 @@ def create_session_token(username: str, ttl_seconds: int = SESSION_TTL_DEFAULT_S
 
 def verify_session_token(token: str) -> bool:
     try:
-        parts = token.split(':')
+        parts = token.rsplit(':', 2)
         if len(parts) != 3:
             return False
         username, expires_str, signature = parts
@@ -120,7 +120,7 @@ async def get_current_user(request: Request) -> str:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="로그인이 필요합니다.",
         )
-    return token.split(':')[0]
+    return token.rsplit(':', 2)[0]
 
 
 async def require_admin_user(current_user: str = Depends(get_current_user)) -> str:

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -62,6 +62,12 @@ def test_session_token_round_trip():
     assert token.split(":")[0] == "admin"
 
 
+def test_session_token_round_trip_with_colon_in_username():
+    token = create_session_token("team:admin")
+    assert verify_session_token(token) is True
+    assert token.rsplit(":", 2)[0] == "team:admin"
+
+
 def test_session_token_rejects_tampered_username():
     token = create_session_token("admin")
     _, expires, sig = token.split(":")
@@ -111,6 +117,18 @@ async def test_get_current_user_still_requires_cookie_when_skip_login_disabled(m
 
     with pytest.raises(HTTPException):
         await get_current_user(FakeRequest())
+
+
+async def test_get_current_user_preserves_colon_in_username(monkeypatch):
+    import services.auth as auth_module
+
+    monkeypatch.setattr(auth_module, "get_skip_login", lambda: False)
+    token = create_session_token("team:admin")
+
+    class FakeRequest:
+        cookies = {"session_token": token}
+
+    assert await get_current_user(FakeRequest()) == "team:admin"
 
 
 def test_login_lockout_starts_unlocked():


### PR DESCRIPTION
# Summary
## 1. 세션 토큰 사용자명 파싱 보강
- 만료 시각과 서명을 오른쪽에서 분리해 콜론이 포함된 사용자명도 정상 인증되도록 수정함
## 2. 세션 인증 회귀 테스트 추가
- 콜론 포함 사용자명의 토큰 검증과 현재 사용자 복원을 검증하는 테스트를 추가함