### PR TITLE
fix: improve multi-reference citation overlay

### DIFF
--- a/frontend/src/citationSearch.js
+++ b/frontend/src/citationSearch.js
@@ -1,0 +1,70 @@
+const QUOTED_TITLE_RE = /["“]([^"”]{8,300})["”]/
+const YEAR_RE = /\b(?:19|20)\d{2}[a-z]?\b/i
+const VENUE_RE = /\b(?:proceedings|conference|journal|transactions|workshop|symposium|arxiv|volume|vol\.?|issue|no\.?|pages?|pp\.?|publisher|press|doi)\b/i
+
+function cleanTitleCandidate(value) {
+  return (value || '')
+    .replace(/\*\*/g, '')
+    .replace(/["“”]/g, '')
+    .replace(/^\s*[-–—,;:.]+|[-–—,;:.]+\s*$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function extractCitationTitle(citationText) {
+  const raw = (citationText || '').replace(/[\u200B-\u200D\uFEFF]/g, ' ').trim()
+  if (!raw) return ''
+
+  const quoted = QUOTED_TITLE_RE.exec(raw)
+  if (quoted) return cleanTitleCandidate(quoted[1])
+
+  let text = raw
+    .replace(/\*\*/g, '')
+    .replace(/^\s*(?:\[[^\]]+\]|\d+[.)])\s*/, '')
+    .replace(/https?:\/\/\S+|www\.\S+/gi, ' ')
+    .replace(/\bdoi\s*:\s*10\.\d{4,9}\/\S+/gi, ' ')
+    .replace(/\b10\.\d{4,9}\/\S+/gi, ' ')
+    .replace(/\barxiv\s*:\s*\S+/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  text = text.replace(/^.*?\bet\s+al\.?(?:\s*[,;:])?\s*/i, '')
+  const apaYear = text.match(/^.*?\((?:19|20)\d{2}[a-z]?\)\s*[.,;:]?\s*(.+)$/i)
+  if (apaYear) text = apaYear[1]
+
+  const candidates = text
+    .split(/\.\s+(?=[A-Z0-9“"])/)
+    .map(cleanTitleCandidate)
+    .filter(Boolean)
+    .filter(part => !YEAR_RE.test(part) || part.replace(YEAR_RE, '').trim().split(/\s+/).length >= 3)
+    .map(part => {
+      const words = part.match(/[\p{L}\p{N}][\p{L}\p{N}'’-]*/gu) || []
+      const commaCount = (part.match(/,/g) || []).length
+      let score = Math.min(words.length, 18)
+      if (words.length < 3) score -= 10
+      if (VENUE_RE.test(part)) score -= 8
+      if (commaCount >= 3) score -= 6
+      if (/^(?:[A-Z]\.?\s*){1,3}[A-Z][a-z]+/.test(part)) score -= 4
+      return { part, score }
+    })
+    .sort((a, b) => b.score - a.score)
+
+  if (candidates.length && candidates[0].score > 0) {
+    return cleanTitleCandidate(candidates[0].part.replace(/\s*\b(?:19|20)\d{2}[a-z]?\b.*$/i, ''))
+  }
+
+  return cleanTitleCandidate(text
+    .replace(YEAR_RE, ' ')
+    .replace(/\b(?:vol|no|pp|pages?)\.?\s*[\d–—-]+/gi, ' ')
+    .replace(/\s+/g, ' '))
+    .split(/\s+/)
+    .slice(0, 18)
+    .join(' ')
+}
+
+export function buildScholarSearchUrl(citationTexts) {
+  const texts = Array.isArray(citationTexts) ? citationTexts : [citationTexts]
+  const titles = [...new Set(texts.map(extractCitationTitle).filter(Boolean))]
+  const query = titles.map(title => `"${title.replace(/"/g, '')}"`).join(' OR ')
+  return `https://scholar.google.com/scholar?q=${encodeURIComponent(query)}`
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -13,6 +13,7 @@ import { createSelectionRect, resolveDragSelection } from './library-selection.j
 import { globalAnalyticsTracker } from './readingAnalytics.js'
 import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
 import { compareDocsByLastRead } from './readPages.js'
+import { buildScholarSearchUrl } from './citationSearch.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -12062,12 +12063,8 @@ document.addEventListener('scroll', () => {
 let citationTooltipEl = null
 let citationTooltipHideTimer = null
 let citationTooltipDocId = null
-let citationTooltipRefNum = null
+let citationTooltipReferences = []
 let citationTooltipBoxEl = null
-
-function buildScholarSearchUrl(refText) {
-  return `https://scholar.google.com/scholar?q=${encodeURIComponent((refText || '').slice(0, 300))}`
-}
 
 // Tauri 데스크탑 webview는 보안상 window.open()/target="_blank"로 외부
 // URL을 새 탭으로 열어주지 않는다(웹 브라우저와 달리 시스템 기본 브라우저를
@@ -12112,8 +12109,7 @@ function getOrCreateCitationTooltip() {
   })
   el.querySelector('.citation-tooltip-scholar-btn').addEventListener('click', (e) => {
     e.stopPropagation()
-    const text = el.querySelector('.citation-tooltip-text').textContent
-    openExternalUrl(buildScholarSearchUrl(text))
+    openExternalUrl(buildScholarSearchUrl(citationTooltipReferences.map(ref => ref.text)))
   })
   // resolveCitationTooltip()이 innerHTML로 채워 넣는 "원문 링크 찾기" 결과의
   // <a> 태그는 그때그때 새로 생기므로, 매번 리스너를 다는 대신 이 안정적인
@@ -12139,14 +12135,13 @@ function positionCitationTooltip() {
   left = Math.max(8, Math.min(left, window.innerWidth - tw - 8))
   let top = rect.top - th - 10
   if (top < 8) top = rect.bottom + 10
+  top = Math.max(8, Math.min(top, window.innerHeight - th - 8))
   citationTooltipEl.style.left = `${left}px`
   citationTooltipEl.style.top = `${top}px`
 }
 
 // refKeys가 여러 개면(예: "[66-69]" 범위 인용, "(A, 2020; B, 2019)" 나열)
-// 각 항목을 "[키] 원문" 형태로 구분해 전부 보여준다. "원문 링크 찾기"/
-// Google Scholar 검색용 textContent에서도 항목 사이가 구분되도록 줄바꿈으로
-// 이어붙인다.
+// 각 항목을 "[키] 원문" 형태로 구분해 전부 보여준다.
 function buildCitationTooltipHtml(refKeys, refMap) {
   if (refKeys.length === 1) return renderBoldText(refMap[refKeys[0]] || '')
   return refKeys
@@ -12160,8 +12155,7 @@ function showCitationTooltip(docId, refKeys, refMap, boxEl) {
   if (state.isSelectionDragging) return
   if (citationTooltipHideTimer) { clearTimeout(citationTooltipHideTimer); citationTooltipHideTimer = null }
   citationTooltipDocId = docId
-  // "원문 링크 찾기"/Google Scholar 검색은 여러 키 중 첫 번째를 기준으로 동작한다.
-  citationTooltipRefNum = refKeys[0]
+  citationTooltipReferences = refKeys.map(key => ({ key, text: refMap[key] || '' }))
   citationTooltipBoxEl = boxEl
 
   const tooltip = getOrCreateCitationTooltip()
@@ -12189,20 +12183,47 @@ function scheduleCitationTooltipHide() {
 }
 
 async function resolveCitationTooltip() {
-  if (!citationTooltipEl || !citationTooltipDocId || !citationTooltipRefNum) return
+  if (!citationTooltipEl || !citationTooltipDocId || !citationTooltipReferences.length) return
   const resolveBtn = citationTooltipEl.querySelector('.citation-tooltip-resolve-btn')
   const resultEl = citationTooltipEl.querySelector('.citation-tooltip-result')
   if (resolveBtn.disabled) return
+
+  const requestedDocId = citationTooltipDocId
+  const requestedRefs = citationTooltipReferences.map(ref => ({ ...ref }))
+  const isCurrentRequest = () => citationTooltipDocId === requestedDocId &&
+    citationTooltipReferences.map(ref => ref.key).join('\u0000') === requestedRefs.map(ref => ref.key).join('\u0000')
 
   resolveBtn.disabled = true
   resolveBtn.innerHTML = `${icon('refreshCw', 12, 'style="vertical-align:-2px;margin-right:4px"')}찾는 중...`
 
   try {
-    const result = await resolveLibraryReference(citationTooltipDocId, citationTooltipRefNum)
-    if (result && result.url) {
+    const results = await Promise.all(requestedRefs.map(async ref => {
+      try {
+        return { ...ref, result: await resolveLibraryReference(requestedDocId, ref.key) }
+      } catch (error) {
+        console.warn(`참고문헌 [${ref.key}] 조회 실패:`, error)
+        return { ...ref, result: null, error: true }
+      }
+    }))
+
+    if (!isCurrentRequest()) return
+
+    const successes = results.filter(item => item.result && item.result.url)
+    if (requestedRefs.length === 1 && successes.length) {
+      const result = successes[0].result
       resultEl.className = 'citation-tooltip-result'
       const label = result.title ? `${result.title}${result.year ? ` (${result.year})` : ''}` : result.url
       resultEl.innerHTML = `<a href="${escapeHtml(result.url)}" target="_blank" rel="noopener">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px;flex-shrink:0"')}<span>${escapeHtml(label)}</span></a>`
+    } else if (requestedRefs.length > 1) {
+      resultEl.className = `citation-tooltip-result${successes.length ? '' : ' citation-tooltip-result-empty'}`
+      resultEl.innerHTML = results.map(({ key, result, error }) => {
+        if (result && result.url) {
+          const label = result.title ? `${result.title}${result.year ? ` (${result.year})` : ''}` : result.url
+          return `<div class="citation-tooltip-result-item"><span class="citation-tooltip-multi-key">[${escapeHtml(key)}]</span><a href="${escapeHtml(result.url)}" target="_blank" rel="noopener">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px;flex-shrink:0"')}<span>${escapeHtml(label)}</span></a></div>`
+        }
+        const message = error ? '조회 중 오류가 발생했습니다.' : '원문 링크를 찾지 못했습니다.'
+        return `<div class="citation-tooltip-result-item citation-tooltip-result-empty"><span class="citation-tooltip-multi-key">[${escapeHtml(key)}]</span><span>${message}</span></div>`
+      }).join('')
     } else {
       resultEl.className = 'citation-tooltip-result citation-tooltip-result-empty'
       resultEl.textContent = '원문 링크를 찾지 못했습니다. Google Scholar 검색을 이용해보세요.'
@@ -12212,6 +12233,7 @@ async function resolveCitationTooltip() {
     resultEl.className = 'citation-tooltip-result citation-tooltip-result-empty'
     resultEl.textContent = '조회 중 오류가 발생했습니다.'
   } finally {
+    if (!isCurrentRequest()) return
     resolveBtn.disabled = false
     resolveBtn.innerHTML = `${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}다시 찾기`
     positionCitationTooltip()
@@ -12220,7 +12242,9 @@ async function resolveCitationTooltip() {
 
 // PDF 스크롤 중에는 인용 박스와 툴팁의 상대 위치가 계속 바뀌므로, 스크롤이
 // 시작되면 곧바로 닫는다(매 스크롤 이벤트마다 재계산하는 것보다 훨씬 가볍다).
-document.addEventListener('scroll', () => {
+document.addEventListener('scroll', (event) => {
+  // 참고문헌이 많아 툴팁 자체를 스크롤한 경우에는 열린 상태를 유지한다.
+  if (citationTooltipEl && event.target && citationTooltipEl.contains(event.target)) return
   if (citationTooltipEl && !citationTooltipEl.classList.contains('hidden')) hideCitationTooltip()
 }, true)
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5907,6 +5907,9 @@ body.light-theme .citation-marker-box:hover {
   z-index: 200;
   width: 300px;
   max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   background: rgba(23, 20, 38, 0.97);
   color: var(--text-primary);
   border: 1px solid var(--border-strong);
@@ -5929,8 +5932,6 @@ body.light-theme .citation-tooltip {
   font-size: 12.5px;
   line-height: 1.55;
   color: var(--text-secondary);
-  max-height: 110px;
-  overflow-y: auto;
   margin-bottom: 10px;
 }
 .citation-tooltip-multi-item + .citation-tooltip-multi-item {
@@ -5961,6 +5962,17 @@ body.light-theme .citation-tooltip {
 }
 .citation-tooltip-result a:hover {
   text-decoration: underline;
+}
+.citation-tooltip-result-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+.citation-tooltip-result-item + .citation-tooltip-result-item {
+  margin-top: 7px;
+}
+.citation-tooltip-result-item > .citation-tooltip-multi-key {
+  flex-shrink: 0;
 }
 .citation-tooltip-result-empty {
   color: var(--text-muted);

--- a/frontend/tests/citationSearch.test.js
+++ b/frontend/tests/citationSearch.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildScholarSearchUrl, extractCitationTitle } from '../src/citationSearch.js'
+
+test('따옴표가 있는 참고문헌에서는 제목만 추출한다', () => {
+  assert.equal(extractCitationTitle('[13] A. Author, "A Carefully Quoted Paper Title," Journal of Tests, vol. 2, 2021.'), 'A Carefully Quoted Paper Title')
+})
+
+test('et al. 형식에서 저자와 연도를 제외하고 제목을 추출한다', () => {
+  assert.equal(extractCitationTitle('Vaswani et al. Attention Is All You Need. 2017.'), 'Attention Is All You Need')
+})
+
+test('APA 형식에서 저자, 게재처, DOI를 제외하고 제목을 추출한다', () => {
+  assert.equal(extractCitationTitle('Smith, J., Doe, A. (2020). Reliable Widget Detection at Scale. Journal of Widgets, 4(2), 10-20. https://doi.org/10.1234/widgets'), 'Reliable Widget Detection at Scale')
+})
+
+test('다중 참고문헌은 정제한 제목을 따옴표와 OR 연산자로 조합한다', () => {
+  const url = new URL(buildScholarSearchUrl([
+    'Vaswani et al. Attention Is All You Need. 2017.',
+    'He et al. Deep Residual Learning for Image Recognition. In CVPR, 2016.',
+    'A. Author, "A Carefully Quoted Paper Title," Journal of Tests, 2021.',
+  ]))
+  assert.equal(url.searchParams.get('q'), '"Attention Is All You Need" OR "Deep Residual Learning for Image Recognition" OR "A Carefully Quoted Paper Title"')
+})

--- a/frontend/tests/e2e/citation-links.spec.js
+++ b/frontend/tests/e2e/citation-links.spec.js
@@ -88,7 +88,7 @@ test('원문 링크를 찾지 못하면 안내 문구가 뜨고, Google Scholar 
     page.click('.citation-tooltip-scholar-btn'),
   ])
   await popup.waitForLoadState('domcontentloaded')
-  expect(decodeURIComponent(popup.url())).toBe('https://scholar.google.com/scholar?q=Vaswani et al. Attention Is All You Need. 2017.')
+  expect(decodeURIComponent(popup.url())).toBe('https://scholar.google.com/scholar?q="Attention Is All You Need"')
 })
 
 test('인용 표기가 아닌 다른 곳을 클릭하면(예: 스크롤) 열려 있던 툴팁이 닫힌다', async ({ page }) => {
@@ -111,4 +111,33 @@ test('인용 표기가 아닌 다른 곳을 클릭하면(예: 스크롤) 열려 
 
   await page.evaluate(() => document.querySelector('#viewer-scroll-container')?.dispatchEvent(new Event('scroll', { bubbles: true })))
   await expect(page.locator('.citation-tooltip')).toHaveClass(/hidden/)
+})
+
+test('참고문헌이 길어 툴팁 내부를 스크롤해도 툴팁이 닫히지 않는다', async ({ page }) => {
+  const docC = { id: 'doc-C', filename: 'Citation.pdf', total_pages: 1, metadata: { title: 'Citation Sample Paper' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [docC] })
+  await page.route('**/api/library/doc-C/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_CITATION }))
+  await page.route('**/api/library/doc-C/references', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ references: { '1': 'Vaswani et al. ' + 'A long citation entry '.repeat(80) + ' Attention Is All You Need. 2017.' } }),
+    }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-C' })
+  await page.waitForTimeout(1500)
+
+  await page.locator('.citation-marker-box').first().dispatchEvent('mouseenter')
+  const tooltip = page.locator('.citation-tooltip')
+  await expect(tooltip).not.toHaveClass(/hidden/)
+  await expect.poll(() => tooltip.evaluate(el => el.scrollHeight > el.clientHeight)).toBe(true)
+
+  await tooltip.evaluate(el => {
+    el.scrollTop = 100
+    el.dispatchEvent(new Event('scroll'))
+  })
+
+  await expect(tooltip).not.toHaveClass(/hidden/)
+  await expect.poll(() => tooltip.evaluate(el => el.scrollTop)).toBeGreaterThan(0)
 })


### PR DESCRIPTION
# Summary
## 1. 레퍼런스 오버레이 스크롤 수정
- 오버레이 전체에 뷰포트 기준 최대 높이와 세로 스크롤 적용
- 오버레이 내부 스크롤을 PDF 스크롤 닫기 이벤트에서 제외
- 긴 오버레이의 뷰포트 경계 위치 보정 및 스크롤 회귀 테스트 추가
## 2. 다중 레퍼런스 검색 개선
- 다중 인용의 모든 참고문헌 원문 링크를 개별 조회하고 항목별 결과 표시 기능을 추가
- 저자, 연도, DOI, 게재처 정보를 제외한 논문 제목 정제 로직을 추가
- 정제된 제목을 Google Scholar OR 연산자로 조합하는 검색 기능을 추가
- 제목 정제 및 검색 조합 단위 테스트 추가