### PR TITLE
feat: 문서 모드별 테마 분리

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -904,7 +904,24 @@
               </label>
             </div>
           </div>
-          
+
+          <div class="settings-section-heading">
+            <strong>화면 테마</strong>
+            <span id="settings-theme-scope">연구 모드에만 적용</span>
+          </div>
+
+          <div class="form-group">
+            <label>테마 색상</label>
+            <div id="setting-accent-swatches" class="accent-swatch-group"></div>
+            <div class="accent-picker-row">
+              <label for="setting-accent-picker" class="accent-picker-swatch">
+                <input type="color" id="setting-accent-picker" value="#2563eb" />
+              </label>
+              <span id="setting-accent-hex" class="accent-hex-label">#2563EB</span>
+              <button type="button" id="setting-accent-reset-btn" class="accent-reset-btn">기본값</button>
+            </div>
+          </div>
+
           <div class="settings-section-heading settings-section-heading-common">
             <strong>PDF 뷰어 및 화면</strong>
             <span>두 모드에 공통으로 적용됩니다.</span>
@@ -928,18 +945,6 @@
               <option value="left">왼쪽</option>
               <option value="right">오른쪽</option>
             </select>
-          </div>
-
-          <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">
-            <label>테마 색상</label>
-            <div id="setting-accent-swatches" class="accent-swatch-group"></div>
-            <div class="accent-picker-row">
-              <label for="setting-accent-picker" class="accent-picker-swatch">
-                <input type="color" id="setting-accent-picker" value="#2563eb" />
-              </label>
-              <span id="setting-accent-hex" class="accent-hex-label">#2563EB</span>
-              <button type="button" id="setting-accent-reset-btn" class="accent-reset-btn">기본값</button>
-            </div>
           </div>
 
           <div class="form-group" style="margin-top: 10px; border-top: 1px solid var(--border); padding-top: 15px;">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -112,6 +112,7 @@ const $ = (id) => document.getElementById(id)
 // opacity/transform 전환을 두 단계(reflow 강제 → 다음 프레임에 클래스 적용)로
 // 분리해 트랜지션이 실제로 재생되게 한다.
 const modalTriggerElements = new WeakMap()
+const modalCloseTimers = new WeakMap()
 const modalFocusableSelector = [
   '[autofocus]',
   'button:not([disabled])',
@@ -124,6 +125,11 @@ const modalFocusableSelector = [
 
 function openOverlayModal(modal) {
   if (!modal) return
+  const closeTimer = modalCloseTimers.get(modal)
+  if (closeTimer !== undefined) {
+    window.clearTimeout(closeTimer)
+    modalCloseTimers.delete(modal)
+  }
   const trigger = document.activeElement
   if (trigger instanceof HTMLElement && trigger !== document.body) {
     modalTriggerElements.set(modal, trigger)
@@ -139,13 +145,18 @@ function openOverlayModal(modal) {
 }
 function closeOverlayModal(modal) {
   if (!modal) return
+  const previousTimer = modalCloseTimers.get(modal)
+  if (previousTimer !== undefined) window.clearTimeout(previousTimer)
   modal.classList.remove('is-visible')
-  window.setTimeout(() => {
+  const closeTimer = window.setTimeout(() => {
+    modalCloseTimers.delete(modal)
+    if (modal.classList.contains('is-visible')) return
     modal.classList.add('hidden')
     const trigger = modalTriggerElements.get(modal)
     if (trigger?.isConnected) trigger.focus()
     modalTriggerElements.delete(modal)
   }, 300) // CSS 트랜지션(0.3s) 종료 후 display:none
+  modalCloseTimers.set(modal, closeTimer)
 }
 const loginScreen       = $('login-screen')
 const loginForm         = $('login-form')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -198,6 +198,7 @@ const settingsAutomationTitle = $('settings-automation-title')
 const settingsKeywordsLabel = $('settings-keywords-label')
 const settingsKeywordsDescription = $('settings-keywords-description')
 const settingsReadingToolsLabel = $('settings-reading-tools-label')
+const settingsThemeScope = $('settings-theme-scope')
 const settingTargetLang   = $('setting-target-lang')
 const settingTransStyle   = $('setting-trans-style')
 const settingTranslationMode = $('setting-translation-mode')
@@ -321,6 +322,7 @@ const workspaceModeController = createWorkspaceModeController({
 
     const incoming = workspaceLibraryState[mode]
     lastWorkspaceMode = mode
+    applyModeTheme(mode)
     if (settingsModal && !settingsModal.classList.contains('hidden')) {
       syncModeSettings(mode)
     }
@@ -605,9 +607,13 @@ function syncModeSettings(documentMode) {
   settingDisableCitationOverlay.checked = !getModeSetting('disableCitationOverlay', settingsTranslationModeContext)
   settingDisableFigureOverlay.checked = !getModeSetting('disableFigureOverlay', settingsTranslationModeContext)
   settingDisablePrimer.checked = !getModeSetting('disablePrimer', settingsTranslationModeContext)
+  updateAccentSettingsUI(getModeSetting('accentColor', settingsTranslationModeContext))
 
   if (settingTranslationModeScope) {
     settingTranslationModeScope.textContent = isGeneral ? '일반 문서 모드에만 적용' : '연구 모드에만 적용'
+  }
+  if (settingsThemeScope) {
+    settingsThemeScope.textContent = isGeneral ? '일반 문서 모드에만 적용' : '연구 모드에만 적용'
   }
   settingsModeTitle.textContent = isGeneral ? '일반 문서 모드 설정' : '연구 모드 설정'
   settingsModeBadge.textContent = isGeneral ? '일반 문서 모드' : '연구 모드'
@@ -2163,6 +2169,7 @@ async function checkAuthentication() {
       lastWorkspaceMode = workspaceModeController.getMode()
       await showLibraryScreen()
     }
+    applyModeTheme(workspaceModeController.getMode())
     await refreshSystemSettings()
     await maybeShowOnboarding()
     // 업데이트 직후(방금 재시작됨) 안내가 있으면 그것부터 먼저 보여주고, 없을
@@ -9443,7 +9450,7 @@ async function syncDesktopWindowTheme(isLight) {
 }
 
 function initTheme() {
-  const savedTheme = localStorage.getItem('theme') || 'dark'
+  const savedTheme = getModeSetting('theme', workspaceModeController.getMode())
   const isLight = savedTheme === 'light'
   document.body.classList.toggle('light-theme', isLight)
   updateThemeIcons(isLight)
@@ -9451,8 +9458,9 @@ function initTheme() {
 }
 
 function toggleTheme() {
+  const mode = workspaceModeController.getMode()
   const isLight = document.body.classList.toggle('light-theme')
-  localStorage.setItem('theme', isLight ? 'light' : 'dark')
+  setModeSetting('theme', mode, isLight ? 'light' : 'dark')
   updateThemeIcons(isLight)
   applyAccentColor(currentAccentColor, { persist: false })
   showToast(isLight ? '라이트 모드로 전환 ✓' : '다크 모드로 전환 ✓', 'success')
@@ -9579,7 +9587,7 @@ function applyAccentColor(hex, { persist = true } = {}) {
   document.body.style.setProperty('--border-glow', isLight ? tokens.borderGlowLight : tokens.borderGlowDark)
 
   currentAccentColor = hex
-  if (persist) localStorage.setItem('easypaper_accent_color', hex)
+  if (persist) setModeSetting('accentColor', workspaceModeController.getMode(), hex)
   updateAccentSettingsUI(hex)
 }
 
@@ -9612,10 +9620,19 @@ if (settingAccentResetBtn) {
 }
 
 function initAccentColor() {
-  const saved = localStorage.getItem('easypaper_accent_color') || DEFAULT_ACCENT_COLOR
+  const saved = getModeSetting('accentColor', workspaceModeController.getMode())
   applyAccentColor(saved, { persist: false })
 }
 initAccentColor()
+
+function applyModeTheme(mode) {
+  const normalizedMode = normalizeSettingsMode(mode)
+  const isLight = getModeSetting('theme', normalizedMode) === 'light'
+  document.body.classList.toggle('light-theme', isLight)
+  updateThemeIcons(isLight)
+  applyAccentColor(getModeSetting('accentColor', normalizedMode), { persist: false })
+  syncDesktopWindowTheme(isLight)
+}
 
 // ── PDF 텍스트 하이라이트 & 밑줄 (Annotation) 기능 ──────────────────
 

--- a/frontend/src/modeSettings.js
+++ b/frontend/src/modeSettings.js
@@ -1,5 +1,7 @@
 const MODE_DEFAULTS = {
   research: {
+    theme: 'dark',
+    accentColor: '#2563eb',
     targetLang: '한국어',
     style: 'academic',
     translationMode: 'auto',
@@ -14,6 +16,8 @@ const MODE_DEFAULTS = {
     disablePrimer: false,
   },
   general: {
+    theme: 'dark',
+    accentColor: '#2563eb',
     targetLang: '한국어',
     style: 'natural',
     translationMode: 'scroll',
@@ -30,6 +34,8 @@ const MODE_DEFAULTS = {
 }
 
 const LEGACY_KEYS = {
+  theme: 'theme',
+  accentColor: 'easypaper_accent_color',
   targetLang: 'easypaper_target_lang',
   style: 'easypaper_style',
   translationMode: 'easypaper_translation_mode',
@@ -43,6 +49,8 @@ const LEGACY_KEYS = {
   disableFigureOverlay: 'easypaper_disable_figure_overlay',
   disablePrimer: 'easypaper_disable_primer',
 }
+
+const SHARED_LEGACY_PREFERENCES = new Set(['theme', 'accentColor', 'targetLang'])
 
 const BOOLEAN_SETTINGS = new Set([
   'ignoreMath', 'ignoreTable', 'ignoreRefs', 'disableInsights',
@@ -65,9 +73,9 @@ export function getModeSetting(name, mode, storage = localStorage) {
   if (fallback === undefined) throw new Error(`Unknown mode setting: ${name}`)
 
   let raw = storage.getItem(modeSettingStorageKey(name, normalizedMode))
-  // 기존 전역 설정은 연구 모드의 값으로 승계한다. 번역 대상 언어는 사용자의
-  // 기본 선호도라 일반 문서도 첫 사용 시 기존 값을 승계한다.
-  if (raw === null && (normalizedMode === 'research' || name === 'targetLang')) {
+  // 기존 전역 설정은 연구 모드의 값으로 승계한다. 테마와 번역 대상 언어는
+  // 사용자의 기본 선호도라 일반 문서도 첫 사용 시 기존 값을 승계한다.
+  if (raw === null && (normalizedMode === 'research' || SHARED_LEGACY_PREFERENCES.has(name))) {
     raw = storage.getItem(LEGACY_KEYS[name])
   }
   if (raw === null) return fallback

--- a/frontend/tests/e2e/translation-policy.spec.js
+++ b/frontend/tests/e2e/translation-policy.spec.js
@@ -137,3 +137,14 @@ test('워크스페이스 모드별 테마와 강조색을 독립적으로 적용
   await expect(page.locator('body')).toHaveClass(/light-theme/)
   expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#e0677a')
 })
+
+test('설정 모달을 빠르게 다시 열어도 열린 상태를 유지한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await gotoApp(page)
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-modal')).toBeVisible()
+  await page.locator('#close-settings-btn').click()
+  await page.locator('#sidebar-settings-btn').click()
+  await page.waitForTimeout(350)
+  await expect(page.locator('#settings-modal')).toBeVisible()
+})

--- a/frontend/tests/e2e/translation-policy.spec.js
+++ b/frontend/tests/e2e/translation-policy.spec.js
@@ -100,3 +100,34 @@ test('번역 범위 선택에서 문서 전체 페이지 목록을 잡 API에 �
   await expect.poll(() => restartPayload).not.toBeNull()
   expect(restartPayload.page_numbers).toEqual([1])
 })
+
+test('워크스페이스 모드별 테마와 강조색을 독립적으로 적용한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_theme_research', 'light')
+    localStorage.setItem('easypaper_theme_general', 'dark')
+    localStorage.setItem('easypaper_accent_color_research', '#e0677a')
+    localStorage.setItem('easypaper_accent_color_general', '#1c9c6b')
+  })
+  await page.reload()
+
+  await expect(page.locator('body')).toHaveClass(/light-theme/)
+  expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#e0677a')
+
+  await page.locator('#workspace-mode-switch [data-workspace-mode="general"]').click()
+  await expect(page.locator('body')).not.toHaveClass(/light-theme/)
+  expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#1c9c6b')
+
+  await page.locator('#sidebar-theme-toggle-btn').click()
+  expect(await page.evaluate(() => localStorage.getItem('easypaper_theme_general'))).toBe('light')
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-theme-scope')).toHaveText('일반 문서 모드에만 적용')
+  await page.locator('.accent-swatch[data-hex="#5457b8"]').click()
+  expect(await page.evaluate(() => localStorage.getItem('easypaper_accent_color_general'))).toBe('#5457b8')
+
+  await page.locator('#close-settings-btn').click()
+  await page.locator('#workspace-mode-switch [data-workspace-mode="research"]').click()
+  await expect(page.locator('body')).toHaveClass(/light-theme/)
+  expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#e0677a')
+})

--- a/frontend/tests/e2e/translation-policy.spec.js
+++ b/frontend/tests/e2e/translation-policy.spec.js
@@ -23,7 +23,9 @@ test('연구와 일반 문서 워크스페이스의 번역 모드를 따로 저�
   await page.locator('#close-settings-btn').click()
 
   await page.locator('#workspace-mode-switch [data-workspace-mode="general"]').click()
+  await expect(page.locator('.document-home')).toBeVisible()
   await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-modal')).toBeVisible()
   await expect(page.locator('#setting-translation-mode')).toHaveValue('scroll')
   await expect(page.locator('#setting-translation-mode-scope')).toHaveText('일반 문서 모드에만 적용')
   await page.locator('#setting-translation-mode').selectOption('auto')
@@ -51,7 +53,9 @@ test('설정 화면이 현재 워크스페이스 모드의 값과 항목 구성�
 
   await page.locator('#close-settings-btn').click()
   await page.locator('#workspace-mode-switch [data-workspace-mode="general"]').click()
+  await expect(page.locator('.document-home')).toBeVisible()
   await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-modal')).toBeVisible()
   await expect(page.locator('#settings-mode-title')).toHaveText('일반 문서 모드 설정')
   await expect(page.locator('#setting-trans-style')).toHaveValue('natural')
   await expect(page.locator('#setting-translation-mode')).toHaveValue('scroll')
@@ -116,12 +120,14 @@ test('워크스페이스 모드별 테마와 강조색을 독립적으로 적용
   expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#e0677a')
 
   await page.locator('#workspace-mode-switch [data-workspace-mode="general"]').click()
+  await expect(page.locator('.document-home')).toBeVisible()
   await expect(page.locator('body')).not.toHaveClass(/light-theme/)
   expect(await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent-mid').trim())).toBe('#1c9c6b')
 
   await page.locator('#sidebar-theme-toggle-btn').click()
   expect(await page.evaluate(() => localStorage.getItem('easypaper_theme_general'))).toBe('light')
   await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-modal')).toBeVisible()
   await expect(page.locator('#settings-theme-scope')).toHaveText('일반 문서 모드에만 적용')
   await page.locator('.accent-swatch[data-hex="#5457b8"]').click()
   expect(await page.evaluate(() => localStorage.getItem('easypaper_accent_color_general'))).toBe('#5457b8')

--- a/frontend/tests/modeSettings.test.js
+++ b/frontend/tests/modeSettings.test.js
@@ -27,6 +27,18 @@ test('기존 일반 설정을 연구 모드에 승계한다', () => {
   assert.equal(getModeSetting('disablePrimer', 'research', storage), true)
 })
 
+test('기존 테마 설정은 두 모드의 최초 값으로 승계한다', () => {
+  const storage = memoryStorage({
+    theme: 'light',
+    easypaper_accent_color: '#e0677a',
+  })
+
+  assert.equal(getModeSetting('theme', 'research', storage), 'light')
+  assert.equal(getModeSetting('theme', 'general', storage), 'light')
+  assert.equal(getModeSetting('accentColor', 'research', storage), '#e0677a')
+  assert.equal(getModeSetting('accentColor', 'general', storage), '#e0677a')
+})
+
 test('일반 문서는 자연스러운 문체와 필요 시 번역을 기본으로 사용한다', () => {
   const defaults = getModeDefaults('general')
 
@@ -44,4 +56,19 @@ test('모드별 저장 값이 서로 덮어쓰지 않는다', () => {
   assert.equal(storage.getItem(modeSettingStorageKey('style', 'general')), 'summary')
   assert.equal(getModeSetting('style', 'research', storage), 'academic')
   assert.equal(getModeSetting('style', 'general', storage), 'summary')
+})
+
+test('모드별 테마와 강조색이 서로 덮어쓰지 않는다', () => {
+  const storage = memoryStorage()
+  setModeSetting('theme', 'research', 'light', storage)
+  setModeSetting('theme', 'general', 'dark', storage)
+  setModeSetting('accentColor', 'research', '#e0677a', storage)
+  setModeSetting('accentColor', 'general', '#1c9c6b', storage)
+
+  assert.equal(storage.getItem(modeSettingStorageKey('theme', 'research')), 'light')
+  assert.equal(storage.getItem(modeSettingStorageKey('theme', 'general')), 'dark')
+  assert.equal(getModeSetting('theme', 'research', storage), 'light')
+  assert.equal(getModeSetting('theme', 'general', storage), 'dark')
+  assert.equal(getModeSetting('accentColor', 'research', storage), '#e0677a')
+  assert.equal(getModeSetting('accentColor', 'general', storage), '#1c9c6b')
 })


### PR DESCRIPTION
# Summary
## 1. 모드별 테마 독립 적용
- 연구 및 일반 문서 모드의 라이트·다크 테마와 강조색을 독립 저장
- 워크스페이스 모드 전환 및 앱 초기화 시 해당 모드의 테마를 즉시 복원
## 2. 기존 설정 승계 및 화면 구성
- 기존 전역 테마와 강조색을 두 모드의 최초 설정으로 승계
- 테마 색상 설정을 공통 구역에서 현재 모드 전용 화면 테마 구역으로 이동
## 3. 회귀 검증
- 기존 테마 승계와 모드별 저장 격리 단위 테스트 추가
- 모드 전환 시 테마·강조색 적용 E2E 테스트 추가