### PR TITLE
fix: 작은 카드 진행률 영역 숨김

### DIFF
--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -255,8 +255,8 @@
 }
 
 /* ── 작은 카드 보기 ──
-   제목과 읽기 진행 상태는 유지하고 태그/등록일/페이지 수처럼 탐색에 덜 중요한
-   정보는 숨긴다. 카드 액션은 축소된 푸터에 그대로 남겨 기능 손실을 막는다. */
+   제목은 유지하고 태그/등록일/페이지 수/진행률처럼 부가적인 정보는 숨긴다.
+   카드 액션은 축소된 푸터에 그대로 남겨 기능 손실을 막는다. */
 .library-grid.compact-view {
   grid-template-columns: repeat(auto-fill, minmax(205px, 1fr));
   gap: 12px;
@@ -281,20 +281,9 @@
   line-height: 1.35;
 }
 .library-grid.compact-view .doc-card-tags,
-.library-grid.compact-view .doc-card-meta {
-  display: none;
-}
+.library-grid.compact-view .doc-card-meta,
 .library-grid.compact-view .lib-card-progress {
-  gap: 6px;
-}
-.library-grid.compact-view .lib-card-progress-bar-wrap {
-  height: 3px;
-}
-.library-grid.compact-view .lib-card-progress-pct {
   display: none;
-}
-.library-grid.compact-view .lib-card-progress-done .doc-meta-chip {
-  font-size: 10px;
 }
 .library-grid.compact-view .doc-card-footer {
   padding: 0 13px 11px;

--- a/frontend/tests/e2e/library-view-size.spec.js
+++ b/frontend/tests/e2e/library-view-size.spec.js
@@ -27,8 +27,7 @@ test('큰 카드, 작은 카드, 리스트 보기를 전환하고 마지막 선�
   await expect(grid.locator('.doc-card')).toHaveCount(1)
   await expect(grid.locator('.doc-card-tags')).toBeHidden()
   await expect(grid.locator('.doc-card-meta')).toBeHidden()
-  await expect(grid.locator('.lib-card-progress')).toBeVisible()
-  await expect(grid.locator('.lib-card-progress-pct')).toBeHidden()
+  await expect(grid.locator('.lib-card-progress')).toBeHidden()
   await expect.poll(() => page.evaluate(() => localStorage.getItem('easypaper_library_view'))).toBe('compact')
 
   await page.reload()


### PR DESCRIPTION
# Summary
## 1. 작은 카드 진행률 정보 제거
- 작은 카드에서 진행률 바, 퍼센트, 완료 표시 영역을 모두 숨김
- 제목과 카드 액션만 중심적으로 표시하도록 정보 밀도를 축소
## 2. 컴팩트 스타일 및 테스트 정리
- 더 이상 사용하지 않는 컴팩트 진행률 스타일을 제거
- 작은 카드에서 진행률 영역 전체가 숨겨지는 E2E 검증으로 변경