### PR TITLE
fix: repair Windows PDF parser installation

### DIFF
--- a/.github/workflows/tauri-desktop-spike.yml
+++ b/.github/workflows/tauri-desktop-spike.yml
@@ -45,6 +45,19 @@ jobs:
             backend/packaging/build.sh
           fi
 
+      - name: Packaged PDF parser installer smoke test
+        shell: bash
+        run: |
+          BIN=backend/packaging/dist/easypaper-backend/easypaper-backend
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            BIN="backend/packaging/dist/easypaper-backend/easypaper-backend.exe"
+          fi
+          PARSER_CONFIG="${{ runner.temp }}/easypaper-parser-smoke"
+          EASYPAPER_CONFIG_DIR="$PARSER_CONFIG" \
+          EASYPAPER_DESKTOP=1 \
+          "$BIN" --easypaper-install-pdf-parser pdfplumber
+          test -d "$PARSER_CONFIG/pdf-parser-packages/pdfplumber/pdfplumber"
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/tauri-desktop-spike.yml
+++ b/.github/workflows/tauri-desktop-spike.yml
@@ -36,6 +36,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pyinstaller
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build frontend (needed for sidecar's bundled dist)
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
       - name: Build sidecar binary (PyInstaller onedir)
         shell: bash
         run: |
@@ -57,26 +67,6 @@ jobs:
           EASYPAPER_DESKTOP=1 \
           "$BIN" --easypaper-install-pdf-parser pdfplumber
           test -d "$PARSER_CONFIG/pdf-parser-packages/pdfplumber/pdfplumber"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Build frontend (needed for sidecar's bundled dist)
-        working-directory: frontend
-        run: |
-          npm ci
-          npm run build
-
-      - name: Re-bundle sidecar with frontend dist
-        shell: bash
-        run: |
-          rm -rf backend/packaging/dist backend/packaging/build
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            backend/packaging/build.bat
-          else
-            backend/packaging/build.sh
-          fi
 
       - name: Standalone healthcheck (no GUI needed)
         shell: bash

--- a/backend/packaging/build.bat
+++ b/backend/packaging/build.bat
@@ -15,4 +15,6 @@ cd /d "%BACKEND_DIR%"
   --workpath "%SCRIPT_DIR%build" ^
   --noconfirm
 
+if errorlevel 1 exit /b %errorlevel%
+
 echo Built: %SCRIPT_DIR%dist\easypaper-backend\

--- a/backend/tests/test_venv_manager.py
+++ b/backend/tests/test_venv_manager.py
@@ -106,6 +106,26 @@ def test_packaged_installer_atomically_publishes_verified_package(tmp_path, monk
     assert not list((tmp_path / "pdf-parser-packages").glob(".pdfplumber-install-*"))
 
 
+def test_windows_frozen_installer_registers_distlib_resource_finder(monkeypatch):
+    from pip._vendor import distlib
+    from pip._vendor.distlib import resources
+
+    class FakeFrozenLoader:
+        pass
+
+    loader_type = FakeFrozenLoader
+    monkeypatch.setattr(venv_manager.sys, "platform", "win32")
+    monkeypatch.setattr(venv_manager.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(distlib, "__loader__", loader_type())
+    resources._finder_registry.pop(loader_type, None)
+
+    try:
+        venv_manager._register_windows_frozen_distlib_finder()
+        assert resources._finder_registry[loader_type] is resources.ResourceFinder
+    finally:
+        resources._finder_registry.pop(loader_type, None)
+
+
 def test_packaged_installer_keeps_existing_package_when_upgrade_fails(
     tmp_path, monkeypatch
 ):

--- a/backend/venv_manager.py
+++ b/backend/venv_manager.py
@@ -61,6 +61,24 @@ def parser_install_command(engine: str) -> list[str]:
     return [sys.executable, _PACKAGED_INSTALL_ARG, engine]
 
 
+def _register_windows_frozen_distlib_finder() -> None:
+    """pip이 번들된 Windows console-script 런처를 읽을 수 있게 한다."""
+    if sys.platform != "win32" or not getattr(sys, "frozen", False):
+        return
+
+    # distlib은 패키지 loader 타입으로 resource finder를 고른다. 기본
+    # registry는 PyInstaller의 PyiFrozenLoader를 모르지만 collect_all("pip")은
+    # distlib 런처 실행 파일을 frozen 패키지 옆에 실제 파일로 배치하므로,
+    # 일반 파일시스템 finder를 그대로 등록하는 것이 맞다.
+    from pip._vendor import distlib
+    from pip._vendor.distlib import resources
+
+    resources._finder_registry.setdefault(
+        type(distlib.__loader__), resources.ResourceFinder
+    )
+    resources._finder_cache.pop("pip._vendor.distlib", None)
+
+
 def run_packaged_parser_installer(argv: list[str] | None = None) -> int:
     """번들 pip로 선택 파서를 사용자 앱 데이터 폴더에 원자적으로 설치한다."""
     # Windows GUI sidecar의 파이프 stdout은 cp1252 등으로 잡힐 수 있어
@@ -88,6 +106,7 @@ def run_packaged_parser_installer(argv: list[str] | None = None) -> int:
     target_dir = parser_packages_dir(engine)
 
     try:
+        _register_windows_frozen_distlib_finder()
         from pip._internal.cli.main import main as pip_main
 
         result = pip_main([


### PR DESCRIPTION
# Summary
## 1. Windows PDF 파서 설치 오류 코드 2 수정
- PyInstaller frozen loader를 pip distlib 리소스 finder에 등록해 Windows console-script 런처 탐색 실패 수정함
- pdfplumber, Marker, MinerU 공통 설치 진입점에 호환 처리 적용함
## 2. 크로스플랫폼 설치 회귀 검증 추가
- Windows, macOS, Linux frozen sidecar에서 실제 pdfplumber 설치 및 패키지 검증 추가함
- frontend 빌드 이후 sidecar를 생성하도록 스모크 CI 순서 수정함
- Windows PyInstaller 실패 코드가 CI에 전달되도록 build.bat 수정함