### PR TITLE
fix(library): refine folder list rows

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5699,6 +5699,36 @@ async function requestDeleteFolder(folder) {
   await renderLibrary()
 }
 
+function closeFolderCardMenus() {
+  document.querySelectorAll('.folder-card-actions').forEach(menu => {
+    menu.classList.add('hidden')
+    const folderId = menu.dataset.folderId
+    const ownerCard = folderId ? document.querySelector(`.library-folder-card[data-folder-id="${CSS.escape(folderId)}"]`) : null
+    const actionGroup = ownerCard?.querySelector('.folder-card-cta')
+    if (actionGroup && menu.parentElement !== actionGroup) {
+      const openButton = actionGroup.querySelector('.folder-card-open-btn')
+      actionGroup.insertBefore(menu, openButton)
+    }
+    menu.removeAttribute('style')
+  })
+}
+
+function positionFolderCardMenu(menu, trigger) {
+  document.body.appendChild(menu)
+  menu.classList.remove('hidden')
+  const triggerRect = trigger.getBoundingClientRect()
+  const menuWidth = menu.offsetWidth
+  const menuHeight = menu.offsetHeight
+  const left = Math.max(8, Math.min(triggerRect.right - menuWidth, window.innerWidth - menuWidth - 8))
+  const belowTop = triggerRect.bottom + 6
+  const top = belowTop + menuHeight <= window.innerHeight - 8 ? belowTop : Math.max(8, triggerRect.top - menuHeight - 6)
+  menu.style.position = 'fixed'
+  menu.style.left = `${left}px`
+  menu.style.top = `${top}px`
+  menu.style.right = 'auto'
+  menu.style.zIndex = '100001'
+}
+
 function createFolderCard(folder) {
   const card = document.createElement('article')
   card.className = 'library-folder-card'
@@ -5708,14 +5738,55 @@ function createFolderCard(folder) {
   card.title = 'Enter/F2: 이름 변경 · Delete/Backspace: 삭제 · Ctrl/Cmd+X: 잘라내기'
   card.dataset.folderId = folder.id
   card.style.setProperty('--folder-color', folder.color)
-  card.innerHTML = `<div class="folder-card-icon">${icon('folder', 32, 'fill="currentColor" stroke="none"')}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div><button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
-  card.addEventListener('click', e => { if (e.target.closest('.folder-card-menu')) return; navigateLibraryFolder(folder.id) })
+  const isListView = libraryViewMode === 'list'
+  const paperCount = currentLibraryDocs.filter(doc => (doc.folder_id || null) === folder.id).length
+  const childFolderCount = libraryFolders.filter(candidate => (candidate.parent_id || null) === folder.id).length
+  const menuHtml = `<button class="folder-card-menu" title="폴더 관리">${icon('moreVertical', 16)}</button><div class="folder-card-actions hidden"><button data-action="rename">이름 변경</button><button data-action="color">폴더 색상</button><button data-action="delete">폴더 삭제</button></div>`
+
+  card.innerHTML = isListView
+    ? `<div class="folder-card-icon">${icon('folder', 18, 'fill="currentColor" stroke="none"')}</div>
+      <div class="folder-card-name" title="${escapeHtml(folder.name)}">${escapeHtml(folder.name)}</div>
+      <div class="folder-card-meta">
+        <span>${icon('fileText', 12)}논문 ${paperCount}편</span>
+        <span class="meta-dot"></span>
+        <span>${icon('folder', 12)}하위 폴더 ${childFolderCount}개</span>
+      </div>
+      <div class="folder-card-cta">
+        <button class="folder-card-rename-btn" title="이름 변경">${icon('edit3', 14)}</button>
+        ${menuHtml}
+        <button class="folder-card-open-btn" title="폴더 열기">${icon('externalLink', 14)}</button>
+      </div>`
+    : `<div class="folder-card-icon">${icon('folder', 32, 'fill="currentColor" stroke="none"')}</div><div class="folder-card-name">${escapeHtml(folder.name)}</div><div class="folder-card-meta">폴더 열기</div>${menuHtml}`
+  card.addEventListener('click', e => {
+    if (e.target.closest('.folder-card-menu, .folder-card-rename-btn, .folder-card-open-btn')) return
+    navigateLibraryFolder(folder.id)
+  })
   card.addEventListener('dragstart', e => { e.dataTransfer.setData('application/x-easypaper-item', JSON.stringify({ kind: 'folder', id: folder.id })); e.dataTransfer.effectAllowed = 'move' })
   setFolderDropTarget(card, folder.id)
   const menu = card.querySelector('.folder-card-actions')
-  card.querySelector('.folder-card-menu').addEventListener('click', e => { e.stopPropagation(); menu.classList.toggle('hidden') })
+  menu.dataset.folderId = folder.id
+  const menuTrigger = card.querySelector('.folder-card-menu')
+  menuTrigger.addEventListener('click', e => {
+    e.stopPropagation()
+    const shouldOpen = menu.classList.contains('hidden')
+    closeFolderCardMenus()
+    if (!shouldOpen) return
+    if (isListView) positionFolderCardMenu(menu, menuTrigger)
+    else menu.classList.remove('hidden')
+  })
+  card.querySelector('.folder-card-rename-btn')?.addEventListener('click', async e => {
+    e.stopPropagation()
+    try { await requestRenameFolder(folder) } catch (err) { showToast(err.message || '폴더 이름 변경 실패', 'error') }
+  })
+  card.querySelector('.folder-card-open-btn')?.addEventListener('click', e => {
+    e.stopPropagation()
+    navigateLibraryFolder(folder.id)
+  })
   menu.addEventListener('click', async e => {
-    e.stopPropagation(); const action = e.target.dataset.action; if (!action) return
+    e.stopPropagation()
+    const action = e.target.dataset.action
+    if (!action) return
+    closeFolderCardMenus()
     try {
       if (action === 'rename') await requestRenameFolder(folder)
       if (action === 'color') { const color = await showFolderColorDialog(folder.color); if (color && color !== folder.color) { await updateFolderWithUndo(folder, { color }); await renderLibrary() } }
@@ -5875,12 +5946,18 @@ function initLibraryContextMenu() {
   })
   document.addEventListener('pointerdown', event => {
     if (libraryContextMenu && !event.target.closest('.library-context-menu')) closeLibraryContextMenu()
+    if (!event.target.closest('.folder-card-menu, .folder-card-actions')) closeFolderCardMenus()
   })
   document.addEventListener('keydown', event => {
-    if (event.key === 'Escape') closeLibraryContextMenu()
+    if (event.key === 'Escape') {
+      closeLibraryContextMenu()
+      closeFolderCardMenus()
+    }
   })
   surface.addEventListener('scroll', closeLibraryContextMenu)
+  document.addEventListener('scroll', closeFolderCardMenus, true)
   window.addEventListener('resize', closeLibraryContextMenu)
+  window.addEventListener('resize', closeFolderCardMenus)
 }
 
 initLibraryContextMenu()

--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -676,10 +676,10 @@ body.light-theme .lib-detail-panel {
 .folder-dialog-input:focus { border-color:var(--control-accent); }
 .library-grid.list-view .library-folder-card {
   min-height:0;
-  padding:12px 16px;
+  padding:11px 14px;
   display:flex;
   align-items:center;
-  gap:16px;
+  gap:12px;
   border-radius:14px;
   background:var(--bg-card);
   transition:background .2s ease, border-color .2s ease, transform .2s ease;
@@ -688,6 +688,7 @@ body.light-theme .lib-detail-panel {
   transform:translateX(2px);
   border-color:var(--border-strong);
   background:var(--bg-card-hover);
+  box-shadow:0 5px 18px -14px color-mix(in srgb, var(--folder-color) 65%, transparent);
 }
 .library-grid.list-view .library-folder-card:focus-visible {
   border-color:var(--control-accent);
@@ -697,21 +698,54 @@ body.light-theme .lib-detail-panel {
   display:flex;
   align-items:center;
   justify-content:center;
-  width:22px;
-  height:22px;
-  flex:0 0 22px;
+  width:30px;
+  height:30px;
+  flex:0 0 30px;
   margin:0;
+  border:1px solid color-mix(in srgb, var(--folder-color) 28%, var(--border));
+  border-radius:9px;
+  background:color-mix(in srgb, var(--folder-color) 13%, var(--bg-elevated));
+  color:var(--folder-color);
   filter:none;
+  box-shadow:inset 0 1px 0 color-mix(in srgb, var(--folder-color) 16%, transparent);
 }
-.library-grid.list-view .folder-card-icon svg { width:22px; height:22px; }
+.library-grid.list-view .folder-card-icon svg { width:17px; height:17px; }
 .library-grid.list-view .folder-card-name {
   flex:1 1 240px;
   min-width:120px;
   font-size:14.5px;
+  font-weight:700;
   letter-spacing:-.01em;
 }
-.library-grid.list-view .folder-card-meta { flex:0 0 auto; margin:0; font-size:11px; font-weight:500; }
-.library-grid.list-view .folder-card-menu {
+.library-grid.list-view .folder-card-meta {
+  display:flex;
+  align-items:center;
+  gap:7px;
+  flex:0 0 auto;
+  margin:0;
+  color:var(--text-muted);
+  font-size:11px;
+  font-weight:500;
+  white-space:nowrap;
+}
+.library-grid.list-view .folder-card-meta > span:not(.meta-dot) { display:inline-flex; align-items:center; gap:4px; }
+.library-grid.list-view .folder-card-meta svg { opacity:.72; }
+.library-grid.list-view .folder-card-meta .meta-dot {
+  width:3px;
+  height:3px;
+  border-radius:50%;
+  background:var(--border-strong);
+}
+.library-grid.list-view .folder-card-cta {
+  display:flex;
+  align-items:center;
+  gap:4px;
+  flex:0 0 auto;
+  margin-left:auto;
+}
+.library-grid.list-view .folder-card-rename-btn,
+.library-grid.list-view .folder-card-menu,
+.library-grid.list-view .folder-card-open-btn {
   position:static;
   display:flex;
   align-items:center;
@@ -722,12 +756,36 @@ body.light-theme .lib-detail-panel {
   padding:0;
   border:1px solid var(--border);
   border-radius:8px;
+  background:transparent;
+  color:var(--text-muted);
+  cursor:pointer;
+  transition:background .15s ease, border-color .15s ease, color .15s ease, transform .15s ease;
 }
+.library-grid.list-view .folder-card-rename-btn:hover,
 .library-grid.list-view .folder-card-menu:hover {
   border-color:var(--border-strong);
   background:var(--bg-hover);
+  color:var(--text-primary);
 }
-.library-grid.list-view .folder-card-actions { top:calc(50% + 20px); right:16px; }
+.library-grid.list-view .folder-card-open-btn {
+  border-color:var(--control-accent);
+  border-radius:50%;
+  background:var(--control-accent);
+  color:#fff;
+}
+.library-grid.list-view .folder-card-open-btn:hover {
+  filter:brightness(1.1);
+  transform:scale(1.04);
+}
+.library-grid.list-view .folder-card-actions { position:fixed; top:auto; right:auto; z-index:100001; }
+@media (max-width:900px) {
+  .library-grid.list-view .folder-card-meta > span:last-child,
+  .library-grid.list-view .folder-card-meta .meta-dot { display:none; }
+}
+@media (max-width:640px) {
+  .library-grid.list-view .folder-card-meta,
+  .library-grid.list-view .folder-card-rename-btn { display:none; }
+}
 
 .doc-card[draggable=true], .doc-list-row[draggable=true] { cursor:grab; }
 .doc-dragging { opacity:.55; cursor:grabbing!important; }

--- a/frontend/tests/e2e/library-folder-list.spec.js
+++ b/frontend/tests/e2e/library-folder-list.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+const folders = [
+  { id: 'folder-root', username: 'admin', parent_id: null, name: 'Research Inbox', color: '#8b5cf6', sort_order: 0, created_at: '2026-08-14T00:00:00Z', updated_at: '2026-08-14T00:00:00Z' },
+  { id: 'folder-child', username: 'admin', parent_id: 'folder-root', name: 'Transformers', color: '#4f8ef7', sort_order: 0, created_at: '2026-08-14T00:00:00Z', updated_at: '2026-08-14T00:00:00Z' },
+]
+
+test('폴더 리스트를 논문 행처럼 표시하고 메뉴가 스크롤 높이를 늘리지 않는다', async ({ page }) => {
+  await mockBaseRoutes(page)
+  await page.route('**/api/library/folders', route => {
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders }) })
+  })
+
+  await gotoApp(page)
+  await page.locator('.sidebar-nav-item[data-page="library"]').click()
+  await page.getByRole('button', { name: '리스트 보기' }).click()
+
+  const grid = page.locator('#library-grid')
+  const folder = grid.locator('.library-folder-card[data-folder-id="folder-root"]')
+  await expect(folder).toBeVisible()
+  await expect(folder.locator('.folder-card-icon')).toBeVisible()
+  await expect(folder.locator('.folder-card-meta')).toContainText('논문 0편')
+  await expect(folder.locator('.folder-card-meta')).toContainText('하위 폴더 1개')
+  await expect(folder.getByTitle('이름 변경')).toBeVisible()
+  await expect(folder.getByTitle('폴더 열기')).toBeVisible()
+
+  const before = await grid.evaluate(el => ({ scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }))
+  expect(before.scrollHeight).toBeLessThanOrEqual(before.clientHeight)
+
+  await folder.getByTitle('폴더 관리').click()
+  const menu = page.locator('.folder-card-actions[data-folder-id="folder-root"]')
+  await expect(menu).toBeVisible()
+  expect(await menu.evaluate(el => el.parentElement === document.body)).toBe(true)
+  expect(await grid.evaluate(el => el.scrollHeight)).toBe(before.scrollHeight)
+
+  await page.keyboard.press('Escape')
+  await expect(menu).toBeHidden()
+  expect(await menu.evaluate(el => el.parentElement?.classList.contains('folder-card-cta'))).toBe(true)
+})


### PR DESCRIPTION
# Summary
## 1. 폴더 리스트 아이템 디자인 리파인
- 폴더 색상을 반영한 아이콘 타일과 논문·하위 폴더 개수 메타 정보를 추가함
- 이름 변경, 폴더 관리, 폴더 열기 액션을 논문 리스트 아이템과 동일한 시각적 위계로 구성함
- 좁은 화면에서 메타 및 보조 액션을 단계적으로 숨기는 반응형 레이아웃을 추가함
## 2. 폴더 케밥 메뉴 스크롤 문제 수정
- 케밥 메뉴를 리스트 스크롤 컨테이너에서 body 오버레이로 분리함
- 화면 경계에 따라 메뉴를 위·아래로 자동 배치하고 닫을 때 원래 액션 그룹으로 복원함
- 폴더만 존재할 때 메뉴가 라이브러리 scrollHeight를 늘리지 않는 Playwright 회귀 테스트를 추가함