### PR TITLE
fix(frontend): restore core UI flows

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,7 +4,7 @@ import './styles/library-page.css'
 import './styles/research-graph.css'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, streamInstallClaudeCodeAPI, streamInstallCodexAPI, streamInstallAntigravityAPI, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
 import { icon } from './icons.js'
@@ -36,6 +36,9 @@ window.fetch = async function (...args) {
 }
 
 // ── 상태 ──────────────────────────────────────────
+const COMPARE_MIN_DOCS = 2
+const COMPARE_MAX_DOCS = 5
+
 const state = {
   currentLibraryTab: 'archive', // 'archive'(보관함) / 'trash'(휴지통) - Library 페이지 내부 상태
   previousLibraryTab: 'archive', // 휴지통 진입 전 이전 탭 기억용

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -323,7 +323,7 @@ html, body {
   align-items: center;
   justify-content: space-between;
   padding: 0 24px;
-  z-index: 100;
+  z-index: 120;
   gap: 16px;
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
   transform: translateY(0);

--- a/frontend/tests/e2e/compare-chat.spec.js
+++ b/frontend/tests/e2e/compare-chat.spec.js
@@ -20,20 +20,16 @@ test('논문 2편을 선택해 비교 채팅을 시작하고, 질문에 대한 �
 
   await gotoApp(page)
 
-  // 선택 모드 진입 전에는 체크박스가 보이지 않는다
-  await expect(page.locator('.doc-card-compare-check').first()).not.toBeVisible()
+  await expect(page.locator('#lib-select-toolbar')).toHaveClass(/hidden/)
 
-  await page.click('#lib-compare-toggle-btn')
-  await expect(page.locator('.doc-card-compare-check').first()).toBeVisible()
-
-  const checkboxes = page.locator('.doc-card-compare-check')
+  const checkboxes = page.locator('.doc-card-check-btn')
   await checkboxes.nth(0).click()
   await checkboxes.nth(1).click()
 
-  await expect(page.locator('#compare-select-count')).toHaveText('2/5개 선택됨')
-  await expect(page.locator('#compare-select-start-btn')).toBeEnabled()
+  await expect(page.locator('#lib-select-count')).toHaveText('2개 선택됨')
+  await expect(page.locator('#lib-select-compare-btn')).toBeEnabled()
 
-  await page.click('#compare-select-start-btn')
+  await page.click('#lib-select-compare-btn')
   await expect(page.locator('#compare-screen')).toHaveClass(/active/)
   await expect(page).toHaveURL(/#compare\?ids=doc-1,doc-2/)
 
@@ -66,16 +62,16 @@ test('선택하지 않은 상태에서는 비교 채팅 시작 버튼이 비활�
   await mockBaseRoutes(page, { documents: docs })
 
   await gotoApp(page)
-  await page.click('#lib-compare-toggle-btn')
-  await expect(page.locator('#compare-select-start-btn')).toBeDisabled()
+  await expect(page.locator('#lib-select-toolbar')).toHaveClass(/hidden/)
 
-  await page.locator('.doc-card-compare-check').first().click()
-  await expect(page.locator('#compare-select-count')).toHaveText('1/5개 선택됨')
-  await expect(page.locator('#compare-select-start-btn')).toBeDisabled()
+  const firstCheckbox = page.locator('.doc-card-check-btn').first()
+  await firstCheckbox.click()
+  await expect(page.locator('#lib-select-count')).toHaveText('1개 선택됨')
+  await expect(page.locator('#lib-select-compare-btn')).toBeDisabled()
 
-  await page.click('#compare-select-cancel-btn')
-  await expect(page.locator('#compare-select-bar')).toHaveClass(/hidden/)
-  await expect(page.locator('.doc-card-compare-check').first()).not.toBeVisible()
+  await page.click('#lib-select-close-btn')
+  await expect(page.locator('#lib-select-toolbar')).toHaveClass(/hidden/)
+  await expect(firstCheckbox).not.toHaveClass(/checked/)
 })
 
 // 비교 선택 모드에서는 카드를 클릭하면 선택 상태만 토글되어야 한다. "열기" 버튼은
@@ -89,12 +85,13 @@ test('비교 선택 모드에서 열기 버튼을 눌러도 뷰어로 이동하�
   await mockBaseRoutes(page, { documents: docs })
 
   await gotoApp(page)
-  await page.click('#lib-compare-toggle-btn')
+  await page.locator('.doc-card-check-btn').first().click()
 
-  const firstCard = page.locator('.doc-card').first()
-  await firstCard.locator('.doc-open-btn').click({ force: true })
+  const secondCard = page.locator('.doc-card').nth(1)
+  await secondCard.locator('.doc-open-btn').click({ force: true })
 
-  await expect(page.locator('#compare-select-count')).toHaveText('1/5개 선택됨')
+  await expect(page.locator('#lib-select-count')).toHaveText('2개 선택됨')
+  await expect(page.locator('#lib-select-compare-btn')).toBeEnabled()
   await expect(page.locator('#library-screen')).toHaveClass(/active/)
   await expect(page.locator('#viewer-screen')).not.toHaveClass(/active/)
 })

--- a/frontend/tests/e2e/export-pdf.spec.js
+++ b/frontend/tests/e2e/export-pdf.spec.js
@@ -31,6 +31,7 @@ test('내보내기 버튼 클릭 시 형식 선택 메뉴가 뜨고, PDF 선택 
   await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
   await page.waitForTimeout(1200)
 
+  await page.click('#toolbar-kebab-btn')
   await page.click('#export-btn')
   await expect(page.locator('#export-format-menu')).not.toHaveClass(/hidden/)
   await expect(page.getByText('마크다운 (.md)')).toBeVisible()
@@ -57,6 +58,7 @@ test('메뉴 바깥을 클릭하면 형식 선택 메뉴가 닫힌다', async ({
   await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
   await page.waitForTimeout(1000)
 
+  await page.click('#toolbar-kebab-btn')
   await page.click('#export-btn')
   await expect(page.locator('#export-format-menu')).not.toHaveClass(/hidden/)
 

--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -44,6 +44,17 @@ export async function mockBaseRoutes(page, { documents = [], folders = [] } = {}
     if (url.includes('/api/settings/post-update-notice')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ show: false, version: 'test0000', version_date: '2026-01-01', changelog: [] }) })
     }
+    const emptyLibraryViews = {
+      '/api/library/dashboard': { stats: {}, recent_papers: [] },
+      '/api/library/graph': { nodes: [], edges: [] },
+      '/api/library/timeline': { events: [] },
+      '/api/library/reading-stats': { total_seconds: 0, total_seconds_by_day: {}, paper_stats: [] },
+      '/api/library/reading-analytics-summary': { paper_stats: {} },
+    }
+    const emptyLibraryView = emptyLibraryViews[new URL(url).pathname]
+    if (emptyLibraryView) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(emptyLibraryView) })
+    }
     if (url.includes('/api/library/folders')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders }) })
     }
@@ -73,15 +84,17 @@ export async function mockBaseRoutes(page, { documents = [], folders = [] } = {}
 }
 
 /** 로그인 상태로 앱을 열고(온보딩은 건너뜀) 라이브러리 화면이 뜰 때까지 기다린다. */
-export async function gotoApp(page) {
+export async function gotoApp(page, { navigateToLibrary = true } = {}) {
   await page.goto('/index.html')
   await page.evaluate(() => {
     localStorage.setItem('easypaper_onboarding_seen', '1')
     localStorage.setItem('easypaper_disable_primer', 'true')
   })
   await page.reload()
-  const libraryNav = page.locator('.sidebar-nav-item[data-page="library"]')
-  await libraryNav.waitFor({ state: 'visible' })
-  await libraryNav.click()
-  await page.locator('#library-screen.active').waitFor()
+  if (navigateToLibrary) {
+    const libraryNav = page.locator('.sidebar-nav-item[data-page="library"]')
+    await libraryNav.waitFor({ state: 'visible' })
+    await libraryNav.click()
+    await page.locator('#library-screen.active').waitFor()
+  }
 }

--- a/frontend/tests/e2e/update-notifications.spec.js
+++ b/frontend/tests/e2e/update-notifications.spec.js
@@ -32,7 +32,7 @@ async function mockUpdateEndpoints(page, { postUpdateShow, updateAvailable }) {
 test('방금 업데이트된 직후에는 완료 안내만 뜨고, 새 업데이트 확인 팝업과 겹치지 않는다', async ({ page }) => {
   await mockBaseRoutes(page, { documents: [] })
   await mockUpdateEndpoints(page, { postUpdateShow: true, updateAvailable: true })
-  await gotoApp(page)
+  await gotoApp(page, { navigateToLibrary: false })
   await page.waitForTimeout(1000)
 
   await expect(page.locator('#update-complete-modal')).not.toHaveClass(/hidden/)
@@ -46,7 +46,7 @@ test('방금 업데이트된 직후에는 완료 안내만 뜨고, 새 업데이
 test('방금 업데이트되지 않았고 새 업데이트가 있으면 변경 로그 팝업이 뜬다', async ({ page }) => {
   await mockBaseRoutes(page, { documents: [] })
   await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: true })
-  await gotoApp(page)
+  await gotoApp(page, { navigateToLibrary: false })
   await page.waitForTimeout(1000)
 
   await expect(page.locator('#update-complete-modal')).toHaveClass(/hidden/)
@@ -62,7 +62,7 @@ test('방금 업데이트되지 않았고 새 업데이트가 있으면 변경 �
 test('업데이트도 없고 방금 업데이트되지도 않았으면 아무 팝업도 뜨지 않는다', async ({ page }) => {
   await mockBaseRoutes(page, { documents: [] })
   await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
-  await gotoApp(page)
+  await gotoApp(page, { navigateToLibrary: false })
   await page.waitForTimeout(1000)
 
   await expect(page.locator('#update-complete-modal')).toHaveClass(/hidden/)
@@ -80,7 +80,8 @@ test('설정 화면에서 업데이트 확인 버튼을 누르면 새 업데이�
 
   await gotoApp(page)
   await page.waitForTimeout(600)
-  await page.click('#global-settings-btn')
+  await page.click('#sidebar-settings-btn')
+  await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
   // 확인 전에는 실행 버튼이 비활성 상태여야 한다
@@ -104,7 +105,8 @@ test('설정 화면에서 업데이트 확인 결과 이미 최신 버전이면 
 
   await gotoApp(page)
   await page.waitForTimeout(600)
-  await page.click('#global-settings-btn')
+  await page.click('#sidebar-settings-btn')
+  await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
   await page.click('#system-update-check-btn')
@@ -124,7 +126,8 @@ test('업데이트 실행 후 확인을 다시 누르지 않고는 실행 버튼
 
   await gotoApp(page)
   await page.waitForTimeout(600)
-  await page.click('#global-settings-btn')
+  await page.click('#sidebar-settings-btn')
+  await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
   await page.click('#system-update-check-btn')
@@ -153,7 +156,8 @@ test('설정 화면에서 업데이트 확인 주기를 변경하면 저장된�
 
   await gotoApp(page)
   await page.waitForTimeout(600)
-  await page.click('#global-settings-btn')
+  await page.click('#sidebar-settings-btn')
+  await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
   await expect(page.locator('#setting-update-check-interval')).toHaveValue('weekly')
@@ -173,7 +177,8 @@ test('현재 버전 텍스트를 클릭하면 CHANGELOG.md 전체 내용을 보�
 
   await gotoApp(page)
   await page.waitForTimeout(600)
-  await page.click('#global-settings-btn')
+  await page.click('#sidebar-settings-btn')
+  await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
   await expect(page.locator('#full-changelog-modal')).toHaveClass(/hidden/)


### PR DESCRIPTION
# Summary
## 1. 비교 채팅 및 업데이트 확인 회귀 수정
- 비교 문서 수 범위 상수와 업데이트 확인 API import 누락을 복구함
- 현재 통합 선택 도구와 설정 정보 탭을 기준으로 E2E 시나리오를 정합화함
## 2. 뷰어 내보내기 메뉴 클릭 수정
- 뷰어 툴바 stacking 순서를 조정해 패널 접기 버튼의 클릭 가로채기를 방지함
- 케밥 메뉴를 통한 실제 내보내기 진입 경로를 검증함
## 3. E2E 공통 환경 보강
- 대시보드, 그래프, 타임라인, 읽기 통계 API의 최소 유효 mock을 추가함
- 업데이트 알림 검증 시 라이브러리 이동을 선택적으로 생략하도록 공통 헬퍼를 확장함