### PR TITLE
fix: improve citation search accuracy

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -886,7 +886,8 @@ async def resolve_library_reference(doc_id: str, ref_num: str, current_user: str
 
     from services.library import get_page_insight, save_page_insight
 
-    cached = get_page_insight(doc_id, 0, "reference_url", suffix=ref_num)
+    cache_suffix = f"v2_{ref_num}"
+    cached = get_page_insight(doc_id, 0, "reference_url", suffix=cache_suffix)
     if cached is not None:
         try:
             data = json.loads(cached)
@@ -910,7 +911,7 @@ async def resolve_library_reference(doc_id: str, ref_num: str, current_user: str
 
     from services.reference_linker import resolve_reference
     result = await resolve_reference(ref_text)
-    save_page_insight(doc_id, 0, "reference_url", json.dumps(result or {}, ensure_ascii=False), suffix=ref_num)
+    save_page_insight(doc_id, 0, "reference_url", json.dumps(result or {}, ensure_ascii=False), suffix=cache_suffix)
 
     if not result:
         raise HTTPException(status_code=404, detail="외부에서 일치하는 논문을 찾지 못했습니다.")

--- a/backend/services/reference_linker.py
+++ b/backend/services/reference_linker.py
@@ -70,37 +70,99 @@ def _calculate_title_similarity(query_title: str, cand_title: str) -> float:
 # recognition" 전체 인용문 검색 시 완전히 무관한 논문이 1위로 나옴, 제목만 검색하면
 # 정확히 매칭됨), 따옴표로 감싸진 제목이 있으면 그 부분만 검색어로 쓴다.
 _QUOTED_TITLE_RE = re.compile(r'["“]([^"”]{8,300})["”]')
+_DOI_RE = re.compile(r'10\.\d{4,9}/[-._;()/:A-Za-z0-9]+', re.IGNORECASE)
+_YEAR_RE = re.compile(r'\b(?:19|20)\d{2}[a-z]?\b', re.IGNORECASE)
+_VENUE_RE = re.compile(
+    r'\b(?:proceedings|conference|journal|transactions|workshop|symposium|'
+    r'arxiv|volume|vol\.?|issue|no\.?|pages?|pp\.?|publisher|press|doi)\b',
+    re.IGNORECASE,
+)
+
+
+def _clean_title_candidate(value: str) -> str:
+    value = re.sub(r'\*\*|["“”]', '', value or '')
+    value = re.sub(r'^\s*[-–—,;:.]+|[-–—,;:.]+\s*$', '', value)
+    return re.sub(r'\s+', ' ', value).strip()
 
 
 def _extract_search_query(citation_text: str) -> str:
-    """인용 원문에서 검색어로 쓸 부분을 뽑는다. 따옴표로 감싼 제목이 있으면 그것만
-    쓰고, 없으면(따옴표 없이 저자 뒤에 바로 제목이 오는 스타일 등, 신뢰할 만하게
-    분리할 방법이 없음) 원문 전체를 그대로 쓴다."""
-    m = _QUOTED_TITLE_RE.search(citation_text)
-    if m:
-        return m.group(1).strip().rstrip(",.")
-    return citation_text
+    """참고문헌에서 저자·연도·게재처·DOI를 제외한 제목 후보를 추출한다."""
+    raw = re.sub(r'[\u200b-\u200d\ufeff]', ' ', citation_text or '').strip()
+    if not raw:
+        return ''
 
+    match = _QUOTED_TITLE_RE.search(raw)
+    if match:
+        return _clean_title_candidate(match.group(1))
+
+    text = re.sub(r'^\s*(?:\[[^]]+]|\d+[.)])\s*', '', raw)
+    text = re.sub(r'https?://\S+|www\.\S+', ' ', text, flags=re.IGNORECASE)
+    text = re.sub(r'\bdoi\s*:\s*10\.\d{4,9}/\S+', ' ', text, flags=re.IGNORECASE)
+    text = _DOI_RE.sub(' ', text)
+    text = re.sub(r'\barxiv\s*:\s*\S+', ' ', text, flags=re.IGNORECASE)
+    text = re.sub(r'\s+', ' ', text).strip()
+
+    # 흔한 "Authors et al. Title" 및 APA "Authors (2020). Title" 앞부분 제거.
+    text = re.sub(r'^.*?\bet\s+al\.?(?:\s*[,;:])?\s*', '', text, flags=re.IGNORECASE)
+    apa_year = re.match(r'^.*?\((?:19|20)\d{2}[a-z]?\)\s*[.,;:]?\s*(.+)$', text, re.IGNORECASE)
+    if apa_year:
+        text = apa_year.group(1)
+
+    candidates = []
+    for part in re.split(r'\.\s+(?=[A-Z0-9“"])', text):
+        part = _clean_title_candidate(part)
+        if not part:
+            continue
+        without_year = _YEAR_RE.sub('', part).strip()
+        words = re.findall(r"\w[\w'’-]*", part, flags=re.UNICODE)
+        if _YEAR_RE.search(part) and len(without_year.split()) < 3:
+            continue
+        score = min(len(words), 18)
+        if len(words) < 3:
+            score -= 10
+        if _VENUE_RE.search(part):
+            score -= 8
+        if part.count(',') >= 3:
+            score -= 6
+        if re.match(r'^(?:[A-Z]\.?)\s+[A-Z][a-z]+', part):
+            score -= 4
+        candidates.append((score, part))
+
+    if candidates:
+        score, candidate = max(candidates, key=lambda item: item[0])
+        if score > 0:
+            candidate = re.sub(
+                r'\s*\b(?:19|20)\d{2}[a-z]?\b.*$', '', candidate, flags=re.IGNORECASE
+            )
+            return _clean_title_candidate(candidate)
+
+    fallback = _YEAR_RE.sub(' ', text)
+    fallback = re.sub(
+        r'\b(?:vol|no|pp|pages?)\.?\s*[\d–—-]+', ' ', fallback, flags=re.IGNORECASE
+    )
+    return ' '.join(_clean_title_candidate(fallback).split()[:18])
 
 def _pick_url(work: dict) -> Optional[str]:
     """work 메타데이터에서 표시할 링크를 고른다. 원문을 무료로 바로 볼 수 있는
-    arXiv 링크를 최우선으로 하고, 그다음은 오픈 액세스 링크, 대표 링크, DOI
-    순으로 폴백한다."""
+    arXiv 링크를 최우선으로 하고, 그다음은 canonical 대표 링크/DOI, 검증이
+    어려운 OpenAlex OA 링크 순으로 폴백한다."""
     for location in work.get("locations") or []:
         source = location.get("source") or {}
         display_name = (source.get("display_name") or "").lower()
         if "arxiv" in display_name and location.get("landing_page_url"):
             return location["landing_page_url"]
 
-    open_access = work.get("open_access") or {}
-    if open_access.get("oa_url"):
-        return open_access["oa_url"]
-
+    # OpenAlex의 oa_url은 다른 저장소 문서에 잘못 연결된 사례가 있어
+    # canonical primary/DOI 링크를 먼저 사용하고, OA URL은 마지막 폴백으로 둔다.
     primary_location = work.get("primary_location") or {}
     if primary_location.get("landing_page_url"):
         return primary_location["landing_page_url"]
 
-    return work.get("doi") or None
+    if work.get("doi"):
+        return work["doi"]
+
+    open_access = work.get("open_access") or {}
+    return open_access.get("oa_url") or None
 
 
 _ARXIV_ID_RE = re.compile(r'arxiv\.org/abs/([0-9]{4}\.[0-9]{4,5}(?:v\d+)?)', re.IGNORECASE)
@@ -204,15 +266,19 @@ async def resolve_paper_metadata(title: str) -> Optional[dict]:
 
 
 async def resolve_reference(query_text: str) -> Optional[dict]:
-    """참고문헌 원문 텍스트로 OpenAlex를 검색해 가장 관련성 높은 논문의
-    제목/링크/연도를 반환합니다. 매칭 실패나 네트워크 오류 시 None.
-    """
+    """참고문헌을 정제해 OpenAlex 상위 후보를 제목·연도로 검증한 뒤 링크를 반환한다."""
     raw = (query_text or "").strip()
     if not raw:
         return None
-    query = _extract_search_query(raw)[:300]
 
-    params = {"search": query, "per_page": 1}
+    query = _extract_search_query(raw)[:300]
+    if not query:
+        return None
+
+    expected_years = {int(year[:4]) for year in _YEAR_RE.findall(raw)}
+    expected_doi = _DOI_RE.search(raw)
+    expected_doi_text = expected_doi.group(0).rstrip(".,;") if expected_doi else None
+    params = {"search": query, "per_page": 5}
     mailto = get_openalex_mailto()
     if mailto:
         params["mailto"] = mailto
@@ -225,20 +291,61 @@ async def resolve_reference(query_text: str) -> Optional[dict]:
                 logger.warning(f"OpenAlex 검색 실패: status={resp.status_code}")
                 return None
 
-            data = resp.json()
-            works = data.get("results") or []
+            works = (resp.json().get("results") or [])
             if not works:
                 return None
 
-            work = works[0]
-            url = _pick_url(work)
-            if not url:
+            best_work = None
+            best_url = None
+            best_score = 0.0
+            best_title_score = 0.0
+            for work in works:
+                url = _pick_url(work)
+                if not url:
+                    continue
+
+                candidate_title = work.get("title") or work.get("display_name") or ""
+                candidate_doi = work.get("doi") or ""
+                if expected_doi_text and expected_doi_text.lower() in candidate_doi.lower():
+                    best_work, best_url, best_score = work, url, 1.0
+                    best_title_score = 1.0
+                    break
+
+                title_score = _calculate_title_similarity(query, candidate_title)
+                score = title_score
+                candidate_year = work.get("publication_year")
+                if expected_years and candidate_year:
+                    year_distance = min(abs(candidate_year - year) for year in expected_years)
+                    score += 0.05 if year_distance <= 1 else -0.15
+
+                # 동일 제목 중복 레코드는 정식 DOI와 인용수가 높은 원 레코드를 우선한다.
+                if candidate_doi:
+                    score += 0.02
+                cited_count = max(0, work.get("cited_by_count") or 0)
+                score += min(0.05, len(str(cited_count)) * 0.01)
+
+                if score > best_score:
+                    best_work, best_url, best_score = work, url, score
+                    best_title_score = title_score
+
+            if not best_work or not best_url or best_title_score < 0.50:
+                logger.info(
+                    f"OpenAlex 참고문헌 매칭 실패 "
+                    f"(제목 유사도: {best_title_score:.2f}, 종합 점수: {best_score:.2f}, "
+                    f"query='{query}')"
+                )
                 return None
 
+            resolved_year = best_work.get("publication_year")
+            if expected_years and resolved_year:
+                closest_year = min(expected_years, key=lambda year: abs(resolved_year - year))
+                if abs(resolved_year - closest_year) > 1:
+                    resolved_year = closest_year
+
             return {
-                "title": work.get("title") or work.get("display_name") or "",
-                "url": url,
-                "year": work.get("publication_year"),
+                "title": best_work.get("title") or best_work.get("display_name") or "",
+                "url": best_url,
+                "year": resolved_year,
             }
     except Exception as e:
         logger.warning(f"참고문헌 검색 중 오류: {e}")

--- a/backend/tests/test_library_references_api.py
+++ b/backend/tests/test_library_references_api.py
@@ -93,3 +93,29 @@ def test_resolve_reference_other_users_document_returns_404(test_client, isolate
     _create_doc(isolated_dirs, doc_id="doc-other2", username="otheruser")
     res = test_client.get("/api/library/doc-other2/references/1")
     assert res.status_code == 404
+
+
+def test_resolve_reference_ignores_legacy_inaccurate_cache(test_client, isolated_dirs):
+    _create_doc(isolated_dirs)
+    db = isolated_dirs["db"]
+    db.db_save_page_insight(
+        "doc-1", 0, "reference_list", json.dumps({"1": "Correct paper title. 2022."})
+    )
+    db.db_save_page_insight(
+        "doc-1", 0, "reference_url",
+        json.dumps({"title": "Wrong", "url": "https://example.com/wrong", "year": 1999}),
+        suffix="1",
+    )
+
+    corrected = {
+        "title": "Correct paper title",
+        "url": "https://example.com/correct",
+        "year": 2022,
+    }
+    mock_resolve = AsyncMock(return_value=corrected)
+    with patch("services.reference_linker.resolve_reference", new=mock_resolve):
+        response = test_client.get("/api/library/doc-1/references/1")
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://example.com/correct"
+    mock_resolve.assert_awaited_once()

--- a/backend/tests/test_reference_linker.py
+++ b/backend/tests/test_reference_linker.py
@@ -51,8 +51,8 @@ async def test_resolve_reference_prefers_arxiv_link_when_available():
 
 
 @pytest.mark.asyncio
-async def test_resolve_reference_falls_back_through_open_access_then_primary_then_doi():
-    # open_access.oa_url 우선
+async def test_resolve_reference_prefers_canonical_primary_over_untrusted_oa_url():
+    # OpenAlex OA 연결이 잘못될 수 있으므로 canonical primary 링크 우선
     mock_response = _make_response(200, {
         "results": [{
             "title": "Some Paper",
@@ -65,9 +65,9 @@ async def test_resolve_reference_falls_back_through_open_access_then_primary_the
     })
     with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
         result = await resolve_reference("Some Paper query text")
-    assert result["url"] == "https://example.com/oa.pdf"
+    assert result["url"] == "https://example.com/primary"
 
-    # open_access 없으면 primary_location
+    # primary_location이 있으면 OA 유무와 관계없이 canonical 링크 사용
     mock_response = _make_response(200, {
         "results": [{
             "title": "Some Paper",
@@ -82,7 +82,7 @@ async def test_resolve_reference_falls_back_through_open_access_then_primary_the
         result = await resolve_reference("Some Paper query text")
     assert result["url"] == "https://example.com/primary"
 
-    # 그마저 없으면 doi
+    # primary가 없으면 DOI 사용
     mock_response = _make_response(200, {
         "results": [{
             "title": "Some Paper",
@@ -146,9 +146,17 @@ def test_extract_search_query_uses_quoted_title_when_present():
     assert _extract_search_query(citation) == "Deep residual learning for image recognition"
 
 
-def test_extract_search_query_falls_back_to_full_text_without_quotes():
+def test_extract_search_query_cleans_unquoted_et_al_citation():
     citation = "A. Vaswani, N. Shazeer, N. Parmar, et al. Attention is all you need. NeurIPS, 2017."
-    assert _extract_search_query(citation) == citation
+    assert _extract_search_query(citation) == "Attention is all you need"
+
+
+def test_extract_search_query_cleans_apa_citation():
+    citation = (
+        "Smith, J., Doe, A. (2020). Reliable Widget Detection at Scale. "
+        "Journal of Widgets, 4(2), 10-20. https://doi.org/10.1234/widgets"
+    )
+    assert _extract_search_query(citation) == "Reliable Widget Detection at Scale"
 
 
 @pytest.mark.asyncio
@@ -160,3 +168,98 @@ async def test_resolve_reference_sends_extracted_title_as_search_param():
 
     sent_params = mock_get.call_args.kwargs["params"]
     assert sent_params["search"] == "The Real Title"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_validates_top_candidates_instead_of_using_first():
+    mock_response = _make_response(200, {
+        "results": [
+            {
+                "title": "An Unrelated Survey of Neural Networks",
+                "publication_year": 2016,
+                "primary_location": {"landing_page_url": "https://example.com/wrong"},
+                "locations": [],
+            },
+            {
+                "title": "Deep Residual Learning for Image Recognition",
+                "publication_year": 2016,
+                "primary_location": {"landing_page_url": "https://example.com/correct"},
+                "locations": [],
+            },
+        ]
+    })
+    mock_get = AsyncMock(return_value=mock_response)
+    with patch("httpx.AsyncClient.get", new=mock_get):
+        result = await resolve_reference(
+            "He et al. Deep Residual Learning for Image Recognition. CVPR, 2016."
+        )
+
+    assert result["url"] == "https://example.com/correct"
+    assert mock_get.call_args.kwargs["params"]["per_page"] == 5
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_rejects_unrelated_openalex_candidates():
+    mock_response = _make_response(200, {
+        "results": [{
+            "title": "Completely Different Research Topic",
+            "publication_year": 2018,
+            "doi": "https://doi.org/10.9999/wrong",
+            "cited_by_count": 999999,
+            "primary_location": {"landing_page_url": "https://example.com/wrong"},
+            "locations": [],
+        }]
+    })
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference(
+            "Vaswani et al. Attention Is All You Need. NeurIPS, 2017."
+        )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_uses_citation_year_to_break_title_tie():
+    mock_response = _make_response(200, {
+        "results": [
+            {
+                "title": "Shared Paper Title",
+                "publication_year": 1999,
+                "primary_location": {"landing_page_url": "https://example.com/wrong-year"},
+                "locations": [],
+            },
+            {
+                "title": "Shared Paper Title",
+                "publication_year": 2021,
+                "primary_location": {"landing_page_url": "https://example.com/right-year"},
+                "locations": [],
+            },
+        ]
+    })
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference("Author et al. Shared Paper Title. 2021.")
+
+    assert result["url"] == "https://example.com/right-year"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_uses_citation_year_when_openalex_year_is_corrupt():
+    mock_response = _make_response(200, {
+        "results": [{
+            "title": "Attention Is All You Need",
+            "publication_year": 2025,
+            "cited_by_count": 6000,
+            "doi": "https://doi.org/10.fake/duplicate",
+            "locations": [{
+                "source": {"display_name": "arXiv"},
+                "landing_page_url": "https://arxiv.org/abs/1706.03762",
+            }],
+        }]
+    })
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await resolve_reference(
+            "Vaswani et al. Attention Is All You Need. NeurIPS, 2017."
+        )
+
+    assert result["url"] == "https://arxiv.org/abs/1706.03762"
+    assert result["year"] == 2017

--- a/frontend/src/citationSearch.js
+++ b/frontend/src/citationSearch.js
@@ -62,9 +62,17 @@ export function extractCitationTitle(citationText) {
     .join(' ')
 }
 
-export function buildScholarSearchUrl(citationTexts) {
+function scholarUrlFromTitle(title) {
+  return `https://scholar.google.com/scholar?q=${encodeURIComponent(`"${title.replace(/"/g, '')}"`)}`
+}
+
+export function buildScholarSearchUrl(citationText) {
+  const title = extractCitationTitle(citationText)
+  return scholarUrlFromTitle(title)
+}
+
+export function buildScholarSearchUrls(citationTexts) {
   const texts = Array.isArray(citationTexts) ? citationTexts : [citationTexts]
   const titles = [...new Set(texts.map(extractCitationTitle).filter(Boolean))]
-  const query = titles.map(title => `"${title.replace(/"/g, '')}"`).join(' OR ')
-  return `https://scholar.google.com/scholar?q=${encodeURIComponent(query)}`
+  return titles.map(scholarUrlFromTitle)
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -13,7 +13,7 @@ import { createSelectionRect, resolveDragSelection } from './library-selection.j
 import { globalAnalyticsTracker } from './readingAnalytics.js'
 import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
 import { compareDocsByLastRead } from './readPages.js'
-import { buildScholarSearchUrl } from './citationSearch.js'
+import { buildScholarSearchUrl, extractCitationTitle } from './citationSearch.js'
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -11585,8 +11585,7 @@ function renderCitationOverlayLayer(textLayerDiv, pageNum) {
 
   // refKeys(여러 개일 수 있음)를 받아 하나의 오버레이 박스를 그린다. 툴팁에는
   // refMap에 실제로 존재하는 키의 원문을 전부 이어붙여 보여준다("[66-69]"
-  // 같은 범위 인용이 여러 참고문헌을 한 번에 가리키는 경우를 위함). "원문
-  // 링크 찾기"/Google Scholar 검색은 첫 번째 키를 기준으로 동작한다.
+  // 같은 범위 인용이 여러 참고문헌을 한 번에 가리키는 경우를 위함).
   const addCitationBox = (charStart, charEnd, refKeys) => {
     const validKeys = refKeys.filter(k => refMap[k])
     if (validKeys.length === 0) return
@@ -12092,6 +12091,7 @@ function getOrCreateCitationTooltip() {
   el.innerHTML = `
     <div class="citation-tooltip-text"></div>
     <div class="citation-tooltip-result hidden"></div>
+    <div class="citation-tooltip-scholar-results hidden"></div>
     <div class="citation-tooltip-actions">
       <button type="button" class="citation-tooltip-action-btn citation-tooltip-resolve-btn">${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}원문 링크 찾기</button>
       <button type="button" class="citation-tooltip-action-btn citation-tooltip-scholar-btn">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px"')}Google Scholar 검색</button>
@@ -12109,7 +12109,20 @@ function getOrCreateCitationTooltip() {
   })
   el.querySelector('.citation-tooltip-scholar-btn').addEventListener('click', (e) => {
     e.stopPropagation()
-    openExternalUrl(buildScholarSearchUrl(citationTooltipReferences.map(ref => ref.text)))
+    const searchableRefs = citationTooltipReferences
+      .map(ref => ({ ...ref, title: extractCitationTitle(ref.text) }))
+      .filter(ref => ref.title)
+    if (searchableRefs.length <= 1) {
+      if (searchableRefs.length) openExternalUrl(buildScholarSearchUrl(searchableRefs[0].text))
+      return
+    }
+
+    const scholarResultsEl = el.querySelector('.citation-tooltip-scholar-results')
+    scholarResultsEl.className = 'citation-tooltip-scholar-results'
+    scholarResultsEl.innerHTML = searchableRefs.map(ref =>
+      `<div class="citation-tooltip-result-item"><span class="citation-tooltip-multi-key">[${escapeHtml(ref.key)}]</span><a href="${escapeHtml(buildScholarSearchUrl(ref.text))}" target="_blank" rel="noopener">${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px;flex-shrink:0"')}<span>${escapeHtml(ref.title)}</span></a></div>`
+    ).join('')
+    positionCitationTooltip()
   })
   // resolveCitationTooltip()이 innerHTML로 채워 넣는 "원문 링크 찾기" 결과의
   // <a> 태그는 그때그때 새로 생기므로, 매번 리스너를 다는 대신 이 안정적인
@@ -12163,9 +12176,15 @@ function showCitationTooltip(docId, refKeys, refMap, boxEl) {
   const resultEl = tooltip.querySelector('.citation-tooltip-result')
   resultEl.className = 'citation-tooltip-result hidden'
   resultEl.innerHTML = ''
+  const scholarResultsEl = tooltip.querySelector('.citation-tooltip-scholar-results')
+  scholarResultsEl.className = 'citation-tooltip-scholar-results hidden'
+  scholarResultsEl.innerHTML = ''
   const resolveBtn = tooltip.querySelector('.citation-tooltip-resolve-btn')
   resolveBtn.disabled = false
   resolveBtn.innerHTML = `${icon('search', 12, 'style="vertical-align:-2px;margin-right:4px"')}원문 링크 찾기`
+  const scholarBtn = tooltip.querySelector('.citation-tooltip-scholar-btn')
+  const scholarLabel = refKeys.length > 1 ? 'Google Scholar 개별 검색' : 'Google Scholar 검색'
+  scholarBtn.innerHTML = `${icon('externalLink', 12, 'style="vertical-align:-2px;margin-right:4px"')}${scholarLabel}`
 
   tooltip.classList.remove('hidden')
   positionCitationTooltip()

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5942,17 +5942,20 @@ body.light-theme .citation-tooltip {
   color: var(--text-primary);
   margin-right: 2px;
 }
-.citation-tooltip-result {
+.citation-tooltip-result,
+.citation-tooltip-scholar-results {
   font-size: 12.5px;
   line-height: 1.5;
   margin-bottom: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border);
 }
-.citation-tooltip-result.hidden {
+.citation-tooltip-result.hidden,
+.citation-tooltip-scholar-results.hidden {
   display: none;
 }
-.citation-tooltip-result a {
+.citation-tooltip-result a,
+.citation-tooltip-scholar-results a {
   display: flex;
   align-items: flex-start;
   gap: 4px;
@@ -5960,7 +5963,8 @@ body.light-theme .citation-tooltip {
   font-weight: 600;
   text-decoration: none;
 }
-.citation-tooltip-result a:hover {
+.citation-tooltip-result a:hover,
+.citation-tooltip-scholar-results a:hover {
   text-decoration: underline;
 }
 .citation-tooltip-result-item {

--- a/frontend/tests/citationSearch.test.js
+++ b/frontend/tests/citationSearch.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildScholarSearchUrl, extractCitationTitle } from '../src/citationSearch.js'
+import { buildScholarSearchUrl, buildScholarSearchUrls, extractCitationTitle } from '../src/citationSearch.js'
 
 test('따옴표가 있는 참고문헌에서는 제목만 추출한다', () => {
   assert.equal(extractCitationTitle('[13] A. Author, "A Carefully Quoted Paper Title," Journal of Tests, vol. 2, 2021.'), 'A Carefully Quoted Paper Title')
@@ -15,11 +15,24 @@ test('APA 형식에서 저자, 게재처, DOI를 제외하고 제목을 추출�
   assert.equal(extractCitationTitle('Smith, J., Doe, A. (2020). Reliable Widget Detection at Scale. Journal of Widgets, 4(2), 10-20. https://doi.org/10.1234/widgets'), 'Reliable Widget Detection at Scale')
 })
 
-test('다중 참고문헌은 정제한 제목을 따옴표와 OR 연산자로 조합한다', () => {
-  const url = new URL(buildScholarSearchUrl([
+test('다중 참고문헌은 제목별 독립 Scholar 검색 URL을 만든다', () => {
+  const urls = buildScholarSearchUrls([
     'Vaswani et al. Attention Is All You Need. 2017.',
     'He et al. Deep Residual Learning for Image Recognition. In CVPR, 2016.',
     'A. Author, "A Carefully Quoted Paper Title," Journal of Tests, 2021.',
-  ]))
-  assert.equal(url.searchParams.get('q'), '"Attention Is All You Need" OR "Deep Residual Learning for Image Recognition" OR "A Carefully Quoted Paper Title"')
+  ]).map(value => new URL(value).searchParams.get('q'))
+
+  assert.deepEqual(urls, [
+    '"Attention Is All You Need"',
+    '"Deep Residual Learning for Image Recognition"',
+    '"A Carefully Quoted Paper Title"',
+  ])
+  assert.ok(urls.every(query => !query.includes(' OR ')))
+})
+
+test('단일 Scholar 검색은 기존처럼 제목 하나만 검색한다', () => {
+  const url = new URL(buildScholarSearchUrl(
+    'Vaswani et al. Attention Is All You Need. 2017.',
+  ))
+  assert.equal(url.searchParams.get('q'), '"Attention Is All You Need"')
 })


### PR DESCRIPTION
# Summary\n## 1. 원문 링크 검색 정확도 개선\n- 참고문헌 제목·연도·DOI 정제 및 OpenAlex 상위 후보 검증 로직 추가\n- 제목 유사도·연도·DOI·인용수 기반 후보 선별과 canonical 링크 우선순위 적용\n- 기존 오매칭 캐시 무효화를 위한 레퍼런스 URL 캐시 버전 갱신\n## 2. 다중 Google Scholar 검색 개선\n- OR 통합 검색 제거 및 참고문헌별 독립 Scholar 링크 표시 기능 추가\n- 단일 참고문헌의 기존 직접 검색 동작 유지\n- 제목 정제·후보 검증·캐시 무효화 회귀 테스트 추가