### PR TITLE
fix(library): match folder and paper row height

### DIFF
--- a/frontend/src/styles/library-page.css
+++ b/frontend/src/styles/library-page.css
@@ -687,8 +687,14 @@ body.light-theme .lib-detail-panel {
 .folder-dialog-label { display:grid; gap:8px; color:var(--text-secondary); font-size:13px; }
 .folder-dialog-input { width:100%; box-sizing:border-box; padding:9px 10px; border:1px solid var(--border-strong); border-radius:var(--radius-sm); background:var(--bg-elevated); color:var(--text-primary); font:inherit; outline:none; }
 .folder-dialog-input:focus { border-color:var(--control-accent); }
+.library-grid.list-view { --library-list-row-min-height:64px; }
+.library-grid.list-view .doc-list-row,
 .library-grid.list-view .library-folder-card {
-  min-height:0;
+  height:var(--library-list-row-min-height);
+  min-height:var(--library-list-row-min-height);
+  flex:0 0 var(--library-list-row-min-height);
+}
+.library-grid.list-view .library-folder-card {
   padding:11px 14px;
   display:flex;
   align-items:center;

--- a/frontend/tests/e2e/library-folder-list.spec.js
+++ b/frontend/tests/e2e/library-folder-list.spec.js
@@ -6,8 +6,12 @@ const folders = [
   { id: 'folder-child', username: 'admin', parent_id: 'folder-root', name: 'Transformers', color: '#4f8ef7', sort_order: 0, created_at: '2026-08-14T00:00:00Z', updated_at: '2026-08-14T00:00:00Z' },
 ]
 
+const docs = [
+  { id: 'doc-root', folder_id: null, filename: 'paper.pdf', created_at: '2026-08-14T00:00:00Z', total_pages: 12, metadata: { title: 'Reference Paper', categories: [] }, translated_pages: [] },
+]
+
 test('폴더 리스트를 논문 행처럼 표시하고 메뉴가 스크롤 높이를 늘리지 않는다', async ({ page }) => {
-  await mockBaseRoutes(page)
+  await mockBaseRoutes(page, { documents: docs })
   await page.route('**/api/library/folders', route => {
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ folders }) })
   })
@@ -21,6 +25,21 @@ test('폴더 리스트를 논문 행처럼 표시하고 메뉴가 스크롤 높�
   await expect(folder).toBeVisible()
   await expect(folder.locator('.folder-card-icon')).toBeVisible()
   await expect(folder.locator('.folder-card-meta')).toContainText('논문 0편')
+
+  const paper = grid.locator('.doc-list-row[data-id="doc-root"]')
+  const [folderBox, paperBox] = await Promise.all([folder.boundingBox(), paper.boundingBox()])
+  expect(folderBox.height).toBe(64)
+  expect(folderBox.height).toBe(paperBox.height)
+
+  await grid.evaluate(el => { el.style.height = '100px'; el.style.maxHeight = '100px'; el.style.flex = '0 0 100px' })
+  const [constrainedFolderBox, constrainedPaperBox] = await Promise.all([folder.boundingBox(), paper.boundingBox()])
+  expect(constrainedFolderBox.height).toBe(64)
+  expect(constrainedPaperBox.height).toBe(64)
+  const constrainedGrid = await grid.evaluate(el => ({ scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }))
+  expect(constrainedGrid.scrollHeight).toBeGreaterThan(constrainedGrid.clientHeight)
+  await grid.evaluate(el => { el.style.removeProperty('height'); el.style.removeProperty('max-height'); el.style.removeProperty('flex') })
+
+
   await expect(folder.locator('.folder-card-meta')).toContainText('하위 폴더 1개')
   await expect(folder.getByTitle('이름 변경')).toBeVisible()
   await expect(folder.getByTitle('폴더 열기')).toBeVisible()


### PR DESCRIPTION
# Summary
## 1. 폴더 및 논문 리스트 행 높이 통일
- 리스트 보기의 폴더와 논문 아이템에 공통 64px 높이를 적용함
- flex 축소를 차단해 세로 공간이 부족해도 폴더 행만 작아지지 않도록 수정함
## 2. 리스트 높이 회귀 테스트 보강
- 최상위 폴더와 논문 행의 실제 높이가 동일한지 검증함
- 제한된 컨테이너 높이에서도 두 행이 64px을 유지하고 리스트 스크롤이 생성되는지 검증함