### PR TITLE
fix(api): limit large JSON payloads

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -3,7 +3,7 @@ import hashlib
 import re
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 
 from routers.upload import sessions, ensure_session, require_session_owner
@@ -26,17 +26,22 @@ _QUOTE_IMAGE_MARKER_RE = re.compile(r'^\[인용된 이미지[^\]|]*\|([A-Za-z0-9
 
 router = APIRouter()
 
+MAX_CHAT_MESSAGES = 100
+MAX_CHAT_MESSAGE_CHARS = 100_000
+MAX_CHAT_IMAGE_BASE64_CHARS = 16 * 1024 * 1024
+
+
 class ChatMessage(BaseModel):
-    role: str
-    content: str
+    role: str = Field(max_length=32)
+    content: str = Field(max_length=MAX_CHAT_MESSAGE_CHARS)
 
 class ChatRequest(BaseModel):
-    session_id: str
-    messages: List[ChatMessage]
+    session_id: str = Field(min_length=1, max_length=128)
+    messages: List[ChatMessage] = Field(max_length=MAX_CHAT_MESSAGES)
     # 캡처 모드로 첨부한 이미지의 raw base64(PNG, data URL 접두사 없음). 있으면
     # 이번 질문(messages의 마지막 user 메시지)에 실제로 첨부해 vision 지원
     # provider(openai/gemini/claude)가 캡처 영역을 직접 보고 답할 수 있게 한다.
-    image_base64: Optional[str] = None
+    image_base64: Optional[str] = Field(default=None, max_length=MAX_CHAT_IMAGE_BASE64_CHARS)
 
 # ── 여러 논문 간 비교 채팅 ──────────────────────────────
 MIN_COMPARE_DOCS = 2
@@ -47,7 +52,7 @@ COMPARE_TOTAL_CONTEXT_CHARS = 60000
 
 class CompareChatRequest(BaseModel):
     doc_ids: List[str]
-    messages: List[ChatMessage]
+    messages: List[ChatMessage] = Field(max_length=MAX_CHAT_MESSAGES)
 
 
 def _build_compare_id(doc_ids: List[str]) -> str:

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -9,7 +9,7 @@ from services.library import (
     patch_document_metadata,
     get_chat_quote_image_path, list_folders, create_folder, update_folder, delete_folder, move_documents_to_folder
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 import json
 import re
 
@@ -35,6 +35,21 @@ class DocumentMoveRequest(BaseModel):
 
 class DocumentTitleUpdateRequest(BaseModel):
     title: str
+
+
+MAX_LIBRARY_MIRROR_JSON_BYTES = 5 * 1024 * 1024
+
+
+class LibraryMirrorPayload(BaseModel):
+    data: dict = Field(default_factory=dict)
+
+    @field_validator("data")
+    @classmethod
+    def limit_serialized_size(cls, value: dict) -> dict:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        if len(encoded) > MAX_LIBRARY_MIRROR_JSON_BYTES:
+            raise ValueError("주석 또는 메모 데이터는 5MiB 이하여야 합니다.")
+        return value
 
 
 @router.get("/library/folders")
@@ -916,11 +931,11 @@ async def get_library_annotations(doc_id: str, current_user: str = Depends(get_c
 
 
 @router.put("/library/{doc_id}/annotations")
-async def put_library_annotations(doc_id: str, payload: dict, current_user: str = Depends(get_current_user)):
+async def put_library_annotations(doc_id: str, payload: LibraryMirrorPayload, current_user: str = Depends(get_current_user)):
     """하이라이트/주석 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
     require_owned_document(doc_id, current_user)
     from services.db import db_put_annotations
-    db_put_annotations(doc_id, payload.get("data", {}))
+    db_put_annotations(doc_id, payload.data)
     return {"status": "ok"}
 
 
@@ -934,11 +949,11 @@ async def get_library_memos(doc_id: str, current_user: str = Depends(get_current
 
 
 @router.put("/library/{doc_id}/memos")
-async def put_library_memos(doc_id: str, payload: dict, current_user: str = Depends(get_current_user)):
+async def put_library_memos(doc_id: str, payload: LibraryMirrorPayload, current_user: str = Depends(get_current_user)):
     """메모 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
     require_owned_document(doc_id, current_user)
     from services.db import db_put_memos
-    db_put_memos(doc_id, payload.get("data", {}))
+    db_put_memos(doc_id, payload.data)
     return {"status": "ok"}
 
 

--- a/backend/tests/test_request_payload_limits.py
+++ b/backend/tests/test_request_payload_limits.py
@@ -1,0 +1,65 @@
+"""Oversized chat and library mirror payloads must be rejected before processing."""
+
+import pytest
+from pydantic import ValidationError
+
+from routers.chat import (
+    ChatMessage,
+    ChatRequest,
+    MAX_CHAT_IMAGE_BASE64_CHARS,
+    MAX_CHAT_MESSAGES,
+    MAX_CHAT_MESSAGE_CHARS,
+)
+from routers.library import LibraryMirrorPayload, MAX_LIBRARY_MIRROR_JSON_BYTES
+
+
+def test_chat_message_rejects_oversized_content():
+    with pytest.raises(ValidationError):
+        ChatMessage(role="user", content="x" * (MAX_CHAT_MESSAGE_CHARS + 1))
+
+
+def test_chat_request_rejects_too_many_messages():
+    message = ChatMessage(role="user", content="hello")
+    with pytest.raises(ValidationError):
+        ChatRequest(
+            session_id="doc-1",
+            messages=[message] * (MAX_CHAT_MESSAGES + 1),
+        )
+
+
+def test_chat_request_rejects_oversized_base64_image():
+    with pytest.raises(ValidationError):
+        ChatRequest(
+            session_id="doc-1",
+            messages=[],
+            image_base64="A" * (MAX_CHAT_IMAGE_BASE64_CHARS + 1),
+        )
+
+
+def test_library_mirror_model_rejects_oversized_json():
+    with pytest.raises(ValidationError):
+        LibraryMirrorPayload(
+            data={"content": "x" * MAX_LIBRARY_MIRROR_JSON_BYTES},
+        )
+
+
+@pytest.mark.parametrize("resource", ["annotations", "memos"])
+def test_library_mirror_endpoint_rejects_oversized_json(
+    test_client, isolated_dirs, resource
+):
+    doc_id = f"doc-large-{resource}"
+    db = isolated_dirs["db"]
+    db.db_save_document(doc_id, "testuser", "paper.pdf", "/x/paper.pdf", 1, {})
+
+    response = test_client.put(
+        f"/api/library/{doc_id}/{resource}",
+        json={"data": {"content": "x" * MAX_LIBRARY_MIRROR_JSON_BYTES}},
+    )
+
+    assert response.status_code == 422
+    getter = (
+        db.db_get_annotations
+        if resource == "annotations"
+        else db.db_get_memos
+    )
+    assert getter(doc_id) is None


### PR DESCRIPTION
# Summary
## 1. AI 채팅 요청 크기 제한
- 메시지 수·개별 메시지·Base64 이미지에 명시적인 상한을 적용함
## 2. 주석·메모 저장 크기 제한
- 서버 미러 JSON을 5MiB로 제한하고 초과 요청을 처리 전에 거부함
## 3. 요청 검증 회귀 테스트 추가
- 각 상한과 API 저장 차단을 검증하는 테스트를 추가함