### PR TITLE
ci: run frontend end-to-end tests

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -37,3 +37,22 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+      - name: Install Playwright browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: frontend
+        run: npm run test:e2e
+
+      - name: Upload E2E failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
# Summary
## 1. 프런트엔드 E2E CI 게이트 추가
- Chromium과 시스템 의존성을 GitHub Actions에서 설치하도록 구성함
- 단위 테스트와 빌드 이후 Playwright 전체 E2E를 실행하도록 추가함
## 2. E2E 실패 진단 결과 보존
- 실패 시 Playwright 리포트와 테스트 결과를 7일간 아티팩트로 업로드하도록 추가함