### PR TITLE
refactor(backend): remove deprecated APIs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 import os
+from contextlib import asynccontextmanager
 import logging
 
 from logging_config import setup_logging
@@ -26,10 +27,23 @@ from routers import insight as insight_router
 from routers import primer as primer_router
 from services.auth import get_current_user
 
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Initialize persistent state and restore library sessions at startup."""
+    from services.db import init_db
+    from services.usage_tracker import init_usage_table
+
+    init_db()
+    init_usage_table()
+    upload.restore_sessions_from_library()
+    yield
+
+
 app = FastAPI(
     title="EasyPaper API",
     description="PDF 논문 번역 서비스 (Gemma 4 E4B + Ollama)",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 # CORS 설정 (모든 오리진 허용 — NPM/리버스 프록시 환경)
@@ -53,14 +67,6 @@ app.include_router(insight_router.router, prefix="/api", dependencies=[Depends(g
 app.include_router(primer_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Primer"])
 
 
-@app.on_event("startup")
-async def startup_event():
-    """서버 시작 시 데이터베이스 초기화 및 라이브러리의 문서들을 세션으로 복원합니다."""
-    from services.db import init_db
-    from services.usage_tracker import init_usage_table
-    init_db()
-    init_usage_table()
-    upload.restore_sessions_from_library()
 
 
 @app.get("/api/pdf-file/{session_id}")

--- a/backend/services/usage_tracker.py
+++ b/backend/services/usage_tracker.py
@@ -7,7 +7,7 @@ Antigravity CLI 사용량 트래킹
 
 import os
 import sqlite3
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
 
 # DB_PATH 환경변수가 있으면 그대로 쓰고(Docker/데스크탑 앱 등에서 데이터 볼륨/
@@ -44,7 +44,7 @@ def init_usage_table():
 
 def record_call(call_type: str = "translate"):
     """agy 호출 한 건 기록"""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     day = now.strftime("%Y-%m-%d")
     week = now.strftime("%Y-W%W")
     month = now.strftime("%Y-%m")
@@ -123,7 +123,7 @@ def _get_antigravity_cloud_quota(retry=True) -> dict:
             daily_pct = round((1.0 - min_fraction) * 100, 1)
 
             # Get database totals for this week/month/total as context
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             this_week = now.strftime("%Y-W%W")
             this_month = now.strftime("%Y-%m")
             try:
@@ -186,7 +186,7 @@ def get_usage_stats() -> dict:
         return real_stats
 
     # Fallback to local DB stats
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     today = now.strftime("%Y-%m-%d")
     this_week = now.strftime("%Y-W%W")
     this_month = now.strftime("%Y-%m")


### PR DESCRIPTION
# Summary
## 1. FastAPI 시작 수명주기 전환
- deprecated on_event 대신 lifespan에서 DB 초기화와 세션 복원을 수행하도록 수정함
## 2. UTC 시각 처리 현대화
- deprecated datetime.utcnow 호출을 timezone-aware UTC 시각으로 교체함