### PR TITLE
fix(viewer): stabilize and resize memos

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1050,10 +1050,36 @@ function replaceBoldOutsideCode(text) {
   return processedBlocks.join('')
 }
 
+const renderedTranslationContent = new WeakMap()
+
 function renderTransContent(pageNum, text, cached = false) {
   const contentEl = $(`trans-content-${pageNum}`)
   const statusEl  = $(`trans-status-${pageNum}`)
   if (!contentEl) return
+
+  // IntersectionObserver의 현재 페이지 콜백은 스크롤 중 노출 비율이 바뀔 때마다
+  // 여러 번 실행된다. 이미 같은 번역을 그린 상태에서 DOM을 다시 만들면 아래의
+  // 재세그멘테이션 경로가 메모 카드까지 제거/재생성해 메모가 깜빡이거나 편집
+  // 포커스를 잃는다. 캐시 배지만 제자리에서 동기화하고 기존 콘텐츠는 유지한다.
+  if (
+    renderedTranslationContent.has(contentEl) &&
+    renderedTranslationContent.get(contentEl) === text &&
+    contentEl.querySelector('.trans-text')
+  ) {
+    const badge = contentEl.querySelector('.cached-badge')
+    if (cached && !badge) {
+      const cachedBadge = document.createElement('div')
+      cachedBadge.className = 'cached-badge'
+      cachedBadge.textContent = '✓ 캐시'
+      contentEl.prepend(cachedBadge)
+    } else if (!cached && badge) {
+      badge.remove()
+    }
+    if (statusEl) { statusEl.textContent = '✓ 완료'; statusEl.classList.add('done') }
+    return
+  }
+
+  renderedTranslationContent.set(contentEl, text)
   contentEl.innerHTML = ''
   if (cached) {
     const badge = document.createElement('div')
@@ -9755,8 +9781,8 @@ function updateMemoConnectorLine(pageWrapper, memo) {
 
   const memoLeft = (memo.x / 100) * pageWrapper.offsetWidth
   const memoTop = (memo.y / 100) * pageWrapper.offsetHeight
-  const memoWidth = 260
   const memoEl = pageWrapper.querySelector(`.floating-memo[data-id="${memo.id}"]`)
+  const memoWidth = memoEl ? memoEl.offsetWidth : (memo.width || 260)
   const memoHeight = memoEl ? memoEl.offsetHeight : 160
 
   const memoCenterX = memoLeft + memoWidth / 2
@@ -9788,7 +9814,11 @@ function renderPageMemos(pageNum) {
   const pageWrapper = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`)
   if (!pageWrapper) return
 
-  pageWrapper.querySelectorAll('.floating-memo').forEach(el => el.remove())
+  pageWrapper.querySelectorAll('.floating-memo').forEach(el => {
+    el._memoResizeObserver?.disconnect()
+    if (el._memoResizeSaveTimer) clearTimeout(el._memoResizeSaveTimer)
+    el.remove()
+  })
   const svg = pageWrapper.querySelector('.memo-connector-svg')
   if (svg) svg.innerHTML = ''
   
@@ -9916,6 +9946,8 @@ function renderPageMemos(pageNum) {
     memoEl.setAttribute('data-id', memo.id)
     memoEl.style.left = `${memo.x}%`
     memoEl.style.top = `${memo.y}%`
+    if (Number.isFinite(memo.width)) memoEl.style.width = `${memo.width}px`
+    if (!memo.collapsed && Number.isFinite(memo.height)) memoEl.style.height = `${memo.height}px`
 
     let isEditing = !memo.content.trim()
 
@@ -10084,6 +10116,7 @@ function renderPageMemos(pageNum) {
       saveMemos(state.sessionId, allMemosObj)
 
       memoEl.classList.toggle('collapsed', memo.collapsed)
+      memoEl.style.height = memo.collapsed || !Number.isFinite(memo.height) ? '' : `${memo.height}px`
       collapseBtn.innerHTML = icon(memo.collapsed ? 'chevronDown' : 'chevronUp', 12)
       collapseBtn.title = memo.collapsed ? '메모 펼치기' : '메모 접기'
       setTimeout(() => updateMemoConnectorLine(pageWrapper, memo), 0)
@@ -10126,6 +10159,36 @@ function renderPageMemos(pageNum) {
     })
 
     pageWrapper.appendChild(memoEl)
+
+    // CSS 네이티브 resize를 사용하는 동안 연결선을 실시간으로 맞추고, 사용자가
+    // 놓은 최종 크기를 메모 데이터에 저장해 문서를 다시 열어도 복원한다.
+    if (window.ResizeObserver) {
+      let observedWidth = memoEl.offsetWidth
+      let observedHeight = memoEl.offsetHeight
+      const resizeObserver = new ResizeObserver(entries => {
+        const entry = entries[0]
+        if (!entry || memo.collapsed) return
+        const borderBox = entry.borderBoxSize?.[0]
+        const nextWidth = Math.round(borderBox?.inlineSize ?? memoEl.offsetWidth)
+        const nextHeight = Math.round(borderBox?.blockSize ?? memoEl.offsetHeight)
+        if (nextWidth === observedWidth && nextHeight === observedHeight) return
+        observedWidth = nextWidth
+        observedHeight = nextHeight
+        memo.width = nextWidth
+        memo.height = nextHeight
+        updateMemoConnectorLine(pageWrapper, memo)
+
+        if (memoEl._memoResizeSaveTimer) clearTimeout(memoEl._memoResizeSaveTimer)
+        memoEl._memoResizeSaveTimer = setTimeout(() => {
+          const allMemosObj = loadMemos(state.sessionId)
+          allMemosObj[`page_${pageNum}`] = pageMemos
+          saveMemos(state.sessionId, allMemosObj)
+          memoEl._memoResizeSaveTimer = null
+        }, 250)
+      })
+      memoEl._memoResizeObserver = resizeObserver
+      resizeObserver.observe(memoEl)
+    }
 
     const header = memoEl.querySelector('.floating-memo-header')
     header.addEventListener('mousedown', (e) => {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4920,7 +4920,10 @@ body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-red {
   position: absolute;
   z-index: 10000;
   width: 260px;
+  min-width: 220px;
+  max-width: min(640px, 90vw);
   min-height: 160px;
+  max-height: min(720px, 85vh);
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
@@ -4930,9 +4933,22 @@ body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-red {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  resize: both;
   font-family: var(--font-sans);
   color: var(--text-primary);
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.floating-memo::after {
+  content: '';
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--text-muted);
+  border-bottom: 2px solid var(--text-muted);
+  opacity: 0.65;
+  pointer-events: none;
 }
 body.light-theme .floating-memo {
   box-shadow: 0 3px 14px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.03);
@@ -5195,6 +5211,11 @@ body.light-theme .custom-confirm-modal {
    그대로 유지되어 헤더 아래에 빈 공간만 남는다. */
 .floating-memo.collapsed {
   min-height: 0;
+  max-height: none;
+  resize: none;
+}
+.floating-memo.collapsed::after {
+  display: none;
 }
 .floating-memo.collapsed .floating-memo-body {
   display: none;

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+async function openViewerWithMemo(page) {
+  const doc = {
+    id: 'doc-memo',
+    filename: 'Memo.pdf',
+    total_pages: 1,
+    metadata: { title: 'Memo document' },
+    translated_pages: [1],
+  }
+
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-memo/pdf', route => {
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A })
+  })
+  await page.route('**/api/library/doc-memo/translation/1**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        translation: 'Cached translation for the memo regression test.',
+        sentences: [],
+      }),
+    })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_hydrated_doc-memo', '1')
+    localStorage.setItem('easypaper_memos_doc-memo', JSON.stringify({
+      page_1: [{
+        id: 'memo-regression',
+        pageNum: 1,
+        sentenceIdx: 0,
+        sentenceText: 'memo anchor',
+        content: '메모 내용',
+        x: 10,
+        y: 10,
+      }],
+    }))
+    location.hash = '#viewer?id=doc-memo'
+  })
+
+  await expect(page.locator('.floating-memo[data-id="memo-regression"]')).toBeVisible()
+  await expect(page.locator('#trans-content-1 .trans-text')).toContainText('Cached translation')
+}
+
+test('스크롤 가시성 갱신 시 이미 렌더링된 메모 DOM을 유지한다', async ({ page }) => {
+  await openViewerWithMemo(page)
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.evaluate(el => { el.dataset.instanceMarker = 'original' })
+
+  await page.setViewportSize({ width: 1280, height: 500 })
+  await page.waitForTimeout(200)
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.waitForTimeout(300)
+
+  await expect(memo).toHaveAttribute('data-instance-marker', 'original')
+})
+
+test('사용자가 조절한 메모 크기를 저장하고 다시 복원한다', async ({ page }) => {
+  await openViewerWithMemo(page)
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.evaluate(el => {
+    el.style.width = '360px'
+    el.style.height = '280px'
+  })
+
+  await expect.poll(() => page.evaluate(() => {
+    const saved = JSON.parse(localStorage.getItem('easypaper_memos_doc-memo') || '{}')
+    const memoData = saved.page_1?.[0]
+    return { width: memoData?.width, height: memoData?.height }
+  })).toEqual({ width: 360, height: 280 })
+
+  await page.reload()
+  await expect(memo).toBeVisible()
+  await expect(memo).toHaveCSS('width', '360px')
+  await expect(memo).toHaveCSS('height', '280px')
+})


### PR DESCRIPTION
# Summary\n## 1. 뷰어 메모 스크롤 재렌더링 수정\n- 동일한 번역 콘텐츠의 중복 DOM 렌더링을 방지해 스크롤 시 메모 카드가 제거·재생성되는 현상 수정함\n- 기존 번역 및 메모 DOM을 유지하면서 캐시 배지와 완료 상태만 동기화하도록 수정함\n## 2. 뷰어 메모 크기 조절 기능 추가\n- 메모 우측 하단에서 너비와 높이를 직접 조절하는 기능 추가\n- 조절한 크기를 메모 데이터에 저장하고 문서 재진입 시 복원하도록 수정함\n- 메모 실제 크기를 연결선 계산에 반영하고 접힌 상태에서는 크기 조절을 비활성화함\n## 3. 회귀 테스트 추가\n- 페이지 가시성 갱신 후 메모 DOM 유지 여부 검증 추가\n- 사용자 지정 메모 크기의 저장 및 재로드 복원 검증 추가