### PR TITLE
perf(frontend): split heavy workspace chunks

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,11 +8,6 @@ import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTransla
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
 import { icon } from './icons.js'
-import { renderKnowledgeGraph, highlightSearchMatches } from './knowledgeGraph.js'
-import { renderDashboardPage } from './pages/dashboardPage.js'
-import { renderReadingHistoryPage } from './pages/readingHistoryPage.js'
-import { renderAiChatsPage } from './pages/aiChatsPage.js'
-import { renderNotesPage } from './pages/notesPage.js'
 import { formatTranslationHtml, applyKatexToElement } from './textFormat.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
@@ -4436,14 +4431,18 @@ async function showWorkspacePage(pageId, { pushState = true } = {}) {
     syncLibraryTabUI('archive')
     await renderLibrary()
   } else if (pageId === 'chats') {
+    const { renderAiChatsPage } = await import('./pages/aiChatsPage.js')
     await renderAiChatsPage()
   } else if (pageId === 'notes') {
+    const { renderNotesPage } = await import('./pages/notesPage.js')
     await renderNotesPage()
   } else if (pageId === 'graph') {
     await renderLibraryGraphTab()
   } else if (pageId === 'dashboard') {
+    const { renderDashboardPage } = await import('./pages/dashboardPage.js')
     await renderDashboardPage()
   } else if (pageId === 'history') {
+    const { renderReadingHistoryPage } = await import('./pages/readingHistoryPage.js')
     await renderReadingHistoryPage()
   }
 }
@@ -6658,6 +6657,7 @@ async function renderLibraryGraphTab() {
       libraryGraphCyInstance = null
     }
     libraryGraphCanvas.innerHTML = ''
+    const { renderKnowledgeGraph } = await import('./knowledgeGraph.js')
     libraryGraphCyInstance = renderKnowledgeGraph(libraryGraphCanvas, data, { onNodeClick: showGraphDetailPanel })
 
     rgGraphLoadedAt = new Date()
@@ -6911,6 +6911,7 @@ if (libraryGraphSearchInput) {
     const query = libraryGraphSearchInput.value.trim()
     libraryGraphSearchTimer = setTimeout(async () => {
       if (!libraryGraphCyInstance) return
+      const { highlightSearchMatches } = await import('./knowledgeGraph.js')
       if (!query) {
         highlightSearchMatches(libraryGraphCyInstance, [])
         return

--- a/frontend/tests/e2e/workspace-lazy-routes.spec.js
+++ b/frontend/tests/e2e/workspace-lazy-routes.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('지연 로드된 워크스페이스 페이지를 모두 열 수 있다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await gotoApp(page)
+
+  const routes = [
+    ['dashboard', '.dash-root'],
+    ['history', '#rh-stat-grid'],
+    ['chats', '.aic-page'],
+    ['notes', '.notes-page-inner'],
+  ]
+
+  for (const [pageId, renderedSelector] of routes) {
+    await page.click(`.sidebar-nav-item[data-page="${pageId}"]`)
+    await expect(page.locator(`#page-${pageId}`)).toHaveClass(/active/)
+    await expect(page.locator(renderedSelector)).toBeVisible()
+  }
+
+  await page.click('.sidebar-nav-item[data-page="graph"]')
+  await expect(page.locator('#page-graph')).toHaveClass(/active/)
+  await expect(page.locator('#library-graph-canvas canvas').first()).toBeVisible()
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,4 +10,16 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/node_modules/cytoscape/')) return 'cytoscape'
+          if (id.includes('/node_modules/cytoscape-fcose/') ||
+              id.includes('/node_modules/cose-base/') ||
+              id.includes('/node_modules/layout-base/')) return 'graph-layout'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
# Summary
## 1. 워크스페이스 페이지 지연 로딩 추가
- Dashboard, Reading History, AI Chats, Notes 렌더러를 각 페이지 진입 시 동적 import하도록 변경함
- 지식 그래프 렌더러와 검색 기능을 Research Graph 진입 시 로드하도록 변경함
## 2. 그래프 의존성 청크 분리
- Cytoscape 코어와 fcose/cose/layout 레이아웃 엔진을 별도 청크로 구성함
- 초기 메인 JS를 1,072.09kB에서 428.07kB로 약 60% 축소함
- 최대 청크를 500kB 미만으로 낮춰 Vite 빌드 크기 경고를 제거함
## 3. 지연 라우트 E2E 검증 추가
- 다섯 워크스페이스 페이지를 순회하며 각 동적 청크의 실제 렌더 완료를 검증함