### PR TITLE
chore(release): prepare v0.1.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easypaper-desktop",
   "private": true,
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "EasyPaper Tauri 데스크탑 스파이크 (src-tauri/ 스캐폴딩 전용, frontend/의 웹 앱 패키지와는 별개)",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "ctrlc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 # 이 파일과 tauri.conf.json/../package.json의 version을 항상 동일하게 유지할 것.
 [package]
 name = "app"
-version = "0.1.23"
+version = "0.1.24"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EasyPaper",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "identifier": "com.easypaper.desktop",
   "build": {
     "frontendDist": "loading-page"


### PR DESCRIPTION
# Summary
## 1. Tauri 데스크탑 v0.1.24 릴리스 준비
- npm 패키지 버전을 0.1.24로 갱신
- Tauri 설정 및 Cargo 패키지·잠금 파일 버전을 0.1.24로 통일
## 2. 최신 수정사항 배포 기준 반영
- PR #444 PDF 파서 설치 수정 병합본을 릴리스 기준에 포함
- PR #445 다중 참고문헌 인용 오버레이 수정 병합본을 릴리스 기준에 포함