### PR TITLE
fix(security): enforce frontend CSP

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -79,6 +79,17 @@ async def serve_pdf(session_id: str, username: str = Depends(get_current_user)):
 # 상대경로로 찾는 위치)에 둘 수 없다. 대신 dist를 _internal/frontend/dist에
 # 두고 이 env var로 실제 위치를 알려준다. 미설정 시(서버/Docker 배포)에는
 # 기존과 동일하게 상대경로로 계산한다.
+FRONTEND_CSP = (
+    "default-src 'self'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*; "
+    "img-src 'self' data: blob: http://127.0.0.1:*; style-src 'self' 'unsafe-inline' "
+    "https://fonts.googleapis.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
+    "font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; "
+    "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
+    "worker-src 'self' blob: https://cdnjs.cloudflare.com; object-src 'none'; "
+    "base-uri 'self'; frame-ancestors 'none'"
+)
+
+
 FRONTEND_DIST = os.getenv("EASYPAPER_FRONTEND_DIST") or os.path.join(os.path.dirname(__file__), "../frontend/dist")
 if os.path.exists(FRONTEND_DIST):
     # /assets 등 정적 자산
@@ -109,7 +120,8 @@ if os.path.exists(FRONTEND_DIST):
             headers={
                 "Cache-Control": "no-cache, no-store, must-revalidate",
                 "Pragma": "no-cache",
-                "Expires": "0"
+                "Expires": "0",
+                "Content-Security-Policy": FRONTEND_CSP,
             }
         )
 else:

--- a/backend/tests/test_content_security_policy.py
+++ b/backend/tests/test_content_security_policy.py
@@ -1,0 +1,20 @@
+"""Desktop and served frontend CSP settings must stay restrictive and aligned."""
+
+import json
+from pathlib import Path
+
+from main import FRONTEND_CSP
+
+
+def test_tauri_and_frontend_csp_match():
+    repo_root = Path(__file__).resolve().parents[2]
+    config = json.loads((repo_root / "src-tauri" / "tauri.conf.json").read_text())
+
+    assert config["app"]["security"]["csp"] == FRONTEND_CSP
+
+
+def test_frontend_csp_blocks_unsafe_embedding_and_plugins():
+    assert "default-src 'self'" in FRONTEND_CSP
+    assert "object-src 'none'" in FRONTEND_CSP
+    assert "frame-ancestors 'none'" in FRONTEND_CSP
+    assert "http://127.0.0.1:*" in FRONTEND_CSP

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*; img-src 'self' data: blob: http://127.0.0.1:*; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdnjs.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     }
   },
   "bundle": {


### PR DESCRIPTION
# Summary
## 1. 데스크톱 CSP 적용
- Tauri 로딩 페이지에 기본 self 정책과 필요한 CDN·로컬 sidecar 출처만 허용함
## 2. 실제 앱 HTML CSP 적용
- FastAPI가 제공하는 index 응답에도 동일한 Content-Security-Policy 헤더를 추가함
## 3. 정책 회귀 테스트 추가
- Tauri와 서버 정책 일치 및 object·frame 차단을 검증하는 테스트를 추가함