### PR TITLE
fix(desktop): repair PDF parser installs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,16 @@
+import sys
+
+# PyInstaller sidecar는 일반 Python 인터프리터가 아니어서 ``-m pip``를
+# 실행할 수 없다. 설치용으로 자신을 다시 띄운 경우 서버 import 전에 분기한다.
+if len(sys.argv) > 1 and sys.argv[1] == "--easypaper-install-pdf-parser":
+    from venv_manager import run_packaged_parser_installer
+    raise SystemExit(run_packaged_parser_installer())
+
+# 선택 파서의 격리 환경을 FastAPI 등 다른 패키지보다 먼저 활성화한다.
+from config import get_pdf_parser_engine
+from venv_manager import relaunch_into_required_venv
+relaunch_into_required_venv(get_pdf_parser_engine())
+
 from fastapi import FastAPI, Request, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -10,13 +23,7 @@ from logging_config import setup_logging
 setup_logging()
 logger = logging.getLogger(__name__)
 
-from config import CORS_ORIGINS, UPLOAD_DIR, APP_HOST, APP_PORT, get_pdf_parser_engine
-
-# mineru 엔진은 marker와 같은 venv에 공존할 수 없어 전용 venv(.venv-mineru)를
-# 쓴다 - 다른 무거운 import보다 먼저, 아직 소켓을 열지 않은 이 시점에 프로세스를
-# 필요한 venv로 교체한다. 자세한 이유는 venv_manager.py 참고.
-from venv_manager import relaunch_into_required_venv
-relaunch_into_required_venv(get_pdf_parser_engine())
+from config import CORS_ORIGINS, UPLOAD_DIR, APP_HOST, APP_PORT
 
 from routers import upload, translate, chat
 from routers import library as library_router

--- a/backend/packaging/easypaper-backend.spec
+++ b/backend/packaging/easypaper-backend.spec
@@ -9,8 +9,13 @@
 # 기존 backend/config.py 패턴과 상성이 나쁘다.
 
 import os
+from PyInstaller.utils.hooks import collect_all
 
 block_cipher = None
+
+# 데스크탑 배포본의 제한된 설치 모드에서 pip를 직접 호출할 수 있도록
+# pip의 동적 모듈과 데이터를 sidecar에 포함한다.
+pip_datas, pip_binaries, pip_hiddenimports = collect_all("pip")
 
 BACKEND_DIR = os.path.join(os.path.dirname(os.path.abspath(SPEC)), "..")
 BACKEND_DIR = os.path.abspath(BACKEND_DIR)
@@ -18,8 +23,8 @@ BACKEND_DIR = os.path.abspath(BACKEND_DIR)
 a = Analysis(
     [os.path.join(BACKEND_DIR, "main.py")],
     pathex=[BACKEND_DIR],
-    binaries=[],
-    datas=[
+    binaries=pip_binaries,
+    datas=pip_datas + [
         # DEFAULT_PROMPT_TEMPLATE 폴백이 config.py에 있어 필수는 아니지만,
         # 사용자가 커스터마이징하기 전 기본 템플릿 파일을 그대로 들고 있으면
         # 첫 실행 UX가 서버/Docker 배포와 동일해진다.
@@ -31,7 +36,7 @@ a = Analysis(
         # "<sidecar 실행파일 디렉토리>/_internal/frontend/dist"로 알려준다.
         (os.path.join(BACKEND_DIR, "..", "frontend", "dist"), "frontend/dist"),
     ],
-    hiddenimports=[
+    hiddenimports=pip_hiddenimports + [
         # uvicorn은 프로토콜/루프 구현체를 동적으로 임포트하므로 PyInstaller의
         # 정적 분석이 놓치기 쉽다. main.py가 uvicorn.run(app, ...)으로 앱
         # 객체를 직접 넘기도록 바뀌어(문자열 임포트 아님) 최소 요구치는 줄었지만,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -344,11 +344,19 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
     update_translation_prompt_template(data.translation_prompt_template)
 
     if restart_needed:
+        if venv_manager.is_packaged_desktop():
+            return {
+                "message": f"'{pdf_parser_engine}' 엔진 적용을 위해 앱을 재시작합니다. 진행 중인 번역이 중단될 수 있습니다.",
+                "restarting": True,
+                "restart_mode": "desktop_app",
+            }
+
         import asyncio
         asyncio.create_task(_restart_server_process(get_project_root()))
         return {
             "message": f"'{pdf_parser_engine}' 엔진 적용을 위해 서버가 잠시 후 재시작됩니다. 진행 중인 번역이 중단될 수 있습니다.",
             "restarting": True,
+            "restart_mode": "server",
         }
 
     return {"message": "시스템 설정이 성공적으로 변경되었습니다.", "restarting": False}
@@ -378,6 +386,18 @@ def _is_package_installed_in_venv(venv_dir: str, module_name: str) -> bool:
     return any(os.path.isdir(os.path.join(sp, module_name)) for sp in site_packages_dirs)
 
 
+def _is_pdf_parser_installed(engine: str) -> bool:
+    if venv_manager.is_packaged_desktop():
+        return venv_manager.is_parser_installed(engine)
+    if engine == "pdfplumber":
+        return _is_package_installed("pdfplumber")
+    venv_dir = (
+        venv_manager.MINERU_VENV if engine == "mineru"
+        else venv_manager.DEFAULT_VENV
+    )
+    return _is_package_installed_in_venv(venv_dir, engine)
+
+
 @router.get("/settings/pdf-parsers")
 async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
     current_engine = get_pdf_parser_engine()
@@ -399,7 +419,7 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
             "pros": "표 구조 및 그래픽 좌표 추적 우수",
             "cons": "PyMuPDF보다 약간 느림",
             "size_info": "약 15 MB",
-            "installed": _is_package_installed("pdfplumber"),
+            "installed": _is_pdf_parser_installed("pdfplumber"),
             "install_package": "pdfplumber"
         },
         {
@@ -409,7 +429,7 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
             "pros": "수식을 LaTeX 변환, 정교한 오버레이 크롭",
             "cons": "PyTorch/Vision 포함 (대용량), 처리 속도 느림",
             "size_info": "약 2.5 GB (PyTorch & Vision 모델 포함)",
-            "installed": _is_package_installed_in_venv(venv_manager.DEFAULT_VENV, "marker"),
+            "installed": _is_pdf_parser_installed("marker"),
             "install_package": "marker-pdf"
         },
         {
@@ -417,9 +437,9 @@ async def get_pdf_parsers_info(current_user: str = Depends(get_current_user)):
             "name": "MinerU",
             "description": "대규모 학술 서적 및 논문 레이아웃 분석 AI 파서",
             "pros": "정밀한 레이아웃/표/수식 세그멘테이션",
-            "cons": "대용량 패키지, 높은 CPU/GPU 및 메모리 소모. marker와 의존성이 충돌해 전용 가상환경(.venv-mineru)에 별도 설치되며, 이 엔진으로 전환/이탈 시 서버가 재시작됩니다.",
+            "cons": "대용량 패키지, 높은 CPU/GPU 및 메모리 소모. marker와 의존성이 충돌해 격리된 환경에 별도 설치되며, 이 엔진으로 전환/이탈 시 서버 또는 데스크탑 앱이 재시작됩니다.",
             "size_info": "약 3.0 GB (전용 가상환경, Layout/Formula/OCR 모델 포함)",
-            "installed": _is_package_installed_in_venv(venv_manager.MINERU_VENV, "mineru"),
+            "installed": _is_pdf_parser_installed("mineru"),
             "install_package": "mineru[pipeline]"
         }
     ]
@@ -436,65 +456,81 @@ async def install_pdf_parser_stream(
 ):
     import asyncio
 
-    package_map = {
-        "pdfplumber": "pdfplumber",
-        "marker": "marker-pdf",
-        "mineru": "mineru[pipeline]"
-    }
-
-    pkg_name = package_map.get(parser_id)
-    if not pkg_name:
+    package = venv_manager.PARSER_PACKAGES.get(parser_id)
+    if not package:
         raise HTTPException(status_code=400, detail="지원되지 않는 파서 엔진입니다.")
+    pkg_name = package[0]
 
-    # marker/mineru는 transformers 버전 요구사항이 정반대라 같은 venv에 절대
-    # 공존할 수 없다(런타임에서 실제 크래시로 확인됨) - mineru만 전용
-    # venv(.venv-mineru)에 설치한다. pdfplumber/marker는 기본 venv 그대로.
-    target_venv = venv_manager.MINERU_VENV if parser_id == "mineru" else venv_manager.DEFAULT_VENV
+    # PyInstaller sidecar는 Python 인터프리터가 아니므로 -m venv/-m pip를
+    # 실행할 수 없고, 앱 번들 내부 경로는 macOS/Windows에서 읽기 전용이다.
+    # 데스크탑에서는 번들 pip 전용 모드로 sidecar를 다시 실행해 사용자 앱
+    # 데이터 폴더에 엔진별 패키지를 설치한다. 일반 서버는 기존 venv를 쓴다.
+    packaged_desktop = venv_manager.is_packaged_desktop()
+    target_venv = (
+        venv_manager.MINERU_VENV if parser_id == "mineru"
+        else venv_manager.DEFAULT_VENV
+    )
 
     async def event_stream():
-        if not venv_manager.is_venv_available(target_venv):
-            yield f"data: {json.dumps({'status': 'progress', 'line': f'전용 가상환경을 새로 만듭니다: {target_venv}'})}\n\n"
-            proc = await asyncio.create_subprocess_exec(
-                sys.executable, "-m", "venv", target_venv,
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, stdin=asyncio.subprocess.DEVNULL
-            )
-            async for text in _stream_subprocess_lines(proc):
-                yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
-            await proc.wait()
-            if proc.returncode != 0:
-                yield f"data: {json.dumps({'status': 'error', 'message': '가상환경 생성 실패'})}\n\n"
-                return
+        if packaged_desktop:
+            install_dir = venv_manager.parser_packages_dir(parser_id)
+            yield f"data: {json.dumps({'status': 'progress', 'line': f'사용자 앱 데이터 폴더에 {pkg_name} 설치를 시작합니다: {install_dir}'})}\n\n"
+            cmd = venv_manager.parser_install_command(parser_id)
+        else:
+            if not venv_manager.is_venv_available(target_venv):
+                yield f"data: {json.dumps({'status': 'progress', 'line': f'전용 가상환경을 새로 만듭니다: {target_venv}'})}\n\n"
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable, "-m", "venv", target_venv,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    stdin=asyncio.subprocess.DEVNULL,
+                )
+                async for text in _stream_subprocess_lines(proc):
+                    yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+                await proc.wait()
+                if proc.returncode != 0:
+                    yield f"data: {json.dumps({'status': 'error', 'message': '가상환경 생성 실패'})}\n\n"
+                    return
 
-            # 이 venv가 나중에 엔진 전환 시 앱 전체를 그대로 구동하게 되므로,
-            # 새 패키지 하나만 있어서는 안 되고 fastapi 등 기본 의존성도 필요하다.
-            requirements_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "requirements.txt")
-            yield f"data: {json.dumps({'status': 'progress', 'line': '기본 의존성(requirements.txt) 설치 중...'})}\n\n"
-            proc = await asyncio.create_subprocess_exec(
-                venv_manager.venv_python(target_venv), "-u", "-m", "pip", "install", "-r", requirements_path,
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, stdin=asyncio.subprocess.DEVNULL
-            )
-            async for text in _stream_subprocess_lines(proc):
-                yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
-            await proc.wait()
-            if proc.returncode != 0:
-                yield f"data: {json.dumps({'status': 'error', 'message': '기본 의존성 설치 실패'})}\n\n"
-                return
+                requirements_path = os.path.join(
+                    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    "requirements.txt",
+                )
+                yield f"data: {json.dumps({'status': 'progress', 'line': '기본 의존성(requirements.txt) 설치 중...'})}\n\n"
+                proc = await asyncio.create_subprocess_exec(
+                    venv_manager.venv_python(target_venv), "-u", "-m", "pip",
+                    "install", "-r", requirements_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    stdin=asyncio.subprocess.DEVNULL,
+                )
+                async for text in _stream_subprocess_lines(proc):
+                    yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
+                await proc.wait()
+                if proc.returncode != 0:
+                    yield f"data: {json.dumps({'status': 'error', 'message': '기본 의존성 설치 실패'})}\n\n"
+                    return
 
-        python_bin = venv_manager.venv_python(target_venv)
-        yield f"data: {json.dumps({'status': 'progress', 'line': f'가상환경({python_bin})에 {pkg_name} 설치를 시작합니다...'})}\n\n"
-        try:
+            python_bin = venv_manager.venv_python(target_venv)
+            yield f"data: {json.dumps({'status': 'progress', 'line': f'가상환경({python_bin})에 {pkg_name} 설치를 시작합니다...'})}\n\n"
             cmd = [python_bin, "-u", "-m", "pip", "install", pkg_name]
+
+        try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
-                stdin=asyncio.subprocess.DEVNULL
+                stdin=asyncio.subprocess.DEVNULL,
             )
             async for text in _stream_subprocess_lines(proc):
                 yield f"data: {json.dumps({'status': 'progress', 'line': text})}\n\n"
             await proc.wait()
-            if proc.returncode == 0:
+            if proc.returncode == 0 and (
+                not packaged_desktop or venv_manager.is_parser_installed(parser_id)
+            ):
                 yield f"data: {json.dumps({'status': 'success', 'message': f'{pkg_name} 설치가 정상적으로 완료되었습니다.'})}\n\n"
+            elif proc.returncode == 0:
+                yield f"data: {json.dumps({'status': 'error', 'message': '설치 프로세스는 완료됐지만 패키지 검증에 실패했습니다.'})}\n\n"
             else:
                 yield f"data: {json.dumps({'status': 'error', 'message': f'설치가 오류 코드 {proc.returncode}로 종료되었습니다.'})}\n\n"
         except Exception as e:
@@ -507,7 +543,7 @@ async def install_pdf_parser_stream(
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",
             "Connection": "keep-alive",
-        }
+        },
     )
 
 @router.post("/settings/uninstall-pdf-parser")
@@ -520,29 +556,37 @@ async def uninstall_pdf_parser(
 
     body = await request.json()
     parser_id = body.get("parser_id", "")
-
-    package_map = {
-        "pdfplumber": "pdfplumber",
-        "marker": "marker-pdf",
-        "mineru": "mineru"
-    }
-
-    pkg_name = package_map.get(parser_id)
-    if not pkg_name:
+    package = venv_manager.PARSER_PACKAGES.get(parser_id)
+    if not package:
         raise HTTPException(status_code=400, detail="지원되지 않는 파서 엔진입니다.")
+    # pip install에는 extras가 필요하지만 uninstall은 배포 패키지 이름만
+    # 받아야 한다 (예: mineru[pipeline] 설치, mineru 삭제).
+    pkg_name = package[0].split("[", 1)[0]
 
-    target_venv = venv_manager.MINERU_VENV if parser_id == "mineru" else venv_manager.DEFAULT_VENV
-    if not venv_manager.is_venv_available(target_venv):
-        raise HTTPException(status_code=400, detail="설치되어 있지 않습니다.")
+    if venv_manager.is_packaged_desktop():
+        try:
+            venv_manager.uninstall_packaged_parser(parser_id)
+        except FileNotFoundError:
+            raise HTTPException(status_code=400, detail="설치되어 있지 않습니다.")
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"삭제 실패: {exc}")
+    else:
+        target_venv = (
+            venv_manager.MINERU_VENV if parser_id == "mineru"
+            else venv_manager.DEFAULT_VENV
+        )
+        if not venv_manager.is_venv_available(target_venv):
+            raise HTTPException(status_code=400, detail="설치되어 있지 않습니다.")
 
-    python_bin = venv_manager.venv_python(target_venv)
-    result = subprocess.run(
-        [python_bin, "-m", "pip", "uninstall", "-y", pkg_name],
-        capture_output=True, text=True
-    )
-
-    if result.returncode != 0:
-        raise HTTPException(status_code=500, detail=f"삭제 실패: {result.stderr.strip() or result.stdout.strip()}")
+        python_bin = venv_manager.venv_python(target_venv)
+        result = subprocess.run(
+            [python_bin, "-m", "pip", "uninstall", "-y", pkg_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise HTTPException(status_code=500, detail=f"삭제 실패: {detail}")
 
     # 삭제한 파서가 현재 엔진이면 pymupdf로 복귀
     from config import update_system_settings
@@ -563,11 +607,10 @@ async def uninstall_pdf_parser(
             gemini_api_key=cfg.GEMINI_API_KEY,
             claude_api_key=cfg.CLAUDE_API_KEY,
             openalex_mailto=cfg.OPENALEX_MAILTO,
-            pdf_parser_engine="pymupdf"
+            pdf_parser_engine="pymupdf",
         )
 
     return {"status": "success", "message": f"{pkg_name} 패키지가 삭제되었습니다."}
-
 
 
 @router.post("/settings/clear-pages-cache")

--- a/backend/tests/test_pdf_parser_install_auth.py
+++ b/backend/tests/test_pdf_parser_install_auth.py
@@ -32,3 +32,131 @@ def test_pdf_parser_package_management_rejects_unauthenticated_requests(
 
     assert response.status_code == 401
     assert response.json() == {"detail": "로그인이 필요합니다."}
+
+
+
+def test_packaged_desktop_install_uses_sidecar_pip_mode(test_client, monkeypatch):
+    import asyncio
+    import routers.auth as auth_router
+
+    commands = []
+
+    class FakeStdout:
+        def __init__(self):
+            self.lines = [b"Collecting marker-pdf\n", b""]
+
+        async def readline(self):
+            return self.lines.pop(0)
+
+    class FakeProcess:
+        def __init__(self):
+            self.stdout = FakeStdout()
+            self.returncode = 0
+
+        async def wait(self):
+            return self.returncode
+
+    async def fake_create_subprocess_exec(*cmd, **_kwargs):
+        commands.append(list(cmd))
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        auth_router.venv_manager, "is_packaged_desktop", lambda: True
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager,
+        "parser_install_command",
+        lambda engine: ["easypaper-backend", "--easypaper-install-pdf-parser", engine],
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager, "parser_packages_dir", lambda engine: f"/app-data/{engine}"
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager, "is_parser_installed", lambda _engine: True
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    response = test_client.get(
+        "/api/settings/install-pdf-parser",
+        params={"parser_id": "marker"},
+    )
+
+    assert response.status_code == 200
+    assert commands == [[
+        "easypaper-backend",
+        "--easypaper-install-pdf-parser",
+        "marker",
+    ]]
+    assert "-m venv" not in response.text
+    assert '"status": "success"' in response.text
+
+
+def test_packaged_desktop_engine_change_requests_app_relaunch(
+    test_client, monkeypatch
+):
+    import routers.auth as auth_router
+
+    monkeypatch.setattr(
+        auth_router.venv_manager, "restart_required_for_engine", lambda _engine: True
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager, "is_packaged_desktop", lambda: True
+    )
+    monkeypatch.setattr(auth_router, "update_system_settings", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        auth_router, "update_translation_prompt_template", lambda _value: None
+    )
+
+    response = test_client.post(
+        "/api/settings/system",
+        json={
+            "ollama_host": "http://localhost:11434",
+            "trans_provider": "ollama",
+            "trans_model": "model",
+            "chat_provider": "ollama",
+            "chat_model": "model",
+            "pdf_parser_engine": "marker",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["restarting"] is True
+    assert response.json()["restart_mode"] == "desktop_app"
+
+
+
+def test_server_mineru_uninstall_uses_distribution_name_without_extras(
+    test_client, monkeypatch
+):
+    import subprocess
+    import routers.auth as auth_router
+
+    commands = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return Result()
+
+    monkeypatch.setattr(
+        auth_router.venv_manager, "is_packaged_desktop", lambda: False
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager, "is_venv_available", lambda _path: True
+    )
+    monkeypatch.setattr(
+        auth_router.venv_manager, "venv_python", lambda _path: "python"
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    response = test_client.post(
+        "/api/settings/uninstall-pdf-parser",
+        json={"parser_id": "mineru"},
+    )
+
+    assert response.status_code == 200
+    assert commands == [["python", "-m", "pip", "uninstall", "-y", "mineru"]]

--- a/backend/tests/test_venv_manager.py
+++ b/backend/tests/test_venv_manager.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+import pytest
+
 import venv_manager
 
 
@@ -47,3 +49,133 @@ def test_restart_required_for_engine_false_when_already_active(tmp_path, monkeyp
     monkeypatch.setattr(venv_manager, "current_venv_root", lambda: os.path.realpath(str(target_venv)))
 
     assert venv_manager.restart_required_for_engine("mineru") is False
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "expected_parts"),
+    [
+        ("darwin", ("bin", "python")),
+        ("linux", ("bin", "python")),
+        ("win32", ("Scripts", "python.exe")),
+    ],
+)
+def test_venv_python_is_platform_aware(monkeypatch, platform_name, expected_parts):
+    monkeypatch.setattr(venv_manager.sys, "platform", platform_name)
+    path = venv_manager.venv_python("/parser-venv")
+    assert path == os.path.join("/parser-venv", *expected_parts)
+
+
+def test_packaged_desktop_installs_outside_read_only_bundle(tmp_path, monkeypatch):
+    app_data = tmp_path / "app-data"
+    monkeypatch.setattr(venv_manager.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("EASYPAPER_DESKTOP", "1")
+    monkeypatch.setenv("EASYPAPER_CONFIG_DIR", str(app_data))
+
+    command = venv_manager.parser_install_command("marker")
+
+    assert venv_manager.is_packaged_desktop() is True
+    assert command == [
+        sys.executable,
+        "--easypaper-install-pdf-parser",
+        "marker",
+    ]
+    assert venv_manager.parser_packages_dir("marker") == str(
+        app_data / "pdf-parser-packages" / "marker"
+    )
+    assert "-m" not in command
+
+
+def test_packaged_installer_atomically_publishes_verified_package(tmp_path, monkeypatch):
+    import pip._internal.cli.main as pip_cli
+
+    monkeypatch.setenv("EASYPAPER_CONFIG_DIR", str(tmp_path))
+
+    def fake_pip_main(args):
+        staging = args[args.index("--target") + 1]
+        os.makedirs(os.path.join(staging, "pdfplumber"))
+        return 0
+
+    monkeypatch.setattr(pip_cli, "main", fake_pip_main)
+
+    result = venv_manager.run_packaged_parser_installer(
+        ["--easypaper-install-pdf-parser", "pdfplumber"]
+    )
+
+    assert result == 0
+    assert venv_manager.is_parser_installed("pdfplumber") is True
+    assert not list((tmp_path / "pdf-parser-packages").glob(".pdfplumber-install-*"))
+
+
+def test_packaged_installer_keeps_existing_package_when_upgrade_fails(
+    tmp_path, monkeypatch
+):
+    import pip._internal.cli.main as pip_cli
+
+    monkeypatch.setenv("EASYPAPER_CONFIG_DIR", str(tmp_path))
+    existing = tmp_path / "pdf-parser-packages" / "marker" / "marker"
+    existing.mkdir(parents=True)
+
+    monkeypatch.setattr(pip_cli, "main", lambda _args: 1)
+
+    result = venv_manager.run_packaged_parser_installer(
+        ["--easypaper-install-pdf-parser", "marker"]
+    )
+
+    assert result == 1
+    assert existing.is_dir()
+    assert not list((tmp_path / "pdf-parser-packages").glob(".marker-install-*"))
+
+
+def test_packaged_parser_activation_and_restart_decision(tmp_path, monkeypatch):
+    app_data = tmp_path / "app-data"
+    package_dir = app_data / "pdf-parser-packages" / "mineru"
+    (package_dir / "mineru").mkdir(parents=True)
+
+    monkeypatch.setattr(venv_manager.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("EASYPAPER_DESKTOP", "1")
+    monkeypatch.setenv("EASYPAPER_CONFIG_DIR", str(app_data))
+    monkeypatch.setattr(venv_manager, "_active_engine", "pymupdf")
+
+    assert venv_manager.restart_required_for_engine("mineru") is True
+
+    original_path = list(sys.path)
+    try:
+        venv_manager.relaunch_into_required_venv("mineru")
+        assert sys.path[0] == str(package_dir)
+        assert venv_manager.restart_required_for_engine("mineru") is False
+        assert venv_manager.restart_required_for_engine("pymupdf") is True
+    finally:
+        sys.path[:] = original_path
+        venv_manager._active_engine = "pymupdf"
+
+
+
+def test_packaged_installer_configures_windows_streams_as_utf8(monkeypatch):
+    class FakeStream:
+        def __init__(self):
+            self.config = None
+            self.output = []
+
+        def reconfigure(self, **kwargs):
+            self.config = kwargs
+
+        def write(self, value):
+            self.output.append(value)
+            return len(value)
+
+        def flush(self):
+            return None
+
+    stdout = FakeStream()
+    stderr = FakeStream()
+    monkeypatch.setattr(venv_manager.sys, "platform", "win32")
+    monkeypatch.setattr(venv_manager.sys, "stdout", stdout)
+    monkeypatch.setattr(venv_manager.sys, "stderr", stderr)
+
+    result = venv_manager.run_packaged_parser_installer(
+        ["--easypaper-install-pdf-parser", "unsupported"]
+    )
+
+    assert result == 2
+    assert stdout.config == {"encoding": "utf-8", "errors": "replace"}
+    assert stderr.config == {"encoding": "utf-8", "errors": "replace"}

--- a/backend/venv_manager.py
+++ b/backend/venv_manager.py
@@ -6,13 +6,141 @@ transformers<5.0.0을 요구해 같은 venv에 절대 공존할 수 없다(런�
 각각 다른 이유로 즉시 크래시함). 그래서 mineru만 별도 venv(.venv-mineru)에
 설치하고, 설정에서 선택된 엔진에 맞는 venv로 프로세스를 전환해 실행한다.
 pymupdf/pdfplumber/marker는 기본 venv(.venv)에서, mineru만 .venv-mineru에서 돈다.
+Tauri PyInstaller 배포본은 일반 Python 인터프리터가 아니므로 별도 venv 대신
+사용자 앱 데이터 폴더의 엔진별 site-packages를 앱 재실행 시 활성화한다.
 """
 import os
+import shutil
+import site
 import sys
+import tempfile
 
 _BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_VENV = os.path.join(_BACKEND_DIR, ".venv")
 MINERU_VENV = os.path.join(_BACKEND_DIR, ".venv-mineru")
+
+PARSER_PACKAGES = {
+    "pdfplumber": ("pdfplumber", "pdfplumber"),
+    "marker": ("marker-pdf", "marker"),
+    "mineru": ("mineru[pipeline]", "mineru"),
+}
+
+_PACKAGED_INSTALL_ARG = "--easypaper-install-pdf-parser"
+_active_engine = "pymupdf"
+
+
+def is_packaged_desktop() -> bool:
+    """Tauri가 실행한 PyInstaller sidecar인지 판별한다."""
+    return bool(getattr(sys, "frozen", False)) and os.getenv("EASYPAPER_DESKTOP") == "1"
+
+
+def parser_packages_root() -> str:
+    config_dir = os.getenv("EASYPAPER_CONFIG_DIR") or _BACKEND_DIR
+    return os.path.join(config_dir, "pdf-parser-packages")
+
+
+def parser_packages_dir(engine: str) -> str:
+    if engine not in PARSER_PACKAGES:
+        raise ValueError(f"지원되지 않는 파서 엔진입니다: {engine}")
+    return os.path.join(parser_packages_root(), engine)
+
+
+def is_parser_installed(engine: str) -> bool:
+    if engine == "pymupdf":
+        return True
+    package = PARSER_PACKAGES.get(engine)
+    if not package:
+        return False
+    return os.path.isdir(os.path.join(parser_packages_dir(engine), package[1]))
+
+
+def parser_install_command(engine: str) -> list[str]:
+    """현재 sidecar를 제한된 pip 설치 모드로 다시 실행하는 명령."""
+    if engine not in PARSER_PACKAGES:
+        raise ValueError(f"지원되지 않는 파서 엔진입니다: {engine}")
+    return [sys.executable, _PACKAGED_INSTALL_ARG, engine]
+
+
+def run_packaged_parser_installer(argv: list[str] | None = None) -> int:
+    """번들 pip로 선택 파서를 사용자 앱 데이터 폴더에 원자적으로 설치한다."""
+    # Windows GUI sidecar의 파이프 stdout은 cp1252 등으로 잡힐 수 있어
+    # 한글 진행/오류 메시지가 UnicodeEncodeError로 설치 프로세스를 죽이지
+    # 않도록 설치 전용 진입점에서도 UTF-8을 명시한다.
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 2 or args[0] != _PACKAGED_INSTALL_ARG:
+        print("잘못된 PDF 파서 설치 명령입니다.", file=sys.stderr, flush=True)
+        return 2
+
+    engine = args[1]
+    package = PARSER_PACKAGES.get(engine)
+    if not package:
+        print(f"지원되지 않는 파서 엔진입니다: {engine}", file=sys.stderr, flush=True)
+        return 2
+
+    root = parser_packages_root()
+    os.makedirs(root, exist_ok=True)
+    staging_dir = tempfile.mkdtemp(prefix=f".{engine}-install-", dir=root)
+    target_dir = parser_packages_dir(engine)
+
+    try:
+        from pip._internal.cli.main import main as pip_main
+
+        result = pip_main([
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--target", staging_dir,
+            package[0],
+        ])
+        if result != 0:
+            return int(result)
+        if not os.path.isdir(os.path.join(staging_dir, package[1])):
+            print(
+                f"설치 완료 후 모듈을 찾을 수 없습니다: {package[1]}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 1
+
+        if os.path.isdir(target_dir):
+            shutil.rmtree(target_dir)
+        os.replace(staging_dir, target_dir)
+        staging_dir = ""
+        print(f"{package[0]} 패키지 검증 및 설치가 완료되었습니다.", flush=True)
+        return 0
+    except Exception as exc:
+        print(f"PDF 파서 패키지 설치 실패: {exc}", file=sys.stderr, flush=True)
+        return 1
+    finally:
+        if staging_dir and os.path.isdir(staging_dir):
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+def uninstall_packaged_parser(engine: str) -> None:
+    target_dir = parser_packages_dir(engine)
+    if not os.path.isdir(target_dir):
+        raise FileNotFoundError(target_dir)
+    shutil.rmtree(target_dir)
+
+
+def _activate_packaged_parser(engine: str) -> None:
+    """선택 엔진의 격리된 site-packages를 이번 sidecar에만 활성화한다."""
+    global _active_engine
+    _active_engine = "pymupdf"
+    if engine == "pymupdf" or not is_parser_installed(engine):
+        return
+
+    package_dir = parser_packages_dir(engine)
+    site.addsitedir(package_dir)
+    while package_dir in sys.path:
+        sys.path.remove(package_dir)
+    sys.path.insert(0, package_dir)
+    _active_engine = engine
 
 
 def required_venv_for_engine(engine: str) -> str:
@@ -39,6 +167,9 @@ def restart_required_for_engine(engine: str) -> bool:
     필요한 venv가 아직 설치 전이면(mineru 미설치 등) 재시작해봐야 의미가
     없으므로(어차피 폴백된다) False를 반환한다 - 설치 자체는 별도 설치
     플로우(install-pdf-parser)의 몫이다."""
+    if is_packaged_desktop():
+        return is_parser_installed(engine) and engine != _active_engine
+
     target = required_venv_for_engine(engine)
     if not is_venv_available(target):
         return False
@@ -53,6 +184,10 @@ def relaunch_into_required_venv(engine: str) -> None:
     _restart_server_process()(systemctl 또는 자체 프로세스 교체)를 통해
     프로세스 자체를 새로 띄워야 하고, 그 새 프로세스가 시작하면서 다시
     이 함수를 거쳐 올바른 venv로 한 번 더 스스로 전환된다."""
+    if is_packaged_desktop():
+        _activate_packaged_parser(engine)
+        return
+
     target = required_venv_for_engine(engine)
     if not is_venv_available(target):
         return

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2420,22 +2420,32 @@ const settingLibraryPicker = new ProviderModelPicker($('setting-library-provider
   onChange: () => { updateSettingsUIVisibility(); autoSaveSystemSettings() }
 })
 
-// marker와 mineru는 필요한 파이썬 패키지 버전이 정반대라(transformers 5.x
-// 이상/미만) 같은 서버 프로세스에 공존할 수 없다 - mineru는 전용
-// 가상환경에서 돌고, 이 둘 사이를 전환하면 백엔드가 스스로 재시작해서
-// 올바른 가상환경으로 다시 올라온다. 재시작이 필요할 만한 전환에서만
-// 사용자에게 미리 경고한다(진행 중인 번역이 끊길 수 있음).
+// marker와 mineru는 상충하는 transformers 버전이 필요하다. 서버 배포는 venv,
+// Tauri 배포는 앱 데이터의 엔진별 패키지 폴더로 격리한다. Tauri에서는
+// 어떤 엔진 전환도 앱을 재실행해 선택 엔진의 의존성만 로드한다.
 let currentSavedPdfEngine = 'pymupdf'
 
 // autoSaveSystemSettings 결과에 restarting이 담겨 있으면(설정 저장 API가
 // 재시작이 트리거됐음을 알려준 것) 재시작 완료를 기다렸다가 새로고침한다.
 async function maybeHandlePdfEngineRestart(res) {
-  if (res && res.restarting) {
-    showToast(res.message || 'PDF 파서 엔진 적용을 위해 서버가 재시작됩니다...', 'info')
-    await waitForServerRestartAndReload()
-    return true
+  if (!res || !res.restarting) return false
+
+  showToast(res.message || 'PDF 파서 엔진 적용을 위해 재시작합니다...', 'info')
+  if (res.restart_mode === 'desktop_app' && isTauriDesktop) {
+    try {
+      // 앱 종료 이벤트에서 현재 sidecar를 정리한 뒤 새 프로세스를 시작한다.
+      const { relaunch } = await import('@tauri-apps/plugin-process')
+      await new Promise(resolve => setTimeout(resolve, 500))
+      await relaunch()
+      return true
+    } catch (err) {
+      showToast('앱 재시작 실패: ' + (err.message || err), 'error')
+      return false
+    }
   }
-  return false
+
+  await waitForServerRestartAndReload()
+  return true
 }
 
 const settingPdfParserPicker = new PdfParserPicker($('setting-pdf-parser-picker'), {
@@ -2445,10 +2455,10 @@ const settingPdfParserPicker = new PdfParserPicker($('setting-pdf-parser-picker'
     // 설치된 파서만 즉시 엔진 변경 저장. 미설치 파서는 카드의 [패키지 설치] 버튼을 눌러야 함.
     if (parser && parser.installed) {
       const needsRestartWarning = selectedId !== currentSavedPdfEngine &&
-        (selectedId === 'mineru' || currentSavedPdfEngine === 'mineru')
+        (isTauriDesktop || selectedId === 'mineru' || currentSavedPdfEngine === 'mineru')
       if (needsRestartWarning) {
         const ok = await showCustomConfirm(
-          `[${parser.name}](으)로 전환하면 서버가 재시작됩니다(약 3~5초 소요). 지금 진행 중인 번역이 있다면 중단될 수 있습니다. 계속할까요?`,
+          `[${parser.name}](으)로 전환하면 ${isTauriDesktop ? '앱' : '서버'}이 재시작됩니다(약 3~5초 소요). 지금 진행 중인 번역이 있다면 중단될 수 있습니다. 계속할까요?`,
           { title: 'PDF 파서 엔진 전환', confirmText: '전환 및 재시작', danger: true }
         )
         if (!ok) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,7 @@ pub fn run() {
             command
                 .env("APP_HOST", "127.0.0.1")
                 .env("EASYPAPER_CONFIG_DIR", &app_data_dir)
+                .env("EASYPAPER_DESKTOP", "1")
                 .env("DB_PATH", &db_path)
                 .env("UPLOAD_DIR", &uploads_dir)
                 .env("CACHE_DIR", &cache_dir)


### PR DESCRIPTION
# Summary
## 1. Tauri PDF 파서 설치 오류 수정
- PyInstaller sidecar를 일반 Python 인터프리터로 실행하던 `-m venv`/`-m pip` 경로 제거
- 사용자 앱 데이터 디렉터리에 엔진별 패키지를 원자적으로 설치하는 전용 sidecar 모드 추가
- macOS, Windows, Linux 공통 읽기 전용 앱 번들 및 실행 파일 재진입 오류 수정
## 2. 플랫폼별 엔진 전환 및 검증 강화
- Tauri 엔진 전환 시 백엔드 자체 복제 대신 앱 전체 재실행 처리 추가
- Windows 설치 로그 UTF-8 처리와 MinerU 삭제 패키지명 수정
- 플랫폼 경로, 설치 SSE, 실패 복구, 앱 재실행 회귀 테스트 추가