### PR TITLE
feat: add durable document task recovery

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,6 +35,7 @@ from routers import insight as insight_router
 from routers import primer as primer_router
 from routers import languages as languages_router
 from routers import workspace as workspace_router
+from routers import tasks as tasks_router
 from services.auth import get_current_user
 
 @asynccontextmanager
@@ -80,6 +81,7 @@ app.include_router(translate.router, prefix="/api", dependencies=[Depends(get_cu
 app.include_router(chat.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Chat"])
 app.include_router(library_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Library"])
 app.include_router(jobs_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Jobs"])
+app.include_router(tasks_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Tasks"])
 app.include_router(agy_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["AGY"])
 app.include_router(insight_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Insight"])
 app.include_router(workspace_router.router, prefix="/api", dependencies=[Depends(get_current_user)], tags=["Workspace"])

--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -54,7 +54,7 @@ _last_failure_at: dict[str, float] = {}
 _RETRY_COOLDOWN_SECONDS = 15
 
 
-def _ensure_generation_started(doc_id: str, target_lang: str, source_lang: str, session: dict, current_user: str) -> None:
+def _ensure_generation_started(doc_id: str, target_lang: str, source_lang: str, session: dict, current_user: str, durable_task_id: str | None = None) -> None:
     """이 문서/언어 조합의 브리핑 생성이 이미 진행 중이 아니면 백그라운드
     태스크로 새로 시작한다. GET(캐시 미스)과 POST(재생성) 양쪽에서 공유한다."""
     from services.processing_policy import ensure_processing_allowed
@@ -76,22 +76,47 @@ def _ensure_generation_started(doc_id: str, target_lang: str, source_lang: str, 
     if last_failure is not None and (time.monotonic() - last_failure) < _RETRY_COOLDOWN_SECONDS:
         return
 
+    from services.document_tasks import create_task, get_task, update_task
+    durable = get_task(durable_task_id) if durable_task_id else None
+    if durable is None:
+        durable = create_task(doc_id, "primer", {
+            "target_lang": target_lang, "source_lang": source_lang,
+            "document_mode": document_mode, "document_type": document_type,
+        }, status="queued")
+    durable_task_id = durable["id"]
+
     async def _generate():
-        try:
+        from services.document_tasks import retry_async
+        from services.document_tasks import wait_for_retry
+        if not await wait_for_retry(durable_task_id):
+            _pending_generations.pop(task_key, None)
+            return
+        update_task(durable_task_id, status="running", increment_attempt=True)
+
+        async def generate_once():
             if document_mode == "general":
-                await generate_document_overview(
+                return await generate_document_overview(
                     doc_id, session["pages"], session["metadata"], document_type,
                     target_lang=target_lang, source_lang=source_lang, session_id=doc_id,
                 )
-            else:
-                await generate_primer(
-                    doc_id, session["pages"], session["metadata"],
-                    username=current_user, pdf_path=session["pdf_path"],
-                    target_lang=target_lang, session_id=doc_id,
-                    source_lang=source_lang,
-                )
+            return await generate_primer(
+                doc_id, session["pages"], session["metadata"],
+                username=current_user, pdf_path=session["pdf_path"],
+                target_lang=target_lang, session_id=doc_id,
+                source_lang=source_lang,
+            )
+
+        def record_retry(_attempt: int, code: str, retry_at: str) -> None:
+            update_task(durable_task_id, status="retry_wait", last_error_code=code,
+                        next_retry_at=retry_at, increment_attempt=True)
+
+        try:
+            await retry_async(generate_once, on_retry=record_retry)
+            update_task(durable_task_id, status="succeeded")
             _last_failure_at.pop(task_key, None)
         except Exception as e:
+            update_task(durable_task_id, status="failed",
+                        last_error_code=getattr(e, "document_task_error_code", "generation_failed"))
             # generate_primer()가 실패하면 캐시에 아무것도 저장하지 않은 채 여기서
             # 끝난다. 태스크가 pop되므로 쿨다운이 지난 뒤 다음 GET/재생성 요청이
             # 처음부터 다시 시도한다(pending 폴링이 이미 그 재시도를 감당하도록

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -1,0 +1,82 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from routers.upload import require_session_owner
+from services.auth import get_current_user
+from services.document_tasks import get_task, list_tasks, request_cancel, reset_failed
+from services.ownership import require_owned_document
+
+router = APIRouter()
+
+
+def _owned_task(task_id: str, current_user: str) -> dict:
+    task = get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="작업을 찾을 수 없습니다.")
+    require_owned_document(task["doc_id"], current_user)
+    return task
+
+
+@router.get("/tasks")
+async def get_document_tasks(doc_id: Optional[str] = Query(default=None), current_user: str = Depends(get_current_user)):
+    if not doc_id:
+        raise HTTPException(status_code=400, detail="doc_id가 필요합니다.")
+    require_owned_document(doc_id, current_user)
+    return {"tasks": list_tasks(doc_id)}
+
+
+@router.get("/tasks/{task_id}")
+async def get_document_task(task_id: str, current_user: str = Depends(get_current_user)):
+    return _owned_task(task_id, current_user)
+
+
+@router.post("/tasks/{task_id}/cancel")
+async def cancel_document_task(task_id: str, current_user: str = Depends(get_current_user)):
+    task = _owned_task(task_id, current_user)
+    if task["kind"] == "translate":
+        from services.translation_job import cancel_job
+        cancel_job(task["doc_id"])
+    elif task["kind"] in {"keywords", "summary"}:
+        from services.insight_job import cancel_insight_job
+        cancel_insight_job(task["doc_id"], task["kind"])
+    return request_cancel(task_id)
+
+
+@router.post("/tasks/{task_id}/retry")
+async def retry_document_task(task_id: str, current_user: str = Depends(get_current_user)):
+    previous = _owned_task(task_id, current_user)
+    if previous["kind"] not in {"translate", "keywords", "summary", "primer"}:
+        raise HTTPException(status_code=409, detail="이 작업 종류는 수동 재시도를 지원하지 않습니다.")
+    failed_pages = previous["failed_pages"] or [
+        page["page_num"] for page in previous["pages"] if page["status"] == "cancelled"
+    ]
+    task = reset_failed(task_id)
+    session = require_session_owner(task["doc_id"], current_user)
+    options = task["options"]
+    if task["kind"] == "translate":
+        from services.translation_job import start_job
+        start_job(
+            task["doc_id"], session["pages"], target_lang=options.get("target_lang", "ko"),
+            source_lang=options.get("source_lang", "auto"), style=options.get("style", "academic"),
+            ignore_math=bool(options.get("ignore_math", False)),
+            ignore_table=bool(options.get("ignore_table", True)),
+            ignore_refs=bool(options.get("ignore_refs", False)),
+            page_numbers=failed_pages or None, durable_task_id=task_id,
+        )
+    elif task["kind"] in {"keywords", "summary"}:
+        from services.insight_job import start_keyword_job, start_summary_job
+        starter = start_keyword_job if task["kind"] == "keywords" else start_summary_job
+        starter(
+            task["doc_id"], session["pages"], options.get("target_lang", "ko"),
+            session.get("metadata", {}).get("title") or session.get("filename", ""),
+            session.get("document_mode", "research"), session.get("document_type", "research_paper"),
+            options.get("source_lang", "auto"), durable_task_id=task_id,
+        )
+    elif task["kind"] == "primer":
+        from routers.primer import _ensure_generation_started
+        _ensure_generation_started(
+            task["doc_id"], options.get("target_lang", "ko"), options.get("source_lang", "auto"),
+            session, current_user, durable_task_id=task_id,
+        )
+    return get_task(task_id)

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -109,14 +109,18 @@ def restore_sessions_from_library():
     준비해둘 필요가 없다. job_status.json 존재 여부만 확인하는 건 PDF를
     열지 않는 가벼운 파일 I/O라 문서 수가 많아도 부담이 없다.
     """
+    from services.document_tasks import recoverable_tasks
+    recoverable_doc_ids = {task["doc_id"] for task in recoverable_tasks()}
     for doc in list_documents():
         doc_id = doc["id"]
         job = get_job_status(doc_id)
-        if job and job.get("status") == "running":
+        if doc_id in recoverable_doc_ids or (job and job.get("status") == "running"):
             ensure_session(doc_id)
 
-    # 미완료 번역 잡 재개 (위에서 세션이 복원된 문서만 대상)
+    # 미완료 번역 잡과 나머지 영속 작업 재개
     resume_incomplete_jobs(sessions)
+    from services.document_tasks import recover_document_tasks
+    recover_document_tasks(sessions)
 
 
 @router.post("/upload", response_model=UploadResponse)
@@ -194,10 +198,14 @@ async def upload_pdf(
     file_size_mb = total_bytes / (1024 * 1024)
 
     # PDF 파싱
+    from services.document_tasks import create_task, update_task
+    parse_task = create_task(session_id, "parse", {"filename": file.filename}, status="running")
     try:
         metadata = get_pdf_metadata(pdf_path)
         pages = extract_pages(pdf_path)
+        update_task(parse_task["id"], status="succeeded")
     except Exception as e:
+        update_task(parse_task["id"], status="failed", last_error_code="invalid_pdf")
         shutil.rmtree(session_dir, ignore_errors=True)
         raise HTTPException(status_code=422, detail=f"PDF 파싱 실패: {str(e)}")
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -98,6 +98,39 @@ def init_db():
         )
         """)
 
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS document_tasks (
+            id TEXT PRIMARY KEY,
+            doc_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            options TEXT NOT NULL DEFAULT '{}',
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 3,
+            last_error_code TEXT,
+            next_retry_at TEXT,
+            cancel_requested INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS document_task_pages (
+            task_id TEXT NOT NULL,
+            page_num INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            last_error_code TEXT,
+            next_retry_at TEXT,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (task_id, page_num),
+            FOREIGN KEY (task_id) REFERENCES document_tasks (id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_tasks_doc ON document_tasks(doc_id, created_at DESC)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_tasks_recovery ON document_tasks(status, next_retry_at)")
+
         # 문서 채팅용 페이지·문단 전문 검색 인덱스. PDF 원문을 문단 단위로
         # 저장해 재시작 후에도 후반부 질문을 검색할 수 있다.
         try:
@@ -759,6 +792,8 @@ def db_delete_document(doc_id: str) -> bool:
         )
         cursor.execute("DELETE FROM annotations WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM memos WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM document_task_pages WHERE task_id IN (SELECT id FROM document_tasks WHERE doc_id = ?)", (doc_id,))
+        cursor.execute("DELETE FROM document_tasks WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM page_insights WHERE doc_id = ?", (doc_id,))
         try:
             cursor.execute("DELETE FROM document_chunks_fts WHERE doc_id = ?", (doc_id,))

--- a/backend/services/document_tasks.py
+++ b/backend/services/document_tasks.py
@@ -1,0 +1,326 @@
+"""Persistent document task state, page checkpoints, and retry policy."""
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Iterable, Optional, TypeVar
+
+import httpx
+
+from services.db import get_db
+
+TASK_KINDS = {"parse", "translate", "keywords", "summary", "primer"}
+TASK_STATUSES = {"queued", "running", "retry_wait", "succeeded", "partial_failed", "failed", "cancelled"}
+PAGE_STATUSES = {"queued", "running", "retry_wait", "succeeded", "failed", "cancelled"}
+RECOVERABLE_STATUSES = {"queued", "running", "retry_wait"}
+BACKOFF_SECONDS = (2, 10, 30)
+T = TypeVar("T")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _decode_task(row: sqlite3.Row, pages: list[sqlite3.Row]) -> dict:
+    task = dict(row)
+    task["options"] = json.loads(task.get("options") or "{}")
+    task["cancel_requested"] = bool(task.get("cancel_requested"))
+    task["pages"] = [dict(page) for page in pages]
+    task["total_pages"] = len(pages)
+    task["completed_pages"] = [p["page_num"] for p in task["pages"] if p["status"] == "succeeded"]
+    task["failed_pages"] = [p["page_num"] for p in task["pages"] if p["status"] == "failed"]
+    task["current_page"] = next((p["page_num"] for p in task["pages"] if p["status"] == "running"), None)
+    return task
+
+
+def create_task(doc_id: str, kind: str, options: Optional[dict] = None,
+                page_numbers: Optional[Iterable[int]] = None, max_attempts: int = 3,
+                task_id: Optional[str] = None, status: str = "queued") -> dict:
+    if kind not in TASK_KINDS:
+        raise ValueError("unsupported document task kind")
+    if status not in TASK_STATUSES:
+        raise ValueError("unsupported document task status")
+    task_id = task_id or str(uuid.uuid4())
+    now = _now()
+    pages = sorted({int(page) for page in (page_numbers or []) if int(page) > 0})
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO document_tasks
+               (id, doc_id, kind, status, options, attempt_count, max_attempts,
+                cancel_requested, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, 0, ?, 0, ?, ?)""",
+            (task_id, doc_id, kind, status, json.dumps(options or {}, ensure_ascii=False),
+             max(1, int(max_attempts)), now, now),
+        )
+        conn.executemany(
+            """INSERT INTO document_task_pages
+               (task_id, page_num, status, attempt_count, updated_at)
+               VALUES (?, ?, 'queued', 0, ?)""",
+            [(task_id, page, now) for page in pages],
+        )
+        conn.commit()
+    return get_task(task_id)
+
+
+def get_task(task_id: str) -> Optional[dict]:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM document_tasks WHERE id = ?", (task_id,)).fetchone()
+        if not row:
+            return None
+        pages = conn.execute(
+            "SELECT * FROM document_task_pages WHERE task_id = ? ORDER BY page_num", (task_id,),
+        ).fetchall()
+    return _decode_task(row, pages)
+
+
+def list_tasks(doc_id: Optional[str] = None) -> list[dict]:
+    with get_db() as conn:
+        if doc_id:
+            rows = conn.execute(
+                "SELECT id FROM document_tasks WHERE doc_id = ? ORDER BY created_at DESC", (doc_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute("SELECT id FROM document_tasks ORDER BY created_at DESC").fetchall()
+    return [task for row in rows if (task := get_task(row["id"]))]
+
+
+def latest_task(doc_id: str, kind: str) -> Optional[dict]:
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT id FROM document_tasks WHERE doc_id = ? AND kind = ? ORDER BY created_at DESC LIMIT 1",
+            (doc_id, kind),
+        ).fetchone()
+    return get_task(row["id"]) if row else None
+
+
+def update_task(task_id: str, *, status: Optional[str] = None,
+                last_error_code: Optional[str] = None, next_retry_at: Optional[str] = None,
+                increment_attempt: bool = False, cancel_requested: Optional[bool] = None) -> dict:
+    if status is not None and status not in TASK_STATUSES:
+        raise ValueError("unsupported document task status")
+    assignments = ["updated_at = ?", "last_error_code = ?", "next_retry_at = ?"]
+    params: list[object] = [_now(), last_error_code, next_retry_at]
+    if status is not None:
+        assignments.append("status = ?")
+        params.append(status)
+    if increment_attempt:
+        assignments.append("attempt_count = attempt_count + 1")
+    if cancel_requested is not None:
+        assignments.append("cancel_requested = ?")
+        params.append(1 if cancel_requested else 0)
+    params.append(task_id)
+    with get_db() as conn:
+        cursor = conn.execute(f"UPDATE document_tasks SET {', '.join(assignments)} WHERE id = ?", params)
+        if cursor.rowcount != 1:
+            raise ValueError("document task not found")
+        conn.commit()
+    return get_task(task_id)
+
+
+def update_page(task_id: str, page_num: int, status: str, *,
+                last_error_code: Optional[str] = None, next_retry_at: Optional[str] = None,
+                increment_attempt: bool = False) -> dict:
+    if status not in PAGE_STATUSES:
+        raise ValueError("unsupported document task page status")
+    assignments = ["status = ?", "last_error_code = ?", "next_retry_at = ?", "updated_at = ?"]
+    params: list[object] = [status, last_error_code, next_retry_at, _now()]
+    if increment_attempt:
+        assignments.append("attempt_count = attempt_count + 1")
+    params.extend([task_id, int(page_num)])
+    with get_db() as conn:
+        cursor = conn.execute(
+            f"UPDATE document_task_pages SET {', '.join(assignments)} WHERE task_id = ? AND page_num = ?", params,
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("document task page not found")
+        conn.execute("UPDATE document_tasks SET updated_at = ? WHERE id = ?", (_now(), task_id))
+        conn.commit()
+    return get_task(task_id)
+
+
+def finish_from_pages(task_id: str) -> dict:
+    task = get_task(task_id)
+    if not task:
+        raise ValueError("document task not found")
+    statuses = {page["status"] for page in task["pages"]}
+    if task["cancel_requested"] or statuses == {"cancelled"}:
+        status = "cancelled"
+    elif "failed" in statuses and "succeeded" in statuses:
+        status = "partial_failed"
+    elif "failed" in statuses:
+        status = "failed"
+    elif not statuses or statuses <= {"succeeded"}:
+        status = "succeeded"
+    else:
+        status = task["status"]
+    return update_task(task_id, status=status, last_error_code=task.get("last_error_code"))
+
+
+def request_cancel(task_id: str) -> dict:
+    task = update_task(task_id, status="cancelled", cancel_requested=True)
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE document_task_pages SET status = 'cancelled', updated_at = ? WHERE task_id = ? AND status IN ('queued','running','retry_wait')",
+            (_now(), task_id),
+        )
+        conn.commit()
+    return get_task(task_id)
+
+
+def reset_failed(task_id: str) -> dict:
+    task = get_task(task_id)
+    if not task:
+        raise ValueError("document task not found")
+    if task["status"] not in {"failed", "partial_failed", "cancelled"}:
+        raise ValueError("only failed or cancelled tasks can be retried")
+    with get_db() as conn:
+        conn.execute(
+            """UPDATE document_task_pages SET status = 'queued', last_error_code = NULL,
+               next_retry_at = NULL, updated_at = ? WHERE task_id = ? AND status IN ('failed','cancelled')""",
+            (_now(), task_id),
+        )
+        conn.execute(
+            """UPDATE document_tasks SET status = 'queued', last_error_code = NULL,
+               next_retry_at = NULL, cancel_requested = 0, updated_at = ? WHERE id = ?""",
+            (_now(), task_id),
+        )
+        conn.commit()
+    return get_task(task_id)
+
+
+def recoverable_tasks() -> list[dict]:
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT id FROM document_tasks WHERE status IN ('queued','running','retry_wait') ORDER BY created_at",
+        ).fetchall()
+    return [task for row in rows if (task := get_task(row["id"]))]
+
+
+def classify_error(exc: Exception) -> tuple[str, bool]:
+    status_code = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status_code = getattr(response, "status_code", status_code)
+    text = str(exc).lower()
+    if status_code == 429:
+        return "rate_limited", True
+    if isinstance(status_code, int) and status_code >= 500:
+        return "provider_unavailable", True
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError, asyncio.TimeoutError)):
+        return "timeout", True
+    if isinstance(exc, (httpx.NetworkError, ConnectionError)):
+        return "network_error", True
+    if status_code in {401, 403} or any(token in text for token in ("api key", "authentication", "unauthorized")):
+        return "authentication_failed", False
+    if any(token in text for token in ("unsupported model", "model not found", "invalid model")):
+        return "unsupported_model", False
+    return "generation_failed", False
+
+
+async def retry_async(operation: Callable[[], Awaitable[T]], *, max_attempts: int = 3,
+                      on_retry: Optional[Callable[[int, str, str], None]] = None,
+                      sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+                      jitter: Callable[[], float] = random.random) -> T:
+    attempts = max(1, int(max_attempts))
+    for attempt in range(1, attempts + 1):
+        try:
+            return await operation()
+        except Exception as exc:
+            code, transient = classify_error(exc)
+            if not transient or attempt >= attempts:
+                setattr(exc, "document_task_error_code", code)
+                raise
+            delay = BACKOFF_SECONDS[min(attempt - 1, len(BACKOFF_SECONDS) - 1)] + jitter()
+            retry_at = (datetime.now(timezone.utc) + timedelta(seconds=delay)).isoformat()
+            if on_retry:
+                on_retry(attempt, code, retry_at)
+            await sleep(delay)
+    raise RuntimeError("retry loop exhausted")
+
+
+async def wait_for_retry(task_id: str, sleep: Callable[[float], Awaitable[None]] = asyncio.sleep) -> bool:
+    """Wait for a persisted retry deadline and stop if the task was cancelled."""
+    task = get_task(task_id)
+    if not task or task["cancel_requested"] or task["status"] == "cancelled":
+        return False
+    retry_at = task.get("next_retry_at")
+    if retry_at:
+        try:
+            deadline = datetime.fromisoformat(retry_at.replace("Z", "+00:00"))
+            delay = max(0.0, (deadline - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError):
+            delay = 0.0
+        if delay:
+            await sleep(delay)
+    task = get_task(task_id)
+    return bool(task and not task["cancel_requested"] and task["status"] != "cancelled")
+
+
+def migrate_legacy_translation(doc_id: str, legacy: dict) -> dict:
+    existing = latest_task(doc_id, "translate")
+    if existing:
+        return existing
+    target_pages = legacy.get("target_pages") or list(range(1, int(legacy.get("total_pages", 0)) + 1))
+    old_status = legacy.get("status", "running")
+    status = "running" if old_status == "running" else "succeeded"
+    task = create_task(doc_id, "translate", legacy.get("options") or {}, target_pages,
+                       task_id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"easypaper:legacy:{doc_id}")), status=status)
+    completed = set(legacy.get("completed_pages") or [])
+    failed = set(legacy.get("failed_pages") or [])
+    for page in target_pages:
+        if page in completed:
+            update_page(task["id"], page, "succeeded")
+        elif page in failed:
+            update_page(task["id"], page, "failed", last_error_code="legacy_generation_failed")
+    if failed:
+        update_task(task["id"], status="partial_failed" if completed else "failed")
+    return get_task(task["id"])
+
+
+def legacy_translation_view(task: dict) -> dict:
+    status_map = {
+        "queued": "running", "running": "running", "retry_wait": "running",
+        "succeeded": "completed", "partial_failed": "completed", "failed": "failed", "cancelled": "cancelled",
+    }
+    return {
+        "task_id": task["id"], "session_id": task["doc_id"],
+        "status": status_map[task["status"]], "task_status": task["status"],
+        "total_pages": task["total_pages"],
+        "target_pages": [page["page_num"] for page in task["pages"]],
+        "completed_pages": task["completed_pages"], "failed_pages": task["failed_pages"],
+        "options": task["options"], "last_error_code": task.get("last_error_code"),
+        "next_retry_at": task.get("next_retry_at"), "updated_at": task["updated_at"],
+    }
+
+
+def recover_document_tasks(sessions: dict) -> None:
+    """Requeue incomplete durable work after sessions have been restored."""
+    for task in recoverable_tasks():
+        session = sessions.get(task["doc_id"])
+        if not session:
+            continue
+        if task["kind"] == "translate":
+            continue
+        if task["kind"] == "parse":
+            update_task(task["id"], status="succeeded")
+        elif task["kind"] in {"keywords", "summary"}:
+            from services.insight_job import start_keyword_job, start_summary_job
+            starter = start_keyword_job if task["kind"] == "keywords" else start_summary_job
+            options = task["options"]
+            starter(
+                task["doc_id"], session["pages"], options.get("target_lang", "ko"),
+                session.get("metadata", {}).get("title") or session.get("filename", ""),
+                session.get("document_mode", "research"), session.get("document_type", "research_paper"),
+                options.get("source_lang", "auto"), durable_task_id=task["id"],
+            )
+        elif task["kind"] == "primer":
+            from routers.primer import _ensure_generation_started
+            options = task["options"]
+            _ensure_generation_started(
+                task["doc_id"], options.get("target_lang", "ko"), options.get("source_lang", "auto"),
+                session, session.get("username", "admin"), durable_task_id=task["id"],
+            )

--- a/backend/services/insight_job.py
+++ b/backend/services/insight_job.py
@@ -39,7 +39,19 @@ def estimate_insight_job(session_id: str, pages: list, target_lang: str, kind: s
 
 def get_insight_job_status(session_id: str, kind: str) -> dict | None:
     value = _job_status.get((session_id, kind))
-    return dict(value) if value else None
+    if value:
+        return dict(value)
+    from services.document_tasks import latest_task
+    task = latest_task(session_id, kind)
+    if not task:
+        return None
+    return {
+        "task_id": task["id"], "session_id": session_id, "kind": kind,
+        "status": task["status"], "completed_pages": len(task["completed_pages"]),
+        "failed_pages": task["failed_pages"], "total_pages": task["total_pages"],
+        "next_retry_at": task.get("next_retry_at"), "last_error_code": task.get("last_error_code"),
+        "updated_at": task["updated_at"],
+    }
 
 
 def cancel_insight_job(session_id: str, kind: str) -> bool:
@@ -49,22 +61,26 @@ def cancel_insight_job(session_id: str, kind: str) -> bool:
         task.cancel()
         status = _job_status.get(key, {})
         status.update({"status": "cancelled", "updated_at": _now()})
+        if status.get("task_id"):
+            from services.document_tasks import request_cancel
+            request_cancel(status["task_id"])
         return True
     return False
 
 
 def start_keyword_job(session_id: str, pages: list, target_lang: str, doc_title: str,
-                      document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto") -> dict:
-    return _start_insight_job(session_id, pages, target_lang, doc_title, "keywords", document_mode, document_type, source_lang)
+                      document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto", durable_task_id: str | None = None) -> dict:
+    return _start_insight_job(session_id, pages, target_lang, doc_title, "keywords", document_mode, document_type, source_lang, durable_task_id)
 
 
 def start_summary_job(session_id: str, pages: list, target_lang: str, doc_title: str,
-                      document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto") -> dict:
-    return _start_insight_job(session_id, pages, target_lang, doc_title, "summary", document_mode, document_type, source_lang)
+                      document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto", durable_task_id: str | None = None) -> dict:
+    return _start_insight_job(session_id, pages, target_lang, doc_title, "summary", document_mode, document_type, source_lang, durable_task_id)
 
 
 def _start_insight_job(session_id: str, pages: list, target_lang: str, doc_title: str, kind: str,
-                       document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto") -> dict:
+                       document_mode: str = "research", document_type: str = "research_paper", source_lang: str = "auto",
+                       durable_task_id: str | None = None) -> dict:
     from services.library import get_document
     from services.processing_policy import ensure_processing_allowed
     document = get_document(session_id)
@@ -75,8 +91,25 @@ def _start_insight_job(session_id: str, pages: list, target_lang: str, doc_title
     key = (session_id, kind)
     cancel_insight_job(session_id, kind)
     estimate = estimate_insight_job(session_id, pages, target_lang, kind, document_mode, document_type, source_lang)
+    from services.document_tasks import create_task, get_task, update_task
+    options = {"target_lang": target_lang, "source_lang": source_lang,
+               "document_mode": document_mode, "document_type": document_type}
+    durable = get_task(durable_task_id) if durable_task_id else None
+    if durable is None:
+        eligible_pages = [int(page["page_num"]) for page in _eligible_pages(
+            session_id, pages, kind,
+            __import__("services.document_policy", fromlist=["insight_cache_suffix"]).insight_cache_suffix(
+                document_mode, document_type, target_lang, source_lang,
+            ),
+        )]
+        durable = create_task(session_id, kind, options, eligible_pages, status="running")
+    else:
+        update_task(durable["id"], status="retry_wait" if durable.get("next_retry_at") else "running",
+                    cancel_requested=False, last_error_code=durable.get("last_error_code"),
+                    next_retry_at=durable.get("next_retry_at"))
     status = {
-        **estimate, "session_id": session_id, "status": "running", "completed_pages": 0,
+        **estimate, "task_id": durable["id"], "session_id": session_id,
+        "status": "retry_wait" if durable.get("next_retry_at") else "running", "completed_pages": 0,
         "failed_pages": [], "started_at": _now(), "updated_at": _now(),
     }
     _job_status[key] = status
@@ -94,18 +127,40 @@ async def _run_insight_job(session_id: str, pages: list, target_lang: str, doc_t
     suffix = insight_cache_suffix(document_mode, document_type, target_lang, source_lang)
     status = _job_status[task_key]
     try:
+        from services.document_tasks import update_task, wait_for_retry
+        if not await wait_for_retry(status["task_id"]):
+            status["status"] = "cancelled"
+            return
+        update_task(status["task_id"], status="running", next_retry_at=None)
         eligible = _eligible_pages(session_id, pages, kind, suffix)
         for page_data in eligible:
             page_num = int(page_data["page_num"])
             text = (page_data.get("text") or "").strip()
             try:
-                result = []
-                async for token in stream_page_insight(
-                    kind, text, target_lang=target_lang, doc_title=doc_title,
-                    document_mode=document_mode, document_type=document_type, session_id=session_id, source_lang=source_lang,
-                ):
-                    result.append(token)
-                content = "".join(result).strip()
+                from services.document_tasks import retry_async, update_page, update_task
+                durable_id = status["task_id"]
+                update_page(durable_id, page_num, "running", increment_attempt=True)
+
+                async def generate_page():
+                    result = []
+                    async for token in stream_page_insight(
+                        kind, text, target_lang=target_lang, doc_title=doc_title,
+                        document_mode=document_mode, document_type=document_type,
+                        session_id=session_id, source_lang=source_lang,
+                    ):
+                        result.append(token)
+                    return "".join(result).strip()
+
+                def record_retry(_attempt: int, code: str, retry_at: str) -> None:
+                    status.update({"status": "retry_wait", "last_error_code": code,
+                                   "next_retry_at": retry_at, "updated_at": _now()})
+                    update_page(durable_id, page_num, "retry_wait", last_error_code=code,
+                                next_retry_at=retry_at, increment_attempt=True)
+                    update_task(durable_id, status="retry_wait", last_error_code=code,
+                                next_retry_at=retry_at)
+
+                content = await retry_async(generate_page, on_retry=record_retry)
+                status.update({"status": "running", "last_error_code": None, "next_retry_at": None})
                 if content:
                     if document_mode == "general" and kind == "keywords":
                         import json
@@ -113,10 +168,15 @@ async def _run_insight_job(session_id: str, pages: list, target_lang: str, doc_t
                         content = json.dumps(validate_vocabulary_result(content, text, page_num), ensure_ascii=False)
                     save_page_insight(session_id, page_num, kind, content, suffix)
                 status["completed_pages"] += 1
-            except Exception:
+                update_page(status["task_id"], page_num, "succeeded")
+            except Exception as exc:
+                code = getattr(exc, "document_task_error_code", "generation_failed")
                 status["failed_pages"].append(page_num)
+                update_page(status["task_id"], page_num, "failed", last_error_code=code)
             status["updated_at"] = _now()
         status["status"] = "completed" if not status["failed_pages"] else "completed_with_errors"
+        from services.document_tasks import finish_from_pages
+        finish_from_pages(status["task_id"])
     except asyncio.CancelledError:
         status["status"] = "cancelled"
         raise

--- a/backend/services/translation_job.py
+++ b/backend/services/translation_job.py
@@ -36,16 +36,53 @@ def _job_path(session_id: str) -> str:
 
 
 def _load_job(session_id: str) -> Optional[dict]:
+    from services.document_tasks import latest_task, legacy_translation_view, migrate_legacy_translation
+    try:
+        task = latest_task(session_id, "translate")
+    except Exception:
+        task = None
+    if task:
+        return legacy_translation_view(task)
     path = _job_path(session_id)
     if not os.path.exists(path):
         return None
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        legacy = json.load(f)
+    try:
+        return legacy_translation_view(migrate_legacy_translation(session_id, legacy))
+    except Exception:
+        return legacy
 
 
 def _save_job(session_id: str, job: dict) -> None:
-    path = _job_path(session_id)
-    atomic_write_text(path, json.dumps(job, ensure_ascii=False, indent=2))
+    from services.document_tasks import create_task, finish_from_pages, get_task, update_page, update_task
+    task_id = job.get("task_id")
+    task = get_task(task_id) if task_id else None
+    if task is None:
+        task = create_task(
+            session_id, "translate", job.get("options") or {},
+            job.get("target_pages") or [], status="running",
+        )
+        task_id = task["id"]
+        job["task_id"] = task_id
+    completed = set(job.get("completed_pages") or [])
+    failed = set(job.get("failed_pages") or [])
+    for page in task["pages"]:
+        page_num = page["page_num"]
+        desired = "succeeded" if page_num in completed else "failed" if page_num in failed else page["status"]
+        if desired != page["status"]:
+            update_page(task_id, page_num, desired,
+                        last_error_code="generation_failed" if desired == "failed" else None)
+    legacy_status = job.get("status", "running")
+    if legacy_status == "cancelled":
+        update_task(task_id, status="cancelled", cancel_requested=True)
+    elif legacy_status in {"failed", "error"}:
+        update_task(task_id, status="failed", last_error_code=job.get("error_code") or "generation_failed")
+    elif legacy_status == "completed":
+        finish_from_pages(task_id)
+    else:
+        update_task(task_id, status="running", last_error_code=job.get("error_code"),
+                    next_retry_at=job.get("next_retry_at"))
 
 
 # ─────────────────────────────────────────────────────────
@@ -67,6 +104,7 @@ def start_job(
     ignore_refs: bool = False,
     page_numbers: Optional[list[int]] = None,
     source_lang: str = "auto",
+    durable_task_id: Optional[str] = None,
 ) -> dict:
     """
     백그라운드 번역 잡을 시작합니다.
@@ -100,6 +138,7 @@ def start_job(
     # 새 잡 세팅
     job = {
         "session_id": session_id,
+        "task_id": durable_task_id,
         "status": "running",
         "total_pages": len(target_pages),
         "target_pages": target_pages,
@@ -150,6 +189,9 @@ def resume_incomplete_jobs(sessions: dict) -> None:
         if job and job.get("status") == "running":
             pages = session.get("pages", [])
             if pages:
+                active = _running_tasks.get(session_id)
+                if active is not None and not active.done():
+                    continue
                 task = asyncio.create_task(_run_job(session_id, pages, job))
                 _running_tasks[session_id] = task
 
@@ -160,6 +202,24 @@ def resume_incomplete_jobs(sessions: dict) -> None:
 
 async def _run_job(session_id: str, pages: list, job: dict) -> None:
     """모든 페이지를 순차적으로 번역합니다."""
+    task_id = job.get("task_id")
+    if task_id:
+        from services.document_tasks import update_task, wait_for_retry
+        try:
+            ready = await wait_for_retry(task_id)
+        except asyncio.CancelledError:
+            job["status"] = "cancelled"
+            _save_job(session_id, job)
+            if _running_tasks.get(session_id) is asyncio.current_task():
+                _running_tasks.pop(session_id, None)
+            return
+        if not ready:
+            if _running_tasks.get(session_id) is asyncio.current_task():
+                _running_tasks.pop(session_id, None)
+            return
+        update_task(task_id, status="running", next_retry_at=None)
+        job["status"] = "running"
+        job["next_retry_at"] = None
     options = job.get("options", {})
     target_lang = options.get("target_lang", "ko")
     source_lang = options.get("source_lang", "auto")
@@ -272,22 +332,44 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
                 # 원문 태깅 처리
                 tagged_text, src_sentences = tag_source_text(text)
 
-                translation = await _translate_page(
-                    tagged_text,
-                    target_lang=target_lang,
-                    source_lang=source_lang,
-                    style=style,
-                    ignore_math=ignore_math,
-                    ignore_table=ignore_table,
-                    ignore_refs=ignore_refs,
-                    doc_title=doc_title,
-                    prev_context=prev_context,
-                    session_id=session_id,
-                    page_num=page_num,
-                    document_mode=document_mode,
-                    document_type=document_type,
-                    page_image_b64=page_image_b64
-                )
+                from services.document_tasks import retry_async, update_page, update_task
+                task_id = job.get("task_id")
+                if task_id:
+                    update_page(task_id, page_num, "running", increment_attempt=True)
+                    update_task(task_id, status="running", increment_attempt=True)
+
+                async def translate_operation():
+                    return await _translate_page(
+                        tagged_text,
+                        target_lang=target_lang,
+                        source_lang=source_lang,
+                        style=style,
+                        ignore_math=ignore_math,
+                        ignore_table=ignore_table,
+                        ignore_refs=ignore_refs,
+                        doc_title=doc_title,
+                        prev_context=prev_context,
+                        session_id=session_id,
+                        page_num=page_num,
+                        document_mode=document_mode,
+                        document_type=document_type,
+                        page_image_b64=page_image_b64,
+                    )
+
+                def record_retry(_attempt: int, code: str, retry_at: str) -> None:
+                    job["status"] = "retry_wait"
+                    job["error_code"] = code
+                    job["next_retry_at"] = retry_at
+                    if task_id:
+                        update_page(task_id, page_num, "retry_wait", last_error_code=code,
+                                    next_retry_at=retry_at, increment_attempt=True)
+                        update_task(task_id, status="retry_wait", last_error_code=code,
+                                    next_retry_at=retry_at)
+
+                translation = await retry_async(translate_operation, on_retry=record_retry)
+                job["status"] = "running"
+                job["error_code"] = None
+                job["next_retry_at"] = None
                 # 태그 분석 및 매핑 생성
                 cleaned_translation, sentences = parse_tagged_translation(translation, src_sentences)
                 if document_mode == "general":
@@ -307,6 +389,8 @@ async def _run_job(session_id: str, pages: list, job: dict) -> None:
                     job["completed_pages"].append(page_num)
             except Exception as e:
                 print(f"[Job {session_id}] page {page_num} failed: {e}")
+                job["error_code"] = getattr(e, "document_task_error_code", "generation_failed")
+                job["next_retry_at"] = None
                 if page_num not in job["failed_pages"]:
                     job["failed_pages"].append(page_num)
 

--- a/backend/tests/test_document_tasks.py
+++ b/backend/tests/test_document_tasks.py
@@ -1,0 +1,153 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _doc(isolated_dirs, doc_id="task-doc", username="testuser"):
+    isolated_dirs["db"].db_save_document(doc_id, username, "paper.pdf", "/x.pdf", 3, {})
+    return doc_id
+
+
+def test_task_page_checkpoints_and_partial_failure(isolated_dirs):
+    from services.document_tasks import create_task, finish_from_pages, update_page
+
+    doc_id = _doc(isolated_dirs)
+    task = create_task(doc_id, "translate", {"target_lang": "ko"}, [1, 2, 3])
+    assert task["status"] == "queued"
+    update_page(task["id"], 1, "succeeded")
+    update_page(task["id"], 2, "failed", last_error_code="authentication_failed")
+    result = finish_from_pages(task["id"])
+    assert result["status"] == "partial_failed"
+    assert result["completed_pages"] == [1]
+    assert result["failed_pages"] == [2]
+
+
+def test_cancel_and_retry_reset_only_incomplete_pages(isolated_dirs):
+    from services.document_tasks import create_task, get_task, request_cancel, reset_failed, update_page
+
+    task = create_task(_doc(isolated_dirs), "summary", {}, [1, 2])
+    update_page(task["id"], 1, "succeeded")
+    cancelled = request_cancel(task["id"])
+    assert cancelled["status"] == "cancelled"
+    reset = reset_failed(task["id"])
+    assert reset["status"] == "queued"
+    pages = {page["page_num"]: page["status"] for page in reset["pages"]}
+    assert pages == {1: "succeeded", 2: "queued"}
+
+
+@pytest.mark.asyncio
+async def test_transient_errors_retry_with_backoff_then_succeed():
+    from services.document_tasks import retry_async
+
+    calls = 0
+    sleeps = []
+    retries = []
+
+    async def operation():
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise httpx.ReadTimeout("slow")
+        return "ok"
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    result = await retry_async(operation, sleep=fake_sleep, jitter=lambda: 0.25,
+                               on_retry=lambda *args: retries.append(args))
+    assert result == "ok"
+    assert calls == 3
+    assert sleeps == [2.25, 10.25]
+    assert [item[1] for item in retries] == ["timeout", "timeout"]
+
+
+@pytest.mark.asyncio
+async def test_permanent_error_fails_without_retry():
+    from services.document_tasks import retry_async
+
+    calls = 0
+
+    async def operation():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("invalid model: unsupported model")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await retry_async(operation, sleep=lambda _delay: asyncio.sleep(0))
+    assert calls == 1
+    assert exc_info.value.document_task_error_code == "unsupported_model"
+
+
+def test_legacy_translation_json_migrates_once(isolated_dirs, monkeypatch):
+    from services import translation_job
+    from services.document_tasks import list_tasks
+
+    doc_id = _doc(isolated_dirs, "legacy-task")
+    library_dir = Path(isolated_dirs["library_dir"])
+    task_dir = library_dir / doc_id
+    task_dir.mkdir()
+    (task_dir / "job_status.json").write_text(json.dumps({
+        "session_id": doc_id, "status": "completed", "total_pages": 3,
+        "target_pages": [1, 2, 3], "completed_pages": [1, 2], "failed_pages": [3],
+        "options": {"target_lang": "ko"},
+    }), encoding="utf-8")
+    monkeypatch.setattr(translation_job, "LIBRARY_DIR", str(library_dir))
+
+    first = translation_job.get_job_status(doc_id)
+    second = translation_job.get_job_status(doc_id)
+    assert first["task_status"] == "partial_failed"
+    assert first["failed_pages"] == [3]
+    assert second["task_id"] == first["task_id"]
+    assert len(list_tasks(doc_id)) == 1
+
+
+def test_task_api_scopes_to_document_owner(test_client, isolated_dirs):
+    from services.document_tasks import create_task
+
+    own = create_task(_doc(isolated_dirs, "task-own"), "translate", {}, [1])
+    other = create_task(_doc(isolated_dirs, "task-other", "otheruser"), "summary", {}, [1])
+
+    response = test_client.get("/api/tasks", params={"doc_id": "task-own"})
+    assert response.status_code == 200
+    assert [task["id"] for task in response.json()["tasks"]] == [own["id"]]
+    assert test_client.get(f"/api/tasks/{other['id']}").status_code == 404
+
+
+def test_empty_task_finishes_successfully(isolated_dirs):
+    from services.document_tasks import create_task, finish_from_pages
+
+    task = create_task(_doc(isolated_dirs, "empty-task"), "summary", {}, [])
+    assert finish_from_pages(task["id"])["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_recovered_task_waits_for_persisted_retry_deadline(isolated_dirs):
+    from services.document_tasks import create_task, update_task, wait_for_retry
+
+    task = create_task(_doc(isolated_dirs, "retry-deadline"), "primer")
+    retry_at = (datetime.now(timezone.utc) + timedelta(seconds=20)).isoformat()
+    update_task(task["id"], status="retry_wait", next_retry_at=retry_at)
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    assert await wait_for_retry(task["id"], sleep=fake_sleep) is True
+    assert len(sleeps) == 1
+    assert 18 <= sleeps[0] <= 20
+
+
+def test_unsupported_retry_does_not_mutate_task(test_client, isolated_dirs):
+    from services.document_tasks import create_task, get_task, update_task
+
+    task = create_task(_doc(isolated_dirs, "parse-retry"), "parse")
+    update_task(task["id"], status="failed", last_error_code="invalid_input")
+    response = test_client.post(f"/api/tasks/{task["id"]}/retry")
+    assert response.status_code == 409
+    current = get_task(task["id"])
+    assert current["status"] == "failed"
+    assert current["last_error_code"] == "invalid_input"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -897,6 +897,30 @@ export function installPdfParserAPI(parserId, onProgress, onSuccess, onError) {
   return es
 }
 
+export async function getDocumentTasksAPI(docId) {
+  const res = await fetch(`${API_BASE}/tasks?doc_id=${encodeURIComponent(docId)}`)
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function getDocumentTaskAPI(taskId) {
+  const res = await fetch(`${API_BASE}/tasks/${encodeURIComponent(taskId)}`)
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function retryDocumentTaskAPI(taskId) {
+  const res = await fetch(`${API_BASE}/tasks/${encodeURIComponent(taskId)}/retry`, { method: 'POST' })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function cancelDocumentTaskAPI(taskId) {
+  const res = await fetch(`${API_BASE}/tasks/${encodeURIComponent(taskId)}/cancel`, { method: 'POST' })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
 export async function getDocumentProcessingPolicyAPI(docId) {
   const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/processing-policy`)
   if (!res.ok) throw await apiError(res)

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3850,5 +3850,20 @@
   },
   "errors:invalid_processing_policy": {
     "description": "Invalid document processing policy value."
+  },
+  "viewer:task.retryAt": {
+    "description": "Persistent document task recovery UI text."
+  },
+  "viewer:task.retryWaiting": {
+    "description": "Persistent document task recovery UI text."
+  },
+  "viewer:task.transientError": {
+    "description": "Persistent document task recovery UI text."
+  },
+  "viewer:task.failedPages": {
+    "description": "Persistent document task recovery UI text."
+  },
+  "chat:retrySameQuestion": {
+    "description": "Persistent document task recovery UI text."
   }
 }

--- a/frontend/src/locales/en/chat.json
+++ b/frontend/src/locales/en/chat.json
@@ -8,5 +8,6 @@
   "suggestions.research.results": "What are the key results and why do they matter?",
   "suggestions.general.summary": "Summarize the key points of this document.",
   "suggestions.general.procedure": "Explain the important procedures and prerequisites.",
-  "suggestions.general.cautions": "Identify the cautions and key figures."
+  "suggestions.general.cautions": "Identify the cautions and key figures.",
+  "retrySameQuestion": "Send same question again"
 }

--- a/frontend/src/locales/en/viewer.json
+++ b/frontend/src/locales/en/viewer.json
@@ -13,5 +13,9 @@
   "language.saved": "Document language override saved.",
   "outline.noToc": "This PDF has no table of contents, so all pages are listed instead.",
   "pageLabel": "Page {{page}}",
-  "goToPage": "Go to page {{page}}"
+  "goToPage": "Go to page {{page}}",
+  "task.retryAt": " · Retry at {{time}}",
+  "task.retryWaiting": "Waiting to retry",
+  "task.transientError": "Temporary error",
+  "task.failedPages": "{{count}} failed pages"
 }

--- a/frontend/src/locales/ko/chat.json
+++ b/frontend/src/locales/ko/chat.json
@@ -8,5 +8,6 @@
   "suggestions.research.results": "실험 결과의 주요 수치와 의의는 무엇이야?",
   "suggestions.general.summary": "이 문서의 핵심 내용을 요약해줘.",
   "suggestions.general.procedure": "중요한 절차와 전제 조건을 설명해줘.",
-  "suggestions.general.cautions": "주의사항과 핵심 수치를 찾아줘."
+  "suggestions.general.cautions": "주의사항과 핵심 수치를 찾아줘.",
+  "retrySameQuestion": "동일 질문 다시 보내기"
 }

--- a/frontend/src/locales/ko/viewer.json
+++ b/frontend/src/locales/ko/viewer.json
@@ -13,5 +13,9 @@
   "language.saved": "문서별 언어 설정을 저장했습니다.",
   "outline.noToc": "이 PDF에는 목차 정보가 없어 전체 페이지를 대신 표시합니다.",
   "pageLabel": "{{page}}페이지",
-  "goToPage": "{{page}}페이지로 이동"
+  "goToPage": "{{page}}페이지로 이동",
+  "task.retryAt": " · {{time}} 재시도",
+  "task.retryWaiting": "재시도 대기",
+  "task.transientError": "일시 오류",
+  "task.failedPages": "실패 {{count}}페이지"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,7 +9,7 @@ import { getModeSetting, normalizeSettingsMode, setModeSetting } from './modeSet
 import { parseStructuredVocabulary, renderStructuredVocabulary } from "./vocabularyView.js"
 import { defaultDocumentType, loadDocumentTypeOptions, saveDocumentTypeOptions, CURRENT_ONBOARDING_VERSION, ONBOARDING_VERSION_KEY } from "./documentModes.js"
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI, retryDocumentTaskAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
 import { icon } from './icons.js'
@@ -644,20 +644,24 @@ function showInsightJobProgress(sessionId, kind, title) {
   const retry = modal.querySelector('[data-action="retry"]')
   const close = modal.querySelector('[data-action="close"]')
   let stopped = false
+  let currentTaskId = null
   async function poll() {
     if (stopped || !modal.isConnected) return
     try {
       const status = await getInsightJobStatusAPI(sessionId, kind)
+      currentTaskId = status.task_id || currentTaskId
       const total = Math.max(1, status.eligible_pages || 0)
       const done = status.completed_pages || 0
       const pct = Math.min(100, Math.round((done / total) * 100))
       bar.style.width = `${pct}%`
-      text.textContent = `${done}/${status.eligible_pages}페이지 · ${pct}%${status.failed_pages?.length ? ` · 실패 ${status.failed_pages.length}` : ''}`
-      if (['completed', 'completed_with_errors', 'cancelled'].includes(status.status)) {
+      const retryLabel = status.status === 'retry_wait' && status.next_retry_at ? t('viewer:task.retryAt', { time: new Date(status.next_retry_at).toLocaleTimeString() }) : ''
+      const errorLabel = status.last_error_code ? ` · ${status.last_error_code}` : ''
+      text.textContent = `${done}/${status.eligible_pages || status.total_pages}페이지 · ${pct}%${status.failed_pages?.length ? ` · 실패 ${status.failed_pages.length}` : ''}${retryLabel}${errorLabel}`
+      if (['completed', 'completed_with_errors', 'succeeded', 'partial_failed', 'failed', 'cancelled'].includes(status.status)) {
         stopped = true
         cancel.classList.add('hidden')
         close.classList.remove('hidden')
-        retry.classList.toggle('hidden', status.status !== 'completed_with_errors')
+        retry.classList.toggle('hidden', !['completed_with_errors', 'partial_failed', 'failed'].includes(status.status))
         return
       }
     } catch (error) {
@@ -672,15 +676,21 @@ function showInsightJobProgress(sessionId, kind, title) {
     poll()
   })
   retry.addEventListener('click', async () => {
+    if (!currentTaskId) return
     retry.disabled = true
-    const options = getTranslationOptions()
-    await startInsightJobAPI(sessionId, kind, options.targetLang, options.sourceLang, true)
-    stopped = false
-    cancel.disabled = false
-    cancel.classList.remove('hidden')
-    retry.classList.add('hidden')
-    close.classList.add('hidden')
-    poll()
+    try {
+      await retryDocumentTaskAPI(currentTaskId)
+      stopped = false
+      retry.classList.add('hidden')
+      cancel.disabled = false
+      cancel.classList.remove('hidden')
+      close.classList.add('hidden')
+      poll()
+    } catch (error) {
+      text.textContent = error.message
+    } finally {
+      retry.disabled = false
+    }
   })
   close.addEventListener('click', () => modal.remove())
   poll()
@@ -1607,10 +1617,16 @@ function startJobPolling(sessionId) {
 
       const done  = (job.completed_pages || []).length
       const total = job.total_pages || state.totalPages
-      const isRunning = job.status === 'running' || job.status === 'pending'
+      const isRunning = ['running', 'pending'].includes(job.status) || job.task_status === 'retry_wait'
       updateProgressMiniRaw(done, total, isRunning)
+      if (job.task_status === 'retry_wait') {
+        progressMiniText.textContent = job.next_retry_at ? t('viewer:task.retryAt', { time: new Date(job.next_retry_at).toLocaleTimeString() }) : t('viewer:task.retryWaiting')
+        progressMini.setAttribute('aria-label', `${job.last_error_code || t('viewer:task.transientError')} · ${progressMiniText.textContent}`)
+      } else if (job.failed_pages?.length) {
+        progressMiniText.textContent = t('viewer:task.failedPages', { count: job.failed_pages.length })
+      }
 
-      if (job.status === 'running') {
+      if (job.status === 'running' || job.task_status === 'retry_wait') {
         cancelTransBtn.classList.remove('hidden')
         resumeTransBtn.classList.add('hidden')
       } else {
@@ -13700,7 +13716,7 @@ async function sendChatMessage() {
       state.chatActiveStream = null
 
       if (firstToken) {
-        appendChatMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
+        appendChatMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span><button type="button" class="chat-retry-message-btn" data-chat-retry="${encodeURIComponent(text)}">${t('chat:retrySameQuestion')}</button>`, true)
       } else if (replyBubble) {
         replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${err.message}]</span>`
       }
@@ -13716,6 +13732,12 @@ async function sendChatMessage() {
 
 function initChatListeners() {
   chatMessages?.addEventListener('click', event => {
+    const retryButton = event.target.closest('[data-chat-retry]')
+    if (retryButton) {
+      chatInput.value = decodeURIComponent(retryButton.dataset.chatRetry || '')
+      sendChatMessage()
+      return
+    }
     const citation = event.target.closest('[data-page-citation]')
     if (!citation) return
     const page = Number(citation.dataset.pageCitation)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7086,3 +7086,5 @@ body.light-theme .chat-drawer {
 .lib-detail-processing-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:6px; font-size:11px; color:var(--text-secondary); }
 .lib-detail-processing-row select { border:1px solid var(--border-strong); border-radius:7px; background:var(--bg-elevated); color:var(--text-primary); padding:4px 7px; font-size:11px; }
 .api-key-delete-btn { margin-top:6px; padding:5px 8px; border:1px solid var(--border-strong); border-radius:7px; background:transparent; color:var(--text-secondary); cursor:pointer; font-size:11px; }
+
+.chat-retry-message-btn { display:block; margin-top:8px; padding:5px 9px; border:1px solid var(--border-strong); border-radius:7px; background:var(--bg-elevated); color:var(--text-primary); cursor:pointer; font-size:11px; }


### PR DESCRIPTION
# Summary
## 1. 문서 작업 영속화
- 파싱·번역·키워드·요약·브리핑 작업과 페이지별 체크포인트를 SQLite에 저장
- queued부터 cancelled까지 공통 상태와 오류 코드·재시도 시각·시도 횟수 관리 기능을 추가
## 2. 재시도와 서버 재시작 복구
- 네트워크·429·5xx·타임아웃에 2초·10초·30초 backoff와 jitter를 적용한 최대 3회 재시도 기능을 추가
- 서버 재시작 시 완료 산출물을 건너뛰고 미완료 작업과 예약된 재시도 시각을 복구
- 기존 job_status.json을 최초 조회 시 영속 작업으로 한 번 이전
## 3. 작업 제어 및 사용자 안내
- 작업 조회·취소·실패 항목 재시도 API와 기존 번역 jobs 호환 어댑터를 추가
- 진행 단계·실패 페이지·재시도 시각과 채팅 동일 질문 재전송 UI를 추가
## 4. 검증
- 백엔드 전체 536개 테스트 통과
- 프론트 단위 48개 테스트, locale 검증, production build 통과