### PR TITLE
feat: add scoped long-document translation

### DIFF
--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
@@ -20,6 +22,8 @@ class RestartJobRequest(BaseModel):
     ignore_math: bool = False
     ignore_table: bool = True
     ignore_refs: bool = False
+    page_numbers: Optional[list[int]] = None
+    resume_scope: bool = False
 
 
 @router.get("/jobs/{session_id}/status")
@@ -114,16 +118,25 @@ async def restart_translation_job(
     """주어진 옵션으로 번역 작업을 중단하고 새로 재시작합니다."""
     session = require_session_owner(session_id, current_user)
     pages = session["pages"]
-    
-    job = start_job(
-        session_id,
-        pages,
-        target_lang=data.target_lang,
-        style=data.style,
-        ignore_math=data.ignore_math,
-        ignore_table=data.ignore_table,
-        ignore_refs=data.ignore_refs
-    )
+    page_numbers = data.page_numbers
+    if data.resume_scope and page_numbers is None:
+        previous_job = get_job_status(session_id)
+        if previous_job:
+            page_numbers = previous_job.get("target_pages")
+
+    try:
+        job = start_job(
+            session_id,
+            pages,
+            target_lang=data.target_lang,
+            style=data.style,
+            ignore_math=data.ignore_math,
+            ignore_table=data.ignore_table,
+            ignore_refs=data.ignore_refs,
+            page_numbers=page_numbers,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"message": "번역 잡이 성공적으로 재시작되었습니다.", "job": job}
 
 

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -20,6 +20,7 @@ router = APIRouter()
 
 # 메모리 내 세션 저장소
 sessions: dict = {}
+LONG_DOCUMENT_PAGE_THRESHOLD = 50
 
 
 def ensure_session(session_id: str) -> bool:
@@ -204,7 +205,9 @@ async def upload_pdf(
 
     # translation_mode가 "auto"(기본값)가 아니면 - 페이지 번역 버튼을 누를 때(pane) 또는
     # 스크롤로 페이지를 볼 때(scroll)만 번역하길 원하는 사용자이므로 - 업로드
-    # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다. 이후
+    # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다.
+    # auto를 선택했더라도 50페이지 이상이면 긴 문서 보호 정책에 따라 전체 잡을
+    # 시작하지 않고, 프런트엔드가 실제로 본 페이지만 지연 번역한다. 이후
     # 번역은 프런트엔드가 /translate/{id}/{page}를 호출해 페이지별로 트리거한다.
     #
     # auto 번역 잡은 선택 기능인 읽기 전 브리핑에 의존하지 않도록
@@ -212,7 +215,7 @@ async def upload_pdf(
     # 멈춰도 job status가 404로 남지 않고 번역이 진행된다. 문서당 세션을
     # 재사용하는 CLI provider의 실제 LLM 호출은 llm_client의 세션 락이
     # 직렬화하므로 동시에 같은 세션을 쓰지 않는다.
-    if translation_mode == "auto":
+    if translation_mode == "auto" and len(pages) < LONG_DOCUMENT_PAGE_THRESHOLD:
         start_job(
             session_id,
             pages,

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -202,11 +202,10 @@ async def upload_pdf(
         "document_type": document_type,
     }
 
-    # translation_mode가 "auto"(기본값)가 아니면 - 번역 창을 펼칠 때(pane) 또는
+    # translation_mode가 "auto"(기본값)가 아니면 - 페이지 번역 버튼을 누를 때(pane) 또는
     # 스크롤로 페이지를 볼 때(scroll)만 번역하길 원하는 사용자이므로 - 업로드
     # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다. 이후
-    # 번역은 프런트엔드가 상황에 맞춰 /jobs/{id}/restart(pane) 또는
-    # /translate/{id}/{page}(scroll) 를 호출해 트리거한다.
+    # 번역은 프런트엔드가 /translate/{id}/{page}를 호출해 페이지별로 트리거한다.
     #
     # auto 번역 잡은 선택 기능인 읽기 전 브리핑에 의존하지 않도록
     # 업로드 응답 전에 즉시 등록한다. 이렇게 해야 primer LLM이 느리거나

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -64,13 +64,21 @@ def start_job(
     style: str = "academic",
     ignore_math: bool = False,
     ignore_table: bool = True,
-    ignore_refs: bool = False
+    ignore_refs: bool = False,
+    page_numbers: Optional[list[int]] = None,
 ) -> dict:
     """
     백그라운드 번역 잡을 시작합니다.
     이미 진행 중이거나 완료된 잡이 있으면 기존 상태를 반환합니다.
     """
     existing = _load_job(session_id)
+    available_pages = {page["page_num"] for page in pages}
+    target_pages = sorted(
+        available_pages if page_numbers is None
+        else available_pages.intersection(page_numbers)
+    )
+    if not target_pages:
+        raise ValueError("번역할 페이지가 없습니다.")
 
     # 이미 동일한 옵션으로 완료된 잡이면 재시작하지 않음
     if existing and existing.get("status") == "completed":
@@ -79,7 +87,8 @@ def start_job(
             opts.get("style") == style and
             opts.get("ignore_math") == ignore_math and
             opts.get("ignore_table") == ignore_table and
-            opts.get("ignore_refs") == ignore_refs):
+            opts.get("ignore_refs") == ignore_refs and
+            existing.get("target_pages", sorted(available_pages)) == target_pages):
             return existing
 
     # 아직 실행 중인 태스크가 있으면 먼저 취소(Restart 대응)
@@ -90,7 +99,8 @@ def start_job(
     job = {
         "session_id": session_id,
         "status": "running",
-        "total_pages": len(pages),
+        "total_pages": len(target_pages),
+        "target_pages": target_pages,
         "completed_pages": [],
         "failed_pages": [],
         "options": {
@@ -173,6 +183,9 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
         ignore_math, ignore_table, ignore_refs,
     )
     suffix = suffix_candidates[0]
+    target_page_numbers = set(job.get("target_pages") or [page["page_num"] for page in pages])
+    job_pages = [page for page in pages if page["page_num"] in target_page_numbers]
+    job["target_pages"] = sorted(target_page_numbers)
 
     # vision을 지원하는 provider면 페이지별로 원본 이미지를 함께 보내 수식(LaTeX)
     # 재현 정확도를 높인다 - ignore_math면 애초에 수식을 생략하므로 렌더링하지 않는다.
@@ -180,7 +193,7 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
 
     # 이미 완료된 페이지들을 루프 돌기 전 한 번에 스캔하여 저장
     scanned_any = False
-    for page_data in pages:
+    for page_data in job_pages:
         page_num = page_data["page_num"]
         cached = None
         cached_suffix = suffix
@@ -210,7 +223,7 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
         _save_job(session_id, job)
 
     try:
-        for page_data in pages:
+        for page_data in job_pages:
             page_num = page_data["page_num"]
 
             # 이미 완료된 페이지는 스킵 (동일 옵션의 영구 저장 확인)
@@ -286,12 +299,18 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
         job["completed_at"] = datetime.now(timezone.utc).isoformat()
         _save_job(session_id, job)
 
-        # 전체 MD 파일 생성
-        _build_full_md(session_id, pages, suffix)
+        # 범위 잡이 문서의 마지막 미번역 구간까지 채운 경우에만 전체 산출물과
+        # 연구 후처리를 생성한다. 부분 범위 완료를 전체 문서 완료로 오인하지 않는다.
+        all_pages_completed = all(
+            get_translation(session_id, page["page_num"], suffix, fallback=False) is not None
+            for page in pages
+        )
+        if all_pages_completed:
+            _build_full_md(session_id, pages, suffix)
 
         # 학술 태그와 지식 그래프는 연구 문서 전용 후처리다. 일반 문서에는
         # 연구 분류·인용 관계를 억지로 생성하지 않고 번역 완료로 끝낸다.
-        if document_mode == "research":
+        if document_mode == "research" and all_pages_completed:
             try:
                 from services.paper_tags import classify_and_store_paper_tags
                 paper_tags = await classify_and_store_paper_tags(

--- a/backend/tests/test_translation_job_scopes.py
+++ b/backend/tests/test_translation_job_scopes.py
@@ -1,0 +1,86 @@
+import routers.jobs as jobs_module
+import routers.upload as upload_module
+
+
+def _session(page_count=5):
+    return {
+        "pages": [{"page_num": page, "text": f"page {page}"} for page in range(1, page_count + 1)],
+        "username": "testuser",
+        "total_pages": page_count,
+    }
+
+
+def test_restart_job_accepts_explicit_page_scope(test_client, monkeypatch):
+    session_id = "scope-explicit"
+    upload_module.sessions[session_id] = _session()
+    captured = {}
+
+    def fake_start_job(*args, **kwargs):
+        captured.update(kwargs)
+        return {"status": "running", "target_pages": kwargs["page_numbers"]}
+
+    monkeypatch.setattr(jobs_module, "start_job", fake_start_job)
+    try:
+        response = test_client.post(
+            f"/api/jobs/{session_id}/restart",
+            json={"page_numbers": [2, 3, 4]},
+        )
+    finally:
+        upload_module.sessions.pop(session_id, None)
+
+    assert response.status_code == 200
+    assert captured["page_numbers"] == [2, 3, 4]
+
+
+def test_restart_job_resumes_previous_page_scope(test_client, monkeypatch):
+    session_id = "scope-resume"
+    upload_module.sessions[session_id] = _session()
+    captured = {}
+
+    monkeypatch.setattr(
+        jobs_module, "get_job_status",
+        lambda _session_id: {"status": "cancelled", "target_pages": [3, 4, 5]},
+    )
+
+    def fake_start_job(*args, **kwargs):
+        captured.update(kwargs)
+        return {"status": "running", "target_pages": kwargs["page_numbers"]}
+
+    monkeypatch.setattr(jobs_module, "start_job", fake_start_job)
+    try:
+        response = test_client.post(
+            f"/api/jobs/{session_id}/restart",
+            json={"resume_scope": True},
+        )
+    finally:
+        upload_module.sessions.pop(session_id, None)
+
+    assert response.status_code == 200
+    assert captured["page_numbers"] == [3, 4, 5]
+
+
+def test_start_job_persists_only_requested_pages(monkeypatch):
+    from services import translation_job
+
+    saved = {}
+
+    class DummyTask:
+        def cancel(self):
+            return None
+
+    def fake_create_task(coro):
+        coro.close()
+        return DummyTask()
+
+    monkeypatch.setattr(translation_job, "_load_job", lambda _session_id: None)
+    monkeypatch.setattr(translation_job, "_save_job", lambda _session_id, job: saved.update(job))
+    monkeypatch.setattr(translation_job.asyncio, "create_task", fake_create_task)
+    translation_job._running_tasks.clear()
+
+    pages = [{"page_num": page, "text": str(page)} for page in range(1, 6)]
+    job = translation_job.start_job("scope-service", pages, page_numbers=[2, 4, 99])
+
+    assert job["target_pages"] == [2, 4]
+    assert job["total_pages"] == 2
+    assert saved["target_pages"] == [2, 4]
+    translation_job._running_tasks.clear()

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -78,3 +78,35 @@ def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, m
     assert res.status_code == 200
     assert events
     assert events[0] == "translation"
+
+
+def test_auto_translation_skips_full_job_at_fifty_pages(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
+    monkeypatch.setattr(
+        upload_module, "extract_pages",
+        lambda _path: [{"page_num": page, "text": ""} for page in range(1, 51)],
+    )
+
+    starts = []
+
+    def fake_start_job(*args, **kwargs):
+        starts.append((args, kwargs))
+        return {"status": "running"}
+
+    async def fake_generate_primer(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(upload_module, "start_job", fake_start_job)
+    monkeypatch.setattr(upload_module, "generate_primer", fake_generate_primer)
+
+    response = test_client.post(
+        "/api/upload?translation_mode=auto",
+        files={"file": ("long.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["total_pages"] == 50
+    assert starts == []
+    upload_module.sessions.pop(response.json()["session_id"], None)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -481,9 +481,13 @@
 
             <div class="kebab-menu-divider"></div>
 
+            <button id="translation-scope-btn" class="kebab-menu-item" title="번역할 페이지 범위 선택">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 6h13"/><path d="M8 12h13"/><path d="M8 18h13"/><path d="M3 6h.01"/><path d="M3 12h.01"/><path d="M3 18h.01"/></svg>
+              <span>번역 범위 선택</span>
+            </button>
             <button id="retranslate-btn" class="kebab-menu-item" title="처음부터 다시 번역하기">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-              <span>처음부터 다시 번역하기</span>
+              <span>문서 전체 재번역</span>
             </button>
             <button id="cancel-trans-btn" class="kebab-menu-item hidden" title="번역 작업 중지" style="color: var(--error);">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
@@ -860,8 +864,9 @@
           
           <div class="form-group">
             <label for="setting-translation-mode">번역 모드</label>
+            <small id="setting-translation-mode-scope" class="setting-scope-hint"></small>
             <select id="setting-translation-mode" class="form-select">
-              <option value="auto">업로드 시 자동 번역 (기본)</option>
+              <option value="auto">업로드 시 자동 번역 (50페이지 미만)</option>
               <option value="pane">번역 버튼으로 한 페이지씩 번역</option>
               <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
             </select>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -862,7 +862,7 @@
             <label for="setting-translation-mode">번역 모드</label>
             <select id="setting-translation-mode" class="form-select">
               <option value="auto">업로드 시 자동 번역 (기본)</option>
-              <option value="pane">번역 창을 펼칠 때만 번역</option>
+              <option value="pane">번역 버튼으로 한 페이지씩 번역</option>
               <option value="scroll">스크롤로 페이지를 볼 때 번역</option>
             </select>
           </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -401,7 +401,9 @@ export async function restartJobAPI(sessionId, options) {
       style: options.style,
       ignore_math: options.ignoreMath,
       ignore_table: options.ignoreTable,
-      ignore_refs: options.ignoreRefs
+      ignore_refs: options.ignoreRefs,
+      page_numbers: options.pageNumbers,
+      resume_scope: options.resumeScope || false,
     })
   })
   if (!res.ok) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -192,6 +192,8 @@ const tabPanes          = document.querySelectorAll('.tab-pane')
 const settingTargetLang   = $('setting-target-lang')
 const settingTransStyle   = $('setting-trans-style')
 const settingTranslationMode = $('setting-translation-mode')
+const settingTranslationModeScope = $('setting-translation-mode-scope')
+let settingsTranslationModeContext = 'research'
 const settingIgnoreMath   = $('setting-ignore-math')
 const settingIgnoreTable  = $('setting-ignore-table')
 const settingIgnoreRefs   = $('setting-ignore-refs')
@@ -310,6 +312,9 @@ const workspaceModeController = createWorkspaceModeController({
 
     const incoming = workspaceLibraryState[mode]
     lastWorkspaceMode = mode
+    if (settingsModal && !settingsModal.classList.contains('hidden')) {
+      syncTranslationModeSetting(mode)
+    }
     state.currentLibraryTab = incoming.tab
     activeCategoryFilter = incoming.category
     activeStatusFilter = incoming.status
@@ -375,6 +380,7 @@ const zoomLabel         = $('zoom-level')
 const syncScrollBtn     = $('sync-scroll-btn')
 const exportBtn         = $('export-btn')
 const memosHideAllBtn   = $('memos-hide-all-btn')
+const translationScopeBtn = $('translation-scope-btn')
 const retranslateBtn    = $('retranslate-btn')
 const captureAreaBtn    = $('capture-area-btn')
 const cancelTransBtn    = $('cancel-trans-btn')
@@ -530,12 +536,52 @@ function applyToolbarPosition(pos) {
 }
 applyToolbarPosition(getToolbarPosition())
 
-// 번역 모드: 'auto'(업로드 시 전체 자동 번역, 기본값) / 'pane'(사용자가 번역 버튼을
-// 눌러 한 페이지씩 번역) / 'scroll'(스크롤로 페이지가 보일 때마다 그 페이지만 번역). 대상 언어/문체와
-// 달리 캐시 접미사에 영향을 주지 않는 "언제 번역할지"만 다루는 옵션이라
-// getTranslationOptions()와는 별도로 관리한다.
-function getTranslationMode() {
-  return localStorage.getItem('easypaper_translation_mode') || 'auto'
+const LONG_DOCUMENT_PAGE_THRESHOLD = 50
+
+// 번역 모드는 연구/일반 문서 워크스페이스별로 독립 저장한다. 기존 전역 키는
+// 업그레이드 직후 두 모드의 초기값으로만 읽어 사용자 설정을 보존한다.
+function translationModeStorageKey(documentMode) {
+  const normalizedMode = documentMode === 'general' ? 'general' : 'research'
+  return `easypaper_translation_mode_${normalizedMode}`
+}
+
+function getTranslationMode(documentMode = null) {
+  const activeMode = documentMode || (state.sessionId ? state.currentDocumentMode : document.body.dataset.workspaceMode) || 'research'
+  return localStorage.getItem(translationModeStorageKey(activeMode))
+    || localStorage.getItem('easypaper_translation_mode')
+    || 'auto'
+}
+
+function isLongDocument(totalPages = state.totalPages) {
+  return Number(totalPages) >= LONG_DOCUMENT_PAGE_THRESHOLD
+}
+
+function getEffectiveTranslationMode(documentMode = state.currentDocumentMode, totalPages = state.totalPages) {
+  const configuredMode = getTranslationMode(documentMode)
+  return configuredMode === 'auto' && isLongDocument(totalPages) ? 'scroll' : configuredMode
+}
+
+function getTranslationPlaceholderHtml(pageNum) {
+  if (getEffectiveTranslationMode() === 'pane') {
+    return `<div class="manual-translation-prompt">
+      <span>필요한 페이지만 직접 번역할 수 있습니다.</span>
+      <button type="button" class="translate-page-btn" data-page="${pageNum}">이 페이지 번역하기</button>
+    </div>`
+  }
+  const message = isLongDocument()
+    ? '페이지를 잠시 보고 있으면 자동으로 번역됩니다'
+    : '스크롤하면 자동으로 번역됩니다'
+  return `<div class="trans-page-placeholder">${message}</div>`
+}
+
+function syncTranslationModeSetting(documentMode) {
+  settingsTranslationModeContext = documentMode === 'general' ? 'general' : 'research'
+  settingTranslationMode.value = getTranslationMode(settingsTranslationModeContext)
+  if (settingTranslationModeScope) {
+    settingTranslationModeScope.textContent = settingsTranslationModeContext === 'general'
+      ? '일반 문서 모드에만 적용'
+      : '연구 모드에만 적용'
+  }
 }
 
 // ── 토스트 ────────────────────────────────────────
@@ -682,7 +728,7 @@ async function handleFiles(files, targetFolderId = null, classification = null) 
       const result = await uploadPDF(file, {
         ...getTranslationOptions(),
         ...rememberedTypeOptions,
-        translationMode: getTranslationMode(),
+        translationMode: getTranslationMode(classification?.documentMode || workspaceModeController.getMode()),
         keywordMode: getKeywordMode(),
         summaryMode: getSummaryMode(),
         documentMode: classification?.documentMode || workspaceModeController.getMode(),
@@ -699,6 +745,13 @@ async function handleFiles(files, targetFolderId = null, classification = null) 
       lastFilename = result.filename
       lastTotalPages = result.total_pages
       lastTitle = (result.metadata && result.metadata.title) ? result.metadata.title : result.filename
+      const uploadedDocumentMode = classification?.documentMode || workspaceModeController.getMode()
+      if (isLongDocument(result.total_pages) && getTranslationMode(uploadedDocumentMode) === 'auto') {
+        showToast(
+          '50페이지 이상 문서는 전체 자동 번역 대신 보는 페이지부터 번역됩니다.',
+          'info',
+        )
+      }
       successCount++
       if (result.document_mode === 'general' && getKeywordMode() === 'auto' && result.total_pages > 20) {
         const estimate = await estimateInsightJobAPI(result.session_id, 'keywords', getTranslationOptions().targetLang)
@@ -800,9 +853,38 @@ function createPagePair(pageNum) {
   return pair
 }
 
+const visibleTranslationTimers = new Map()
+
+function scheduleVisiblePageTranslation(pageNum) {
+  const previousTimer = visibleTranslationTimers.get(pageNum)
+  if (previousTimer) clearTimeout(previousTimer)
+
+  if (!isLongDocument()) {
+    translatePage(pageNum)
+    return
+  }
+
+  const sessionId = state.sessionId
+  const timer = setTimeout(() => {
+    visibleTranslationTimers.delete(pageNum)
+    if (state.sessionId !== sessionId || state.translatedPages.has(pageNum)) return
+
+    const pagePair = viewerScrollContainer.querySelector(`.page-pair[data-page="${pageNum}"]`)
+    if (!pagePair) return
+    const pageRect = pagePair.getBoundingClientRect()
+    const viewportRect = viewerScrollContainer.getBoundingClientRect()
+    const visibleHeight = Math.max(0, Math.min(pageRect.bottom, viewportRect.bottom) - Math.max(pageRect.top, viewportRect.top))
+    const visibilityRatio = visibleHeight / Math.max(1, Math.min(pageRect.height, viewportRect.height))
+    if (visibilityRatio >= 0.5) translatePage(pageNum)
+  }, 800)
+  visibleTranslationTimers.set(pageNum, timer)
+}
+
 // ── 스크롤 뷰어 초기화 ────────────────────────────
 async function initScrollViewer() {
   viewerScrollContainer.innerHTML = ''
+  visibleTranslationTimers.forEach(timer => clearTimeout(timer))
+  visibleTranslationTimers.clear()
 
   if (state.sessionId) {
     readingTimeActivityTracker.reset('reading')
@@ -872,10 +954,10 @@ async function initScrollViewer() {
           // 않도록, 이미 그려진 문장 분할 기준으로 메모를 다시 그려준다.
           renderPageMemos(pageNum)
         }
-      } else if (getTranslationMode() === 'scroll') {
+      } else if (getEffectiveTranslationMode() === 'scroll') {
         // 번역 모드가 'scroll'이면 전체 문서 백그라운드 잡이 아예 시작되지
         // 않으므로, 스크롤로 보이게 된 페이지를 그때그때 개별 번역한다.
-        translatePage(pageNum)
+        scheduleVisiblePageTranslation(pageNum)
       }
 
       // 비동기 다음 페이지 번역 프리페칭 및 미리 렌더링
@@ -897,7 +979,7 @@ async function initScrollViewer() {
               renderPageMemos(nextPage)
             }
           })
-        } else if (getTranslationMode() === 'scroll') {
+        } else if (getEffectiveTranslationMode() === 'scroll' && !isLongDocument()) {
           // 다음 페이지도 미리 번역해둬 스크롤이 도착했을 때 바로 보이게 한다.
           translatePage(nextPage)
         }
@@ -924,12 +1006,7 @@ function createTransBlock(pageNum) {
   const rightChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>`
   const chevron = isTransPaneCollapsed ? rightChevron : leftChevron
   const btnTitle = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
-  const translationPlaceholder = getTranslationMode() === 'pane'
-    ? `<div class="manual-translation-prompt">
-        <span>필요한 페이지만 직접 번역할 수 있습니다.</span>
-        <button type="button" class="translate-page-btn" data-page="${pageNum}">이 페이지 번역하기</button>
-      </div>`
-    : '<div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>'
+  const translationPlaceholder = getTranslationPlaceholderHtml(pageNum)
 
   block.innerHTML = `
     <div class="trans-page-label">
@@ -1331,7 +1408,7 @@ function startJobPolling(sessionId) {
         }
       }
 
-      const done  = state.translatedPages.size
+      const done  = (job.completed_pages || []).length
       const total = job.total_pages || state.totalPages
       const isRunning = job.status === 'running' || job.status === 'pending'
       updateProgressMiniRaw(done, total, isRunning)
@@ -1685,6 +1762,113 @@ if (viewerClearCacheBtn) {
   })
 }
 
+function showTranslationScopeDialog() {
+  return new Promise(resolve => {
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `
+      <div class="custom-confirm-modal translation-scope-modal">
+        <div class="custom-confirm-modal-header">
+          <span class="custom-confirm-modal-title">번역 범위 선택</span>
+        </div>
+        <div class="custom-confirm-modal-body">필요한 범위만 선택해 번역할 수 있습니다.</div>
+        <div class="translation-scope-options">
+          <button data-scope="current"><strong>현재 페이지</strong><span>${state.currentPage}페이지 한 장만 번역</span></button>
+          <button data-scope="remaining"><strong>남은 페이지</strong><span>${state.currentPage}–${state.totalPages}페이지 번역</span></button>
+          <button data-scope="range"><strong>페이지 범위</strong><span>시작·끝 페이지를 직접 지정</span></button>
+          <button data-scope="all"><strong>문서 전체</strong><span>1–${state.totalPages}페이지 번역</span></button>
+        </div>
+        <div class="custom-confirm-modal-footer">
+          <button class="custom-confirm-btn cancel-btn">취소</button>
+        </div>
+      </div>`
+    document.body.appendChild(modal)
+
+    const close = value => {
+      modal.classList.remove('active')
+      setTimeout(() => { modal.remove(); resolve(value) }, 200)
+    }
+    modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
+    modal.querySelectorAll('[data-scope]').forEach(button => {
+      button.addEventListener('click', () => close(button.dataset.scope))
+    })
+    modal.addEventListener('click', event => { if (event.target === modal) close(null) })
+    setTimeout(() => modal.classList.add('active'), 10)
+  })
+}
+
+function parseTranslationPageRange(value) {
+  const match = String(value || '').match(/^\s*(\d+)\s*[-~]\s*(\d+)\s*$/)
+  if (!match) return null
+  const startPage = Number.parseInt(match[1], 10)
+  const endPage = Number.parseInt(match[2], 10)
+  if (startPage < 1 || endPage < startPage || endPage > state.totalPages) return null
+  return Array.from({ length: endPage - startPage + 1 }, (_, index) => startPage + index)
+}
+
+async function startScopedTranslation(pageNumbers, label) {
+  const pendingPages = pageNumbers.filter(pageNum => !state.translatedPages.has(pageNum))
+  if (pendingPages.length === 0) {
+    showToast('선택한 범위는 이미 번역되었습니다.', 'info')
+    return
+  }
+
+  if (pendingPages.length >= LONG_DOCUMENT_PAGE_THRESHOLD) {
+    const confirmed = await showCustomConfirm(
+      `${label} ${pendingPages.length}페이지를 백그라운드에서 번역합니다. 계속하시겠습니까?\n작업은 언제든 중지하고 같은 범위부터 재개할 수 있습니다.`,
+      { title: '긴 문서 번역', confirmText: '번역 시작', danger: false },
+    )
+    if (!confirmed) return
+  }
+
+  try {
+    showToast(`${label} 번역 작업을 시작합니다.`, 'info')
+    await restartJobAPI(state.sessionId, { ...getTranslationOptions(), pageNumbers: pendingPages })
+    startJobPolling(state.sessionId)
+    showToast(`${label} 번역이 시작되었습니다.`, 'success')
+  } catch (err) {
+    showToast(err.message || '번역 작업 시작 실패', 'error')
+  }
+}
+
+translationScopeBtn?.addEventListener('click', async () => {
+  toolbarKebabMenu?.classList.add('hidden')
+  if (!state.sessionId) return
+  const scope = await showTranslationScopeDialog()
+  if (!scope) return
+
+  if (scope === 'current') {
+    translatePage(state.currentPage)
+    return
+  }
+
+  let pageNumbers
+  let label = '선택 범위'
+  if (scope === 'remaining') {
+    pageNumbers = Array.from({ length: state.totalPages - state.currentPage + 1 }, (_, index) => state.currentPage + index)
+    label = '남은 페이지'
+  } else if (scope === 'range') {
+    const rawRange = await showCustomTextDialog({
+      title: '페이지 범위 번역',
+      label: `번역 범위 (예: 10-25, 전체 ${state.totalPages}페이지)`,
+      value: `${state.currentPage}-${Math.min(state.currentPage + 9, state.totalPages)}`,
+      confirmText: '범위 선택',
+    })
+    if (!rawRange) return
+    pageNumbers = parseTranslationPageRange(rawRange)
+    if (!pageNumbers) {
+      showToast(`1-${state.totalPages} 사이의 올바른 범위를 입력해주세요.`, 'error')
+      return
+    }
+    label = `${pageNumbers[0]}-${pageNumbers.at(-1)}페이지`
+  } else {
+    pageNumbers = Array.from({ length: state.totalPages }, (_, index) => index + 1)
+    label = '문서 전체'
+  }
+
+  await startScopedTranslation(pageNumbers, label)
+})
+
 // ── 다시 번역하기 ──────────────────────────────────
 
 retranslateBtn.addEventListener('click', async () => {
@@ -1703,7 +1887,7 @@ retranslateBtn.addEventListener('click', async () => {
       const contentEl = $(`trans-content-${i}`)
       const statusEl = $(`trans-status-${i}`)
       if (contentEl) {
-        contentEl.innerHTML = '<div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>'
+        contentEl.innerHTML = getTranslationPlaceholderHtml(i)
       }
       if (statusEl) {
         statusEl.textContent = '대기 중'
@@ -1762,7 +1946,7 @@ resumeTransBtn.addEventListener('click', async () => {
 
   try {
     showToast('중단된 지점부터 번역을 재개하는 중...', 'info')
-    await restartJobAPI(state.sessionId, getTranslationOptions())
+    await restartJobAPI(state.sessionId, { ...getTranslationOptions(), resumeScope: true })
     startJobPolling(state.sessionId)
     showToast('번역이 이어서 재개되었습니다.', 'success')
   } catch (err) {
@@ -3201,7 +3385,7 @@ globalSettingsBtn.addEventListener('click', async () => {
   // 2. 일반 설정값 로드
   settingTargetLang.value = localStorage.getItem('easypaper_target_lang') || '한국어'
   settingTransStyle.value = localStorage.getItem('easypaper_style') || 'academic'
-  settingTranslationMode.value = getTranslationMode()
+  syncTranslationModeSetting(workspaceModeController.getMode())
   settingIgnoreMath.checked = localStorage.getItem('easypaper_ignore_math') === 'true'
   settingIgnoreTable.checked = localStorage.getItem('easypaper_ignore_table') !== 'false'
   settingIgnoreRefs.checked = localStorage.getItem('easypaper_ignore_refs') === 'true'
@@ -3401,7 +3585,7 @@ document.querySelectorAll('.recommend-model-btn').forEach(btn => {
 function persistGeneralSettingsToStorage() {
   localStorage.setItem('easypaper_target_lang', settingTargetLang.value)
   localStorage.setItem('easypaper_style', settingTransStyle.value)
-  localStorage.setItem('easypaper_translation_mode', settingTranslationMode.value)
+  localStorage.setItem(translationModeStorageKey(settingsTranslationModeContext), settingTranslationMode.value)
   localStorage.setItem('easypaper_keyword_mode', settingAutoGenerateKeywords.checked ? 'auto' : 'manual')
   localStorage.setItem('easypaper_summary_mode', settingAutoGenerateSummaries.checked ? 'auto' : 'manual')
   localStorage.setItem('easypaper_ignore_math', settingIgnoreMath.checked)
@@ -3430,7 +3614,7 @@ async function handleTranslationAffectingSettingChange() {
         const contentEl = $(`trans-content-${i}`)
         const statusEl = $(`trans-status-${i}`)
         if (contentEl) {
-          contentEl.innerHTML = '<div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>'
+          contentEl.innerHTML = getTranslationPlaceholderHtml(i)
         }
         if (statusEl) {
           statusEl.textContent = '대기 중'

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -530,8 +530,8 @@ function applyToolbarPosition(pos) {
 }
 applyToolbarPosition(getToolbarPosition())
 
-// 번역 모드: 'auto'(업로드 시 전체 자동 번역, 기본값) / 'pane'(번역 창을 펼칠 때만
-// 시작) / 'scroll'(스크롤로 페이지가 보일 때마다 그 페이지만 번역). 대상 언어/문체와
+// 번역 모드: 'auto'(업로드 시 전체 자동 번역, 기본값) / 'pane'(사용자가 번역 버튼을
+// 눌러 한 페이지씩 번역) / 'scroll'(스크롤로 페이지가 보일 때마다 그 페이지만 번역). 대상 언어/문체와
 // 달리 캐시 접미사에 영향을 주지 않는 "언제 번역할지"만 다루는 옵션이라
 // getTranslationOptions()와는 별도로 관리한다.
 function getTranslationMode() {
@@ -800,23 +800,6 @@ function createPagePair(pageNum) {
   return pair
 }
 
-// 번역 모드가 'pane'일 때, 번역 창이 펼쳐진 시점에 전체 문서 백그라운드 번역
-// 잡을 시작한다. 이미 잡이 있으면(과거에 시작되었거나 완료됨) 아무 것도 하지
-// 않는다 - start_job은 동일 옵션으로 이미 완료된 잡이면 재시작하지 않고,
-// 실행 중인 잡을 다시 시작해도 캐시된 페이지는 건너뛰므로 여러 번 호출돼도
-// 안전하지만, 불필요한 네트워크 호출을 줄이기 위해 잡 존재 여부를 먼저 확인한다.
-async function ensureTranslationJobStarted() {
-  if (!state.sessionId) return
-  try {
-    const job = await getJobStatus(state.sessionId)
-    if (!job) {
-      await restartJobAPI(state.sessionId, getTranslationOptions())
-    }
-  } catch (err) {
-    console.warn('번역 잡 시작 확인 실패:', err)
-  }
-}
-
 // ── 스크롤 뷰어 초기화 ────────────────────────────
 async function initScrollViewer() {
   viewerScrollContainer.innerHTML = ''
@@ -922,14 +905,6 @@ async function initScrollViewer() {
     }
   })
 
-  // 번역 모드가 'pane'이고 번역 창이 이미 펼쳐진 상태로 문서를 열었다면,
-  // (예: 이전에 펼친 채로 남겨둔 경우) 폴링을 시작하기 전에 전체 문서 번역
-  // 잡을 지금 시작해둔다. 접힌 채로 열었다면 아래 trans-collapse-btn
-  // 클릭 핸들러가 나중에 펼칠 때 시작한다.
-  if (getTranslationMode() === 'pane' && !isTransPaneCollapsed) {
-    ensureTranslationJobStarted()
-  }
-
   // 백그라운드 잡 폴링 시작
   startJobPolling(state.sessionId)
 }
@@ -949,6 +924,12 @@ function createTransBlock(pageNum) {
   const rightChevron = `<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>`
   const chevron = isTransPaneCollapsed ? rightChevron : leftChevron
   const btnTitle = isTransPaneCollapsed ? '번역 창 펴기' : '번역 창 접기'
+  const translationPlaceholder = getTranslationMode() === 'pane'
+    ? `<div class="manual-translation-prompt">
+        <span>필요한 페이지만 직접 번역할 수 있습니다.</span>
+        <button type="button" class="translate-page-btn" data-page="${pageNum}">이 페이지 번역하기</button>
+      </div>`
+    : '<div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>'
 
   block.innerHTML = `
     <div class="trans-page-label">
@@ -962,7 +943,7 @@ function createTransBlock(pageNum) {
       <button class="trans-tab-refresh-btn insight-tab-btn hidden" title="다시 생성">${icon('refreshCw', 12)}</button>
     </div>
     <div class="trans-page-content" id="trans-content-${pageNum}">
-      <div class="trans-page-placeholder">스크롤하면 자동으로 번역됩니다</div>
+      ${translationPlaceholder}
     </div>
     <div class="trans-insight-content hidden" id="keywords-content-${pageNum}"></div>
     <div class="trans-insight-content hidden" id="summary-content-${pageNum}"></div>
@@ -1120,8 +1101,8 @@ function renderInsightContent(contentEl, kind, text) {
 }
 
 // ── 페이지 번역 ───────────────────────────────────
-// 번역 모드가 'scroll'일 때 - 전체 문서 백그라운드 잡이 돌고 있지 않으므로 -
-// 스크롤로 보이게 된 페이지 하나만 그 자리에서 즉시 번역한다(/translate/{id}/{page}
+// 번역 모드가 'scroll'이거나 'pane'에서 사용자가 버튼을 눌렀을 때, 페이지 하나를
+// 그 자리에서 즉시 번역한다(/translate/{id}/{page}
 // SSE 엔드포인트, 캐시가 있으면 즉시 반환). 완료되면 job-polling 경로와 동일하게
 // state.translatedPages/translationCache/translationSentences를 채워 이후
 // 다시 방문했을 때는 재번역 없이 캐시를 바로 쓴다.
@@ -15567,8 +15548,16 @@ document.addEventListener('mouseup', () => {
 
 window.addEventListener('resize', triggerMemosRedraw)
 
-// 인라인 접기/펴기 버튼 클릭 이벤트 바인딩 (이벤트 위임)
+// 페이지 번역 및 인라인 접기/펴기 버튼 클릭 이벤트 바인딩 (이벤트 위임)
 viewerScrollContainer.addEventListener('click', (e) => {
+  const translateBtn = e.target.closest('.translate-page-btn')
+  if (translateBtn) {
+    e.stopPropagation()
+    const pageNum = Number.parseInt(translateBtn.dataset.page, 10)
+    if (Number.isInteger(pageNum)) translatePage(pageNum)
+    return
+  }
+
   const btn = e.target.closest('.trans-collapse-btn')
   if (!btn) return
   e.stopPropagation()
@@ -15588,11 +15577,6 @@ viewerScrollContainer.addEventListener('click', (e) => {
 
   showToast(isTransPaneCollapsed ? '번역 창이 접혔습니다.' : '번역 창이 펼쳐졌습니다.', 'info')
 
-  // 번역 모드가 'pane'이면 번역 창을 펼치는 순간이 곧 "번역을 시작해도 좋다"는
-  // 신호다 - 접혀 있는 동안은 백그라운드 잡을 시작하지 않고 아껴뒀다가 여기서 시작한다.
-  if (!isTransPaneCollapsed && getTranslationMode() === 'pane') {
-    ensureTranslationJobStarted()
-  }
 });
 
 // 초기 로드 시 localStorage 상태 복원 및 초기화 실행

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1039,6 +1039,35 @@ body:not(.light-theme) .pdf-page-inner canvas {
   padding: 12px 0;
 }
 
+.manual-translation-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.translate-page-btn {
+  padding: 8px 14px;
+  border: 1px solid var(--accent-mid);
+  border-radius: var(--radius-sm);
+  background: rgba(74, 135, 181, 0.1);
+  color: var(--accent-light);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.translate-page-btn:hover {
+  background: rgba(74, 135, 181, 0.2);
+}
+
+.translate-page-btn:focus-visible {
+  outline: 2px solid var(--accent-light);
+  outline-offset: 2px;
+}
+
 .trans-text {
   font-size: 15.5px;
   line-height: 1.9;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2407,6 +2407,12 @@ body.light-theme .pdf-annotation-underline {
   color: var(--text-secondary);
 }
 
+.setting-scope-hint {
+  color: var(--accent-light);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
 .form-group input {
   padding: 12px 16px;
   background: var(--bg-elevated);
@@ -5260,6 +5266,43 @@ body.light-theme .custom-confirm-modal {
 .custom-confirm-btn.confirm-btn.primary-btn:hover {
   background: var(--accent-strong);
   box-shadow: 0 0 4px rgba(126, 196, 232, 0.25);
+}
+
+.translation-scope-modal {
+  width: min(420px, calc(100vw - 32px));
+}
+
+.translation-scope-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.translation-scope-options button {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.translation-scope-options button:hover {
+  border-color: var(--accent-mid);
+  background: var(--bg-hover);
+}
+
+.translation-scope-options span {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+@media (max-width: 480px) {
+  .translation-scope-options { grid-template-columns: 1fr; }
 }
 
 /* ── Color picker in memo header ── */

--- a/frontend/tests/e2e/manual-page-translation.spec.js
+++ b/frontend/tests/e2e/manual-page-translation.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+test('수동 번역 모드는 버튼을 누른 한 페이지만 번역한다', async ({ page }) => {
+  const doc = {
+    id: 'doc-manual',
+    filename: 'Manual.pdf',
+    total_pages: 1,
+    metadata: { title: 'Manual translation document' },
+    translated_pages: [],
+  }
+  let translationRequests = 0
+  let restartRequests = 0
+
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-manual/pdf', route => route.fulfill({
+    status: 200,
+    contentType: 'application/pdf',
+    body: SAMPLE_PDF_A,
+  }))
+  await page.route('**/api/translate/doc-manual/1**', route => {
+    translationRequests += 1
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'data: {"content":"수동 페이지 번역"}\n\ndata: {"done":true,"sentences":[]}\n\n',
+    })
+  })
+  await page.route('**/api/jobs/doc-manual/restart', route => {
+    restartRequests += 1
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_translation_mode', 'pane')
+    location.hash = '#viewer?id=doc-manual'
+  })
+
+  const translateButton = page.locator('#trans-content-1 .translate-page-btn')
+  await expect(translateButton).toBeVisible()
+  expect(translationRequests).toBe(0)
+  expect(restartRequests).toBe(0)
+
+  await translateButton.click()
+
+  await expect(page.locator('#trans-content-1 .trans-text')).toContainText('수동 페이지 번역')
+  expect(translationRequests).toBe(1)
+  expect(restartRequests).toBe(0)
+})

--- a/frontend/tests/e2e/translation-policy.spec.js
+++ b/frontend/tests/e2e/translation-policy.spec.js
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+test('연구와 일반 문서 워크스페이스의 번역 모드를 따로 저장한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await page.route('**/api/document-types', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ modes: [
+      { value: 'research', types: [{ value: 'research_paper', mode: 'research', label: '연구 논문' }] },
+      { value: 'general', types: [{ value: 'other', mode: 'general', label: '기타 문서' }] },
+    ] }),
+  }))
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_translation_mode_research', 'pane')
+    localStorage.setItem('easypaper_translation_mode_general', 'scroll')
+  })
+
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#setting-translation-mode')).toHaveValue('pane')
+  await expect(page.locator('#setting-translation-mode-scope')).toHaveText('연구 모드에만 적용')
+  await page.locator('#close-settings-btn').click()
+
+  await page.locator('#workspace-mode-switch [data-workspace-mode="general"]').click()
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#setting-translation-mode')).toHaveValue('scroll')
+  await expect(page.locator('#setting-translation-mode-scope')).toHaveText('일반 문서 모드에만 적용')
+  await page.locator('#setting-translation-mode').selectOption('auto')
+  await page.locator('#close-settings-btn').click()
+
+  await page.locator('#workspace-mode-switch [data-workspace-mode="research"]').click()
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#setting-translation-mode')).toHaveValue('pane')
+  expect(await page.evaluate(() => localStorage.getItem('easypaper_translation_mode_general'))).toBe('auto')
+})
+
+test('번역 범위 선택에서 문서 전체 페이지 목록을 잡 API에 전달한다', async ({ page }) => {
+  const doc = {
+    id: 'doc-scope', filename: 'Scope.pdf', total_pages: 1,
+    metadata: { title: 'Scoped translation' }, translated_pages: [],
+  }
+  let restartPayload = null
+
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-scope/pdf', route => route.fulfill({
+    status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A,
+  }))
+  await page.route('**/api/jobs/doc-scope/restart', route => {
+    restartPayload = route.request().postDataJSON()
+    return route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ job: { status: 'running', total_pages: 1, target_pages: [1] } }),
+    })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-scope' })
+  await expect(page.locator('#viewer-screen')).toHaveClass(/active/)
+  await page.locator('#toolbar-kebab-btn').click()
+  await page.locator('#translation-scope-btn').click()
+  await page.locator('.translation-scope-modal [data-scope="all"]').click()
+
+  await expect.poll(() => restartPayload).not.toBeNull()
+  expect(restartPayload.page_numbers).toEqual([1])
+})


### PR DESCRIPTION
# Summary
## 1. 긴 문서 자동 번역 정책
- 50페이지 이상 문서 업로드 시 전체 자동 번역 차단
- 실제 페이지 50% 이상 노출 및 0.8초 체류 후 페이지별 번역 시작
- 긴 문서의 다음 미열람 페이지 선번역 비활성화
- ## 2. 연구/일반 문서 번역 설정 분리
- 워크스페이스별 번역 모드 저장 키 분리
- 기존 전역 설정값 fallback 호환 및 설정 적용 범위 안내 추가
- ## 3. 명시적 번역 범위 작업
- 현재 페이지·남은 페이지·직접 범위·문서 전체 선택 UI 추가
- 범위별 백그라운드 작업 상태 및 중단 범위 재개 지원
- 부분 번역 완료 시 전체 산출물·연구 후처리 조기 실행 방지
## 4. 회귀 테스트
- 50페이지 경계값, 범위 작업·재개, 설정 분리 및 범위 요청 검증 추가