### PR TITLE
fix(e2e): enter library through navigation

### DIFF
--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -75,7 +75,13 @@ export async function mockBaseRoutes(page, { documents = [], folders = [] } = {}
 /** 로그인 상태로 앱을 열고(온보딩은 건너뜀) 라이브러리 화면이 뜰 때까지 기다린다. */
 export async function gotoApp(page) {
   await page.goto('/index.html')
-  await page.evaluate(() => localStorage.setItem('easypaper_onboarding_seen', '1'))
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_onboarding_seen', '1')
+    localStorage.setItem('easypaper_disable_primer', 'true')
+  })
   await page.reload()
-  await page.waitForTimeout(600)
+  const libraryNav = page.locator('.sidebar-nav-item[data-page="library"]')
+  await libraryNav.waitFor({ state: 'visible' })
+  await libraryNav.click()
+  await page.locator('#library-screen.active').waitFor()
 }


### PR DESCRIPTION
# Summary
## 1. E2E 앱 진입 동작 최신화
- 대시보드 시작 후 라이브러리 내비게이션을 실제 클릭하고 활성 화면을 대기하도록 수정함
## 2. 독립 테스트 환경 보강
- 공용 헬퍼에서 온보딩과 자동 Primer를 비활성화해 대상 기능만 검증하도록 수정함