### PR TITLE
feat: improve Notes annotation browsing

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9193,7 +9193,8 @@ function applyAnnotationToRange(range, type, textLayerDiv, pageNum, color) {
     text,
     startOffset: offsets.startOffset,
     endOffset: offsets.endOffset,
-    color: chosenColor
+    color: chosenColor,
+    createdAt: new Date().toISOString()
   })
   saveAnnotations(state.sessionId, annotations)
   globalAnalyticsTracker.trackInteraction(type, pageNum)
@@ -9880,6 +9881,7 @@ function renderPageMemos(pageNum) {
             box.style.top = `${r.top}px`
             box.style.width = `${r.width}px`
             box.style.height = `${r.height}px`
+            box.dataset.memoId = memo.id
             if (isHiddenIndividually) {
               box.title = '숨겨진 메모 다시 표시'
               box.addEventListener('click', (e) => { e.stopPropagation(); revealHiddenMemo() })
@@ -9897,6 +9899,7 @@ function renderPageMemos(pageNum) {
         if (pdfElements) {
           pdfElements.forEach(el => {
             el.classList.add('pdf-sentence-has-memo', `color-${memo.color || 'default'}`)
+            el.dataset.memoId = memo.id
             if (isHiddenIndividually) {
               // 클릭 시 되살리기는 pageWrapper에 위임된 리스너(위 참고)가 처리한다 -
               // 이 요소는 재렌더링 때마다 파괴되지 않고 남아있어 직접 리스너를
@@ -10223,6 +10226,7 @@ function createFloatingMemoForSentence(pageNum, sentenceIdx, explicitRange) {
     charStart: memoRange.charStart,
     charEnd: memoRange.charEnd,
     content: '',
+    createdAt: new Date().toISOString(),
     x: leftPct,
     y: topPct
   }
@@ -15247,6 +15251,62 @@ viewerScrollContainer.addEventListener('click', (e) => {
 })()
 
 // ── 해시 라우팅 및 뒤로가기 제어 ──────────────────────
+function viewerAnnotationTargetFromParams(params) {
+  const page = parseInt(params.get('page'), 10)
+  if (!Number.isInteger(page) || page < 1) return null
+  const toOptionalInt = (key) => {
+    const raw = params.get(key)
+    if (raw === null) return null
+    const value = parseInt(raw, 10)
+    return Number.isInteger(value) && value >= 0 ? value : null
+  }
+  return {
+    page,
+    kind: params.get('kind') || null,
+    memoId: params.get('memoId') || null,
+    startOffset: toOptionalInt('start'),
+    endOffset: toOptionalInt('end'),
+  }
+}
+
+function findViewerAnnotationElement(target) {
+  const pageWrapper = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${target.page}"]`)
+  if (!pageWrapper) return null
+  if (target.memoId) {
+    const memoId = CSS.escape(target.memoId)
+    return pageWrapper.querySelector(`.sentence-memo-box[data-memo-id="${memoId}"]`)
+      || pageWrapper.querySelector(`.pdf-sentence-has-memo[data-memo-id="${memoId}"]`)
+      || pageWrapper.querySelector(`.floating-memo[data-id="${memoId}"]`)
+  }
+  if ((target.kind === 'highlight' || target.kind === 'underline') && target.startOffset !== null) {
+    const className = target.kind === 'highlight' ? 'pdf-annotation-highlight' : 'pdf-annotation-underline'
+    return Array.from(pageWrapper.querySelectorAll(`.${className}[data-start-offset]`)).find(el => {
+      if (Number(el.dataset.startOffset) !== target.startOffset) return false
+      return target.endOffset === null || Number(el.dataset.endOffset) === target.endOffset
+    }) || null
+  }
+  return null
+}
+
+async function navigateToViewerAnnotation(target) {
+  if (!target || target.page > state.totalPages) return
+  scrollToPage(viewerScrollContainer, target.page, { instant: true })
+
+  const hasExactAnchor = target.memoId || target.startOffset !== null
+  if (!hasExactAnchor) return
+  const deadline = Date.now() + 4000
+  let targetEl = findViewerAnnotationElement(target)
+  while (!targetEl && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 50))
+    targetEl = findViewerAnnotationElement(target)
+  }
+  if (!targetEl) return
+
+  targetEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
+  targetEl.classList.add('viewer-note-jump-target')
+  setTimeout(() => targetEl.classList.remove('viewer-note-jump-target'), 1800)
+}
+
 async function handleRouting() {
   try {
     const hash = location.hash
@@ -15256,9 +15316,11 @@ async function handleRouting() {
       const params = new URLSearchParams(hash.slice('#viewer?'.length))
       const docId = params.get('id')
       const wantChatOpen = params.get('chat') === '1'
+      const annotationTarget = viewerAnnotationTargetFromParams(params)
       if (docId) {
         if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
           console.log("[Router] Viewer already active for document:", docId)
+          if (annotationTarget) await navigateToViewerAnnotation(annotationTarget)
           if (wantChatOpen) openChatSidebar()
           return
         }
@@ -15266,6 +15328,7 @@ async function handleRouting() {
         const doc = await fetchLibraryDoc(docId)
         if (doc) {
           await openFromLibrary(doc, false)
+          if (annotationTarget && state.sessionId === docId) await navigateToViewerAnnotation(annotationTarget)
           if (wantChatOpen) openChatSidebar()
           return
         }

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -57,6 +57,7 @@ let sortMode = 'recent'     // 'recent' | 'title' | 'uploaded'
 let searchQuery = ''
 let selectedDocId = null
 let activeSubtab = 'summary' // 'summary' | 'memo' | 'highlight' | 'underline' | 'all'
+let annotationSortMode = 'page-asc' // 'page-asc' | 'page-desc' | 'newest' | 'oldest'
 
 // 요약(primer)은 문서당 LLM 호출 비용이 있으므로 탭을 실제로 열었을 때만
 // 가져오고, 한 번 가져오면 페이지 재방문 동안 재사용한다.
@@ -105,15 +106,25 @@ async function getDocAnnotationsAndMemos(docId) {
   return { annotationsByPage, memosByPage }
 }
 
-// 메모 객체에는 별도 createdAt 필드가 없고, id가 `memo_${Date.now()}` 형태로
-// 생성 시각을 담고 있다(main.js createFloatingMemoForSentence 참고) - 이게
-// 유일한 시각 정보라 여기서 역산한다. 하이라이트/언더라인 객체는 애초에
-// 시각 필드 자체가 저장되지 않으므로(타입/텍스트/오프셋/색만 저장) 카드에
-// 시간을 표시할 수 없다 - 페이지 배지만 노출한다.
+// 새 데이터는 createdAt을 사용하고, 구버전 메모는 `memo_${Date.now()}` ID에서
+// 생성 시각을 역산한다. 구버전 하이라이트/언더라인은 시각 정보가 없으므로
+// 저장 배열 순서를 생성순 정렬의 fallback으로 사용한다.
 function memoTimestamp(memo) {
+  const stored = memo && (memo.createdAt || memo.created_at)
+  if (stored) {
+    const d = new Date(stored)
+    if (!isNaN(d.getTime())) return d
+  }
   const m = /^memo_(\d+)/.exec(String((memo && memo.id) || ''))
   if (!m) return null
   const d = new Date(Number(m[1]))
+  return isNaN(d.getTime()) ? null : d
+}
+
+function annotationTimestamp(annotation) {
+  const stored = annotation && (annotation.createdAt || annotation.created_at)
+  if (!stored) return null
+  const d = new Date(stored)
   return isNaN(d.getTime()) ? null : d
 }
 
@@ -131,6 +142,7 @@ async function buildPaperEntry(doc) {
   const memoItems = []
   const highlightItems = []
   const underlineItems = []
+  let storageOrder = 0
 
   Object.keys(memosByPage).forEach(pageKey => {
     const pageNum = parseInt(pageKey.replace('page_', ''), 10)
@@ -139,7 +151,11 @@ async function buildPaperEntry(doc) {
       const ts = memoTimestamp(memo)
       const text = (memo.content && memo.content.trim()) || memo.sentenceText || '(내용 없음)'
       const color = MEMO_ACCENT_COLORS[memo.color] || null
-      memoItems.push({ kind: 'memo', docId: doc.id, page: pageNum, ts, text, color })
+      memoItems.push({
+        kind: 'memo', docId: doc.id, page: pageNum, ts, text, color,
+        memoId: memo.id || null,
+        storageOrder: storageOrder++,
+      })
     })
   })
 
@@ -147,16 +163,23 @@ async function buildPaperEntry(doc) {
     const pageNum = parseInt(pageKey.replace('page_', ''), 10)
     if (isNaN(pageNum)) return
     ;(annotationsByPage[pageKey] || []).forEach(ann => {
-      const item = { kind: ann.type, docId: doc.id, page: pageNum, ts: null, text: ann.text || '(내용 없음)', color: ann.color || null }
+      const item = {
+        kind: ann.type,
+        docId: doc.id,
+        page: pageNum,
+        ts: annotationTimestamp(ann),
+        text: ann.text || '(내용 없음)',
+        color: ann.color || null,
+        startOffset: ann.startOffset,
+        endOffset: ann.endOffset,
+        storageOrder: storageOrder++,
+      }
       if (ann.type === 'highlight') highlightItems.push(item)
       else if (ann.type === 'underline') underlineItems.push(item)
     })
   })
 
-  memoItems.sort((a, b) => (b.ts ? b.ts.getTime() : 0) - (a.ts ? a.ts.getTime() : 0))
-  highlightItems.sort((a, b) => a.page - b.page)
-  underlineItems.sort((a, b) => a.page - b.page)
-  const allItems = [...memoItems, ...highlightItems, ...underlineItems].sort((a, b) => a.page - b.page)
+  const allItems = [...memoItems, ...highlightItems, ...underlineItems]
 
   const meta = doc.metadata || {}
   const title = meta.title || doc.filename
@@ -431,8 +454,16 @@ function renderAnnotationCard(item) {
   const canExpand = item.text.trim().length > 220
   const tsHtml = item.ts ? `<span class="notes-card-ts">${escapeHtml(formatTs(item.ts))}</span>` : ''
   const style = item.color ? ` style="--notes-item-accent:${escapeHtml(item.color)}"` : ''
+  const targetData = [
+    `data-doc-id="${escapeHtml(item.docId)}"`,
+    `data-page="${item.page}"`,
+    `data-kind="${escapeHtml(item.kind)}"`,
+    item.memoId ? `data-memo-id="${escapeHtml(item.memoId)}"` : '',
+    Number.isInteger(item.startOffset) ? `data-start-offset="${item.startOffset}"` : '',
+    Number.isInteger(item.endOffset) ? `data-end-offset="${item.endOffset}"` : '',
+  ].filter(Boolean).join(' ')
   return `
-    <div class="notes-annotation-card notes-card-${item.kind} ${canExpand ? 'notes-card-collapsible' : ''}"${style} data-doc-id="${escapeHtml(item.docId)}">
+    <div class="notes-annotation-card notes-card-${item.kind} ${canExpand ? 'notes-card-collapsible' : ''}"${style} ${targetData} role="link" tabindex="0" aria-label="${item.page}페이지 ${escapeHtml(item.kind)} 위치로 이동">
       <div class="notes-card-top">
         <span class="notes-card-badge">${icon(iconName, 12)}p. ${item.page}</span>
         ${tsHtml}
@@ -443,13 +474,47 @@ function renderAnnotationCard(item) {
   `
 }
 
+function compareAnnotationItems(a, b) {
+  if (annotationSortMode === 'page-asc' || annotationSortMode === 'page-desc') {
+    const direction = annotationSortMode === 'page-asc' ? 1 : -1
+    return direction * (a.page - b.page) || a.storageOrder - b.storageOrder
+  }
+  const aTime = a.ts ? a.ts.getTime() : null
+  const bTime = b.ts ? b.ts.getTime() : null
+  if (aTime !== null && bTime !== null && aTime !== bTime) {
+    return annotationSortMode === 'newest' ? bTime - aTime : aTime - bTime
+  }
+  if (aTime !== null || bTime !== null) {
+    return annotationSortMode === 'newest' ? (aTime !== null ? -1 : 1) : (aTime !== null ? 1 : -1)
+  }
+  return annotationSortMode === 'newest' ? b.storageOrder - a.storageOrder : a.storageOrder - b.storageOrder
+}
+
+function renderAnnotationSortControl() {
+  return `
+    <div class="notes-annotation-toolbar">
+      <label for="notes-annotation-sort">주석 정렬</label>
+      <div class="notes-annotation-sort-box">
+        <select id="notes-annotation-sort" class="notes-annotation-sort-select" aria-label="주석 정렬 기준">
+          <option value="page-asc"${annotationSortMode === 'page-asc' ? ' selected' : ''}>페이지 오름차순</option>
+          <option value="page-desc"${annotationSortMode === 'page-desc' ? ' selected' : ''}>페이지 내림차순</option>
+          <option value="newest"${annotationSortMode === 'newest' ? ' selected' : ''}>최근 생성순</option>
+          <option value="oldest"${annotationSortMode === 'oldest' ? ' selected' : ''}>오래된 생성순</option>
+        </select>
+        <span class="notes-annotation-sort-icon">${icon('chevronDown', 12)}</span>
+      </div>
+    </div>
+  `
+}
+
 function renderTabContent(entry) {
   if (activeSubtab === 'summary') return renderSummaryTabContent(entry.doc.id)
   const items = entry.items[activeSubtab] || []
   if (items.length === 0) {
     return `<div class="notes-empty"><p>${EMPTY_MESSAGES[activeSubtab]}</p></div>`
   }
-  return `<div class="notes-card-list">${items.map(renderAnnotationCard).join('')}</div>`
+  const sortedItems = items.slice().sort(compareAnnotationItems)
+  return `${renderAnnotationSortControl()}<div class="notes-card-list">${sortedItems.map(renderAnnotationCard).join('')}</div>`
 }
 
 function renderDetail(root) {
@@ -573,6 +638,9 @@ function attachListeners(root) {
       return
     }
 
+    const annotationSortSelect = e.target.closest('.notes-annotation-sort-select')
+    if (annotationSortSelect) return
+
     // 카드 "더보기/접기" 토글 (뷰어 이동으로 전파되지 않도록 별도 처리)
     const expandBtn = e.target.closest('.notes-card-expand-btn')
     if (expandBtn) {
@@ -583,11 +651,10 @@ function attachListeners(root) {
       return
     }
 
-    // 주석 카드 클릭 → 뷰어에서 해당 논문 열기(뷰어 라우터는 정확한 페이지
-    // 이동을 위한 쿼리 파라미터를 지원하지 않아 문서까지만 이동한다)
+    // 주석 카드 클릭 → 문서/페이지와 저장된 정확한 앵커를 함께 전달한다.
     const card = e.target.closest('.notes-annotation-card')
     if (card && card.dataset.docId) {
-      location.hash = 'viewer?id=' + encodeURIComponent(card.dataset.docId)
+      openAnnotationInViewer(card)
       return
     }
 
@@ -597,6 +664,30 @@ function attachListeners(root) {
       location.hash = 'viewer?id=' + encodeURIComponent(openBtn.dataset.docId)
     }
   })
+
+  root.addEventListener('change', (e) => {
+    const select = e.target.closest('.notes-annotation-sort-select')
+    if (!select) return
+    annotationSortMode = select.value
+    renderDetail(root)
+  })
+
+  root.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    const card = e.target.closest('.notes-annotation-card')
+    if (!card || e.target.closest('button, select, a')) return
+    e.preventDefault()
+    openAnnotationInViewer(card)
+  })
+}
+
+function openAnnotationInViewer(card) {
+  const params = new URLSearchParams({ id: card.dataset.docId, page: card.dataset.page })
+  if (card.dataset.kind) params.set('kind', card.dataset.kind)
+  if (card.dataset.memoId) params.set('memoId', card.dataset.memoId)
+  if (card.dataset.startOffset) params.set('start', card.dataset.startOffset)
+  if (card.dataset.endOffset) params.set('end', card.dataset.endOffset)
+  location.hash = `viewer?${params.toString()}`
 }
 
 function shellHtml() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2219,6 +2219,16 @@ body.light-theme .pdf-annotation-underline {
   border-bottom: 2px solid rgba(220, 53, 69, 0.9);
 }
 
+@keyframes viewer-note-jump-pulse {
+  0%, 100% { outline-color: transparent; }
+  35% { outline-color: var(--control-accent); }
+}
+.viewer-note-jump-target {
+  outline: 3px solid transparent;
+  outline-offset: 3px;
+  animation: viewer-note-jump-pulse 0.6s ease-in-out 3;
+}
+
 /* ── 텍스트 선택 팝업 메뉴 리파인 ── */
 .selection-menu {
   position: absolute;

--- a/frontend/src/styles/notes.css
+++ b/frontend/src/styles/notes.css
@@ -331,6 +331,46 @@
   padding: 18px 22px 26px;
 }
 
+.notes-annotation-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.notes-annotation-toolbar label {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+.notes-annotation-sort-box { position: relative; }
+.notes-annotation-sort-select {
+  min-width: 138px;
+  padding: 6px 28px 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 11.5px;
+  cursor: pointer;
+  appearance: none;
+}
+.notes-annotation-sort-select:hover,
+.notes-annotation-sort-select:focus {
+  border-color: var(--control-accent);
+  color: var(--text-primary);
+}
+.notes-annotation-sort-icon {
+  position: absolute;
+  top: 50%;
+  right: 9px;
+  display: inline-flex;
+  color: var(--text-muted);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
 .notes-card-list {
   display: flex;
   flex-direction: column;
@@ -394,6 +434,15 @@
 .notes-card-text ol,
 .notes-card-text pre,
 .notes-card-text blockquote { margin: 0 0 0.55em; }
+.notes-card-text ul,
+.notes-card-text ol {
+  padding-inline-start: 1.55rem;
+}
+.notes-card-text li > ul,
+.notes-card-text li > ol {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
 .notes-card-text .katex-display { margin: 0.45em 0; overflow-x: auto; overflow-y: hidden; }
 .notes-card-text pre { overflow-x: auto; }
 .notes-card-expand-btn {

--- a/frontend/tests/e2e/notes-annotations.spec.js
+++ b/frontend/tests/e2e/notes-annotations.spec.js
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+const doc = {
+  id: 'doc-notes',
+  filename: 'notes.pdf',
+  total_pages: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  metadata: { title: 'Notes Paper', primer_shown: true },
+  translated_pages: [],
+}
+
+async function seedNotes(page) {
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_annotations_doc-notes', JSON.stringify({
+      page_3: [{ type: 'highlight', text: 'third page', startOffset: 20, endOffset: 30, color: '#eab308', createdAt: '2026-01-03T00:00:00Z' }],
+      page_1: [{ type: 'highlight', text: 'first page', startOffset: 0, endOffset: 10, color: '#eab308', createdAt: '2026-01-02T00:00:00Z' }],
+      page_2: [{ type: 'highlight', text: 'second page', startOffset: 10, endOffset: 20, color: '#eab308', createdAt: '2026-01-01T00:00:00Z' }],
+    }))
+    localStorage.setItem('easypaper_memos_doc-notes', JSON.stringify({
+      page_1: [{
+        id: 'memo_1767225600000', pageNum: 1, sentenceIdx: 0,
+        sentenceText: 'memo anchor', content: '- first item\n- second item',
+        charStart: 0, charEnd: 10, x: 20, y: 20,
+      }],
+    }))
+  })
+}
+
+async function cardTexts(page) {
+  const texts = await page.locator('.notes-annotation-card .notes-card-text').allTextContents()
+  return texts.map(text => text.trim())
+}
+
+test('Notes 주석을 페이지와 생성 시간 기준으로 정렬한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [doc] })
+  await gotoApp(page)
+  await seedNotes(page)
+  await page.click('.sidebar-nav-item[data-page="notes"]')
+  await page.click('.notes-tab-btn[data-subtab="highlight"]')
+
+  await expect(page.locator('.notes-annotation-sort-select')).toBeVisible()
+  expect(await cardTexts(page)).toEqual(['first page', 'second page', 'third page'])
+
+  await page.selectOption('.notes-annotation-sort-select', 'page-desc')
+  expect(await cardTexts(page)).toEqual(['third page', 'second page', 'first page'])
+
+  await page.selectOption('.notes-annotation-sort-select', 'newest')
+  expect(await cardTexts(page)).toEqual(['third page', 'first page', 'second page'])
+
+  await page.selectOption('.notes-annotation-sort-select', 'oldest')
+  expect(await cardTexts(page)).toEqual(['second page', 'first page', 'third page'])
+})
+
+test('Notes 카드가 정확한 뷰어 앵커를 hash에 전달하고 Markdown 리스트 여백을 유지한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [doc] })
+  await gotoApp(page)
+  await seedNotes(page)
+  await page.click('.sidebar-nav-item[data-page="notes"]')
+
+  await page.click('.notes-tab-btn[data-subtab="memo"]')
+  const list = page.locator('.notes-card-text ul')
+  await expect(list).toBeVisible()
+  expect(await list.evaluate(el => parseFloat(getComputedStyle(el).paddingInlineStart))).toBeGreaterThan(10)
+
+  const memoCard = page.locator('.notes-annotation-card').first()
+  await expect(memoCard).toHaveAttribute('data-page', '1')
+  await memoCard.click()
+  await expect.poll(() => page.evaluate(() => location.hash)).toContain('page=1')
+  await expect.poll(() => page.evaluate(() => location.hash)).toContain('memoId=memo_1767225600000')
+})
+
+test('Notes 하이라이트 클릭 시 뷰어의 저장 오프셋 위치를 강조한다', async ({ page }) => {
+  const viewerDoc = { ...doc, total_pages: 1 }
+  await mockBaseRoutes(page, { documents: [viewerDoc] })
+  await page.route('**/api/library/doc-notes/pdf', route => route.fulfill({
+    status: 200,
+    contentType: 'application/pdf',
+    body: SAMPLE_PDF_A,
+  }))
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_annotations_doc-notes', JSON.stringify({
+      page_1: [{ type: 'highlight', text: 'sample', startOffset: 0, endOffset: 6, color: '#eab308', createdAt: '2026-01-02T00:00:00Z' }],
+    }))
+  })
+  await page.click('.sidebar-nav-item[data-page="notes"]')
+  await page.click('.notes-tab-btn[data-subtab="highlight"]')
+  await page.locator('.notes-annotation-card').click()
+
+  await expect(page.locator('#viewer-screen')).toHaveClass(/active/)
+  await expect(page.locator('.pdf-annotation-highlight[data-start-offset="0"][data-end-offset="6"]')).toHaveClass(/viewer-note-jump-target/, { timeout: 10_000 })
+  await expect(page.locator('#page-input')).toHaveValue('1')
+})


### PR DESCRIPTION
# Summary
## 1. 메모/하이라이트/언더라인 위치 이동
- Notes 주석 카드에 문서, 페이지, 메모 ID 또는 텍스트 오프셋 앵커를 연결함
- 카드 클릭 및 키보드 실행 시 뷰어의 정확한 주석 위치로 이동하고 대상 강조 효과를 추가함
- 동일 문서가 이미 열린 상태에서도 선택한 주석 위치로 다시 이동하도록 라우터를 확장함
## 2. Notes 주석 정렬 기능
- 페이지 오름차순, 페이지 내림차순, 최근 생성순, 오래된 생성순 dropdown을 추가함
- 신규 메모/하이라이트/언더라인에 생성 시각을 저장하고 구버전 데이터 fallback 정렬을 지원함
## 3. Markdown 리스트 레이아웃 수정
- Notes 카드의 Markdown 불렛 및 번호 목록에 내부 여백을 적용해 카드 왼쪽 경계 침범을 수정함
- 정렬, hash 앵커 전달, Markdown 여백, 실제 뷰어 위치 이동 E2E 테스트를 추가함
