### PR TITLE
feat: add document privacy controls

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -255,9 +255,17 @@ class SystemSettingsRequest(BaseModel):
     openai_api_key: str = ""
     gemini_api_key: str = ""
     claude_api_key: str = ""
+    delete_openai_api_key: bool = False
+    delete_gemini_api_key: bool = False
+    delete_claude_api_key: bool = False
     openalex_mailto: str = ""
     translation_prompt_template: str = ""
     pdf_parser_engine: str = "pymupdf"
+
+def _masked_key_status(value: str) -> dict:
+    value = value or ""
+    return {"configured": bool(value), "masked": ("••••" + value[-4:]) if value else ""}
+
 
 @router.get("/settings/system")
 async def get_system_settings(current_user: str = Depends(get_current_user)):
@@ -277,9 +285,11 @@ async def get_system_settings(current_user: str = Depends(get_current_user)):
         "analysis_model": get_analysis_model(),
         "library_provider": get_library_provider(),
         "library_model": get_library_model(),
-        "openai_api_key": get_openai_api_key(),
-        "gemini_api_key": get_gemini_api_key(),
-        "claude_api_key": get_claude_api_key(),
+        "api_keys": {
+            "openai": _masked_key_status(get_openai_api_key()),
+            "gemini": _masked_key_status(get_gemini_api_key()),
+            "claude": _masked_key_status(get_claude_api_key()),
+        },
         "openalex_mailto": get_openalex_mailto(),
         "translation_prompt_template": get_translation_prompt_template(),
         "pdf_parser_engine": get_pdf_parser_engine()
@@ -321,6 +331,10 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
     # 다시 올라오게 한다.
     restart_needed = venv_manager.restart_required_for_engine(pdf_parser_engine)
 
+    openai_api_key = "" if data.delete_openai_api_key else (data.openai_api_key.strip() or get_openai_api_key())
+    gemini_api_key = "" if data.delete_gemini_api_key else (data.gemini_api_key.strip() or get_gemini_api_key())
+    claude_api_key = "" if data.delete_claude_api_key else (data.claude_api_key.strip() or get_claude_api_key())
+
     update_system_settings(
         ollama_host=data.ollama_host.strip(),
         trans_provider=trans_provider,
@@ -333,9 +347,9 @@ async def save_system_settings(data: SystemSettingsRequest, current_user: str = 
         analysis_model=data.analysis_model.strip(),
         library_provider=library_provider,
         library_model=data.library_model.strip(),
-        openai_api_key=data.openai_api_key.strip(),
-        gemini_api_key=data.gemini_api_key.strip(),
-        claude_api_key=data.claude_api_key.strip(),
+        openai_api_key=openai_api_key,
+        gemini_api_key=gemini_api_key,
+        claude_api_key=claude_api_key,
         openalex_mailto=data.openalex_mailto.strip(),
         pdf_parser_engine=pdf_parser_engine
     )

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -71,9 +71,11 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
     """
     논문 내용을 기반으로 AI 전문가와 챗을 진행하고 실시간 스트리밍 답변을 반환합니다.
     """
-    enforce_rate_limit("chat", current_user)
     session_id = data.session_id
     session = require_session_owner(session_id, current_user)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "chat")
+    enforce_rate_limit("chat", current_user)
 
     # 질문 관련 문단을 FTS5로 찾고 명시 페이지·현재 페이지·선택 영역을
     # 우선 재순위화한다. 장/절이 이어지는 인접 문단도 함께 확장한다.
@@ -175,9 +177,11 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
 async def chat_suggestions(data: ChatRequest, current_user: str = Depends(get_current_user)):
     """직전 어시스턴트 답변과 논문 본문을 참고해 후속 질문 3개를 추천합니다. 채팅
     기록(chats 테이블)에는 남기지 않는 보조 UI(추천 질문 칩) 전용 엔드포인트입니다."""
-    enforce_rate_limit("chat", current_user)
     session_id = data.session_id
     session = require_session_owner(session_id, current_user)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "chat")
+    enforce_rate_limit("chat", current_user)
 
     pages = session.get("pages", [])
     history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
@@ -210,7 +214,6 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
     """여러 논문을 함께 컨텍스트로 제공해, 논문 간 비교/종합 질문에 답하는
     스트리밍 채팅입니다.
     """
-    enforce_rate_limit("chat", current_user)
     doc_ids = _dedupe_preserve_order(data.doc_ids)
     if len(doc_ids) < MIN_COMPARE_DOCS or len(doc_ids) > MAX_COMPARE_DOCS:
         raise HTTPException(
@@ -219,6 +222,9 @@ async def chat_compare_stream(data: CompareChatRequest, current_user: str = Depe
         )
 
     docs = require_owned_documents(doc_ids, current_user)
+    from services.processing_policy import ensure_documents_processing_allowed
+    ensure_documents_processing_allowed(docs, "chat")
+    enforce_rate_limit("chat", current_user)
 
     per_doc_budget = COMPARE_TOTAL_CONTEXT_CHARS // len(doc_ids)
     paper_blocks = []

--- a/backend/routers/insight.py
+++ b/backend/routers/insight.py
@@ -57,6 +57,8 @@ async def estimate_page_insight_job(session_id: str, kind: str, target_lang: str
 @router.post("/insight-jobs/{session_id}/{kind}/start")
 async def start_page_insight_job(session_id: str, kind: str, body: InsightJobStartRequest, current_user: str = Depends(get_current_user)):
     session = require_session_owner(session_id, current_user)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "insight")
     target_lang, source_lang = _validated_languages(session, body.target_lang, body.source_lang)
     _require_insight_feature(session, kind)
     from services.insight_job import estimate_insight_job, start_keyword_job, start_summary_job, VALID_JOB_KINDS
@@ -108,6 +110,8 @@ async def get_page_insight_stream(
         raise HTTPException(status_code=400, detail=f"kind는 {VALID_KINDS} 중 하나여야 합니다.")
 
     session = require_session_owner(session_id, current_user)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "insight")
     target_lang, source_lang = _validated_languages(session, target_lang, source_lang)
     _require_insight_feature(session, kind)
     total_pages = session["total_pages"]

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -147,6 +147,8 @@ async def restart_translation_job(
     """주어진 옵션으로 번역 작업을 중단하고 새로 재시작합니다."""
     session = require_session_owner(session_id, current_user)
     target_lang, source_lang = _validated_languages(session, data.target_lang, data.source_lang)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "translate")
     if source_lang == target_lang:
         raise HTTPException(status_code=409, detail={
             "code": "same_source_and_target_language", "params": {"language": target_lang},

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -50,6 +50,9 @@ class DocumentLanguagesUpdateRequest(BaseModel):
     source_language: str
     preferred_target_language: Optional[str] = None
 
+class DocumentProcessingPolicyUpdateRequest(BaseModel):
+    processing_policy: str
+
 
 MAX_LIBRARY_MIRROR_JSON_BYTES = 5 * 1024 * 1024
 
@@ -199,6 +202,8 @@ async def get_library_reading_recommendations(force: bool = False, current_user:
     /library/{doc_id}보다 먼저 등록해야 한다 - /library/search와 동일한
     이유로, 그렇지 않으면 "graph"가 doc_id 경로 파라미터로 잘못 매칭된다.
     """
+    from services.processing_policy import ensure_documents_processing_allowed
+    ensure_documents_processing_allowed(list_documents(current_user), "recommendation")
     from services.knowledge_graph import get_reading_recommendations
     return {"recommendations": await get_reading_recommendations(current_user, force=force)}
 
@@ -556,6 +561,29 @@ async def get_paper_reading_analytics_api(doc_id: str, current_user: str = Depen
         "paperId": doc_id,
         **stats,
     }
+
+
+@router.get("/library/{doc_id}/processing-policy")
+async def get_document_processing_policy(doc_id: str, current_user: str = Depends(get_current_user)):
+    doc = require_owned_document(doc_id, current_user)
+    from services.processing_policy import document_processing_status
+    return document_processing_status(doc)
+
+
+@router.patch("/library/{doc_id}/processing-policy")
+async def patch_document_processing_policy(doc_id: str, body: DocumentProcessingPolicyUpdateRequest, current_user: str = Depends(get_current_user)):
+    require_owned_document(doc_id, current_user)
+    from services.db import db_update_processing_policy
+    from services.processing_policy import document_processing_status, normalize_processing_policy
+    try:
+        policy = normalize_processing_policy(body.processing_policy)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail={"code": "invalid_processing_policy", "fallback": str(exc)})
+    updated = db_update_processing_policy(doc_id, policy)
+    from routers.upload import sessions
+    if doc_id in sessions:
+        sessions[doc_id]["processing_policy"] = policy
+    return document_processing_status(updated)
 
 
 @router.get("/library/{doc_id}")

--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -57,6 +57,8 @@ _RETRY_COOLDOWN_SECONDS = 15
 def _ensure_generation_started(doc_id: str, target_lang: str, source_lang: str, session: dict, current_user: str) -> None:
     """이 문서/언어 조합의 브리핑 생성이 이미 진행 중이 아니면 백그라운드
     태스크로 새로 시작한다. GET(캐시 미스)과 POST(재생성) 양쪽에서 공유한다."""
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "primer")
     document_mode = session.get("document_mode", "research")
     document_type = session.get("document_type", "research_paper")
     # 기존 연구 브리핑의 task key는 유지해 쿨다운/진행 중 상태 호환성을 보존한다.
@@ -109,6 +111,8 @@ async def get_primer(doc_id: str, target_lang: str = "ko", current_user: str = D
     시작(또는 이미 진행 중이면 그대로 두고)하고 {"status": "pending"}을 반환합니다."""
     session = require_session_owner(doc_id, current_user)
     target_lang, source_lang = _validated_languages(session, target_lang)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "primer")
     if session.get("document_mode", "research") == "general":
         cached = get_cached_document_overview(
             doc_id, session.get("document_type", "other"), target_lang=target_lang, source_lang=source_lang,
@@ -129,6 +133,8 @@ async def regenerate_primer(doc_id: str, target_lang: str = "ko", current_user: 
     생성은 백그라운드로 돌리고 즉시 {"status": "pending"}을 반환한다."""
     session = require_session_owner(doc_id, current_user)
     target_lang, source_lang = _validated_languages(session, target_lang)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "primer")
     if session.get("document_mode", "research") == "general":
         invalidate_document_overview(doc_id, session.get("document_type", "other"), target_lang, source_lang)
     else:

--- a/backend/routers/translate.py
+++ b/backend/routers/translate.py
@@ -37,8 +37,10 @@ async def translate_page(
     특정 페이지를 번역하고 SSE 스트리밍으로 반환합니다.
     이미 동일한 옵션으로 번역된 페이지는 캐시에서 즉시 반환합니다.
     """
-    enforce_rate_limit("translate", current_user)
     session = require_session_owner(session_id, current_user)
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(session, "translate")
+    enforce_rate_limit("translate", current_user)
     from services.languages import api_language_error, normalize_document_language
     try:
         target_lang = normalize_document_language(target_lang, allow_legacy=True)

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -70,6 +70,7 @@ def ensure_session(session_id: str) -> bool:
             "detected_source_language": doc.get("detected_source_language", "und"),
             "source_language_confidence": doc.get("source_language_confidence"),
             "preferred_target_language": doc.get("preferred_target_language"),
+            "processing_policy": doc.get("processing_policy", "inherit"),
         }
         return True
     except Exception:
@@ -237,6 +238,7 @@ async def upload_pdf(
         "detected_source_language": detected_source_language,
         "source_language_confidence": detection["confidence"],
         "preferred_target_language": target_lang,
+        "processing_policy": "inherit",
     }
 
     # translation_mode가 "auto"(기본값)가 아니면 - 페이지 번역 버튼을 누를 때(pane) 또는

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -51,6 +51,7 @@ def init_db():
             detected_source_language TEXT NOT NULL DEFAULT 'und',
             source_language_confidence REAL,
             preferred_target_language TEXT,
+            processing_policy TEXT NOT NULL DEFAULT 'inherit',
             created_at TEXT NOT NULL,
             FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE ON UPDATE CASCADE
         )
@@ -140,6 +141,7 @@ def init_db():
             "ALTER TABLE documents ADD COLUMN detected_source_language TEXT NOT NULL DEFAULT 'und'",
             "ALTER TABLE documents ADD COLUMN source_language_confidence REAL",
             "ALTER TABLE documents ADD COLUMN preferred_target_language TEXT",
+            "ALTER TABLE documents ADD COLUMN processing_policy TEXT NOT NULL DEFAULT 'inherit'",
         ):
             try:
                 cursor.execute(column_sql)
@@ -589,6 +591,7 @@ def db_save_document(
     source_language: str = "auto", detected_source_language: str = "und",
     source_language_confidence: Optional[float] = None,
     preferred_target_language: Optional[str] = None,
+    processing_policy: str = "inherit",
 ) -> dict:
     meta_str = json.dumps(metadata, ensure_ascii=False)
     created_at = datetime.now(timezone.utc).isoformat()
@@ -598,12 +601,12 @@ def db_save_document(
             """
             INSERT OR REPLACE INTO documents
                 (id, username, filename, pdf_path, total_pages, metadata,
-                 document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (doc_id, username, filename, pdf_path, total_pages, meta_str,
              document_mode, document_type, mode_schema_version, source_language, detected_source_language,
-             source_language_confidence, preferred_target_language, created_at)
+             source_language_confidence, preferred_target_language, processing_policy, created_at)
         )
         conn.commit()
     return {
@@ -614,13 +617,14 @@ def db_save_document(
         "source_language": source_language, "detected_source_language": detected_source_language,
         "source_language_confidence": source_language_confidence,
         "preferred_target_language": preferred_target_language,
+        "processing_policy": processing_policy,
     }
 
 def db_get_document(doc_id: str) -> Optional[dict]:
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, username, filename, pdf_path, total_pages, metadata, document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, is_deleted, created_at FROM documents WHERE id = ?",
+            "SELECT id, username, filename, pdf_path, total_pages, metadata, document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, is_deleted, created_at FROM documents WHERE id = ?",
             (doc_id,)
         )
         row = cursor.fetchone()
@@ -646,7 +650,7 @@ def db_list_documents(username: Optional[str] = None, only_trash: bool = False, 
     query = (
         "SELECT id, username, filename, pdf_path, total_pages, metadata, "
         "document_mode, document_type, mode_schema_version, source_language, detected_source_language, "
-        "source_language_confidence, preferred_target_language, is_deleted, created_at "
+        "source_language_confidence, preferred_target_language, processing_policy, is_deleted, created_at "
         "FROM documents"
     )
     if conditions:
@@ -698,7 +702,7 @@ def db_search_documents(username: str, query: str, only_trash: bool = False, doc
             SELECT DISTINCT d.id, d.username, d.filename, d.pdf_path, d.total_pages,
                    d.metadata, d.document_mode, d.document_type,
                    d.mode_schema_version, d.source_language, d.detected_source_language,
-                   d.source_language_confidence, d.preferred_target_language,
+                   d.source_language_confidence, d.preferred_target_language, d.processing_policy,
                    d.is_deleted, d.created_at
             FROM documents d
             LEFT JOIN translations t ON t.doc_id = d.id
@@ -1282,6 +1286,15 @@ def db_update_document_languages(doc_id: str, source_language: str,
         )
         conn.commit()
         return cursor.rowcount > 0
+
+
+def db_update_processing_policy(doc_id: str, policy: str) -> dict:
+    with get_db() as conn:
+        cursor = conn.execute("UPDATE documents SET processing_policy = ? WHERE id = ?", (policy, doc_id))
+        if cursor.rowcount != 1:
+            raise ValueError("document not found")
+        conn.commit()
+    return db_get_document(doc_id)
 
 
 def db_update_detected_source_language(doc_id: str, detected_source_language: str,

--- a/backend/services/insight_job.py
+++ b/backend/services/insight_job.py
@@ -65,6 +65,11 @@ def start_summary_job(session_id: str, pages: list, target_lang: str, doc_title:
 
 def _start_insight_job(session_id: str, pages: list, target_lang: str, doc_title: str, kind: str,
                        document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto") -> dict:
+    from services.library import get_document
+    from services.processing_policy import ensure_processing_allowed
+    document = get_document(session_id)
+    if document:
+        ensure_processing_allowed(document, "insight")
     if kind not in VALID_JOB_KINDS:
         raise ValueError("unsupported insight job kind")
     key = (session_id, kind)

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -29,6 +29,12 @@ from services.db import (
 )
 
 
+def _attach_processing_status(doc: dict) -> dict:
+    from services.processing_policy import document_processing_status
+    doc["processing"] = document_processing_status(doc)
+    return doc
+
+
 def _translation_suffix_for_doc(doc: dict, target_lang: Optional[str], style: Optional[str], ignore_math: Optional[bool], ignore_table: Optional[bool], ignore_refs: Optional[bool]) -> Optional[str]:
     if target_lang is None or style is None:
         return None
@@ -119,6 +125,7 @@ def get_document(
 
         rows = db_bulk_translation_rows([doc_id]).get(doc_id, [])
         doc["translated_pages"] = _resolve_translated_pages(rows, suffix)
+        _attach_processing_status(doc)
         return doc
     return None
 
@@ -152,6 +159,7 @@ def list_documents(
         )
         doc["translated_pages"] = _resolve_translated_pages(rows_by_doc.get(doc["id"], []), suffix)
         doc["folder_id"] = folder_map.get(doc["id"])
+        _attach_processing_status(doc)
     return docs
 
 
@@ -171,6 +179,7 @@ def search_documents(username: str, query: str, only_trash: bool = False, docume
         doc["folder_id"] = folder_map.get(doc["id"])
         pages = sorted({r[0] for r in rows_by_doc.get(doc["id"], [])})
         doc["translated_pages"] = pages
+        _attach_processing_status(doc)
     return docs
 
 

--- a/backend/services/processing_policy.py
+++ b/backend/services/processing_policy.py
@@ -1,0 +1,125 @@
+"""Server-enforced document processing privacy policy."""
+from __future__ import annotations
+
+import ipaddress
+from typing import Iterable
+from urllib.parse import urlparse
+
+from fastapi import HTTPException
+
+VALID_PROCESSING_POLICIES = {"inherit", "local_only"}
+
+_TRANSFER_ITEMS = {
+    "translate": ["document_text", "page_image"],
+    "chat": ["document_text", "chat_history", "page_image"],
+    "insight": ["document_text"],
+    "primer": ["document_text", "document_metadata", "page_image"],
+    "recommendation": ["document_metadata", "notes", "chat_history"],
+    "reparse": ["document_file"],
+}
+
+
+def normalize_processing_policy(value: str) -> str:
+    policy = (value or "inherit").strip().lower()
+    if policy not in VALID_PROCESSING_POLICIES:
+        raise ValueError("processing_policy must be 'inherit' or 'local_only'")
+    return policy
+
+
+def is_loopback_ollama_host(host: str) -> bool:
+    """Only an explicit loopback hostname/address counts as local processing."""
+    try:
+        parsed = urlparse((host or "").strip())
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+    except ValueError:
+        return False
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def provider_is_local(provider: str, ollama_host: str | None = None) -> bool:
+    if (provider or "").strip().lower() != "ollama":
+        return False
+    if ollama_host is None:
+        from config import get_ollama_host
+        ollama_host = get_ollama_host()
+    return is_loopback_ollama_host(ollama_host)
+
+
+def provider_for_operation(operation: str) -> str:
+    from config import (
+        get_analysis_provider, get_chat_provider, get_library_provider,
+        get_trans_provider,
+    )
+    if operation == "translate":
+        return get_trans_provider()
+    if operation == "chat":
+        return get_chat_provider()
+    if operation in {"insight", "primer"}:
+        return get_analysis_provider()
+    if operation == "recommendation":
+        return get_library_provider()
+    return get_analysis_provider()
+
+
+def processing_disclosure(provider: str, operation: str) -> dict:
+    local = provider_is_local(provider)
+    return {
+        "provider": provider,
+        "local_processing": local,
+        "badge": "local_processing" if local else "external_transfer",
+        "transfer_items": [] if local else list(_TRANSFER_ITEMS.get(operation, ["document_text"])),
+    }
+
+
+def ensure_processing_allowed(document: dict, operation: str, provider: str | None = None) -> dict:
+    """Raise before work/rate accounting starts when local-only would be violated."""
+    policy = normalize_processing_policy(document.get("processing_policy", "inherit"))
+    selected_provider = (provider or provider_for_operation(operation)).strip().lower()
+    disclosure = processing_disclosure(selected_provider, operation)
+    if policy == "local_only" and not disclosure["local_processing"]:
+        raise HTTPException(status_code=409, detail={
+            "code": "external_processing_blocked",
+            "params": {"provider": selected_provider, "operation": operation},
+            "fallback": "This document allows local processing only. Select a loopback Ollama provider.",
+        })
+    return {"processing_policy": policy, **disclosure}
+
+
+def ensure_documents_processing_allowed(
+    documents: Iterable[dict], operation: str, provider: str | None = None,
+) -> list[dict]:
+    return [ensure_processing_allowed(doc, operation, provider) for doc in documents]
+
+
+def document_processing_status(document: dict, operation: str | None = None) -> dict:
+    policy = normalize_processing_policy(document.get("processing_policy", "inherit"))
+    if operation is not None:
+        disclosure = processing_disclosure(provider_for_operation(operation), operation)
+    else:
+        operations = ("translate", "chat", "insight", "recommendation")
+        providers = {name: provider_for_operation(name) for name in operations}
+        disclosures = {
+            name: processing_disclosure(provider, name) for name, provider in providers.items()
+        }
+        external_operations = [name for name, value in disclosures.items() if not value["local_processing"]]
+        transfer_items = list(dict.fromkeys(
+            item for name in external_operations for item in disclosures[name]["transfer_items"]
+        ))
+        disclosure = {
+            "provider": providers["chat"],
+            "providers": providers,
+            "local_processing": not external_operations,
+            "badge": "external_transfer" if external_operations else "local_processing",
+            "external_operations": external_operations,
+            "transfer_items": transfer_items,
+        }
+    if policy == "local_only":
+        disclosure["badge"] = "local_only"
+        disclosure["blocked_external_operations"] = disclosure.get("external_operations", [])
+        disclosure["transfer_items"] = []
+    return {"processing_policy": policy, **disclosure}

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -172,6 +172,7 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
     doc_title = ""
     document_mode = "research"
     document_type = "research_paper"
+    doc = None
     try:
         doc = get_document(session_id)
         if doc:
@@ -180,6 +181,18 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
             document_type = doc.get("document_type", "research_paper")
     except Exception as e:
         print(f"[Job {session_id}] Failed to get document title: {e}")
+
+    if doc:
+        from fastapi import HTTPException
+        from services.processing_policy import ensure_processing_allowed
+        try:
+            ensure_processing_allowed(doc, "translate")
+        except HTTPException as exc:
+            job["status"] = "failed"
+            job["error_code"] = exc.detail.get("code", "external_processing_blocked")
+            job["updated_at"] = datetime.now(timezone.utc).isoformat()
+            _save_job(session_id, job)
+            return
 
     from services.document_policy import translation_cache_candidates
     suffix_candidates = translation_cache_candidates(

--- a/backend/tests/test_processing_privacy.py
+++ b/backend/tests/test_processing_privacy.py
@@ -1,0 +1,186 @@
+import pytest
+from fastapi import HTTPException
+
+from services.processing_policy import (
+    ensure_processing_allowed,
+    is_loopback_ollama_host,
+    provider_is_local,
+)
+
+
+@pytest.mark.parametrize("host", [
+    "http://localhost:11434", "http://127.0.0.1:11434", "http://[::1]:11434",
+])
+def test_loopback_ollama_is_local(host):
+    assert is_loopback_ollama_host(host)
+    assert provider_is_local("ollama", host)
+
+
+@pytest.mark.parametrize("provider,host", [
+    ("openai", "http://127.0.0.1:11434"),
+    ("gemini", "http://127.0.0.1:11434"),
+    ("claude", "http://127.0.0.1:11434"),
+    ("antigravity", "http://127.0.0.1:11434"),
+    ("claude_code", "http://127.0.0.1:11434"),
+    ("codex", "http://127.0.0.1:11434"),
+    ("ollama", "http://192.168.1.20:11434"),
+    ("ollama", "https://ollama.example.com"),
+])
+def test_external_providers_and_remote_ollama_are_not_local(provider, host):
+    assert not provider_is_local(provider, host)
+
+
+def test_local_only_returns_structured_409(monkeypatch):
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    with pytest.raises(HTTPException) as exc_info:
+        ensure_processing_allowed({"processing_policy": "local_only"}, "chat")
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "external_processing_blocked"
+    assert exc_info.value.detail["params"] == {"provider": "openai", "operation": "chat"}
+
+
+def test_inherit_keeps_existing_external_behavior(monkeypatch):
+    monkeypatch.setattr("config.get_trans_provider", lambda: "gemini")
+    status = ensure_processing_allowed({"processing_policy": "inherit"}, "translate")
+    assert status["badge"] == "external_transfer"
+    assert status["transfer_items"] == ["document_text", "page_image"]
+
+
+def _create_doc(isolated_dirs, doc_id, username="testuser"):
+    isolated_dirs["db"].db_save_document(
+        doc_id, username, "paper.pdf", "/x/paper.pdf", 1, {"title": "Paper"},
+    )
+
+
+def test_processing_policy_api_defaults_updates_and_checks_ownership(test_client, isolated_dirs):
+    _create_doc(isolated_dirs, "privacy-own")
+    _create_doc(isolated_dirs, "privacy-other", "otheruser")
+
+    initial = test_client.get("/api/library/privacy-own/processing-policy")
+    assert initial.status_code == 200
+    assert initial.json()["processing_policy"] == "inherit"
+
+    updated = test_client.patch(
+        "/api/library/privacy-own/processing-policy", json={"processing_policy": "local_only"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["processing_policy"] == "local_only"
+    assert isolated_dirs["db"].db_get_document("privacy-own")["processing_policy"] == "local_only"
+
+    assert test_client.get("/api/library/privacy-other/processing-policy").status_code == 404
+    assert test_client.patch(
+        "/api/library/privacy-other/processing-policy", json={"processing_policy": "local_only"},
+    ).status_code == 404
+    assert test_client.patch(
+        "/api/library/privacy-own/processing-policy", json={"processing_policy": "cloud"},
+    ).status_code == 400
+
+
+def test_chat_policy_blocks_before_rate_accounting(test_client, monkeypatch):
+    import routers.chat as chat_router
+    import routers.upload as upload_router
+
+    session_id = "privacy-chat-block"
+    upload_router.sessions[session_id] = {
+        "pdf_path": "/x.pdf", "filename": "x.pdf", "pages": [{"page_num": 1, "text": "text"}],
+        "total_pages": 1, "metadata": {}, "username": "testuser",
+        "processing_policy": "local_only",
+    }
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    calls = []
+    monkeypatch.setattr(chat_router, "enforce_rate_limit", lambda *_args: calls.append(True))
+    try:
+        response = test_client.post("/api/chat/suggestions", json={
+            "session_id": session_id, "messages": [{"role": "user", "content": "question"}],
+        })
+    finally:
+        upload_router.sessions.pop(session_id, None)
+    assert response.status_code == 409
+    assert response.json()["code"] == "external_processing_blocked"
+    assert calls == []
+
+
+def test_system_settings_never_returns_key_material(test_client, monkeypatch):
+    import routers.auth as auth_router
+
+    async def healthy():
+        return {"available_models": []}
+
+    monkeypatch.setattr(auth_router, "check_ollama_health", healthy)
+    monkeypatch.setattr(auth_router, "get_openai_api_key", lambda: "sk-secret-1234")
+    monkeypatch.setattr(auth_router, "get_gemini_api_key", lambda: "gem-secret-5678")
+    monkeypatch.setattr(auth_router, "get_claude_api_key", lambda: "claude-secret-9012")
+    response = test_client.get("/api/settings/system")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "openai_api_key" not in payload
+    assert "gemini_api_key" not in payload
+    assert "claude_api_key" not in payload
+    assert payload["api_keys"] == {
+        "openai": {"configured": True, "masked": "••••1234"},
+        "gemini": {"configured": True, "masked": "••••5678"},
+        "claude": {"configured": True, "masked": "••••9012"},
+    }
+    assert "secret" not in response.text
+
+
+def test_system_settings_empty_keeps_keys_and_delete_flag_removes_one(test_client, monkeypatch):
+    import routers.auth as auth_router
+
+    existing = {"openai": "openai-old", "gemini": "gemini-old", "claude": "claude-old"}
+    monkeypatch.setattr(auth_router, "get_openai_api_key", lambda: existing["openai"])
+    monkeypatch.setattr(auth_router, "get_gemini_api_key", lambda: existing["gemini"])
+    monkeypatch.setattr(auth_router, "get_claude_api_key", lambda: existing["claude"])
+    monkeypatch.setattr(auth_router.venv_manager, "restart_required_for_engine", lambda _engine: False)
+    monkeypatch.setattr(auth_router, "update_translation_prompt_template", lambda _value: None)
+    captured = {}
+    monkeypatch.setattr(auth_router, "update_system_settings", lambda **kwargs: captured.update(kwargs))
+
+    body = {
+        "ollama_host": "http://localhost:11434", "trans_provider": "ollama", "trans_model": "model",
+        "chat_provider": "ollama", "chat_model": "model", "openai_api_key": "",
+        "gemini_api_key": "", "claude_api_key": "", "delete_gemini_api_key": True,
+    }
+    response = test_client.post("/api/settings/system", json=body)
+    assert response.status_code == 200
+    assert captured["openai_api_key"] == "openai-old"
+    assert captured["gemini_api_key"] == ""
+    assert captured["claude_api_key"] == "claude-old"
+
+
+def test_all_document_ai_entrypoints_block_external_processing(test_client, isolated_dirs, monkeypatch):
+    import routers.upload as upload_router
+
+    session_id = "privacy-all-entrypoints"
+    isolated_dirs["db"].db_save_document(
+        session_id, "testuser", "paper.pdf", "/x/paper.pdf", 1, {"title": "Paper"},
+        processing_policy="local_only", detected_source_language="en",
+    )
+    upload_router.sessions[session_id] = {
+        "pdf_path": "/x.pdf", "filename": "paper.pdf", "pages": [{"page_num": 1, "text": "text"}],
+        "total_pages": 1, "metadata": {"title": "Paper"}, "username": "testuser",
+        "document_mode": "research", "document_type": "research_paper",
+        "detected_source_language": "en", "source_language": "auto",
+        "processing_policy": "local_only",
+    }
+    monkeypatch.setattr("config.get_trans_provider", lambda: "openai")
+    monkeypatch.setattr("config.get_chat_provider", lambda: "gemini")
+    monkeypatch.setattr("config.get_analysis_provider", lambda: "claude")
+    monkeypatch.setattr("config.get_library_provider", lambda: "codex")
+
+    requests = [
+        ("get", f"/api/translate/{session_id}/1?source_lang=en"),
+        ("get", f"/api/insight/{session_id}/1?kind=summary&source_lang=en"),
+        ("post", f"/api/insight-jobs/{session_id}/summary/start", {"target_lang": "ko", "source_lang": "en"}),
+        ("post", f"/api/jobs/{session_id}/restart", {"target_lang": "ko", "source_lang": "en"}),
+        ("get", f"/api/library/{session_id}/primer?target_lang=ko"),
+        ("get", "/api/library/graph/recommendations"),
+    ]
+    try:
+        for request in requests:
+            method, url, *rest = request
+            response = getattr(test_client, method)(url, **({"json": rest[0]} if rest else {}))
+            assert response.status_code == 409, (url, response.status_code, response.text)
+            assert response.json()["code"] == "external_processing_blocked"
+    finally:
+        upload_router.sessions.pop(session_id, None)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -422,6 +422,7 @@
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
         <span id="viewer-document-type-chip" class="document-type-chip research"></span>
+        <span id="viewer-processing-badge" class="processing-badge hidden"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
         </button>
@@ -1055,14 +1056,17 @@
             <div class="form-group" id="setting-openai-key-group" style="display: none;">
               <label for="setting-openai-key">OpenAI API Key</label>
               <input type="password" id="setting-openai-key" placeholder="sk-..." style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
+              <button type="button" class="api-key-delete-btn" data-api-key-delete="openai" data-i18n="settings:deleteApiKey">저장된 키 삭제</button>
             </div>
             <div class="form-group" id="setting-gemini-key-group" style="display: none;">
               <label for="setting-gemini-key">Gemini API Key</label>
               <input type="password" id="setting-gemini-key" placeholder="AIzaSy..." style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
+              <button type="button" class="api-key-delete-btn" data-api-key-delete="gemini" data-i18n="settings:deleteApiKey">저장된 키 삭제</button>
             </div>
             <div class="form-group" id="setting-claude-key-group" style="display: none;">
               <label for="setting-claude-key">Claude API Key</label>
               <input type="password" id="setting-claude-key" placeholder="sk-ant-..." style="width: 100%; padding: 12px 16px; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: 12px; color: var(--text-primary); outline: none; font-size: 14px;" />
+              <button type="button" class="api-key-delete-btn" data-api-key-delete="claude" data-i18n="settings:deleteApiKey">저장된 키 삭제</button>
             </div>
           </div>
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -897,6 +897,22 @@ export function installPdfParserAPI(parserId, onProgress, onSuccess, onError) {
   return es
 }
 
+export async function getDocumentProcessingPolicyAPI(docId) {
+  const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/processing-policy`)
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function patchDocumentProcessingPolicyAPI(docId, processingPolicy) {
+  const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/processing-policy`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ processing_policy: processingPolicy })
+  })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
 export async function uninstallPdfParserAPI(parserId) {
   const res = await fetch(`${API_BASE}/settings/uninstall-pdf-parser`, {
     method: 'POST',

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3799,5 +3799,56 @@
   },
   "settings:themeDarkEnabled": {
     "description": "Toast shown after switching to dark mode"
+  },
+  "library:privacy.localOnly": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.localProcessing": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.externalTransfer": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.policy": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.inherit": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.transferItems": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.document_text": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.chat_history": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.page_image": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.document_metadata": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.notes": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.items.document_file": {
+    "description": "Document processing privacy control UI text."
+  },
+  "library:privacy.updated": {
+    "description": "Document processing privacy control UI text."
+  },
+  "settings:deleteApiKey": {
+    "description": "Document processing privacy control UI text."
+  },
+  "settings:apiKeyConfigured": {
+    "description": "Document processing privacy control UI text."
+  },
+  "errors:external_processing_blocked": {
+    "description": "Server-enforced local-only document processing block."
+  },
+  "errors:invalid_processing_policy": {
+    "description": "Invalid document processing policy value."
   }
 }

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -6,5 +6,7 @@
   "unknown": "Something went wrong. Please try again.",
   "source_language_not_translatable": "{{language}} cannot be translated automatically. Choose a supported source language.",
   "generation_failed": "Generation failed. Please try again.",
-  "network": "Could not connect to the server."
+  "network": "Could not connect to the server.",
+  "external_processing_blocked": "This document allows local processing only. Select a loopback Ollama provider for {{operation}}.",
+  "invalid_processing_policy": "Unsupported document processing policy."
 }

--- a/frontend/src/locales/en/library.json
+++ b/frontend/src/locales/en/library.json
@@ -7,5 +7,18 @@
   "subtitle.research.archive": "Manage all saved papers in one place.",
   "subtitle.research.trash": "These papers are in the trash. Restore or permanently delete them.",
   "subtitle.general.archive": "Manage all saved documents in one place.",
-  "subtitle.general.trash": "These documents are in the trash. Restore or permanently delete them."
+  "subtitle.general.trash": "These documents are in the trash. Restore or permanently delete them.",
+  "privacy.localOnly": "Local only",
+  "privacy.localProcessing": "Local processing",
+  "privacy.externalTransfer": "External transfer",
+  "privacy.policy": "Document processing policy",
+  "privacy.inherit": "Use system setting",
+  "privacy.transferItems": "Sent items: {{items}}",
+  "privacy.items.document_text": "document text",
+  "privacy.items.chat_history": "chat history",
+  "privacy.items.page_image": "page images",
+  "privacy.items.document_metadata": "document metadata",
+  "privacy.items.notes": "notes",
+  "privacy.items.document_file": "document file",
+  "privacy.updated": "Document processing policy saved."
 }

--- a/frontend/src/locales/en/settings.json
+++ b/frontend/src/locales/en/settings.json
@@ -8,5 +8,7 @@
   "themeScopeGeneral": "Applies to general document mode only",
   "accentColor": "Accent color",
   "themeLightEnabled": "Switched to light mode ✓",
-  "themeDarkEnabled": "Switched to dark mode ✓"
+  "themeDarkEnabled": "Switched to dark mode ✓",
+  "deleteApiKey": "Delete saved key",
+  "apiKeyConfigured": "Configured (ending {{masked}})"
 }

--- a/frontend/src/locales/ko/errors.json
+++ b/frontend/src/locales/ko/errors.json
@@ -6,5 +6,7 @@
   "unknown": "문제가 발생했습니다. 다시 시도해 주세요.",
   "source_language_not_translatable": "{{language}} 언어는 자동 번역할 수 없습니다. 지원하는 원문 언어를 선택하세요.",
   "generation_failed": "생성하지 못했습니다. 다시 시도해 주세요.",
-  "network": "서버에 연결할 수 없습니다."
+  "network": "서버에 연결할 수 없습니다.",
+  "external_processing_blocked": "이 문서는 로컬 처리만 허용합니다. {{operation}} 작업에는 loopback 주소의 Ollama를 선택하세요.",
+  "invalid_processing_policy": "지원하지 않는 문서 처리 정책입니다."
 }

--- a/frontend/src/locales/ko/library.json
+++ b/frontend/src/locales/ko/library.json
@@ -7,5 +7,18 @@
   "subtitle.research.archive": "보관함에 저장된 모든 논문을 한 곳에서 관리하세요.",
   "subtitle.research.trash": "휴지통에 보관 중인 논문입니다. 복원하거나 영구 삭제할 수 있습니다.",
   "subtitle.general.archive": "보관함에 저장된 모든 문서를 한 곳에서 관리하세요.",
-  "subtitle.general.trash": "휴지통에 보관 중인 문서입니다. 복원하거나 영구 삭제할 수 있습니다."
+  "subtitle.general.trash": "휴지통에 보관 중인 문서입니다. 복원하거나 영구 삭제할 수 있습니다.",
+  "privacy.localOnly": "로컬 전용",
+  "privacy.localProcessing": "로컬 처리",
+  "privacy.externalTransfer": "외부 전송",
+  "privacy.policy": "문서 처리 정책",
+  "privacy.inherit": "시스템 설정 따름",
+  "privacy.transferItems": "전송 항목: {{items}}",
+  "privacy.items.document_text": "문서 텍스트",
+  "privacy.items.chat_history": "채팅 기록",
+  "privacy.items.page_image": "페이지 이미지",
+  "privacy.items.document_metadata": "문서 메타데이터",
+  "privacy.items.notes": "메모",
+  "privacy.items.document_file": "문서 파일",
+  "privacy.updated": "문서 처리 정책이 저장되었습니다."
 }

--- a/frontend/src/locales/ko/settings.json
+++ b/frontend/src/locales/ko/settings.json
@@ -8,5 +8,7 @@
   "themeScopeGeneral": "일반 문서 모드에만 적용",
   "accentColor": "테마 색상",
   "themeLightEnabled": "라이트 모드로 전환 ✓",
-  "themeDarkEnabled": "다크 모드로 전환 ✓"
+  "themeDarkEnabled": "다크 모드로 전환 ✓",
+  "deleteApiKey": "저장된 키 삭제",
+  "apiKeyConfigured": "설정됨 (끝자리 {{masked}})"
 }

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -1110,5 +1110,6 @@
   "페이지 오류": "common:legacy.ui.1109",
   "–페이지로 이동": "common:legacy.ui.1110",
   "페이지로 이동": "common:legacy.ui.1111",
-  "화면 테마": "settings:themeHeading"
+  "화면 테마": "settings:themeHeading",
+  "저장된 키 삭제": "settings:deleteApiKey"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,7 +9,7 @@ import { getModeSetting, normalizeSettingsMode, setModeSetting } from './modeSet
 import { parseStructuredVocabulary, renderStructuredVocabulary } from "./vocabularyView.js"
 import { defaultDocumentType, loadDocumentTypeOptions, saveDocumentTypeOptions, CURRENT_ONBOARDING_VERSION, ONBOARDING_VERSION_KEY } from "./documentModes.js"
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
 import { icon } from './icons.js'
@@ -55,6 +55,8 @@ const state = {
   sourceLanguage: "auto",
   detectedSourceLanguage: "und",
   preferredTargetLanguage: null,
+  processingPolicy: "inherit",
+  processingStatus: null,
   sessionId: null,
   filename: null,
   title: null,
@@ -3164,9 +3166,18 @@ async function refreshSystemSettings() {
     }
 
     settingOllamaHost.value = sys.ollama_host || ''
-    settingOpenAIKey.value = sys.openai_api_key || ''
-    settingGeminiKey.value = sys.gemini_api_key || ''
-    settingClaudeKey.value = sys.claude_api_key || ''
+    const keyInputs = { openai: settingOpenAIKey, gemini: settingGeminiKey, claude: settingClaudeKey }
+    Object.entries(keyInputs).forEach(([provider, input]) => {
+      if (!input) return
+      const status = sys.api_keys?.[provider] || { configured: false, masked: '' }
+      input.value = ''
+      input.dataset.configured = status.configured ? 'true' : 'false'
+      input.dataset.deleteRequested = 'false'
+      input.placeholder = status.configured
+        ? t('settings:apiKeyConfigured', { masked: status.masked })
+        : ({ openai: 'sk-...', gemini: 'AIzaSy...', claude: 'sk-ant-...' }[provider] || '')
+      document.querySelector(`[data-api-key-delete="${provider}"]`)?.classList.toggle('hidden', !status.configured)
+    })
     settingOpenAlexMailto.value = sys.openalex_mailto || ''
 
     const defaultProvider = sys.default_ai_provider || sys.trans_provider || 'antigravity'
@@ -3538,9 +3549,9 @@ async function changeProviderAndModel(type, newProvider, newModel) {
       analysis_model: sys.analysis_model || sys.chat_model || '',
       library_provider: sys.library_provider || sys.analysis_provider || sys.chat_provider || 'antigravity',
       library_model: sys.library_model || sys.analysis_model || sys.chat_model || '',
-      openai_api_key: sys.openai_api_key || '',
-      gemini_api_key: sys.gemini_api_key || '',
-      claude_api_key: sys.claude_api_key || '',
+      openai_api_key: '',
+      gemini_api_key: '',
+      claude_api_key: '',
       openalex_mailto: sys.openalex_mailto || '',
       translation_prompt_template: sys.translation_prompt_template || '',
       pdf_parser_engine: sys.pdf_parser_engine || 'pymupdf'
@@ -3950,6 +3961,9 @@ async function autoSaveSystemSettings({ silent = false } = {}) {
     openai_api_key: settingOpenAIKey ? settingOpenAIKey.value.trim() : '',
     gemini_api_key: settingGeminiKey ? settingGeminiKey.value.trim() : '',
     claude_api_key: settingClaudeKey ? settingClaudeKey.value.trim() : '',
+    delete_openai_api_key: settingOpenAIKey?.dataset.deleteRequested === 'true',
+    delete_gemini_api_key: settingGeminiKey?.dataset.deleteRequested === 'true',
+    delete_claude_api_key: settingClaudeKey?.dataset.deleteRequested === 'true',
     openalex_mailto: settingOpenAlexMailto ? settingOpenAlexMailto.value.trim() : '',
     translation_prompt_template: $('setting-prompt-template') ? $('setting-prompt-template').value : '',
     pdf_parser_engine: pdfParserEngine
@@ -3971,6 +3985,21 @@ async function autoSaveSystemSettings({ silent = false } = {}) {
 
 ;[settingOllamaHost, settingOpenAIKey, settingGeminiKey, settingClaudeKey, settingOpenAlexMailto].forEach(el => {
   if (el) el.addEventListener('change', () => autoSaveSystemSettings())
+})
+
+;[settingOpenAIKey, settingGeminiKey, settingClaudeKey].forEach(input => {
+  input?.addEventListener('input', () => { if (input.value.trim()) input.dataset.deleteRequested = 'false' })
+})
+document.querySelectorAll('[data-api-key-delete]').forEach(button => {
+  button.addEventListener('click', async () => {
+    const input = $(`setting-${button.dataset.apiKeyDelete}-key`)
+    if (!input) return
+    input.value = ''
+    input.dataset.deleteRequested = 'true'
+    await autoSaveSystemSettings({ silent: true })
+    await refreshSystemSettings()
+    showToast(t('settings:saved'), 'success')
+  })
 })
 
 ;[settingAutoGenerateKeywords, settingAutoGenerateSummaries].forEach(el => {
@@ -8158,6 +8187,36 @@ function documentTypeChipHtml(doc, includeMode = false) {
   return `<span class="document-type-chip ${docMode}" title="${escapeHtml(label)}">${escapeHtml(label)}</span>`
 }
 
+function processingBadgeHtml(doc) {
+  const processing = doc?.processing || doc?.processingStatus
+  if (!processing) return ''
+  const label = processing.badge === 'local_only'
+    ? t('library:privacy.localOnly')
+    : processing.badge === 'local_processing' ? t('library:privacy.localProcessing') : t('library:privacy.externalTransfer')
+  const itemLabels = {
+    document_text: t('library:privacy.items.document_text'),
+    chat_history: t('library:privacy.items.chat_history'),
+    page_image: t('library:privacy.items.page_image'),
+    document_metadata: t('library:privacy.items.document_metadata'),
+    notes: t('library:privacy.items.notes'),
+    document_file: t('library:privacy.items.document_file')
+  }
+  const items = (processing.transfer_items || []).map(item => itemLabels[item] || item).join(', ')
+  const title = items ? t('library:privacy.transferItems', { items }) : label
+  return `<span class="processing-badge ${escapeHtml(processing.badge)}" title="${escapeHtml(title)}">${escapeHtml(label)}</span>`
+}
+
+function renderViewerProcessingBadge(processing) {
+  const el = $('viewer-processing-badge')
+  if (!el) return
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = processingBadgeHtml({ processing })
+  const badge = wrapper.firstElementChild
+  if (!badge) { el.className = 'processing-badge hidden'; el.textContent = ''; return }
+  el.className = badge.className
+  el.textContent = badge.textContent
+  el.title = badge.title
+}
 function createDocCard(doc) {
   const d = prepareDocItemHtml(doc)
   const isFav = isFavoriteDoc(doc.id)
@@ -8207,6 +8266,7 @@ function createDocCard(doc) {
         <div class="lib-card-top-body">
           <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
           ${documentTypeChipHtml(doc, true)}
+          ${processingBadgeHtml(doc)}
         </div>
       </div>
       ${d.tagsHtml}
@@ -8300,6 +8360,14 @@ function ensureLibraryDetailPanel() {
         <div class="lib-detail-title-block">
           <h2 id="lib-detail-title" class="lib-detail-title"></h2>
           <p id="lib-detail-subtitle" class="lib-detail-subtitle"></p>
+          <div class="lib-detail-processing-row">
+            <span id="lib-detail-processing-badge"></span>
+            <label for="lib-detail-processing-policy">${t('library:privacy.policy')}</label>
+            <select id="lib-detail-processing-policy">
+              <option value="inherit">${t('library:privacy.inherit')}</option>
+              <option value="local_only">${t('library:privacy.localOnly')}</option>
+            </select>
+          </div>
         </div>
       </div>
       <div class="lib-detail-actions">
@@ -8457,6 +8525,34 @@ function openLibraryDetailPanel(doc) {
   if (subtitleEl) {
     const date = new Date(doc.created_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
     subtitleEl.textContent = `등록 ${date} · ${doc.total_pages || 1}페이지`
+  }
+  const processingBadge = $('lib-detail-processing-badge')
+  if (processingBadge) processingBadge.innerHTML = processingBadgeHtml(doc)
+  const processingSelect = $('lib-detail-processing-policy')
+  if (processingSelect) {
+    processingSelect.value = doc.processing_policy || 'inherit'
+    processingSelect.onchange = async () => {
+      const previous = doc.processing_policy || 'inherit'
+      processingSelect.disabled = true
+      try {
+        const processing = await patchDocumentProcessingPolicyAPI(doc.id, processingSelect.value)
+        doc.processing_policy = processing.processing_policy
+        doc.processing = processing
+        if (processingBadge) processingBadge.innerHTML = processingBadgeHtml(doc)
+        if (state.currentDocId === doc.id) {
+          state.processingPolicy = processing.processing_policy
+          state.processingStatus = processing
+          renderViewerProcessingBadge(processing)
+        }
+        showToast(t('library:privacy.updated'), 'success')
+        await renderLibrary()
+      } catch (error) {
+        processingSelect.value = previous
+        showToast(error.message, 'error')
+      } finally {
+        processingSelect.disabled = false
+      }
+    }
   }
 
   const coverWrap = $('lib-detail-cover')
@@ -9405,6 +9501,8 @@ async function openFromLibrary(doc, shouldPushState = true) {
     state.sourceLanguage = doc.source_language || "auto"
     state.detectedSourceLanguage = doc.detected_source_language || "und"
     state.preferredTargetLanguage = doc.preferred_target_language || null
+    state.processingPolicy = doc.processing_policy || "inherit"
+    state.processingStatus = doc.processing || null
     populateLanguageControls()
 
     // 읽기 전 브리핑 게이팅: 설정에서 껐거나 이미 이 문서의 브리핑을 본 적
@@ -9490,6 +9588,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
       viewerDocumentTypeChip.className = `document-type-chip ${docMode}`
       viewerDocumentTypeChip.textContent = workspaceModeController.getTypeLabel(docMode, doc.document_type || "research_paper")
     }
+    renderViewerProcessingBadge(doc.processing)
     pageTotal.textContent = `/ ${doc.total_pages}`
     pageInput.max   = doc.total_pages
 

--- a/frontend/src/onboarding.js
+++ b/frontend/src/onboarding.js
@@ -170,13 +170,13 @@ export function createOnboarding({
     if (cli.antigravity) {
       detected.push({ provider: 'antigravity', label: 'Antigravity', sub: 'CLI 감지됨' })
     }
-    if (sys.openai_api_key) {
+    if (sys.api_keys?.openai?.configured) {
       detected.push({ provider: 'openai', label: 'OpenAI', sub: 'API 키 설정됨' })
     }
-    if (sys.gemini_api_key) {
+    if (sys.api_keys?.gemini?.configured) {
       detected.push({ provider: 'gemini', label: 'Gemini', sub: 'API 키 설정됨' })
     }
-    if (sys.claude_api_key) {
+    if (sys.api_keys?.claude?.configured) {
       detected.push({ provider: 'claude', label: 'Anthropic Claude', sub: 'API 키 설정됨' })
     }
     onboardingState.detected = detected
@@ -312,9 +312,9 @@ export function createOnboarding({
           analysis_model: model,
           library_provider: entry.provider,
           library_model: model,
-          openai_api_key: sys.openai_api_key,
-          gemini_api_key: sys.gemini_api_key,
-          claude_api_key: sys.claude_api_key,
+          openai_api_key: '',
+          gemini_api_key: '',
+          claude_api_key: '',
           translation_prompt_template: sys.translation_prompt_template,
         })
         // sync compact pickers so the viewer/chat UI reflects the newly selected engine immediately

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7078,3 +7078,11 @@ body.light-theme .chat-drawer {
 .document-language-controls label { display:flex; align-items:center; justify-content:space-between; gap:8px; }
 .document-language-controls select { max-width:150px; background:var(--bg-elevated); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 5px; }
 #document-language-status { max-width:230px; white-space:normal; }
+
+.processing-badge { display:inline-flex; align-items:center; width:max-content; padding:2px 7px; border-radius:999px; font-size:10px; font-weight:700; border:1px solid var(--border-strong); color:var(--text-secondary); background:var(--bg-elevated); }
+.processing-badge.local_only { color:#166534; background:#dcfce7; border-color:#86efac; }
+.processing-badge.local_processing { color:#075985; background:#e0f2fe; border-color:#7dd3fc; }
+.processing-badge.external_transfer { color:#9a3412; background:#ffedd5; border-color:#fdba74; }
+.lib-detail-processing-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:6px; font-size:11px; color:var(--text-secondary); }
+.lib-detail-processing-row select { border:1px solid var(--border-strong); border-radius:7px; background:var(--bg-elevated); color:var(--text-primary); padding:4px 7px; font-size:11px; }
+.api-key-delete-btn { margin-top:6px; padding:5px 8px; border:1px solid var(--border-strong); border-radius:7px; background:transparent; color:var(--text-secondary); cursor:pointer; font-size:11px; }


### PR DESCRIPTION
# Summary
## 1. 문서별 처리 정책 추가
- documents.processing_policy에 inherit 및 local_only 정책을 추가
- loopback Ollama만 로컬 처리로 분류하고 원격 Ollama 및 외부 공급자를 서버에서 차단
- 번역, 채팅, 인사이트, 브리핑, 추천 진입점에 구조화 409 오류 적용
## 2. 개인정보 상태 UI 추가
- 라이브러리 카드, 문서 상세, 뷰어에 로컬 처리, 외부 전송, 로컬 전용 배지를 표시
- 외부 전송 공급자와 문서 텍스트, 채팅 기록, 페이지 이미지 등 전송 항목을 표시
- 문서 상세에서 처리 정책을 변경하는 소유권 검증 API와 UI를 추가
## 3. API 키 응답 보호
- 시스템 설정 조회에서 API 키 원문을 제거하고 configured 상태와 끝자리만 반환
- 빈 값은 기존 키 유지, 명시적 삭제 플래그만 키를 삭제하도록 변경
- 한국어 및 영어 오류·개인정보 UI 현지화를 추가
## 4. 회귀 테스트 추가
- 공급자 분류, 원격 Ollama, 모든 AI 진입점 차단, 기본 inherit 호환을 테스트
- 정책 API 소유권과 API 키 비노출·유지·삭제를 테스트