### PR TITLE
fix(library): remove category color indicators

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -206,11 +206,6 @@
                 <div id="library-category-filters" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;"></div>
                 <button type="button" id="library-category-filter-toggle" class="library-category-filter-toggle hidden" aria-controls="library-category-filters" aria-expanded="true"></button>
               </div>
-              <div class="document-mode-legend" aria-label="문서 분류 색상 안내">
-                <span class="document-mode-legend-title">분류 색상</span>
-                <span class="document-mode-legend-item research"><span class="document-mode-legend-dot" aria-hidden="true"></span>연구 문서</span>
-                <span class="document-mode-legend-item general"><span class="document-mode-legend-dot" aria-hidden="true"></span>일반 문서</span>
-              </div>
               <div id="library-view-toggle" class="library-view-toggle" role="group" aria-label="논문 보기 방식">
                 <button type="button" class="view-toggle-btn" data-view="card" title="큰 카드 보기" aria-label="큰 카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg></button>
                 <button type="button" class="view-toggle-btn" data-view="compact" title="작은 카드 보기" aria-label="작은 카드 보기"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="5" height="5" x="3" y="3" rx="1"/><rect width="5" height="5" x="10" y="3" rx="1"/><rect width="5" height="5" x="17" y="3" rx="1"/><rect width="5" height="5" x="3" y="10" rx="1"/><rect width="5" height="5" x="10" y="10" rx="1"/><rect width="5" height="5" x="17" y="10" rx="1"/><rect width="5" height="5" x="3" y="17" rx="1"/><rect width="5" height="5" x="10" y="17" rx="1"/><rect width="5" height="5" x="17" y="17" rx="1"/></svg></button>


### PR DESCRIPTION
# Summary
## 1. 라이브러리 분류 색상 안내 제거
- 라이브러리 상단의 연구 문서·일반 문서 분류 색상 범례를 제거함
- 카테고리 필터와 보기 방식 전환 기능은 유지함