### PR TITLE
fix: 작은 카드 폴더 높이 축소

### DIFF
--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -670,6 +670,19 @@ body.light-theme .lib-detail-panel {
 .folder-card-meta { margin-top:6px; color:var(--text-muted); font-size:12px; }
 .folder-card-menu { position:absolute; top:12px; right:12px; padding:5px; border:0; border-radius:var(--radius-sm); background:transparent; color:var(--text-muted); cursor:pointer; }
 .folder-card-menu:hover { color:var(--text-primary); background:var(--bg-surface); }
+.library-grid.compact-view .library-folder-card { min-height:0; padding:12px 13px; border-radius:14px; }
+.library-grid.compact-view .folder-card-icon { margin-bottom:10px; filter:none; }
+.library-grid.compact-view .folder-card-icon svg { width:26px; height:26px; }
+.library-grid.compact-view .folder-card-name { font-size:12.5px; }
+.library-grid.compact-view .folder-card-meta { margin-top:4px; font-size:11px; }
+.library-grid.compact-view .folder-card-menu {
+  top:8px;
+  right:8px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
 .folder-drop-target { outline:2px solid var(--control-accent); background:var(--control-accent-soft)!important; }
 .folder-dialog-label { display:grid; gap:8px; color:var(--text-secondary); font-size:13px; }
 .folder-dialog-input { width:100%; box-sizing:border-box; padding:9px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-sm); background:var(--bg-elevated); color:var(--text-primary); font:inherit; outline:none; }

--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -14,9 +14,9 @@ export const SAMPLE_PDF_CITATION = fs.readFileSync(path.join(__dirname, 'fixture
  * page.route()를 추가로 덮어써서 시나리오별 응답을 얹는다.
  *
  * @param {import('@playwright/test').Page} page
- * @param {object} [overrides] - { documents, onRoute } 등 확장 옵션
+ * @param {object} [overrides] - { documents, folders } 등 확장 옵션
  */
-export async function mockBaseRoutes(page, { documents = [] } = {}) {
+export async function mockBaseRoutes(page, { documents = [], folders = [] } = {}) {
   await page.route('**/api/**', async route => {
     const url = route.request().url()
 
@@ -45,7 +45,7 @@ export async function mockBaseRoutes(page, { documents = [] } = {}) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ show: false, version: 'test0000', version_date: '2026-01-01', changelog: [] }) })
     }
     if (url.includes('/api/library/folders')) {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders: [] }) })
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders }) })
     }
     if (url.includes('/api/library/trash')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ documents: [], total: 0 }) })

--- a/frontend/tests/e2e/library-view-size.spec.js
+++ b/frontend/tests/e2e/library-view-size.spec.js
@@ -10,8 +10,15 @@ const docs = [{
   translated_pages: [],
 }]
 
+const folders = [{
+  id: 'folder-card-size',
+  name: 'Reading List',
+  parent_id: null,
+  color: '#4f8ef7',
+}]
+
 test('큰 카드, 작은 카드, 리스트 보기를 전환하고 마지막 선택을 기억한다', async ({ page }) => {
-  await mockBaseRoutes(page, { documents: docs })
+  await mockBaseRoutes(page, { documents: docs, folders })
   await gotoApp(page)
   await page.getByRole('button', { name: 'Library' }).click()
   await expect(page.locator('#library-screen')).toHaveClass(/active/)
@@ -21,6 +28,9 @@ test('큰 카드, 작은 카드, 리스트 보기를 전환하고 마지막 선�
   await expect(grid).not.toHaveClass(/compact-view|list-view/)
   await expect(grid.locator('.doc-card-tags')).toBeVisible()
   await expect(grid.locator('.doc-card-meta')).toBeVisible()
+  const folderCard = grid.locator('.library-folder-card')
+  await expect(folderCard).toBeVisible()
+  const largeFolderHeight = await folderCard.evaluate(el => el.getBoundingClientRect().height)
 
   await page.getByRole('button', { name: '작은 카드 보기' }).click()
   await expect(grid).toHaveClass(/compact-view/)
@@ -28,6 +38,10 @@ test('큰 카드, 작은 카드, 리스트 보기를 전환하고 마지막 선�
   await expect(grid.locator('.doc-card-tags')).toBeHidden()
   await expect(grid.locator('.doc-card-meta')).toBeHidden()
   await expect(grid.locator('.lib-card-progress')).toBeHidden()
+  const compactFolderHeight = await folderCard.evaluate(el => el.getBoundingClientRect().height)
+  const compactDocHeight = await grid.locator('.doc-card').evaluate(el => el.getBoundingClientRect().height)
+  expect(compactFolderHeight).toBeLessThan(largeFolderHeight)
+  expect(Math.abs(compactFolderHeight - compactDocHeight)).toBeLessThanOrEqual(1)
   await expect.poll(() => page.evaluate(() => localStorage.getItem('easypaper_library_view'))).toBe('compact')
 
   await page.reload()


### PR DESCRIPTION
# Summary
## 1. 작은 카드 폴더 크기 조정
- 작은 카드 모드에서 폴더 카드의 최소 높이를 해제
- 폴더 패딩, 아이콘, 제목, 메타 정보, 메뉴 위치를 컴팩트 크기로 축소
- 폴더가 같은 행의 논문 카드를 불필요하게 늘리지 않도록 높이를 통일
## 2. 폴더 포함 회귀 테스트 추가
- E2E 기본 API 모킹에서 폴더 픽스처 주입을 지원
- 작은 폴더 높이가 큰 카드 모드보다 줄고 논문 카드 높이와 일치하는지 검증