### PR TITLE
fix(reading): accumulate page evidence

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -357,8 +357,9 @@ async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessio
         db_get_user_reading_profile,
         db_save_reading_session,
         db_get_reading_session,
+        db_upsert_reading_page_evidence,
     )
-    from services.reading_analytics import process_reading_analytics
+    from services.reading_analytics import build_page_evidence, process_reading_analytics
 
     doc = get_document(doc_id)
     doc_total_pages = doc.get("total_pages", 0) if doc else 0
@@ -406,6 +407,15 @@ async def post_reading_session_heartbeat_api(doc_id: str, payload: ReadingSessio
     if not saved:
         current = db_get_reading_session(payload.sessionId, current_user)
         return {"stale": True, "version": current["version"] if current else payload.version}
+
+    if res.readingActivity != "ignored":
+        db_upsert_reading_page_evidence(
+            current_user,
+            doc_id,
+            payload.sessionId,
+            build_page_evidence(payload.pageSessions, user_ema, res.totalPages),
+            res.totalPages,
+        )
     return res.model_dump()
 
 
@@ -423,9 +433,11 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         db_get_user_reading_profile,
         db_save_reading_session,
         db_save_user_reading_profile,
+        db_upsert_reading_page_evidence,
     )
     from services.reading_analytics import (
-        count_meaningful_page_sessions, process_reading_analytics, update_user_ema,
+        build_page_evidence, count_meaningful_page_sessions,
+        process_reading_analytics, update_user_ema,
     )
 
     doc = get_document(doc_id)
@@ -473,6 +485,15 @@ async def end_reading_session_api(doc_id: str, payload: ReadingSessionPayload, c
         current = db_get_reading_session(payload.sessionId, current_user)
         return {"stale": True, "version": current["version"] if current else payload.version}
 
+    if res.readingActivity != "ignored":
+        db_upsert_reading_page_evidence(
+            current_user,
+            doc_id,
+            payload.sessionId,
+            build_page_evidence(payload.pageSessions, user_ema, res.totalPages),
+            res.totalPages,
+        )
+
     if not existing or not existing.get("ended_at"):
         new_ema, new_count = update_user_ema(
             user_ema,
@@ -499,41 +520,25 @@ async def get_reading_analytics_summary_api(since_days: Optional[int] = None, cu
 
 @router.get("/library/{doc_id}/reading-analytics")
 async def get_paper_reading_analytics_api(doc_id: str, current_user: str = Depends(get_current_user)):
-    """특정 논문의 Reading Analytics (Page Score, Reading Score, Depth, Confidence) 정보를 반환합니다."""
+    """Return cumulative per-page Reading Analytics for one paper."""
     require_owned_document(doc_id, current_user)
-    import json
-    from services.db import db_get_latest_reading_session
-    session = db_get_latest_reading_session(doc_id, current_user)
-    if not session:
+    from services.db import db_get_paper_reading_stats
+
+    stats = db_get_paper_reading_stats(doc_id, current_user)
+    if not stats:
         return {
             "reading_score": 0.0,
             "reading_confidence": 0.0,
             "reading_depth": "Opened",
             "verified_pages_count": 0,
+            "meaningful_pages_count": 0,
             "total_pages": 0,
             "active_reading_time": 0,
             "page_scores": {},
         }
-    page_scores = {}
-    if session.get("page_sessions_json"):
-        try:
-            ps_list = json.loads(session["page_sessions_json"])
-            from services.reading_analytics import analyze_page_sessions, PageSession
-            ps_objs = [PageSession(**p) for p in ps_list]
-            page_scores, _, _ = analyze_page_sessions(ps_objs, 600.0, session.get("total_pages", 0))
-        except Exception:
-            pass
-
     return {
-        "sessionId": session["id"],
         "paperId": doc_id,
-        "reading_score": session["reading_score"],
-        "reading_confidence": session["reading_confidence"],
-        "reading_depth": session["reading_depth"],
-        "verified_pages_count": session["verified_pages_count"],
-        "total_pages": session["total_pages"],
-        "active_reading_time": session["active_reading_time"],
-        "page_scores": page_scores,
+        **stats,
     }
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -303,7 +303,7 @@ def init_db():
             total_pages INTEGER DEFAULT 0,
             reading_activity TEXT DEFAULT 'unclassified',
             minimum_evidence_time REAL DEFAULT 90.0,
-            analytics_version INTEGER NOT NULL DEFAULT 2,
+            analytics_version INTEGER NOT NULL DEFAULT 3,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         )
@@ -318,6 +318,39 @@ def init_db():
             updated_at TEXT NOT NULL
         )
         """)
+
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS reading_page_evidence (
+            username TEXT NOT NULL,
+            paper_id TEXT NOT NULL,
+            page_number INTEGER NOT NULL,
+            best_score REAL NOT NULL,
+            evidence_time REAL NOT NULL,
+            interaction_quality REAL NOT NULL,
+            source_session_id TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (username, paper_id, page_number)
+        )
+        """)
+
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS paper_reading_stats (
+            username TEXT NOT NULL,
+            paper_id TEXT NOT NULL,
+            reading_score REAL NOT NULL DEFAULT 0.0,
+            reading_confidence REAL NOT NULL DEFAULT 0.0,
+            reading_depth TEXT NOT NULL DEFAULT 'Opened',
+            verified_pages_count INTEGER NOT NULL DEFAULT 0,
+            meaningful_pages_count INTEGER NOT NULL DEFAULT 0,
+            total_pages INTEGER NOT NULL DEFAULT 0,
+            active_reading_time INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (username, paper_id)
+        )
+        """)
+
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_page_evidence_user_paper ON reading_page_evidence(username, paper_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_paper_reading_stats_user_updated ON paper_reading_stats(username, updated_at)")
 
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_sessions_user_paper ON reading_sessions(username, paper_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_reading_sessions_user_updated ON reading_sessions(username, updated_at)")
@@ -400,6 +433,7 @@ def init_db():
             print(f"Default user '{default_user}' created in SQLite database.")
 
     db_migrate_reading_analytics_v2()
+    db_migrate_reading_analytics_v3()
     db_backfill_document_titles()
 
 
@@ -444,6 +478,8 @@ def update_user_credentials(old_username: str, new_username: str, new_password_h
                     "documents",
                     "reading_time",
                     "reading_sessions",
+                    "reading_page_evidence",
+                    "paper_reading_stats",
                     "user_reading_profiles",
                     "compare_sessions",
                     "folders",
@@ -1645,7 +1681,7 @@ def db_save_reading_session(
     reading_activity: str = "unclassified",
     minimum_evidence_time: float = 90.0,
     verified_pages_json: Optional[str] = None,
-    analytics_version: int = 2,
+    analytics_version: int = 3,
 ) -> bool:
     """Insert a session or replace it only with a newer heartbeat version."""
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -1767,18 +1803,164 @@ def db_save_user_reading_profile(username: str, ema_seconds_per_page: float, ses
         conn.commit()
 
 
+
+def db_upsert_reading_page_evidence(
+    username: str,
+    paper_id: str,
+    source_session_id: str,
+    page_evidence: Dict[int, Dict[str, float]],
+    total_pages: int,
+) -> Optional[Dict[str, Any]]:
+    """Keep the strongest evidence per page and refresh cumulative paper stats."""
+    if not page_evidence:
+        return db_get_paper_reading_stats(paper_id, username)
+
+    from services.reading_analytics import calculate_paper_reading_analytics
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        for page, evidence in page_evidence.items():
+            conn.execute(
+                """
+                INSERT INTO reading_page_evidence (
+                    username, paper_id, page_number, best_score, evidence_time,
+                    interaction_quality, source_session_id, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(username, paper_id, page_number) DO UPDATE SET
+                    best_score = excluded.best_score,
+                    evidence_time = excluded.evidence_time,
+                    interaction_quality = excluded.interaction_quality,
+                    source_session_id = excluded.source_session_id,
+                    updated_at = excluded.updated_at
+                WHERE excluded.best_score > reading_page_evidence.best_score
+                   OR (
+                        excluded.best_score = reading_page_evidence.best_score
+                        AND excluded.evidence_time > reading_page_evidence.evidence_time
+                   )
+                """,
+                (
+                    username, paper_id, int(page), float(evidence.get("score", 0.0)),
+                    float(evidence.get("evidence_time", 0.0)),
+                    float(evidence.get("interaction_quality", 0.0)),
+                    source_session_id, now_iso,
+                ),
+            )
+
+        rows = conn.execute(
+            """
+            SELECT page_number, best_score, evidence_time, interaction_quality
+            FROM reading_page_evidence
+            WHERE username = ? AND paper_id = ?
+            ORDER BY page_number
+            """,
+            (username, paper_id),
+        ).fetchall()
+        cumulative_evidence = {
+            row["page_number"]: {
+                "score": row["best_score"],
+                "evidence_time": row["evidence_time"],
+                "interaction_quality": row["interaction_quality"],
+            }
+            for row in rows
+        }
+        previous = conn.execute(
+            """
+            SELECT reading_score, reading_depth
+            FROM paper_reading_stats
+            WHERE username = ? AND paper_id = ?
+            """,
+            (username, paper_id),
+        ).fetchone()
+        session_totals = conn.execute(
+            """
+            SELECT COALESCE(SUM(active_reading_time), 0) AS active_time,
+                   COALESCE(MAX(total_pages), 0) AS total_pages
+            FROM reading_sessions
+            WHERE username = ? AND paper_id = ?
+              AND reading_activity IN ('browsed', 'read')
+            """,
+            (username, paper_id),
+        ).fetchone()
+        aggregate = calculate_paper_reading_analytics(
+            cumulative_evidence,
+            total_pages=max(total_pages, session_totals["total_pages"] or 0),
+            active_reading_time=session_totals["active_time"] or 0,
+            previous_reading_score=previous["reading_score"] if previous else 0.0,
+            previous_reading_depth=previous["reading_depth"] if previous else "Opened",
+        )
+        conn.execute(
+            """
+            INSERT INTO paper_reading_stats (
+                username, paper_id, reading_score, reading_confidence, reading_depth,
+                verified_pages_count, meaningful_pages_count, total_pages,
+                active_reading_time, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(username, paper_id) DO UPDATE SET
+                reading_score = excluded.reading_score,
+                reading_confidence = excluded.reading_confidence,
+                reading_depth = excluded.reading_depth,
+                verified_pages_count = excluded.verified_pages_count,
+                meaningful_pages_count = excluded.meaningful_pages_count,
+                total_pages = excluded.total_pages,
+                active_reading_time = excluded.active_reading_time,
+                updated_at = excluded.updated_at
+            """,
+            (
+                username, paper_id, aggregate.readingScore, aggregate.readingConfidence,
+                aggregate.readingDepth, aggregate.verifiedPagesCount,
+                aggregate.meaningfulPagesCount, aggregate.totalPages,
+                int(aggregate.activeReadingTime), now_iso,
+            ),
+        )
+        conn.commit()
+
+    return db_get_paper_reading_stats(paper_id, username)
+
+
+def db_get_paper_reading_stats(paper_id: str, username: str) -> Optional[Dict[str, Any]]:
+    """Return cumulative paper analytics and strongest page scores."""
+    with get_db() as conn:
+        row = conn.execute(
+            """
+            SELECT paper_id, reading_score, reading_confidence, reading_depth,
+                   verified_pages_count, meaningful_pages_count, total_pages,
+                   active_reading_time, updated_at
+            FROM paper_reading_stats
+            WHERE username = ? AND paper_id = ?
+            """,
+            (username, paper_id),
+        ).fetchone()
+        if not row:
+            return None
+        result = dict(row)
+        page_rows = conn.execute(
+            """
+            SELECT page_number, best_score
+            FROM reading_page_evidence
+            WHERE username = ? AND paper_id = ?
+            ORDER BY page_number
+            """,
+            (username, paper_id),
+        ).fetchall()
+        result["page_scores"] = {
+            row["page_number"]: row["best_score"] for row in page_rows
+        }
+        return result
+
 def db_migrate_reading_analytics_v2() -> None:
     """Recalculate legacy sessions and rebuild EMA from meaningful page visits."""
     from services.reading_analytics import (
-        READING_ANALYTICS_VERSION, InteractionSummary, PageSession,
+        InteractionSummary, PageSession,
         ReadingSessionPayload, count_meaningful_page_sessions,
         process_reading_analytics, update_user_ema,
     )
 
+    target_version = 2
+
     with get_db() as conn:
         affected_rows = conn.execute(
             "SELECT DISTINCT username FROM reading_sessions WHERE analytics_version < ?",
-            (READING_ANALYTICS_VERSION,),
+            (target_version,),
         ).fetchall()
         affected_users = [row["username"] for row in affected_rows]
         if not affected_users:
@@ -1819,11 +2001,11 @@ def db_migrate_reading_analytics_v2() -> None:
             except (TypeError, ValueError, json.JSONDecodeError):
                 conn.execute(
                     "UPDATE reading_sessions SET analytics_version = ? WHERE id = ?",
-                    (READING_ANALYTICS_VERSION, row["id"]),
+                    (target_version, row["id"]),
                 )
                 continue
 
-            if (row["analytics_version"] < READING_ANALYTICS_VERSION):
+            if (row["analytics_version"] < target_version):
                 result = process_reading_analytics(
                     payload, max(0, row["total_pages"] or 0), user_ema,
                 )
@@ -1842,7 +2024,7 @@ def db_migrate_reading_analytics_v2() -> None:
                         result.readingDepth, result.readingScore, result.readingConfidence,
                         result.verifiedPagesCount, json.dumps(verified_pages), result.totalPages,
                         result.readingActivity, result.minimumEvidenceTime,
-                        READING_ANALYTICS_VERSION, row["id"],
+                        target_version, row["id"],
                     ),
                 )
 
@@ -1868,6 +2050,88 @@ def db_migrate_reading_analytics_v2() -> None:
             )
         conn.commit()
 
+
+
+def db_migrate_reading_analytics_v3() -> None:
+    """Build cumulative per-page evidence for installations upgrading to v3."""
+    from services.reading_analytics import (
+        READING_ANALYTICS_VERSION, PageSession, build_page_evidence,
+    )
+
+    with get_db() as conn:
+        affected = conn.execute(
+            """
+            SELECT DISTINCT username
+            FROM reading_sessions
+            WHERE analytics_version < ?
+            """,
+            (READING_ANALYTICS_VERSION,),
+        ).fetchall()
+        affected_users = [row["username"] for row in affected]
+        if not affected_users:
+            return
+        placeholders = ",".join("?" for _ in affected_users)
+        rows = conn.execute(
+            f"""
+            SELECT id, username, paper_id, page_sessions_json, total_pages,
+                   reading_activity
+            FROM reading_sessions
+            WHERE username IN ({placeholders})
+            ORDER BY started_at, created_at
+            """,
+            affected_users,
+        ).fetchall()
+        profile_rows = conn.execute(
+            f"""
+            SELECT username, ema_seconds_per_page
+            FROM user_reading_profiles
+            WHERE username IN ({placeholders})
+            """,
+            affected_users,
+        ).fetchall()
+        profiles = {
+            row["username"]: row["ema_seconds_per_page"] for row in profile_rows
+        }
+        conn.execute(
+            f"DELETE FROM reading_page_evidence WHERE username IN ({placeholders})",
+            affected_users,
+        )
+        conn.execute(
+            f"DELETE FROM paper_reading_stats WHERE username IN ({placeholders})",
+            affected_users,
+        )
+        conn.commit()
+
+    for row in rows:
+        if row["reading_activity"] not in ("browsed", "read"):
+            continue
+        try:
+            raw_pages = json.loads(row["page_sessions_json"] or "[]")
+            page_sessions = [
+                PageSession(**page) for page in raw_pages if isinstance(page, dict)
+            ]
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        user_ema = profiles.get(row["username"], 600.0)
+        evidence = build_page_evidence(
+            page_sessions, user_ema, max(0, row["total_pages"] or 0),
+        )
+        if evidence:
+            db_upsert_reading_page_evidence(
+                row["username"], row["paper_id"], row["id"], evidence,
+                max(0, row["total_pages"] or 0),
+            )
+
+    with get_db() as conn:
+        conn.execute(
+            f"""
+            UPDATE reading_sessions
+            SET analytics_version = ?
+            WHERE username IN ({placeholders})
+            """,
+            [READING_ANALYTICS_VERSION, *affected_users],
+        )
+        conn.commit()
 
 def db_backfill_document_titles() -> None:
     """Restore extracted paper titles lost by legacy metadata replacement."""
@@ -1905,9 +2169,8 @@ def db_backfill_document_titles() -> None:
 
 
 def db_get_all_reading_analytics_summary(username: str, since_days: Optional[int] = None) -> Dict[str, Any]:
-    """Aggregates reading analytics metrics per paper and overall for dashboard and history."""
+    """Aggregate cumulative paper achievements for dashboard and history."""
     with get_db() as conn:
-        cursor = conn.cursor()
         params: List[Any] = [username]
         day_filter = ""
         if since_days is not None:
@@ -1915,51 +2178,25 @@ def db_get_all_reading_analytics_summary(username: str, since_days: Optional[int
             day_filter = " AND updated_at >= ?"
             params.append(cutoff)
 
-        cursor.execute(
+        rows = conn.execute(
             f"""
             SELECT paper_id, reading_score, reading_confidence, reading_depth,
-                   verified_pages_count, total_pages, active_reading_time, updated_at
-            FROM reading_sessions
+                   verified_pages_count, meaningful_pages_count, total_pages,
+                   active_reading_time, updated_at
+            FROM paper_reading_stats
             WHERE username = ?{day_filter}
             ORDER BY updated_at DESC
             """,
             params,
-        )
-        rows = cursor.fetchall()
+        ).fetchall()
 
-    paper_stats: Dict[str, Dict[str, Any]] = {}
-    total_active_time = 0
-    scores = []
-    confidences = []
-    verified_sum = 0
-
-    for r in rows:
-        pid = r["paper_id"]
-        # Keep latest session info per paper
-        if pid not in paper_stats:
-            paper_stats[pid] = {
-                "paper_id": pid,
-                "reading_score": r["reading_score"],
-                "reading_confidence": r["reading_confidence"],
-                "reading_depth": r["reading_depth"],
-                "verified_pages_count": r["verified_pages_count"],
-                "total_pages": r["total_pages"],
-                "active_reading_time": r["active_reading_time"],
-                "updated_at": r["updated_at"],
-            }
-            scores.append(r["reading_score"])
-            confidences.append(r["reading_confidence"])
-            verified_sum += r["verified_pages_count"]
-
-        total_active_time += r["active_reading_time"]
-
-    avg_score = round(sum(scores) / len(scores), 1) if scores else 0.0
-    avg_confidence = round(sum(confidences) / len(confidences), 1) if confidences else 0.0
-
+    paper_stats = {row["paper_id"]: dict(row) for row in rows}
+    scores = [row["reading_score"] for row in rows]
+    confidences = [row["reading_confidence"] for row in rows]
     return {
-        "overall_avg_score": avg_score,
-        "overall_avg_confidence": avg_confidence,
-        "overall_verified_pages": verified_sum,
-        "total_active_reading_time": total_active_time,
+        "overall_avg_score": round(sum(scores) / len(scores), 1) if scores else 0.0,
+        "overall_avg_confidence": round(sum(confidences) / len(confidences), 1) if confidences else 0.0,
+        "overall_verified_pages": sum(row["verified_pages_count"] for row in rows),
+        "total_active_reading_time": sum(row["active_reading_time"] for row in rows),
         "paper_stats": paper_stats,
     }

--- a/backend/services/reading_analytics.py
+++ b/backend/services/reading_analytics.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field
 from typing import Dict, List
 
 
-READING_ANALYTICS_VERSION = 2
+READING_ANALYTICS_VERSION = 3
 MIN_MEANINGFUL_PAGE_SECONDS = 10.0
 SEMANTIC_INTERACTION_FIELDS = (
     "selection", "highlight", "underline", "memo", "question",
@@ -57,6 +57,17 @@ class ReadingAnalyticsResult(BaseModel):
     minimumEvidenceTime: float
 
 
+class PaperReadingAnalyticsResult(BaseModel):
+    readingScore: float
+    readingConfidence: float
+    readingDepth: str
+    verifiedPagesCount: int
+    meaningfulPagesCount: int
+    totalPages: int
+    activeReadingTime: float
+    pageScores: Dict[int, float] = Field(default_factory=dict)
+
+
 # --- 1. Interaction Quality Calculation ---
 def calculate_interaction_quality(interaction: InteractionSummary) -> float:
     """Calculate interaction evidence without letting raw scroll events dominate."""
@@ -89,6 +100,29 @@ def is_meaningful_page_session(page_session: PageSession) -> bool:
 
 def count_meaningful_page_sessions(page_sessions: List[PageSession]) -> int:
     return len({ps.page for ps in page_sessions if is_meaningful_page_session(ps)})
+
+
+def consolidate_page_sessions(page_sessions: List[PageSession]) -> Dict[int, PageSession]:
+    """Merge repeated payload entries into one cumulative record per page."""
+    consolidated: Dict[int, PageSession] = {}
+    for ps in page_sessions:
+        previous = consolidated.get(ps.page)
+        if previous is None:
+            consolidated[ps.page] = ps.model_copy(deep=True)
+            continue
+        positive_enter_times = [v for v in (previous.enterTime, ps.enterTime) if v > 0]
+        previous.enterTime = min(positive_enter_times) if positive_enter_times else 0
+        previous.leaveTime = max(previous.leaveTime, ps.leaveTime)
+        previous.visibleTime += ps.visibleTime
+        previous.activeTime += ps.activeTime
+        previous.scrollCoverage = max(previous.scrollCoverage, ps.scrollCoverage)
+        for field_name in InteractionSummary.model_fields:
+            setattr(
+                previous.interaction,
+                field_name,
+                getattr(previous.interaction, field_name) + getattr(ps.interaction, field_name),
+            )
+    return consolidated
 
 
 def calculate_minimum_evidence_time(user_ema: float) -> float:
@@ -151,24 +185,7 @@ def analyze_page_sessions(
 
     # A client should send one cumulative entry per page, but consolidating here
     # prevents duplicate page entries from inflating verified-page counts.
-    consolidated: Dict[int, PageSession] = {}
-    for ps in page_sessions:
-        previous = consolidated.get(ps.page)
-        if previous is None:
-            consolidated[ps.page] = ps.model_copy(deep=True)
-            continue
-        positive_enter_times = [v for v in (previous.enterTime, ps.enterTime) if v > 0]
-        previous.enterTime = min(positive_enter_times) if positive_enter_times else 0
-        previous.leaveTime = max(previous.leaveTime, ps.leaveTime)
-        previous.visibleTime += ps.visibleTime
-        previous.activeTime += ps.activeTime
-        previous.scrollCoverage = max(previous.scrollCoverage, ps.scrollCoverage)
-        for field_name in InteractionSummary.model_fields:
-            setattr(
-                previous.interaction,
-                field_name,
-                getattr(previous.interaction, field_name) + getattr(ps.interaction, field_name),
-            )
+    consolidated = consolidate_page_sessions(page_sessions)
 
     for ps in consolidated.values():
         page_num = ps.page
@@ -223,6 +240,34 @@ def analyze_page_sessions(
 
     avg_confidence = round(weighted_confidence_sum / confidence_weight_sum, 1) if confidence_weight_sum else 0.0
     return page_scores, verified_count, avg_confidence
+
+
+def build_page_evidence(
+    page_sessions: List[PageSession],
+    expected_page_time: float,
+    total_pages: int,
+) -> Dict[int, Dict[str, float]]:
+    """Return persistable evidence for meaningful pages in one session."""
+    consolidated = consolidate_page_sessions(page_sessions)
+    page_scores, _, _ = analyze_page_sessions(
+        list(consolidated.values()), expected_page_time, total_pages,
+    )
+    evidence: Dict[int, Dict[str, float]] = {}
+    for page, page_session in consolidated.items():
+        if not is_meaningful_page_session(page_session):
+            continue
+        evidence[page] = {
+            "score": page_scores[page],
+            "evidence_time": max(
+                MIN_MEANINGFUL_PAGE_SECONDS,
+                min(
+                    page_session.activeTime,
+                    max(MIN_MEANINGFUL_PAGE_SECONDS, expected_page_time),
+                ),
+            ),
+            "interaction_quality": calculate_interaction_quality(page_session.interaction),
+        }
+    return evidence
 
 
 # --- 3. Reading Depth Analyzer ---
@@ -288,6 +333,75 @@ def calculate_reading_score(
     )
 
     return round(max(0.0, min(100.0, score)), 1)
+
+
+def calculate_paper_reading_analytics(
+    page_evidence: Dict[int, Dict[str, float]],
+    total_pages: int,
+    active_reading_time: float,
+    previous_reading_score: float = 0.0,
+    previous_reading_depth: str = "Opened",
+) -> PaperReadingAnalyticsResult:
+    """Calculate cumulative paper achievement from each page's strongest evidence."""
+    page_scores = {
+        int(page): round(max(0.0, min(100.0, evidence.get("score", 0.0))), 1)
+        for page, evidence in page_evidence.items()
+    }
+    meaningful_count = len(page_scores)
+    verified_count = sum(score >= 50.0 for score in page_scores.values())
+    confidence_weight = sum(
+        max(MIN_MEANINGFUL_PAGE_SECONDS, evidence.get("evidence_time", 0.0))
+        for evidence in page_evidence.values()
+    )
+    weighted_confidence = sum(
+        page_scores[int(page)]
+        * max(MIN_MEANINGFUL_PAGE_SECONDS, evidence.get("evidence_time", 0.0))
+        for page, evidence in page_evidence.items()
+    )
+    confidence = round(weighted_confidence / confidence_weight, 1) if confidence_weight else 0.0
+    total_iq = sum(
+        max(0.0, evidence.get("interaction_quality", 0.0))
+        for evidence in page_evidence.values()
+    )
+
+    depth = determine_reading_depth(
+        active_reading_time, verified_count, total_pages, 0.0, meaningful_count,
+    )
+    for _ in range(3):
+        score = calculate_reading_score(
+            verified_count, total_pages, confidence, depth, total_iq, meaningful_count,
+        )
+        next_depth = determine_reading_depth(
+            active_reading_time, verified_count, total_pages, score, meaningful_count,
+        )
+        if next_depth == depth:
+            break
+        depth = next_depth
+    score = calculate_reading_score(
+        verified_count, total_pages, confidence, depth, total_iq, meaningful_count,
+    )
+
+    depth_rank = {
+        "Opened": 0,
+        "Browsing": 1,
+        "Reading": 2,
+        "Deep Reading": 3,
+        "Completed": 4,
+    }
+    score = round(max(previous_reading_score, score), 1)
+    if depth_rank.get(previous_reading_depth, 0) > depth_rank.get(depth, 0):
+        depth = previous_reading_depth
+
+    return PaperReadingAnalyticsResult(
+        readingScore=score,
+        readingConfidence=confidence,
+        readingDepth=depth,
+        verifiedPagesCount=verified_count,
+        meaningfulPagesCount=meaningful_count,
+        totalPages=max(1, total_pages),
+        activeReadingTime=max(0.0, active_reading_time),
+        pageScores=page_scores,
+    )
 
 
 # --- 5. EMA Learning Engine ---

--- a/backend/tests/test_db_service.py
+++ b/backend/tests/test_db_service.py
@@ -111,6 +111,21 @@ def test_update_user_credentials_propagates_username_to_user_data(isolated_dirs)
             ("admin", 300.0, 1, now),
         )
         conn.execute(
+            """INSERT INTO reading_page_evidence
+               (username, paper_id, page_number, best_score, evidence_time,
+                interaction_quality, source_session_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("admin", "doc-1", 1, 80.0, 120.0, 3.0, "session-1", now),
+        )
+        conn.execute(
+            """INSERT INTO paper_reading_stats
+               (username, paper_id, reading_score, reading_confidence,
+                reading_depth, verified_pages_count, meaningful_pages_count,
+                total_pages, active_reading_time, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("admin", "doc-1", 70.0, 80.0, "Reading", 1, 1, 5, 120, now),
+        )
+        conn.execute(
             """INSERT INTO compare_sessions
                (id, username, doc_ids, created_at, updated_at)
                VALUES (?, ?, ?, ?, ?)""",
@@ -130,6 +145,8 @@ def test_update_user_credentials_propagates_username_to_user_data(isolated_dirs)
         for table in (
             "reading_time",
             "reading_sessions",
+            "reading_page_evidence",
+            "paper_reading_stats",
             "user_reading_profiles",
             "compare_sessions",
             "folders",
@@ -287,6 +304,36 @@ def test_reading_analytics_v2_migrates_legacy_sessions(isolated_dirs):
     assert migrated["reading_confidence"] >= 90
     assert migrated["reading_score"] >= 70
     assert db.db_get_user_reading_profile("admin")["session_count"] == 1
+
+
+def test_reading_analytics_v3_builds_cumulative_page_evidence(isolated_dirs):
+    db = isolated_dirs["db"]
+    pages = [{
+        "page": 3,
+        "activeTime": 600,
+        "visibleTime": 600,
+        "scrollCoverage": 0.8,
+        "interaction": {"highlight": 1},
+    }]
+    db.db_save_reading_session(
+        session_id="v2-session", username="admin", paper_id="paper",
+        started_at="2026-08-10T01:00:00+00:00",
+        ended_at="2026-08-10T02:00:00+00:00", active_reading_time=600,
+        version=1, page_sessions_json=json.dumps(pages),
+        interaction_summary_json=json.dumps({"highlight": 1}),
+        reading_depth="Reading", reading_score=60.0, reading_confidence=80.0,
+        verified_pages_count=1, verified_pages_json="[3]", total_pages=10,
+        reading_activity="read", analytics_version=2,
+    )
+
+    db.db_migrate_reading_analytics_v3()
+
+    migrated = db.db_get_reading_session("v2-session", "admin")
+    stats = db.db_get_paper_reading_stats("paper", "admin")
+    assert migrated["analytics_version"] == 3
+    assert stats["verified_pages_count"] == 1
+    assert stats["meaningful_pages_count"] == 1
+    assert stats["page_scores"][3] >= 50.0
 
 
 def test_backfill_document_title_preserves_metadata_and_snapshot(

--- a/backend/tests/test_reading_analytics.py
+++ b/backend/tests/test_reading_analytics.py
@@ -9,6 +9,8 @@ from services.reading_analytics import (
     determine_reading_depth,
     calculate_reading_score,
     calculate_minimum_evidence_time,
+    build_page_evidence,
+    calculate_paper_reading_analytics,
     classify_reading_activity,
     count_meaningful_page_sessions,
     update_user_ema,
@@ -240,6 +242,66 @@ class TestReadingAnalytics(unittest.TestCase):
         result = process_reading_analytics(payload, total_paper_pages=10, user_ema=600)
         self.assertEqual(result.readingScore, 55.0)
 
+    def test_page_evidence_only_contains_meaningful_pages(self):
+        pages = [
+            PageSession(page=1, activeTime=1, scrollCoverage=1.0),
+            PageSession(
+                page=2, activeTime=300, scrollCoverage=0.8,
+                interaction=InteractionSummary(highlight=1),
+            ),
+        ]
+
+        evidence = build_page_evidence(pages, expected_page_time=600, total_pages=10)
+
+        self.assertNotIn(1, evidence)
+        self.assertIn(2, evidence)
+        self.assertGreaterEqual(evidence[2]["score"], 50.0)
+        self.assertEqual(evidence[2]["evidence_time"], 300)
+
+    def test_paper_analytics_accumulates_unique_page_evidence(self):
+        first = calculate_paper_reading_analytics(
+            {
+                1: {"score": 95.0, "evidence_time": 600, "interaction_quality": 3.0},
+            },
+            total_pages=10,
+            active_reading_time=600,
+        )
+        accumulated = calculate_paper_reading_analytics(
+            {
+                1: {"score": 95.0, "evidence_time": 600, "interaction_quality": 3.0},
+                2: {"score": 90.0, "evidence_time": 600, "interaction_quality": 4.0},
+            },
+            total_pages=10,
+            active_reading_time=1200,
+            previous_reading_score=first.readingScore,
+            previous_reading_depth=first.readingDepth,
+        )
+
+        self.assertEqual(accumulated.verifiedPagesCount, 2)
+        self.assertEqual(accumulated.meaningfulPagesCount, 2)
+        self.assertGreaterEqual(accumulated.readingScore, first.readingScore)
+        self.assertEqual(accumulated.pageScores, {1: 95.0, 2: 90.0})
+
+    def test_weaker_new_page_cannot_reduce_paper_achievement(self):
+        established = calculate_paper_reading_analytics(
+            {1: {"score": 100.0, "evidence_time": 600, "interaction_quality": 5.0}},
+            total_pages=10,
+            active_reading_time=600,
+        )
+        with_weak_page = calculate_paper_reading_analytics(
+            {
+                1: {"score": 100.0, "evidence_time": 600, "interaction_quality": 5.0},
+                2: {"score": 20.0, "evidence_time": 10, "interaction_quality": 0.0},
+            },
+            total_pages=10,
+            active_reading_time=610,
+            previous_reading_score=established.readingScore,
+            previous_reading_depth=established.readingDepth,
+        )
+
+        self.assertEqual(with_weak_page.readingScore, established.readingScore)
+        self.assertEqual(with_weak_page.readingDepth, established.readingDepth)
+
     def test_previous_score_is_preserved_while_new_page_is_in_progress(self):
         established_payload = ReadingSessionPayload(
             sessionId="session", paperId="paper", activeReadingTime=600,
@@ -393,6 +455,81 @@ def test_heartbeat_preserves_the_session_high_score(test_client, isolated_dirs):
     assert db.db_get_reading_session(
         session_id, "testuser",
     )["reading_score"] == first.json()["readingScore"]
+
+
+def test_paper_analytics_accumulates_pages_across_sessions_and_ignores_brief_reopen(
+    test_client, isolated_dirs,
+):
+    db = isolated_dirs["db"]
+    db.db_save_document("paper-1", "testuser", "paper.pdf", "/x/paper.pdf", 5, {})
+
+    first_id = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    ).json()["sessionId"]
+    first_payload = _analytics_payload(first_id, "paper-1", 1, active_time=600)
+    assert test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat", json=first_payload,
+    ).status_code == 200
+    first_payload["version"] = 2
+    assert test_client.post(
+        "/api/library/paper-1/reading-session/end", json=first_payload,
+    ).status_code == 200
+
+    first_stats = db.db_get_paper_reading_stats("paper-1", "testuser")
+    assert first_stats["verified_pages_count"] == 1
+    first_score = first_stats["reading_score"]
+
+    ignored_id = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    ).json()["sessionId"]
+    ignored = _analytics_payload(ignored_id, "paper-1", 1, active_time=20)
+    ignored_response = test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat", json=ignored,
+    )
+    assert ignored_response.json()["readingActivity"] == "ignored"
+    assert db.db_get_paper_reading_stats(
+        "paper-1", "testuser",
+    )["reading_score"] == first_score
+
+    ignored["version"] = 2
+    test_client.post("/api/library/paper-1/reading-session/end", json=ignored)
+    second_id = test_client.post(
+        "/api/library/paper-1/reading-session/start", json={"totalPages": 5},
+    ).json()["sessionId"]
+    second = _analytics_payload(second_id, "paper-1", 1, active_time=600)
+    second["currentPage"] = 2
+    second["pageSessions"][0]["page"] = 2
+    assert test_client.post(
+        "/api/library/paper-1/reading-session/heartbeat", json=second,
+    ).status_code == 200
+
+    cumulative = db.db_get_paper_reading_stats("paper-1", "testuser")
+    assert cumulative["verified_pages_count"] == 2
+    assert cumulative["page_scores"].keys() == {1, 2}
+    assert cumulative["reading_score"] >= first_score
+
+    summary = test_client.get("/api/library/reading-analytics-summary").json()
+    assert summary["paper_stats"]["paper-1"]["reading_score"] == cumulative["reading_score"]
+    detail = test_client.get("/api/library/paper-1/reading-analytics").json()
+    assert detail["verified_pages_count"] == 2
+    assert detail["page_scores"].keys() == {"1", "2"}
+
+
+def test_weaker_page_evidence_does_not_replace_best_record(isolated_dirs):
+    db = isolated_dirs["db"]
+    db.db_upsert_reading_page_evidence(
+        "testuser", "paper", "strong", {
+            1: {"score": 90.0, "evidence_time": 300, "interaction_quality": 3.0},
+        }, 5,
+    )
+    db.db_upsert_reading_page_evidence(
+        "testuser", "paper", "weak", {
+            1: {"score": 40.0, "evidence_time": 600, "interaction_quality": 10.0},
+        }, 5,
+    )
+
+    stats = db.db_get_paper_reading_stats("paper", "testuser")
+    assert stats["page_scores"] == {1: 90.0}
 
 
 def test_reading_session_rejects_mismatched_paper_id(test_client, isolated_dirs):


### PR DESCRIPTION
# Summary
## 1. 페이지 단위 Reading Evidence 누적
- 사용자·논문·페이지별 최고 evidence를 저장하는 reading_page_evidence 추가
- ignored 세션 제외 및 서로 다른 세션의 고유 페이지 evidence 누적
- 낮은 신규 evidence가 기존 최고 기록을 덮어쓰지 않도록 upsert 조건 추가
## 2. 논문 단위 누적 Reading Analytics 제공
- 누적 페이지 evidence 기반 paper_reading_stats 계산 및 achievement floor 적용
- Reading History, Dashboard, 논문 상세 API를 누적 통계 기반으로 변경
- analytics v3 마이그레이션을 통한 기존 세션 데이터 재구성 추가
## 3. 회귀 검증 추가
- 짧은 재오픈 세션의 점수 하락 방지 테스트 추가
- 세션 간 verified page 누적 및 최고 evidence 보존 테스트 추가
- 기존 DB 백업본의 v3 마이그레이션 검증 완료