### PR TITLE
ci: add backend pytest gate

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,40 @@
+name: Backend Test
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-test.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run backend tests
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python -m pytest -p no:cacheprovider -q

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest==9.1.1
 pytest-asyncio==1.4.0
+beautifulsoup4==4.15.0


### PR DESCRIPTION
# Summary
## 1. 백엔드 테스트 CI 추가
- 백엔드 및 워크플로 변경 PR에서 Python 3.12 전체 pytest를 실행하도록 구성함
## 2. 테스트 의존성 캐시 적용
- requirements 파일을 기준으로 pip 캐시를 적용해 반복 실행 비용을 줄임