### PR TITLE
feat(pdf): add revisioned reparse previews

### DIFF
--- a/backend/parser_worker.py
+++ b/backend/parser_worker.py
@@ -1,0 +1,47 @@
+"""Isolated parser worker used by reparse previews."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from services.atomic_io import atomic_write_text
+from services.pdf_diagnostics import diagnose_pages, parser_version, pdf_fingerprint
+from services.pdf_parser import extract_pages, extract_pdf_images
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pdf", required=True)
+    parser.add_argument("--engine", required=True, choices=("pymupdf", "pdfplumber", "marker", "mineru"))
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    pages = extract_pages(args.pdf, engine=args.engine)
+    actual_engines = {str(page.get("parser_engine") or "") for page in pages}
+    if not pages or actual_engines != {args.engine}:
+        actual = ", ".join(sorted(actual_engines)) or "no output"
+        raise RuntimeError(f"{args.engine} parser unavailable; worker returned {actual}")
+
+    images = extract_pdf_images(args.pdf, engine=args.engine)
+    version = parser_version(args.engine)
+    payload = {
+        "pdf_fingerprint": pdf_fingerprint(args.pdf),
+        "parser_engine": args.engine,
+        "parser_version": version,
+        "pages": pages,
+        "images": images,
+        "diagnostics": diagnose_pages(pages, images, args.engine, version),
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    atomic_write_text(args.output, json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"parser_worker_failed: {exc}", file=sys.stderr)
+        raise

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -636,6 +636,10 @@ async def clear_pages_cache(current_user: str = Depends(get_current_user)):
     from services.cache import clear_all_pages_cache, clear_all_images_cache
     pages_count, pages_bytes = clear_all_pages_cache()
     images_count, images_bytes = clear_all_images_cache()
+    from services.pdf_parser import clear_parser_memory_cache
+    clear_parser_memory_cache()
+    from routers.upload import sessions
+    sessions.clear()
     return {
         "cleared_files": pages_count + images_count,
         "freed_bytes": pages_bytes + images_bytes,

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -341,5 +341,5 @@ async def get_compare_chat_sessions(current_user: str = Depends(get_current_user
 async def get_chat_history(session_id: str, current_user: str = Depends(get_current_user)):
     """특정 문서의 이전 채팅 히스토리를 반환합니다."""
     require_session_owner(session_id, current_user)
-    history = db_get_chat_history(session_id)
+    history = db_get_chat_history(session_id, include_revision=True)
     return {"history": history}

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -54,6 +54,32 @@ class DocumentProcessingPolicyUpdateRequest(BaseModel):
     processing_policy: str
 
 
+class ReparsePreviewRequest(BaseModel):
+    candidate_engine: str
+
+
+
+async def _load_diagnostic_images(doc_id: str, doc: dict, pdf_path: str) -> list[dict]:
+    from services.cache import get_cached_images, save_images_cache
+    images = get_cached_images(
+        doc_id, pdf_path, doc.get("parser_engine"), doc.get("parser_version"),
+    )
+    if images is not None:
+        return images
+    try:
+        import asyncio
+        from services.pdf_parser import extract_pdf_images
+        images = await asyncio.to_thread(
+            extract_pdf_images, pdf_path, doc.get("parser_engine") or "pymupdf",
+        )
+        save_images_cache(
+            doc_id, pdf_path, images, doc.get("parser_engine"), doc.get("parser_version"),
+        )
+        return images
+    except Exception:
+        return []
+
+
 MAX_LIBRARY_MIRROR_JSON_BYTES = 5 * 1024 * 1024
 
 
@@ -586,6 +612,73 @@ async def patch_document_processing_policy(doc_id: str, body: DocumentProcessing
     return document_processing_status(updated)
 
 
+
+@router.get("/library/{doc_id}/parsing-diagnostics")
+async def get_document_parsing_diagnostics(doc_id: str, revision: Optional[int] = None,
+                                           current_user: str = Depends(get_current_user)):
+    doc = require_owned_document(doc_id, current_user)
+    from services.reparse import get_diagnostics, save_diagnostics
+    requested_revision = int(revision or doc.get("content_revision") or 1)
+    report = get_diagnostics(doc_id, requested_revision)
+    if report is None and requested_revision == int(doc.get("content_revision") or 1):
+        from routers.upload import require_session_owner
+        session = require_session_owner(doc_id, current_user)
+        images = await _load_diagnostic_images(doc_id, doc, session["pdf_path"])
+        from services.pdf_diagnostics import diagnose_pages
+        report = diagnose_pages(
+            session["pages"], images, doc.get("parser_engine"), doc.get("parser_version"),
+        )
+        save_diagnostics(doc_id, requested_revision, report)
+    if report is None:
+        raise HTTPException(status_code=404, detail="파싱 진단 보고서를 찾을 수 없습니다.")
+    return report
+
+
+@router.post("/library/{doc_id}/reparse-preview")
+async def create_document_reparse_preview(doc_id: str, body: ReparsePreviewRequest,
+                                          current_user: str = Depends(get_current_user)):
+    doc = require_owned_document(doc_id, current_user)
+    from routers.upload import require_session_owner
+    session = require_session_owner(doc_id, current_user)
+    images = await _load_diagnostic_images(doc_id, doc, session["pdf_path"])
+    from services.reparse import create_preview
+    try:
+        return create_preview(doc, session["pages"], session["pdf_path"], body.candidate_engine, images)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/library/{doc_id}/reparse-preview/{task_id}")
+async def get_document_reparse_preview(doc_id: str, task_id: str,
+                                       current_user: str = Depends(get_current_user)):
+    require_owned_document(doc_id, current_user)
+    from services.reparse import get_preview, preview_impact
+    preview = get_preview(task_id)
+    if not preview or preview["doc_id"] != doc_id:
+        raise HTTPException(status_code=404, detail="재분석 미리보기를 찾을 수 없습니다.")
+    preview["impact"] = preview_impact(doc_id, int(preview["source_revision"]))
+    return preview
+
+
+@router.post("/library/{doc_id}/reparse-preview/{task_id}/apply")
+async def apply_document_reparse_preview(doc_id: str, task_id: str,
+                                         current_user: str = Depends(get_current_user)):
+    require_owned_document(doc_id, current_user)
+    from routers.upload import sessions
+    from services.reparse import apply_preview
+    try:
+        return await apply_preview(doc_id, task_id, sessions)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="재분석 미리보기를 찾을 수 없습니다.")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail={"code": "reparse_preview_not_ready", "fallback": str(exc)})
+    except RuntimeError as exc:
+        code = str(exc)
+        if code in {"pdf_revision_conflict", "content_revision_conflict"}:
+            raise HTTPException(status_code=409, detail={"code": code, "fallback": "문서가 변경되어 후보 결과를 적용할 수 없습니다."})
+        raise HTTPException(status_code=500, detail={"code": "reparse_apply_failed", "fallback": code})
+
+
 @router.get("/library/{doc_id}")
 async def get_library_document(
     doc_id: str,
@@ -820,6 +913,10 @@ async def clear_library_document_cache(doc_id: str, current_user: str = Depends(
     require_owned_document(doc_id, current_user)
     from services.cache import clear_document_cache
     cleared_files, freed_bytes = clear_document_cache(doc_id)
+    from services.pdf_parser import clear_parser_memory_cache
+    clear_parser_memory_cache()
+    from routers.upload import sessions
+    sessions.pop(doc_id, None)
     return {
         "message": "PDF 추출 캐시가 삭제되었습니다.",
         "cleared_files": cleared_files,
@@ -842,19 +939,19 @@ async def get_library_document_images(doc_id: str, current_user: str = Depends(g
     import asyncio
     from services.cache import get_cached_images, save_images_cache
 
-    require_owned_document(doc_id, current_user)
+    doc = require_owned_document(doc_id, current_user)
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
 
-    images = get_cached_images(doc_id, pdf_path)
+    images = get_cached_images(doc_id, pdf_path, doc.get("parser_engine"), doc.get("parser_version"))
     if images is not None:
         return {"images": images}
 
     try:
         from services.pdf_parser import extract_pdf_images
-        images = await asyncio.to_thread(extract_pdf_images, pdf_path)
-        save_images_cache(doc_id, pdf_path, images)
+        images = await asyncio.to_thread(extract_pdf_images, pdf_path, doc.get("parser_engine"))
+        save_images_cache(doc_id, pdf_path, images, doc.get("parser_engine"), doc.get("parser_version"))
         return {"images": images}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"이미지 좌표 추출 실패: {str(e)}")
@@ -869,12 +966,12 @@ async def get_library_figure_image(doc_id: str, index: int, current_user: str = 
     from services.cache import get_cached_images
     from services.pdf_parser import render_image_crop_bytes
 
-    require_owned_document(doc_id, current_user)
+    doc = require_owned_document(doc_id, current_user)
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
 
-    images = get_cached_images(doc_id, pdf_path)
+    images = get_cached_images(doc_id, pdf_path, doc.get("parser_engine"), doc.get("parser_version"))
     if images is None or index < 0 or index >= len(images):
         raise HTTPException(status_code=404, detail="Figure 정보를 찾을 수 없습니다.")
 
@@ -897,7 +994,7 @@ async def get_library_references(doc_id: str, current_user: str = Depends(get_cu
     참고문헌이 수십~백여 개인 경우가 흔한데, 열 때마다 전부 미리 조회하면
     외부 API 레이트리밋에 바로 걸리고 대부분은 클릭되지도 않아 낭비다.
     """
-    require_owned_document(doc_id, current_user)
+    doc = require_owned_document(doc_id, current_user)
 
     from services.library import get_page_insight, save_page_insight
 
@@ -920,10 +1017,10 @@ async def get_library_references(doc_id: str, current_user: str = Depends(get_cu
         # ensure_session()/get_cached_pages()와 같은 디스크 캐시를 공유한다 -
         # 그렇지 않으면 세션이 아직 복원되지 않은 상태(서버 재시작 직후 첫
         # 열람)에서 텍스트를 한 번 더 처음부터 추출하게 된다.
-        pages = get_cached_pages(doc_id, pdf_path)
+        pages = get_cached_pages(doc_id, pdf_path, doc.get("parser_engine"), doc.get("parser_version"))
         if pages is None:
-            pages = await asyncio.to_thread(extract_pages, pdf_path)
-            save_pages_cache(doc_id, pdf_path, pages)
+            pages = await asyncio.to_thread(extract_pages, pdf_path, doc.get("parser_engine"))
+            save_pages_cache(doc_id, pdf_path, pages, doc.get("parser_engine"), doc.get("parser_version"))
         references = extract_reference_list(pages)
     except Exception:
         references = {}
@@ -1068,10 +1165,10 @@ async def reclassify_paper_tags(
     pdf_path = get_pdf_path(doc_id)
     if not pdf_path:
         raise HTTPException(status_code=404, detail="PDF 파일을 찾을 수 없습니다.")
-    pages = get_cached_pages(doc_id, pdf_path)
+    pages = get_cached_pages(doc_id, pdf_path, doc.get("parser_engine"), doc.get("parser_version"))
     if pages is None:
-        pages = await asyncio.to_thread(extract_pages, pdf_path)
-        save_pages_cache(doc_id, pdf_path, pages)
+        pages = await asyncio.to_thread(extract_pages, pdf_path, doc.get("parser_engine"))
+        save_pages_cache(doc_id, pdf_path, pages, doc.get("parser_engine"), doc.get("parser_version"))
     title = (doc.get("metadata") or {}).get("title") or doc.get("filename") or ""
     paper_tags = await classify_and_store_paper_tags(doc_id, pages, title, force=True)
     if not paper_tags:

--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -54,6 +54,17 @@ _last_failure_at: dict[str, float] = {}
 _RETRY_COOLDOWN_SECONDS = 15
 
 
+
+def cancel_primer_generation(doc_id: str) -> bool:
+    cancelled = False
+    prefix = f"{doc_id}:"
+    for task_key, task in list(_pending_generations.items()):
+        if task_key.startswith(prefix) and not task.done():
+            task.cancel()
+            cancelled = True
+    return cancelled
+
+
 def _ensure_generation_started(doc_id: str, target_lang: str, source_lang: str, session: dict, current_user: str, durable_task_id: str | None = None) -> None:
     """이 문서/언어 조합의 브리핑 생성이 이미 진행 중이 아니면 백그라운드
     태스크로 새로 시작한다. GET(캐시 미스)과 POST(재생성) 양쪽에서 공유한다."""

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -2,6 +2,7 @@ import uuid
 import os
 import shutil
 import asyncio
+import json
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from fastapi.responses import JSONResponse
 import aiofiles
@@ -41,10 +42,25 @@ def ensure_session(session_id: str) -> bool:
             
     try:
         from services.cache import get_cached_pages, save_pages_cache
-        pages = get_cached_pages(session_id, pdf_path)
+        parser_engine = doc.get("parser_engine") or "pymupdf"
+        parser_version = doc.get("parser_version")
+        pages = get_cached_pages(session_id, pdf_path, parser_engine, parser_version)
         if pages is None:
-            pages = extract_pages(pdf_path)
-            save_pages_cache(session_id, pdf_path, pages)
+            if parser_engine in {"marker", "mineru"}:
+                from services.reparse import parse_document_isolated
+                payload = parse_document_isolated(pdf_path, parser_engine)
+                pages = payload["pages"]
+                parser_version = payload["parser_version"]
+                from services.cache import save_images_cache
+                save_images_cache(
+                    session_id, pdf_path, payload.get("images") or [],
+                    parser_engine, parser_version,
+                )
+            else:
+                pages = extract_pages(pdf_path, engine=parser_engine)
+                from services.pdf_diagnostics import parser_version as resolve_parser_version
+                parser_version = resolve_parser_version(parser_engine)
+            save_pages_cache(session_id, pdf_path, pages, parser_engine, parser_version)
         if doc.get("source_language", "auto") == "auto" and doc.get("detected_source_language", "und") == "und":
             from services.languages import detect_document_language
             detection = detect_document_language(pages)
@@ -71,6 +87,9 @@ def ensure_session(session_id: str) -> bool:
             "source_language_confidence": doc.get("source_language_confidence"),
             "preferred_target_language": doc.get("preferred_target_language"),
             "processing_policy": doc.get("processing_policy", "inherit"),
+            "content_revision": int(doc.get("content_revision") or 1),
+            "parser_engine": parser_engine,
+            "parser_version": parser_version,
         }
         return True
     except Exception:
@@ -121,6 +140,8 @@ def restore_sessions_from_library():
     resume_incomplete_jobs(sessions)
     from services.document_tasks import recover_document_tasks
     recover_document_tasks(sessions)
+    from services.reparse import recover_reparse_previews
+    recover_reparse_previews()
 
 
 @router.post("/upload", response_model=UploadResponse)
@@ -222,7 +243,48 @@ async def upload_pdf(
         source_language=source_lang, detected_source_language=detected_source_language,
         source_language_confidence=float(detection["confidence"]),
         preferred_target_language=target_lang,
+        content_revision=1,
+        parser_engine=((pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"),
+        parser_version=__import__("services.pdf_diagnostics", fromlist=["parser_version"]).parser_version(
+            (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
+        ),
     )
+
+    active_parser_engine = (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
+    from services.pdf_diagnostics import diagnose_pages, parser_version
+    active_parser_version = parser_version(active_parser_engine)
+    persistent_pdf_path = lib_pdf_path(session_id)
+    detected_images = []
+    if persistent_pdf_path:
+        from services.cache import save_images_cache, save_pages_cache
+        save_pages_cache(session_id, persistent_pdf_path, pages, active_parser_engine, active_parser_version)
+        try:
+            from services.pdf_parser import extract_pdf_images
+            detected_images = await asyncio.to_thread(extract_pdf_images, persistent_pdf_path, active_parser_engine)
+            save_images_cache(
+                session_id, persistent_pdf_path, detected_images,
+                active_parser_engine, active_parser_version,
+            )
+        except Exception:
+            detected_images = []
+    initial_report = diagnose_pages(
+        pages, detected_images, active_parser_engine, active_parser_version,
+    )
+    from services.db import get_db
+    from datetime import datetime, timezone
+    with get_db() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO parsing_diagnostics
+               (doc_id, content_revision, parser_engine, parser_version, report, created_at)
+               VALUES (?, 1, ?, ?, ?, ?)""",
+            (
+                session_id, active_parser_engine, active_parser_version,
+                json.dumps(initial_report, ensure_ascii=False),
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+
     from services.context_retrieval import index_document_chunks
     indexed_chunks = index_document_chunks(session_id, pages)
     from services.observability import record_document_mode_event
@@ -247,6 +309,11 @@ async def upload_pdf(
         "source_language_confidence": detection["confidence"],
         "preferred_target_language": target_lang,
         "processing_policy": "inherit",
+        "content_revision": 1,
+        "parser_engine": (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf",
+        "parser_version": __import__("services.pdf_diagnostics", fromlist=["parser_version"]).parser_version(
+            (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
+        ),
     }
 
     # translation_mode가 "auto"(기본값)가 아니면 - 페이지 번역 버튼을 누를 때(pane) 또는

--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -85,33 +85,67 @@ def _pages_cache_path(doc_id: str) -> str:
     return os.path.join(CACHE_DIR, f"{doc_id}{_PAGES_CACHE_SUFFIX}")
 
 
-def get_cached_pages(doc_id: str, pdf_path: str) -> Optional[list]:
-    """PDF에서 추출한 페이지 텍스트(extract_pages 결과)의 디스크 캐시를
-    반환합니다. 캐시가 없거나, 원본 PDF의 mtime/크기가 캐시 저장 당시와
-    달라졌다면(파일이 교체된 경우 등) None을 반환해 재추출을 유도합니다.
-    """
+
+def _document_parser_identity(doc_id: str, engine: str | None,
+                              version: str | None) -> tuple[str, str]:
+    if engine is None:
+        try:
+            from services.db import db_get_document
+            doc = db_get_document(doc_id)
+            if doc:
+                engine = doc.get("parser_engine") or "pymupdf"
+                if version is None:
+                    version = doc.get("parser_version")
+        except Exception:
+            pass
+    from services.pdf_diagnostics import parser_identity
+    resolved_engine, resolved_version = parser_identity(engine)
+    return resolved_engine, version if version is not None else resolved_version
+
+
+def get_cached_pages(doc_id: str, pdf_path: str, engine: str | None = None,
+                     version: str | None = None) -> Optional[list]:
+    """Return cached pages only when PDF, parser, version, and schema all match."""
     path = _pages_cache_path(doc_id)
     if not os.path.exists(path):
         return None
     try:
+        from services.pdf_diagnostics import (
+            PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
+        )
+        expected_engine, expected_version = _document_parser_identity(doc_id, engine, version)
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        stat = os.stat(pdf_path)
-        if data.get("mtime") != stat.st_mtime or data.get("size") != stat.st_size:
+        if (
+            data.get("cache_schema_version") != PAGES_CACHE_SCHEMA_VERSION
+            or data.get("pdf_fingerprint") != pdf_fingerprint(pdf_path)
+            or data.get("parser_engine") != expected_engine
+            or data.get("parser_version") != expected_version
+        ):
             return None
         return data.get("pages")
     except Exception:
         return None
 
 
-def save_pages_cache(doc_id: str, pdf_path: str, pages: list) -> None:
-    """extract_pages() 결과를 디스크에 캐싱해, 다음 서버 재시작 이후
-    첫 열람 시에도 PDF를 다시 파싱하지 않고 즉시 불러올 수 있게 합니다."""
+def save_pages_cache(doc_id: str, pdf_path: str, pages: list, engine: str | None = None,
+                     version: str | None = None) -> None:
+    """Persist parser-aware page extraction output."""
     try:
-        stat = os.stat(pdf_path)
+        from services.pdf_diagnostics import (
+            PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
+        )
+        actual_engine = engine or next(
+            (str(page.get("parser_engine")) for page in pages if page.get("parser_engine")), None
+        )
+        actual_engine, actual_version = parser_identity(actual_engine)
+        if version is not None:
+            actual_version = version
         atomic_write_text(_pages_cache_path(doc_id), json.dumps({
-            "mtime": stat.st_mtime,
-            "size": stat.st_size,
+            "cache_schema_version": PAGES_CACHE_SCHEMA_VERSION,
+            "pdf_fingerprint": pdf_fingerprint(pdf_path),
+            "parser_engine": actual_engine,
+            "parser_version": actual_version,
             "pages": pages,
         }, ensure_ascii=False))
     except Exception:
@@ -142,34 +176,46 @@ def _images_cache_path(doc_id: str) -> str:
     return os.path.join(CACHE_DIR, f"{doc_id}{_IMAGES_CACHE_SUFFIX}")
 
 
-def get_cached_images(doc_id: str, pdf_path: str) -> Optional[list]:
-    """extract_pdf_images() 결과(그림/표 좌표)의 디스크 캐시를 반환합니다.
-    캐시가 없거나 원본 PDF의 mtime/크기가 저장 당시와 달라졌다면 None을
-    반환해 재추출을 유도합니다. get_cached_pages()와 동일한 방식이다 -
-    이 함수가 없으면 문서를 열 때마다 매번 PyMuPDF로 페이지별 표/그림
-    탐지(find_tables, get_drawings 등 비용이 큰 연산)를 처음부터 다시
-    수행하게 되어, 텍스트 추출 캐시가 있어도 열람이 계속 느리다."""
+def get_cached_images(doc_id: str, pdf_path: str, engine: str | None = None,
+                      version: str | None = None) -> Optional[list]:
+    """Return cached visual regions only for the matching parser identity."""
     path = _images_cache_path(doc_id)
     if not os.path.exists(path):
         return None
     try:
+        from services.pdf_diagnostics import (
+            PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
+        )
+        expected_engine, expected_version = _document_parser_identity(doc_id, engine, version)
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        stat = os.stat(pdf_path)
-        if data.get("mtime") != stat.st_mtime or data.get("size") != stat.st_size:
+        if (
+            data.get("cache_schema_version") != PAGES_CACHE_SCHEMA_VERSION
+            or data.get("pdf_fingerprint") != pdf_fingerprint(pdf_path)
+            or data.get("parser_engine") != expected_engine
+            or data.get("parser_version") != expected_version
+        ):
             return None
         return data.get("images")
     except Exception:
         return None
 
 
-def save_images_cache(doc_id: str, pdf_path: str, images: list) -> None:
-    """extract_pdf_images() 결과를 디스크에 캐싱합니다."""
+def save_images_cache(doc_id: str, pdf_path: str, images: list, engine: str | None = None,
+                      version: str | None = None) -> None:
+    """Persist parser-aware image/table coordinates."""
     try:
-        stat = os.stat(pdf_path)
+        from services.pdf_diagnostics import (
+            PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
+        )
+        actual_engine, actual_version = parser_identity(engine)
+        if version is not None:
+            actual_version = version
         atomic_write_text(_images_cache_path(doc_id), json.dumps({
-            "mtime": stat.st_mtime,
-            "size": stat.st_size,
+            "cache_schema_version": PAGES_CACHE_SCHEMA_VERSION,
+            "pdf_fingerprint": pdf_fingerprint(pdf_path),
+            "parser_engine": actual_engine,
+            "parser_version": actual_version,
             "images": images,
         }, ensure_ascii=False))
     except Exception:

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -52,6 +52,9 @@ def init_db():
             source_language_confidence REAL,
             preferred_target_language TEXT,
             processing_policy TEXT NOT NULL DEFAULT 'inherit',
+            content_revision INTEGER NOT NULL DEFAULT 1,
+            parser_engine TEXT NOT NULL DEFAULT 'pymupdf',
+            parser_version TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE ON UPDATE CASCADE
         )
@@ -64,10 +67,11 @@ def init_db():
             doc_id TEXT NOT NULL,
             page_num INTEGER NOT NULL,
             suffix TEXT NOT NULL,
+            content_revision INTEGER NOT NULL DEFAULT 1,
             translation TEXT NOT NULL,
             saved_at TEXT NOT NULL,
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
-            UNIQUE(doc_id, page_num, suffix)
+            UNIQUE(doc_id, page_num, suffix, content_revision)
         )
         """)
         
@@ -78,6 +82,7 @@ def init_db():
             doc_id TEXT NOT NULL,
             role TEXT NOT NULL,
             content TEXT NOT NULL,
+            content_revision INTEGER NOT NULL DEFAULT 1,
             created_at TEXT NOT NULL,
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
         )
@@ -91,10 +96,11 @@ def init_db():
             page_num INTEGER NOT NULL,
             kind TEXT NOT NULL,
             suffix TEXT NOT NULL,
+            content_revision INTEGER NOT NULL DEFAULT 1,
             content TEXT NOT NULL,
             saved_at TEXT NOT NULL,
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
-            UNIQUE(doc_id, page_num, kind, suffix)
+            UNIQUE(doc_id, page_num, kind, suffix, content_revision)
         )
         """)
 
@@ -130,6 +136,38 @@ def init_db():
         """)
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_tasks_doc ON document_tasks(doc_id, created_at DESC)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_document_tasks_recovery ON document_tasks(status, next_retry_at)")
+
+
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS parsing_diagnostics (
+            doc_id TEXT NOT NULL,
+            content_revision INTEGER NOT NULL,
+            parser_engine TEXT NOT NULL,
+            parser_version TEXT,
+            report TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (doc_id, content_revision),
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS reparse_previews (
+            id TEXT PRIMARY KEY,
+            doc_id TEXT NOT NULL,
+            candidate_engine TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            source_revision INTEGER NOT NULL,
+            source_pdf_fingerprint TEXT,
+            staging_path TEXT,
+            current_report TEXT,
+            candidate_report TEXT,
+            last_error_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_reparse_previews_doc ON reparse_previews(doc_id, created_at DESC)")
 
         # 문서 채팅용 페이지·문단 전문 검색 인덱스. PDF 원문을 문단 단위로
         # 저장해 재시작 후에도 후반부 질문을 검색할 수 있다.
@@ -175,11 +213,80 @@ def init_db():
             "ALTER TABLE documents ADD COLUMN source_language_confidence REAL",
             "ALTER TABLE documents ADD COLUMN preferred_target_language TEXT",
             "ALTER TABLE documents ADD COLUMN processing_policy TEXT NOT NULL DEFAULT 'inherit'",
+            "ALTER TABLE documents ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE documents ADD COLUMN parser_engine TEXT NOT NULL DEFAULT 'pymupdf'",
+            "ALTER TABLE documents ADD COLUMN parser_version TEXT",
         ):
             try:
                 cursor.execute(column_sql)
             except sqlite3.OperationalError:
                 pass
+
+
+        for column_sql in (
+            "ALTER TABLE translations ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE page_insights ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE chats ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
+        ):
+            try:
+                cursor.execute(column_sql)
+            except sqlite3.OperationalError:
+                pass
+
+        try:
+            cursor.execute("ALTER TABLE reparse_previews ADD COLUMN source_pdf_fingerprint TEXT")
+        except sqlite3.OperationalError:
+            pass
+
+        def migrate_revision_unique(table: str, create_sql: str, copy_columns: str) -> None:
+            schema_row = cursor.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+            ).fetchone()
+            normalized = re.sub(r"\s+", "", (schema_row["sql"] if schema_row else "").lower())
+            if "content_revision)" in normalized and (
+                "unique(doc_id,page_num,suffix,content_revision)" in normalized
+                or "unique(doc_id,page_num,kind,suffix,content_revision)" in normalized
+            ):
+                return
+            old_table = f"{table}_pre_revision"
+            cursor.execute(f"ALTER TABLE {table} RENAME TO {old_table}")
+            cursor.execute(create_sql)
+            cursor.execute(
+                f"INSERT INTO {table} ({copy_columns}) SELECT {copy_columns} FROM {old_table}"
+            )
+            cursor.execute(f"DROP TABLE {old_table}")
+
+        migrate_revision_unique(
+            "translations",
+            """CREATE TABLE translations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                doc_id TEXT NOT NULL,
+                page_num INTEGER NOT NULL,
+                suffix TEXT NOT NULL,
+                content_revision INTEGER NOT NULL DEFAULT 1,
+                translation TEXT NOT NULL,
+                saved_at TEXT NOT NULL,
+                FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+                UNIQUE(doc_id, page_num, suffix, content_revision)
+            )""",
+            "id, doc_id, page_num, suffix, content_revision, translation, saved_at",
+        )
+        migrate_revision_unique(
+            "page_insights",
+            """CREATE TABLE page_insights (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                doc_id TEXT NOT NULL,
+                page_num INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                suffix TEXT NOT NULL,
+                content_revision INTEGER NOT NULL DEFAULT 1,
+                content TEXT NOT NULL,
+                saved_at TEXT NOT NULL,
+                FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+                UNIQUE(doc_id, page_num, kind, suffix, content_revision)
+            )""",
+            "id, doc_id, page_num, kind, suffix, content_revision, content, saved_at",
+        )
 
         # chats 테이블 동적 스키마 마이그레이션 (graph_synced_at 컬럼 추가).
         # 질문이 어떤 Concept과도 매칭되지 않는 것은 정상 케이스라
@@ -625,6 +732,8 @@ def db_save_document(
     source_language_confidence: Optional[float] = None,
     preferred_target_language: Optional[str] = None,
     processing_policy: str = "inherit",
+    content_revision: int = 1, parser_engine: str = "pymupdf",
+    parser_version: Optional[str] = None,
 ) -> dict:
     meta_str = json.dumps(metadata, ensure_ascii=False)
     created_at = datetime.now(timezone.utc).isoformat()
@@ -634,12 +743,12 @@ def db_save_document(
             """
             INSERT OR REPLACE INTO documents
                 (id, username, filename, pdf_path, total_pages, metadata,
-                 document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, content_revision, parser_engine, parser_version, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (doc_id, username, filename, pdf_path, total_pages, meta_str,
              document_mode, document_type, mode_schema_version, source_language, detected_source_language,
-             source_language_confidence, preferred_target_language, processing_policy, created_at)
+             source_language_confidence, preferred_target_language, processing_policy, int(content_revision), parser_engine, parser_version, created_at)
         )
         conn.commit()
     return {
@@ -651,13 +760,15 @@ def db_save_document(
         "source_language_confidence": source_language_confidence,
         "preferred_target_language": preferred_target_language,
         "processing_policy": processing_policy,
+        "content_revision": int(content_revision), "parser_engine": parser_engine,
+        "parser_version": parser_version,
     }
 
 def db_get_document(doc_id: str) -> Optional[dict]:
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, username, filename, pdf_path, total_pages, metadata, document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, is_deleted, created_at FROM documents WHERE id = ?",
+            "SELECT id, username, filename, pdf_path, total_pages, metadata, document_mode, document_type, mode_schema_version, source_language, detected_source_language, source_language_confidence, preferred_target_language, processing_policy, content_revision, parser_engine, parser_version, is_deleted, created_at FROM documents WHERE id = ?",
             (doc_id,)
         )
         row = cursor.fetchone()
@@ -683,7 +794,7 @@ def db_list_documents(username: Optional[str] = None, only_trash: bool = False, 
     query = (
         "SELECT id, username, filename, pdf_path, total_pages, metadata, "
         "document_mode, document_type, mode_schema_version, source_language, detected_source_language, "
-        "source_language_confidence, preferred_target_language, processing_policy, is_deleted, created_at "
+        "source_language_confidence, preferred_target_language, processing_policy, content_revision, parser_engine, parser_version, is_deleted, created_at "
         "FROM documents"
     )
     if conditions:
@@ -736,9 +847,9 @@ def db_search_documents(username: str, query: str, only_trash: bool = False, doc
                    d.metadata, d.document_mode, d.document_type,
                    d.mode_schema_version, d.source_language, d.detected_source_language,
                    d.source_language_confidence, d.preferred_target_language, d.processing_policy,
-                   d.is_deleted, d.created_at
+                   d.content_revision, d.parser_engine, d.parser_version, d.is_deleted, d.created_at
             FROM documents d
-            LEFT JOIN translations t ON t.doc_id = d.id
+            LEFT JOIN translations t ON t.doc_id = d.id AND t.content_revision = d.content_revision
             WHERE d.username = ? AND d.is_deleted = ?
               AND (? IS NULL OR d.document_mode = ?)
               AND (
@@ -794,6 +905,8 @@ def db_delete_document(doc_id: str) -> bool:
         cursor.execute("DELETE FROM memos WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM document_task_pages WHERE task_id IN (SELECT id FROM document_tasks WHERE doc_id = ?)", (doc_id,))
         cursor.execute("DELETE FROM document_tasks WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM parsing_diagnostics WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM reparse_previews WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM page_insights WHERE doc_id = ?", (doc_id,))
         try:
             cursor.execute("DELETE FROM document_chunks_fts WHERE doc_id = ?", (doc_id,))
@@ -829,38 +942,51 @@ def db_restore_document(doc_id: str) -> bool:
 
 # ── 번역 (Translations) ────────────────────────────────────────────────────────
 
-def db_save_translation(doc_id: str, page_num: int, translation: str, suffix: str = "") -> None:
+
+def db_get_content_revision(doc_id: str) -> int:
+    with get_db() as conn:
+        row = conn.execute("SELECT content_revision FROM documents WHERE id = ?", (doc_id,)).fetchone()
+    return int(row["content_revision"]) if row else 1
+
+
+def db_save_translation(doc_id: str, page_num: int, translation: str, suffix: str = "",
+                        content_revision: Optional[int] = None) -> None:
     saved_at = datetime.now(timezone.utc).isoformat()
     with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT OR REPLACE INTO translations (doc_id, page_num, suffix, translation, saved_at)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (doc_id, page_num, suffix, translation, saved_at)
+        revision = content_revision
+        if revision is None:
+            row = conn.execute("SELECT content_revision FROM documents WHERE id = ?", (doc_id,)).fetchone()
+            revision = int(row["content_revision"]) if row else 1
+        conn.execute(
+            """INSERT OR REPLACE INTO translations
+               (doc_id, page_num, suffix, content_revision, translation, saved_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (doc_id, page_num, suffix, int(revision), translation, saved_at),
         )
         conn.commit()
 
-def db_get_translation(doc_id: str, page_num: int, suffix: str = "", fallback: bool = True) -> Optional[str]:
+def db_get_translation(doc_id: str, page_num: int, suffix: str = "", fallback: bool = True,
+                       content_revision: Optional[int] = None) -> Optional[str]:
     with get_db() as conn:
-        cursor = conn.cursor()
+        revision = content_revision
+        if revision is None:
+            row = conn.execute("SELECT content_revision FROM documents WHERE id = ?", (doc_id,)).fetchone()
+            revision = int(row["content_revision"]) if row else 1
         if suffix:
-            cursor.execute(
-                "SELECT translation FROM translations WHERE doc_id = ? AND page_num = ? AND suffix = ?",
-                (doc_id, page_num, suffix)
-            )
-            row = cursor.fetchone()
+            row = conn.execute(
+                """SELECT translation FROM translations
+                   WHERE doc_id = ? AND page_num = ? AND suffix = ? AND content_revision = ?""",
+                (doc_id, page_num, suffix, int(revision)),
+            ).fetchone()
             if row:
                 return row["translation"]
-        
         if fallback:
-            # Fallback: get the most recently saved translation for this page, regardless of suffix
-            cursor.execute(
-                "SELECT translation FROM translations WHERE doc_id = ? AND page_num = ? ORDER BY saved_at DESC LIMIT 1",
-                (doc_id, page_num)
-            )
-            row = cursor.fetchone()
+            row = conn.execute(
+                """SELECT translation FROM translations
+                   WHERE doc_id = ? AND page_num = ? AND content_revision = ?
+                   ORDER BY saved_at DESC LIMIT 1""",
+                (doc_id, page_num, int(revision)),
+            ).fetchone()
             if row:
                 return row["translation"]
         return None
@@ -869,8 +995,10 @@ def db_list_translated_pages(doc_id: str, suffix: str = "") -> List[int]:
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT page_num FROM translations WHERE doc_id = ? AND suffix = ? ORDER BY page_num ASC",
-            (doc_id, suffix)
+            """SELECT t.page_num FROM translations t JOIN documents d ON d.id = t.doc_id
+               WHERE t.doc_id = ? AND t.suffix = ? AND t.content_revision = d.content_revision
+               ORDER BY t.page_num ASC""",
+            (doc_id, suffix),
         )
         return [r["page_num"] for r in cursor.fetchall()]
 
@@ -897,8 +1025,11 @@ def db_bulk_translation_rows(doc_ids: List[str]) -> Dict[str, List[tuple]]:
             chunk = doc_ids[i:i + CHUNK]
             placeholders = ",".join("?" for _ in chunk)
             cursor.execute(
-                f"SELECT doc_id, page_num, suffix, saved_at FROM translations WHERE doc_id IN ({placeholders})",
-                chunk
+                f"""SELECT t.doc_id, t.page_num, t.suffix, t.saved_at
+                    FROM translations t JOIN documents d ON d.id = t.doc_id
+                    WHERE t.doc_id IN ({placeholders})
+                      AND t.content_revision = d.content_revision""",
+                chunk,
             )
             for row in cursor.fetchall():
                 result[row["doc_id"]].append((row["page_num"], row["suffix"], row["saved_at"]))
@@ -924,21 +1055,36 @@ def db_save_chat_message(doc_id: str, role: str, content: str) -> Optional[int]:
         if last_msg and last_msg["role"] == role and last_msg["content"] == content:
             return None
 
+        revision_row = cursor.execute(
+            "SELECT content_revision FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        revision = int(revision_row["content_revision"]) if revision_row else 1
         cursor.execute(
-            "INSERT INTO chats (doc_id, role, content, created_at) VALUES (?, ?, ?, ?)",
-            (doc_id, role, content, created_at)
+            """INSERT INTO chats (doc_id, role, content, content_revision, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (doc_id, role, content, revision, created_at),
         )
         conn.commit()
         return cursor.lastrowid
 
-def db_get_chat_history(doc_id: str) -> List[Dict[str, str]]:
+def db_get_chat_history(doc_id: str, include_revision: bool = False) -> List[Dict[str, Any]]:
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT role, content FROM chats WHERE doc_id = ? ORDER BY id ASC",
-            (doc_id,)
+            """SELECT c.role, c.content, c.content_revision,
+                      COALESCE(d.content_revision, c.content_revision) AS current_revision
+               FROM chats c LEFT JOIN documents d ON d.id = c.doc_id
+               WHERE c.doc_id = ? ORDER BY c.id ASC""",
+            (doc_id,),
         )
-        return [{"role": r["role"], "content": r["content"]} for r in cursor.fetchall()]
+        rows = cursor.fetchall()
+        if not include_revision:
+            return [{"role": r["role"], "content": r["content"]} for r in rows]
+        return [{
+            "role": r["role"], "content": r["content"],
+            "content_revision": int(r["content_revision"]),
+            "stale": int(r["content_revision"]) < int(r["current_revision"]),
+        } for r in rows]
 
 def db_clear_chat_history(doc_id: str) -> None:
     with get_db() as conn:
@@ -1053,16 +1199,19 @@ def db_list_compare_chat_sessions(username: str) -> List[Dict[str, Any]]:
 
 # ── 페이지 인사이트 (키워드/단어, 요약) ─────────────────────────────────────────
 
-def db_save_page_insight(doc_id: str, page_num: int, kind: str, content: str, suffix: str = "") -> None:
+def db_save_page_insight(doc_id: str, page_num: int, kind: str, content: str, suffix: str = "",
+                         content_revision: Optional[int] = None) -> None:
     saved_at = datetime.now(timezone.utc).isoformat()
     with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT OR REPLACE INTO page_insights (doc_id, page_num, kind, suffix, content, saved_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (doc_id, page_num, kind, suffix, content, saved_at)
+        revision = content_revision
+        if revision is None:
+            row = conn.execute("SELECT content_revision FROM documents WHERE id = ?", (doc_id,)).fetchone()
+            revision = int(row["content_revision"]) if row else 1
+        conn.execute(
+            """INSERT OR REPLACE INTO page_insights
+               (doc_id, page_num, kind, suffix, content_revision, content, saved_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (doc_id, page_num, kind, suffix, int(revision), content, saved_at),
         )
         conn.commit()
 
@@ -1070,8 +1219,12 @@ def db_get_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = "")
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT content FROM page_insights WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?",
-            (doc_id, page_num, kind, suffix)
+            """SELECT content FROM page_insights
+               WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?
+                 AND content_revision = COALESCE(
+                     (SELECT content_revision FROM documents WHERE id = ?), 1
+                 )""",
+            (doc_id, page_num, kind, suffix, doc_id),
         )
         row = cursor.fetchone()
         return row["content"] if row else None
@@ -1093,8 +1246,9 @@ def db_delete_page_insight(doc_id: str, page_num: int, kind: str, suffix: str = 
     with get_db() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "DELETE FROM page_insights WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?",
-            (doc_id, page_num, kind, suffix)
+            """DELETE FROM page_insights WHERE doc_id = ? AND page_num = ? AND kind = ? AND suffix = ?
+               AND content_revision = (SELECT content_revision FROM documents WHERE id = ?)""",
+            (doc_id, page_num, kind, suffix, doc_id)
         )
         conn.commit()
 

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -235,8 +235,8 @@ async def _backfill_one(doc_id: str) -> None:
         from services.pdf_parser import extract_pages
         pages = get_cached_pages(doc_id, pdf_path)
         if pages is None:
-            pages = await asyncio.to_thread(extract_pages, pdf_path)
-            save_pages_cache(doc_id, pdf_path, pages)
+            pages = await asyncio.to_thread(extract_pages, pdf_path, doc.get("parser_engine"))
+            save_pages_cache(doc_id, pdf_path, pages, doc.get("parser_engine"), doc.get("parser_version"))
 
         doc_title = doc.get("metadata", {}).get("title") or doc.get("filename")
         await sync_document_for_graph(doc_id, pages, doc_title)
@@ -258,8 +258,8 @@ async def _backfill_paper_tags(doc_id: str) -> None:
             return
         pages = get_cached_pages(doc_id, pdf_path)
         if pages is None:
-            pages = await asyncio.to_thread(extract_pages, pdf_path)
-            save_pages_cache(doc_id, pdf_path, pages)
+            pages = await asyncio.to_thread(extract_pages, pdf_path, doc.get("parser_engine"))
+            save_pages_cache(doc_id, pdf_path, pages, doc.get("parser_engine"), doc.get("parser_version"))
         title = (doc.get("metadata") or {}).get("title") or doc.get("filename") or ""
         await classify_and_store_paper_tags(doc_id, pages, title, force=False)
     except Exception as e:
@@ -314,9 +314,12 @@ def _queue_figure_nodes(doc_ids: List[str], nodes: list, edges: list) -> None:
     재생성되면 바뀔 수 있음 - 인용 매칭처럼 완벽하지 않아도 되는 수준으로
     받아들인다). 라벨이 없는(캡션 매칭 실패) 사각형은 사용자에게 의미가
     없으므로 노드로 만들지 않는다."""
-    from services.library import get_pdf_path
+    from services.library import get_document, get_pdf_path
     from services.cache import get_cached_images
     for doc_id in doc_ids:
+        doc = get_document(doc_id)
+        if not doc:
+            continue
         pdf_path = get_pdf_path(doc_id)
         if not pdf_path:
             continue
@@ -872,16 +875,17 @@ async def _get_paper_text_for_scoring(doc_id: str) -> str:
     채점을 시도하거나 등장 여부 기반 값으로 대체할 수 있어 파이프라인을
     막지 않는다."""
     try:
-        from services.library import get_pdf_path
+        from services.library import get_document, get_pdf_path
         from services.cache import get_cached_pages, save_pages_cache
         from services.pdf_parser import extract_pages
+        doc = get_document(doc_id)
         pdf_path = get_pdf_path(doc_id)
-        if not pdf_path:
+        if not doc or not pdf_path:
             return ""
         pages = get_cached_pages(doc_id, pdf_path)
         if pages is None:
-            pages = await asyncio.to_thread(extract_pages, pdf_path)
-            save_pages_cache(doc_id, pdf_path, pages)
+            pages = await asyncio.to_thread(extract_pages, pdf_path, doc.get("parser_engine"))
+            save_pages_cache(doc_id, pdf_path, pages, doc.get("parser_engine"), doc.get("parser_version"))
         return "\n".join(p.get("text", "") for p in pages[:2])
     except Exception:
         return ""

--- a/backend/services/library.py
+++ b/backend/services/library.py
@@ -88,7 +88,9 @@ def save_document(doc_id: str, filename: str, pdf_src_path: str,
                   document_mode: str = "research", document_type: str = "research_paper",
                   source_language: str = "auto", detected_source_language: str = "und",
                   source_language_confidence: Optional[float] = None,
-                  preferred_target_language: Optional[str] = None) -> dict:
+                  preferred_target_language: Optional[str] = None,
+                  content_revision: int = 1, parser_engine: str = "pymupdf",
+                  parser_version: Optional[str] = None) -> dict:
     """PDF를 라이브러리에 영구 저장하고 데이터베이스에 기록합니다."""
     doc_dir = os.path.join(LIBRARY_DIR, doc_id)
     os.makedirs(os.path.join(doc_dir, "translations"), exist_ok=True)
@@ -103,6 +105,8 @@ def save_document(doc_id: str, filename: str, pdf_src_path: str,
         source_language=source_language, detected_source_language=detected_source_language,
         source_language_confidence=source_language_confidence,
         preferred_target_language=preferred_target_language,
+        content_revision=content_revision, parser_engine=parser_engine,
+        parser_version=parser_version,
     )
     doc_meta["translated_pages"] = []
     return doc_meta

--- a/backend/services/pdf_diagnostics.py
+++ b/backend/services/pdf_diagnostics.py
@@ -1,0 +1,188 @@
+"""Parser identity, PDF fingerprints, and page-quality diagnostics."""
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import re
+import unicodedata
+from collections import Counter
+from typing import Any, Iterable
+
+PAGES_CACHE_SCHEMA_VERSION = 2
+_PARSER_DISTRIBUTIONS = {
+    "pymupdf": "PyMuPDF",
+    "pdfplumber": "pdfplumber",
+    "marker": "marker-pdf",
+    "mineru": "mineru",
+}
+_MOJIBAKE_RE = re.compile(r"(?:Ã.|Â.|â€|\ufffd)")
+_PRIVATE_INDENT_SENTINEL = "\ue000"
+
+
+def pdf_fingerprint(pdf_path: str) -> str:
+    digest = hashlib.sha256()
+    with open(pdf_path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parser_version(engine: str) -> str:
+    distribution = _PARSER_DISTRIBUTIONS.get((engine or "pymupdf").lower(), engine)
+    try:
+        return importlib.metadata.version(distribution)
+    except (importlib.metadata.PackageNotFoundError, TypeError):
+        return "unknown"
+
+
+def parser_identity(engine: str | None = None) -> tuple[str, str]:
+    if engine is None:
+        try:
+            from config import get_pdf_parser_engine
+            engine = get_pdf_parser_engine()
+        except Exception:
+            engine = "pymupdf"
+    normalized = (engine or "pymupdf").strip().lower()
+    return normalized, parser_version(normalized)
+
+
+def _abnormal_character_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    abnormal = 0
+    for char in text:
+        if char == _PRIVATE_INDENT_SENTINEL or char.isspace():
+            continue
+        category = unicodedata.category(char)
+        if char == "\ufffd" or category in {"Cc", "Cs", "Co", "Cn"}:
+            abnormal += 1
+    return abnormal / max(1, len(text))
+
+
+def _repeated_lines(text: str) -> tuple[int, float]:
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    lines = [line for line in lines if len(line) >= 8]
+    counts = Counter(lines)
+    repeated = sum(count - 1 for count in counts.values() if count > 1)
+    return repeated, repeated / max(1, len(lines))
+
+
+def _block_count(page: dict) -> int:
+    blocks = page.get("blocks")
+    return len(blocks) if isinstance(blocks, list) else 0
+
+
+def _suspicious_reading_order(page: dict) -> bool:
+    explicit = page.get("reading_order_suspicious")
+    if isinstance(explicit, bool):
+        return explicit
+    blocks = page.get("blocks")
+    if not isinstance(blocks, list) or len(blocks) < 4:
+        return False
+    centers = []
+    for block in blocks:
+        bbox = block.get("bbox") if isinstance(block, dict) else None
+        if not bbox or len(bbox) != 4:
+            continue
+        centers.append(((float(bbox[0]) + float(bbox[2])) / 2, float(bbox[1])))
+    if len(centers) < 4:
+        return False
+    page_mid = (min(x for x, _ in centers) + max(x for x, _ in centers)) / 2
+    sides = [x >= page_mid for x, _ in centers]
+    switches = sum(a != b for a, b in zip(sides, sides[1:]))
+    return bool(page.get("is_two_column")) and switches > 2
+
+
+def _visual_counts(images: Iterable[dict], page_num: int) -> tuple[int, int]:
+    image_count = 0
+    table_count = 0
+    for item in images:
+        if int(item.get("page_num") or item.get("page") or 0) != page_num:
+            continue
+        label = str(item.get("label") or "").lower()
+        kind = str(item.get("kind") or item.get("type") or "").lower()
+        if label.startswith("table") or kind == "table":
+            table_count += 1
+        else:
+            image_count += 1
+    return image_count, table_count
+
+
+def diagnose_pages(pages: list[dict], images: list[dict] | None = None,
+                   engine: str | None = None, version: str | None = None) -> dict[str, Any]:
+    images = images or []
+    page_reports = []
+    problem_pages = []
+    for page in pages:
+        page_num = int(page.get("page_num") or len(page_reports) + 1)
+        text = str(page.get("text") or "")
+        stripped = text.strip()
+        replacement_count = len(_MOJIBAKE_RE.findall(text))
+        broken_ratio = replacement_count / max(1, len(text))
+        repeated_count, repeated_ratio = _repeated_lines(text)
+        abnormal_ratio = _abnormal_character_ratio(text)
+        image_count, table_count = _visual_counts(images, page_num)
+        ocr_confidence = page.get("ocr_confidence")
+        if not isinstance(ocr_confidence, (int, float)):
+            ocr_confidence = None
+
+        language = "und"
+        language_confidence = 0.0
+        if stripped:
+            try:
+                from services.languages import detect_document_language
+                detected = detect_document_language([{"page_num": page_num, "text": text}])
+                language = str(detected.get("language") or "und")
+                language_confidence = float(detected.get("confidence") or 0.0)
+            except Exception:
+                pass
+
+        suspicious_order = _suspicious_reading_order(page)
+        issues = []
+        if not stripped:
+            issues.append("empty_text")
+        if broken_ratio > 0.005:
+            issues.append("broken_characters")
+        if repeated_ratio > 0.15:
+            issues.append("repeated_lines")
+        if abnormal_ratio > 0.01:
+            issues.append("abnormal_characters")
+        if suspicious_order:
+            issues.append("reading_order")
+        if stripped and language_confidence < 0.35:
+            issues.append("low_language_confidence")
+        if issues:
+            problem_pages.append(page_num)
+
+        page_reports.append({
+            "page_num": page_num,
+            "empty_text": not bool(stripped),
+            "broken_character_ratio": round(broken_ratio, 6),
+            "repeated_line_count": repeated_count,
+            "repeated_line_ratio": round(repeated_ratio, 6),
+            "abnormal_character_ratio": round(abnormal_ratio, 6),
+            "block_count": _block_count(page),
+            "suspicious_reading_order": suspicious_order,
+            "image_count": image_count,
+            "table_count": table_count,
+            "detected_language": language,
+            "language_confidence": round(language_confidence, 6),
+            "ocr_confidence": ocr_confidence,
+            "issues": issues,
+            "preview": stripped[:600],
+        })
+
+    resolved_engine = engine or next(
+        (str(page.get("parser_engine")) for page in pages if page.get("parser_engine")), "unknown"
+    )
+    return {
+        "parser_engine": resolved_engine,
+        "parser_version": version or parser_version(resolved_engine),
+        "page_count": len(pages),
+        "problem_pages": problem_pages,
+        "problem_page_count": len(problem_pages),
+        "empty_page_count": sum(1 for page in page_reports if page["empty_text"]),
+        "image_count": sum(page["image_count"] for page in page_reports),
+        "table_count": sum(page["table_count"] for page in page_reports),
+        "pages": page_reports,
+    }

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -174,6 +174,10 @@ def _extract_page(page: fitz.Page, page_num: int) -> Dict[str, Any]:
         "text": text_content,
         "is_two_column": is_two_column,
         "word_count": len(text_content.split()),
+        "blocks": [
+            {"bbox": [b[0], b[1], b[2], b[3]], "text": b[4], "type": 0}
+            for b in sorted_blocks
+        ],
     }
 
 
@@ -2085,3 +2089,9 @@ def extract_pdf_images(pdf_path: str, engine: Optional[str] = None) -> List[Dict
     doc.close()
     return images_data
 
+
+
+def clear_parser_memory_cache() -> None:
+    """Discard document-specific advanced parser artifacts after cache invalidation."""
+    _build_marker_document.cache_clear()
+    _run_mineru.cache_clear()

--- a/backend/services/reparse.py
+++ b/backend/services/reparse.py
@@ -1,0 +1,438 @@
+"""Candidate parser previews and atomic content-revision application."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from config import LIBRARY_DIR
+from services.db import get_db
+from services.pdf_diagnostics import diagnose_pages, parser_identity, pdf_fingerprint
+
+_ALLOWED_ENGINES = {"pymupdf", "pdfplumber", "marker", "mineru"}
+_preview_workers: dict[str, asyncio.Task] = {}
+_apply_locks: dict[str, asyncio.Lock] = {}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _decode_json(value: str | None) -> dict | None:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return None
+
+
+def _preview_row(task_id: str) -> dict | None:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM reparse_previews WHERE id = ?", (task_id,)).fetchone()
+    if not row:
+        return None
+    result = dict(row)
+    result["current_report"] = _decode_json(result.get("current_report"))
+    result["candidate_report"] = _decode_json(result.get("candidate_report"))
+    result.pop("staging_path", None)
+    return result
+
+
+def get_preview(task_id: str) -> dict | None:
+    return _preview_row(task_id)
+
+
+def get_diagnostics(doc_id: str, revision: int | None = None) -> dict | None:
+    with get_db() as conn:
+        if revision is None:
+            row = conn.execute(
+                """SELECT p.report FROM parsing_diagnostics p JOIN documents d ON d.id = p.doc_id
+                   WHERE p.doc_id = ? AND p.content_revision = d.content_revision""",
+                (doc_id,),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT report FROM parsing_diagnostics WHERE doc_id = ? AND content_revision = ?",
+                (doc_id, int(revision)),
+            ).fetchone()
+    return _decode_json(row["report"]) if row else None
+
+
+
+def save_diagnostics(doc_id: str, revision: int, report: dict) -> None:
+    with get_db() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO parsing_diagnostics
+               (doc_id, content_revision, parser_engine, parser_version, report, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                doc_id, int(revision), report.get("parser_engine") or "unknown",
+                report.get("parser_version"), json.dumps(report, ensure_ascii=False), _now(),
+            ),
+        )
+        conn.commit()
+
+
+def _staging_path(doc_id: str, task_id: str) -> str:
+    return os.path.join(LIBRARY_DIR, doc_id, "reparse_previews", f"{task_id}.json")
+
+
+def _worker_command(engine: str, pdf_path: str, output_path: str) -> tuple[list[str], dict[str, str]]:
+    import venv_manager
+
+    env = dict(os.environ)
+    python_executable = sys.executable
+    if not venv_manager.is_packaged_desktop():
+        target_venv = venv_manager.required_venv_for_engine(engine)
+        if venv_manager.is_venv_available(target_venv):
+            python_executable = venv_manager.venv_python(target_venv)
+    elif engine != "pymupdf":
+        package_dir = venv_manager.parser_packages_dir(engine)
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = package_dir if not existing else os.pathsep.join((package_dir, existing))
+
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    command = [
+        python_executable,
+        os.path.join(backend_dir, "parser_worker.py"),
+        "--pdf", pdf_path,
+        "--engine", engine,
+        "--output", output_path,
+    ]
+    return command, env
+
+
+
+def parse_document_isolated(pdf_path: str, engine: str) -> dict:
+    """Run an applied advanced parser in its managed environment without changing globals."""
+    import subprocess
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="easypaper-parser-") as temp_dir:
+        output_path = os.path.join(temp_dir, "result.json")
+        command, env = _worker_command(engine, pdf_path, output_path)
+        result = subprocess.run(
+            command,
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=1800,
+            check=False,
+        )
+        if result.returncode != 0:
+            message = result.stderr.decode("utf-8", errors="replace")[-1000:]
+            raise RuntimeError(message or "isolated parser failed")
+        with open(output_path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    if payload.get("parser_engine") != engine or not isinstance(payload.get("pages"), list):
+        raise RuntimeError("isolated parser returned invalid output")
+    return payload
+
+
+async def _run_preview(task_id: str, pdf_path: str) -> None:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM reparse_previews WHERE id = ?", (task_id,)).fetchone()
+        if not row:
+            return
+        preview = dict(row)
+        conn.execute(
+            "UPDATE reparse_previews SET status = 'running', updated_at = ? WHERE id = ?",
+            (_now(), task_id),
+        )
+        conn.commit()
+
+    output_path = preview["staging_path"]
+    command, env = _worker_command(preview["candidate_engine"], pdf_path, output_path)
+    process = None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+        )
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=1800)
+        if process.returncode != 0:
+            message = stderr.decode("utf-8", errors="replace")[-1000:]
+            raise RuntimeError(message or stdout.decode("utf-8", errors="replace")[-1000:])
+        with open(output_path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        report = payload.get("diagnostics")
+        if not isinstance(report, dict):
+            raise ValueError("candidate diagnostics missing")
+        with get_db() as conn:
+            conn.execute(
+                """UPDATE reparse_previews
+                   SET status = 'succeeded', candidate_report = ?, last_error_code = NULL, updated_at = ?
+                   WHERE id = ?""",
+                (json.dumps(report, ensure_ascii=False), _now(), task_id),
+            )
+            conn.commit()
+    except asyncio.CancelledError:
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.wait()
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE reparse_previews SET status = 'cancelled', updated_at = ? WHERE id = ?",
+                (_now(), task_id),
+            )
+            conn.commit()
+        raise
+    except Exception as exc:
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.wait()
+        code = "parser_unavailable" if "unavailable" in str(exc).lower() or "no such file" in str(exc).lower() else "reparse_failed"
+        with get_db() as conn:
+            conn.execute(
+                """UPDATE reparse_previews
+                   SET status = 'failed', last_error_code = ?, updated_at = ? WHERE id = ?""",
+                (code, _now(), task_id),
+            )
+            conn.commit()
+    finally:
+        if _preview_workers.get(task_id) is asyncio.current_task():
+            _preview_workers.pop(task_id, None)
+
+
+
+def recover_reparse_previews() -> None:
+    """Resume queued/running candidate parser workers after a server restart."""
+    from services.library import get_pdf_path
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT id, doc_id FROM reparse_previews WHERE status IN ('queued','running') ORDER BY created_at"
+        ).fetchall()
+    for row in rows:
+        if row["id"] in _preview_workers:
+            continue
+        pdf_path = get_pdf_path(row["doc_id"])
+        if not pdf_path:
+            with get_db() as conn:
+                conn.execute(
+                    """UPDATE reparse_previews SET status = 'failed',
+                       last_error_code = 'pdf_not_found', updated_at = ? WHERE id = ?""",
+                    (_now(), row["id"]),
+                )
+                conn.commit()
+            continue
+        task = asyncio.create_task(_run_preview(row["id"], pdf_path))
+        _preview_workers[row["id"]] = task
+
+
+def create_preview(doc: dict, pages: list[dict], pdf_path: str, engine: str,
+                   current_images: list[dict] | None = None) -> dict:
+    normalized = (engine or "").strip().lower()
+    if normalized not in _ALLOWED_ENGINES:
+        raise ValueError("unsupported parser engine")
+    task_id = str(uuid.uuid4())
+    current_engine = doc.get("parser_engine") or next(
+        (page.get("parser_engine") for page in pages if page.get("parser_engine")), "pymupdf"
+    )
+    current_version = doc.get("parser_version") or parser_identity(current_engine)[1]
+    current_report = diagnose_pages(pages, current_images or [], current_engine, current_version)
+    output_path = _staging_path(doc["id"], task_id)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    now = _now()
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO reparse_previews
+               (id, doc_id, candidate_engine, status, source_revision, source_pdf_fingerprint, staging_path,
+                current_report, created_at, updated_at)
+               VALUES (?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?)""",
+            (
+                task_id, doc["id"], normalized, int(doc.get("content_revision") or 1),
+                pdf_fingerprint(pdf_path), output_path,
+                json.dumps(current_report, ensure_ascii=False), now, now,
+            ),
+        )
+        conn.commit()
+    task = asyncio.create_task(_run_preview(task_id, pdf_path))
+    _preview_workers[task_id] = task
+    return _preview_row(task_id)
+
+
+def _preview_with_path(task_id: str) -> dict | None:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM reparse_previews WHERE id = ?", (task_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def preview_impact(doc_id: str, source_revision: int) -> dict[str, Any]:
+    with get_db() as conn:
+        translations = conn.execute(
+            "SELECT COUNT(*) AS count FROM translations WHERE doc_id = ? AND content_revision = ?",
+            (doc_id, source_revision),
+        ).fetchone()["count"]
+        insights = conn.execute(
+            "SELECT COUNT(*) AS count FROM page_insights WHERE doc_id = ? AND content_revision = ?",
+            (doc_id, source_revision),
+        ).fetchone()["count"]
+        tasks = conn.execute(
+            """SELECT COUNT(*) AS count FROM document_tasks
+               WHERE doc_id = ? AND status IN ('queued','running','retry_wait')""",
+            (doc_id,),
+        ).fetchone()["count"]
+    return {
+        "translations_to_regenerate": int(translations),
+        "insights_to_regenerate": int(insights),
+        "running_tasks_to_cancel": int(tasks),
+        "preserved": ["memos", "annotations", "chat_history"],
+    }
+
+
+def _cancel_derived_tasks(doc_id: str) -> None:
+    from services.document_tasks import recoverable_tasks, request_cancel
+    for task in recoverable_tasks():
+        if task["doc_id"] == doc_id and task["kind"] != "parse":
+            request_cancel(task["id"])
+    from services.translation_job import cancel_job
+    from services.insight_job import cancel_insight_job
+    cancel_job(doc_id)
+    cancel_insight_job(doc_id, "keywords")
+    cancel_insight_job(doc_id, "summary")
+    try:
+        from routers.primer import cancel_primer_generation
+        cancel_primer_generation(doc_id)
+    except ImportError:
+        pass
+
+
+async def apply_preview(doc_id: str, task_id: str, sessions: dict) -> dict:
+    lock = _apply_locks.setdefault(doc_id, asyncio.Lock())
+    async with lock:
+        preview = _preview_with_path(task_id)
+        if not preview or preview["doc_id"] != doc_id:
+            raise KeyError("preview not found")
+        if preview["status"] != "succeeded":
+            raise ValueError("preview not ready")
+        with open(preview["staging_path"], "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+
+        if (
+            payload.get("parser_engine") != preview["candidate_engine"]
+            or not isinstance(payload.get("pages"), list)
+            or not isinstance(payload.get("diagnostics"), dict)
+        ):
+            raise RuntimeError("invalid_staging_result")
+
+        from services.library import get_pdf_path
+        pdf_path = get_pdf_path(doc_id)
+        candidate_fingerprint = payload.get("pdf_fingerprint")
+        source_fingerprint = preview.get("source_pdf_fingerprint")
+        if (
+            not pdf_path
+            or not source_fingerprint
+            or candidate_fingerprint != source_fingerprint
+            or candidate_fingerprint != pdf_fingerprint(pdf_path)
+        ):
+            raise RuntimeError("pdf_revision_conflict")
+
+        with get_db() as conn:
+            revision_row = conn.execute(
+                "SELECT content_revision FROM documents WHERE id = ?", (doc_id,)
+            ).fetchone()
+        if (
+            not revision_row
+            or int(revision_row["content_revision"]) != int(preview["source_revision"])
+        ):
+            raise RuntimeError("content_revision_conflict")
+
+        impact = preview_impact(doc_id, int(preview["source_revision"]))
+        _cancel_derived_tasks(doc_id)
+        pages = payload["pages"]
+        images = payload.get("images") or []
+        report = payload["diagnostics"]
+        engine = payload["parser_engine"]
+        version = payload["parser_version"]
+        from services.languages import detect_document_language
+        detection = detect_document_language(pages)
+        from services.context_retrieval import chunk_pages
+        chunks = chunk_pages(pages)
+        now = _now()
+
+        with get_db() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            doc = conn.execute(
+                "SELECT content_revision, metadata FROM documents WHERE id = ?", (doc_id,)
+            ).fetchone()
+            if not doc or int(doc["content_revision"]) != int(preview["source_revision"]):
+                conn.rollback()
+                raise RuntimeError("content_revision_conflict")
+            new_revision = int(doc["content_revision"]) + 1
+            try:
+                metadata = json.loads(doc["metadata"]) if doc["metadata"] else {}
+            except (TypeError, json.JSONDecodeError):
+                metadata = {}
+            for key in ("bibliography", "references", "reference_list"):
+                metadata.pop(key, None)
+            conn.execute(
+                """UPDATE documents
+                   SET total_pages = ?, metadata = ?, content_revision = ?,
+                       parser_engine = ?, parser_version = ?,
+                       detected_source_language = ?, source_language_confidence = ?
+                   WHERE id = ?""",
+                (
+                    len(pages), json.dumps(metadata, ensure_ascii=False), new_revision,
+                    engine, version, str(detection["language"]), float(detection["confidence"]), doc_id,
+                ),
+            )
+            conn.execute(
+                """INSERT INTO parsing_diagnostics
+                   (doc_id, content_revision, parser_engine, parser_version, report, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (doc_id, new_revision, engine, version, json.dumps(report, ensure_ascii=False), now),
+            )
+            conn.execute(
+                "UPDATE reparse_previews SET status = 'applied', updated_at = ? WHERE id = ?",
+                (now, task_id),
+            )
+            conn.execute("DELETE FROM document_chunks_fts WHERE doc_id = ?", (doc_id,))
+            conn.executemany(
+                "INSERT INTO document_chunks_fts(doc_id,page_num,ordinal,section,content) VALUES(?,?,?,?,?)",
+                [(doc_id, chunk["page_num"], chunk["ordinal"], chunk["section"], chunk["content"])
+                 for chunk in chunks],
+            )
+            conn.commit()
+
+        from services.cache import clear_session_cache, save_images_cache, save_pages_cache
+        clear_session_cache(doc_id)
+        save_pages_cache(doc_id, pdf_path, pages, engine, version)
+        save_images_cache(doc_id, pdf_path, images, engine, version)
+        from services.pdf_parser import clear_parser_memory_cache
+        clear_parser_memory_cache()
+        indexed_chunks = len(chunks)
+
+        existing = sessions.get(doc_id, {})
+        sessions[doc_id] = {
+            **existing,
+            "pdf_path": pdf_path,
+            "pages": pages,
+            "total_pages": len(pages),
+            "metadata": metadata,
+            "detected_source_language": str(detection["language"]),
+            "source_language_confidence": float(detection["confidence"]),
+            "content_revision": new_revision,
+            "parser_engine": engine,
+            "parser_version": version,
+        }
+        return {
+            "status": "applied",
+            "content_revision": new_revision,
+            "parser_engine": engine,
+            "parser_version": version,
+            "total_pages": len(pages),
+            "indexed_chunks": indexed_chunks,
+            "stale_results": impact,
+        }

--- a/backend/tests/test_pdf_reparse.py
+++ b/backend/tests/test_pdf_reparse.py
@@ -1,0 +1,298 @@
+import json
+import subprocess
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import fitz
+import pytest
+
+
+def _make_document(isolated_dirs, doc_id="reparse-doc"):
+    library_dir = Path(isolated_dirs["library_dir"])
+    doc_dir = library_dir / doc_id
+    doc_dir.mkdir(parents=True)
+    pdf_path = doc_dir / "document.pdf"
+    pdf = fitz.open()
+    page = pdf.new_page()
+    page.insert_text((72, 72), "Original document text for parser diagnostics.")
+    pdf.save(pdf_path)
+    pdf.close()
+    isolated_dirs["db"].db_save_document(
+        doc_id, "testuser", "paper.pdf", str(pdf_path), 1,
+        {"title": "Paper", "bibliography": {"old": True}},
+        parser_engine="pymupdf", parser_version="test-old",
+    )
+    return pdf_path
+
+
+def _insert_preview(isolated_dirs, doc_id, staging_path, source_revision=1, status="succeeded"):
+    from services.pdf_diagnostics import pdf_fingerprint
+
+    task_id = "preview-" + doc_id
+    now = datetime.now(timezone.utc).isoformat()
+    document = isolated_dirs["db"].db_get_document(doc_id)
+    source_fingerprint = pdf_fingerprint(document["pdf_path"])
+    with isolated_dirs["db"].get_db() as conn:
+        conn.execute(
+            """INSERT INTO reparse_previews
+               (id, doc_id, candidate_engine, status, source_revision, source_pdf_fingerprint,
+                staging_path, current_report, candidate_report, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (task_id, doc_id, "pdfplumber", status, source_revision, source_fingerprint,
+             str(staging_path), "{}", "{}", now, now),
+        )
+        conn.commit()
+    return task_id
+
+
+def test_diagnostics_report_real_metrics_without_fake_ocr_confidence():
+    from services.pdf_diagnostics import diagnose_pages
+
+    pages = [
+        {"page_num": 1, "text": "", "blocks": [], "parser_engine": "pymupdf"},
+        {
+            "page_num": 2,
+            "text": "Repeated line\nRepeated line\nBad \ufffd text",
+            "blocks": [{"bbox": [0, 0, 10, 10], "text": "x"}],
+            "parser_engine": "pymupdf",
+        },
+    ]
+    report = diagnose_pages(pages, [{"page": 2, "label": "Table 1"}], "pymupdf", "1.0")
+    assert report["problem_pages"] == [1, 2]
+    assert report["pages"][0]["empty_text"] is True
+    assert report["pages"][1]["repeated_line_count"] == 1
+    assert report["pages"][1]["table_count"] == 1
+    assert report["pages"][1]["ocr_confidence"] is None
+
+
+def test_pages_cache_invalidates_parser_engine_and_version(isolated_dirs, tmp_path):
+    from services.cache import get_cached_pages, save_pages_cache
+
+    pdf_path = tmp_path / "cache.pdf"
+    pdf_path.write_bytes(b"%PDF cache identity")
+    pages = [{"page_num": 1, "text": "cached", "parser_engine": "pymupdf"}]
+    save_pages_cache("cache-doc", str(pdf_path), pages, "pymupdf", "1.0")
+    assert get_cached_pages("cache-doc", str(pdf_path), "pymupdf", "1.0") == pages
+    assert get_cached_pages("cache-doc", str(pdf_path), "pdfplumber", "1.0") is None
+    assert get_cached_pages("cache-doc", str(pdf_path), "pymupdf", "2.0") is None
+
+
+@pytest.mark.asyncio
+async def test_apply_reparse_increments_revision_and_preserves_user_data(isolated_dirs, monkeypatch):
+    from routers import upload
+    from services import reparse
+    from services.pdf_diagnostics import diagnose_pages, pdf_fingerprint
+
+    pdf_path = _make_document(isolated_dirs)
+    monkeypatch.setattr(reparse, "LIBRARY_DIR", str(isolated_dirs["library_dir"]))
+    old_pages = [{"page_num": 1, "text": "Original text", "parser_engine": "pymupdf"}]
+    new_pages = [{"page_num": 1, "text": "Improved candidate text", "parser_engine": "pdfplumber",
+                  "blocks": [{"bbox": [0, 0, 100, 20], "text": "Improved candidate text", "type": 0}]}]
+    report = diagnose_pages(new_pages, [], "pdfplumber", "test-new")
+    staging_path = isolated_dirs["library_dir"] / "candidate.json"
+    staging_path.write_text(json.dumps({
+        "pdf_fingerprint": pdf_fingerprint(str(pdf_path)),
+        "parser_engine": "pdfplumber",
+        "parser_version": "test-new",
+        "pages": new_pages,
+        "images": [{"page": 1, "label": "Figure 1"}],
+        "diagnostics": report,
+    }), encoding="utf-8")
+    task_id = _insert_preview(isolated_dirs, "reparse-doc", staging_path)
+
+    db = isolated_dirs["db"]
+    db.db_save_translation("reparse-doc", 1, "old translation", "ko")
+    db.db_save_page_insight("reparse-doc", 1, "summary", "old summary", "ko")
+    db.db_save_chat_message("reparse-doc", "user", "question")
+    db.db_save_chat_message("reparse-doc", "assistant", "old answer")
+    db.db_put_annotations("reparse-doc", {"page_1": [{"id": "a1"}]})
+    db.db_put_memos("reparse-doc", {"page_1": [{"id": "m1"}]})
+    sessions = {
+        "reparse-doc": {
+            "pdf_path": str(pdf_path), "pages": old_pages, "total_pages": 1,
+            "metadata": {"title": "Paper", "bibliography": {"old": True}},
+            "username": "testuser",
+        }
+    }
+    monkeypatch.setattr(upload, "sessions", sessions)
+
+    result = await reparse.apply_preview("reparse-doc", task_id, sessions)
+
+    assert result["content_revision"] == 2
+    doc = db.db_get_document("reparse-doc")
+    assert doc["content_revision"] == 2
+    assert doc["parser_engine"] == "pdfplumber"
+    assert "bibliography" not in doc["metadata"]
+    assert sessions["reparse-doc"]["pages"] == new_pages
+    assert db.db_get_translation("reparse-doc", 1, "ko", fallback=False) is None
+    assert db.db_get_translation("reparse-doc", 1, "ko", fallback=False, content_revision=1) == "old translation"
+    assert db.db_get_page_insight("reparse-doc", 1, "summary", "ko") is None
+    assert db.db_get_annotations("reparse-doc")["data"]["page_1"][0]["id"] == "a1"
+    assert db.db_get_memos("reparse-doc")["data"]["page_1"][0]["id"] == "m1"
+    history = db.db_get_chat_history("reparse-doc", include_revision=True)
+    assert history[-1]["stale"] is True
+    assert reparse.get_diagnostics("reparse-doc")["parser_engine"] == "pdfplumber"
+    with db.get_db() as conn:
+        fts = conn.execute(
+            "SELECT content FROM document_chunks_fts WHERE doc_id = ?", ("reparse-doc",)
+        ).fetchall()
+        preview_status = conn.execute(
+            "SELECT status FROM reparse_previews WHERE id = ?", (task_id,)
+        ).fetchone()["status"]
+    assert any("Improved candidate text" in row["content"] for row in fts)
+    assert preview_status == "applied"
+
+
+@pytest.mark.asyncio
+async def test_apply_revision_conflict_keeps_existing_content(isolated_dirs, monkeypatch):
+    from services import reparse
+    from services.pdf_diagnostics import diagnose_pages, pdf_fingerprint
+
+    pdf_path = _make_document(isolated_dirs, "conflict-doc")
+    pages = [{"page_num": 1, "text": "candidate", "parser_engine": "pdfplumber"}]
+    staging_path = isolated_dirs["library_dir"] / "conflict.json"
+    staging_path.write_text(json.dumps({
+        "pdf_fingerprint": pdf_fingerprint(str(pdf_path)),
+        "parser_engine": "pdfplumber", "parser_version": "2",
+        "pages": pages, "images": [],
+        "diagnostics": diagnose_pages(pages, [], "pdfplumber", "2"),
+    }), encoding="utf-8")
+    task_id = _insert_preview(isolated_dirs, "conflict-doc", staging_path)
+    with isolated_dirs["db"].get_db() as conn:
+        conn.execute("UPDATE documents SET content_revision = 2 WHERE id = ?", ("conflict-doc",))
+        conn.commit()
+
+    sessions = {"conflict-doc": {"pages": [{"page_num": 1, "text": "still current"}]}}
+    cancelled = []
+    monkeypatch.setattr(reparse, "_cancel_derived_tasks", lambda doc_id: cancelled.append(doc_id))
+    with pytest.raises(RuntimeError, match="content_revision_conflict"):
+        await reparse.apply_preview("conflict-doc", task_id, sessions)
+    assert sessions["conflict-doc"]["pages"][0]["text"] == "still current"
+    assert isolated_dirs["db"].db_get_document("conflict-doc")["parser_engine"] == "pymupdf"
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_pdf_changed_after_preview_started(isolated_dirs, monkeypatch):
+    from services import reparse
+    from services.pdf_diagnostics import diagnose_pages, pdf_fingerprint
+
+    pdf_path = _make_document(isolated_dirs, "pdf-conflict")
+    original_fingerprint = pdf_fingerprint(str(pdf_path))
+    pages = [{"page_num": 1, "text": "candidate", "parser_engine": "pdfplumber"}]
+    staging_path = isolated_dirs["library_dir"] / "pdf-conflict.json"
+    staging_path.write_text(json.dumps({
+        "pdf_fingerprint": original_fingerprint,
+        "parser_engine": "pdfplumber", "parser_version": "2",
+        "pages": pages, "images": [],
+        "diagnostics": diagnose_pages(pages, [], "pdfplumber", "2"),
+    }), encoding="utf-8")
+    task_id = _insert_preview(isolated_dirs, "pdf-conflict", staging_path)
+    pdf_path.write_bytes(pdf_path.read_bytes() + b"\n% replaced after preview")
+    cancelled = []
+    monkeypatch.setattr(reparse, "_cancel_derived_tasks", lambda doc_id: cancelled.append(doc_id))
+
+    with pytest.raises(RuntimeError, match="pdf_revision_conflict"):
+        await reparse.apply_preview("pdf-conflict", task_id, {})
+    assert isolated_dirs["db"].db_get_document("pdf-conflict")["content_revision"] == 1
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_candidate_worker_failure_does_not_change_document(isolated_dirs, monkeypatch):
+    from services import reparse
+
+    pdf_path = _make_document(isolated_dirs, "worker-fail")
+    output_path = isolated_dirs["library_dir"] / "worker-fail.json"
+    task_id = _insert_preview(
+        isolated_dirs, "worker-fail", output_path, status="queued",
+    )
+
+    async def fail_subprocess(*_args, **_kwargs):
+        raise FileNotFoundError("parser executable missing")
+
+    monkeypatch.setattr(reparse.asyncio, "create_subprocess_exec", fail_subprocess)
+    await reparse._run_preview(task_id, str(pdf_path))
+
+    assert reparse.get_preview(task_id)["status"] == "failed"
+    doc = isolated_dirs["db"].db_get_document("worker-fail")
+    assert doc["content_revision"] == 1
+    assert doc["parser_engine"] == "pymupdf"
+
+
+def test_mineru_preview_uses_isolated_parser_venv(monkeypatch, tmp_path):
+    from services import reparse
+    import venv_manager
+
+    mineru_venv = tmp_path / "mineru-venv"
+    python_path = mineru_venv / "bin" / "python"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(venv_manager, "MINERU_VENV", str(mineru_venv))
+    monkeypatch.setattr(venv_manager, "is_packaged_desktop", lambda: False)
+
+    command, _env = reparse._worker_command("mineru", "/tmp/source.pdf", "/tmp/result.json")
+    assert command[0] == str(python_path)
+    assert command[-2:] == ["--output", "/tmp/result.json"]
+
+
+def test_parser_worker_writes_complete_staging_payload(tmp_path):
+    pdf_path = tmp_path / "worker.pdf"
+    pdf = fitz.open()
+    page = pdf.new_page()
+    page.insert_text((72, 72), "Worker extraction text")
+    pdf.save(pdf_path)
+    pdf.close()
+    output_path = tmp_path / "result.json"
+    backend_dir = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, str(backend_dir / "parser_worker.py"), "--pdf", str(pdf_path),
+         "--engine", "pymupdf", "--output", str(output_path)],
+        cwd=backend_dir, capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["parser_engine"] == "pymupdf"
+    assert payload["pdf_fingerprint"]
+    assert payload["pages"][0]["blocks"]
+    assert payload["diagnostics"]["page_count"] == 1
+
+
+def test_existing_database_migrates_revision_uniques(tmp_path, monkeypatch):
+    from services import db
+
+    database = tmp_path / "legacy.db"
+    conn = sqlite3.connect(database)
+    conn.executescript("""
+        CREATE TABLE users (username TEXT PRIMARY KEY, password_hash TEXT NOT NULL, created_at TEXT NOT NULL);
+        CREATE TABLE documents (id TEXT PRIMARY KEY, username TEXT NOT NULL, filename TEXT NOT NULL, pdf_path TEXT NOT NULL, total_pages INTEGER NOT NULL, metadata TEXT, created_at TEXT NOT NULL);
+        CREATE TABLE translations (id INTEGER PRIMARY KEY AUTOINCREMENT, doc_id TEXT NOT NULL, page_num INTEGER NOT NULL, suffix TEXT NOT NULL, translation TEXT NOT NULL, saved_at TEXT NOT NULL, UNIQUE(doc_id,page_num,suffix));
+        CREATE TABLE page_insights (id INTEGER PRIMARY KEY AUTOINCREMENT, doc_id TEXT NOT NULL, page_num INTEGER NOT NULL, kind TEXT NOT NULL, suffix TEXT NOT NULL, content TEXT NOT NULL, saved_at TEXT NOT NULL, UNIQUE(doc_id,page_num,kind,suffix));
+        CREATE TABLE chats (id INTEGER PRIMARY KEY AUTOINCREMENT, doc_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL);
+        INSERT INTO documents VALUES ('legacy','admin','paper.pdf','/x.pdf',1,'{}','2026-01-01');
+        INSERT INTO translations(doc_id,page_num,suffix,translation,saved_at) VALUES ('legacy',1,'ko','old','2026-01-01');
+        INSERT INTO page_insights(doc_id,page_num,kind,suffix,content,saved_at) VALUES ('legacy',1,'summary','ko','old','2026-01-01');
+    """)
+    conn.commit(); conn.close()
+    monkeypatch.setattr(db, "DB_PATH", str(database))
+
+    db.init_db()
+    with db.get_db() as migrated:
+        migrated.execute("INSERT INTO translations(doc_id,page_num,suffix,content_revision,translation,saved_at) VALUES ('legacy',1,'ko',2,'new','2026-01-02')")
+        migrated.execute("INSERT INTO page_insights(doc_id,page_num,kind,suffix,content_revision,content,saved_at) VALUES ('legacy',1,'summary','ko',2,'new','2026-01-02')")
+        migrated.commit()
+        assert migrated.execute("SELECT COUNT(*) FROM translations WHERE doc_id='legacy'").fetchone()[0] == 2
+        assert migrated.execute("SELECT COUNT(*) FROM page_insights WHERE doc_id='legacy'").fetchone()[0] == 2
+
+
+def test_document_cache_clear_removes_memory_session(test_client, isolated_dirs):
+    from routers.upload import sessions
+
+    _make_document(isolated_dirs, "clear-memory")
+    sessions["clear-memory"] = {"username": "testuser", "pages": [{"page_num": 1, "text": "stale"}]}
+    response = test_client.post("/api/library/clear-memory/clear-cache")
+    assert response.status_code == 200
+    assert "clear-memory" not in sessions

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -921,6 +921,37 @@ export async function cancelDocumentTaskAPI(taskId) {
   return res.json()
 }
 
+
+
+export async function getParsingDiagnosticsAPI(docId, revision = null) {
+  const query = revision == null ? '' : '?revision=' + encodeURIComponent(revision)
+  const res = await fetch(API_BASE + '/library/' + encodeURIComponent(docId) + '/parsing-diagnostics' + query)
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function createReparsePreviewAPI(docId, candidateEngine) {
+  const res = await fetch(API_BASE + '/library/' + encodeURIComponent(docId) + '/reparse-preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ candidate_engine: candidateEngine })
+  })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function getReparsePreviewAPI(docId, taskId) {
+  const res = await fetch(API_BASE + '/library/' + encodeURIComponent(docId) + '/reparse-preview/' + encodeURIComponent(taskId), { cache: 'no-store' })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+export async function applyReparsePreviewAPI(docId, taskId) {
+  const res = await fetch(API_BASE + '/library/' + encodeURIComponent(docId) + '/reparse-preview/' + encodeURIComponent(taskId) + '/apply', { method: 'POST' })
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
 export async function getDocumentProcessingPolicyAPI(docId) {
   const res = await fetch(`${API_BASE}/library/${encodeURIComponent(docId)}/processing-policy`)
   if (!res.ok) throw await apiError(res)

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3865,5 +3865,56 @@
   },
   "chat:retrySameQuestion": {
     "description": "Persistent document task recovery UI text."
+  },
+  "chat:staleRevision": {
+    "description": "Badge for an assistant response generated from an older document revision."
+  },
+  "library:reparse.menu": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.selectTitle": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.selectLabel": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.start": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.running": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.failed": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.compareTitle": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.current": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.candidate": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.problemPages": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.affected": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.preserved": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.apply": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.applied": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.noInstalled": {
+    "description": "PDF parsing diagnostics and candidate reparse UI."
+  },
+  "library:reparse.cancel": {
+    "description": "Cancel PDF reparse dialog."
   }
 }

--- a/frontend/src/locales/en/chat.json
+++ b/frontend/src/locales/en/chat.json
@@ -9,5 +9,6 @@
   "suggestions.general.summary": "Summarize the key points of this document.",
   "suggestions.general.procedure": "Explain the important procedures and prerequisites.",
   "suggestions.general.cautions": "Identify the cautions and key figures.",
-  "retrySameQuestion": "Send same question again"
+  "retrySameQuestion": "Send same question again",
+  "staleRevision": "Based on an earlier document analysis"
 }

--- a/frontend/src/locales/en/library.json
+++ b/frontend/src/locales/en/library.json
@@ -20,5 +20,21 @@
   "privacy.items.document_metadata": "document metadata",
   "privacy.items.notes": "notes",
   "privacy.items.document_file": "document file",
-  "privacy.updated": "Document processing policy saved."
+  "privacy.updated": "Document processing policy saved.",
+  "reparse.menu": "Diagnose and reparse PDF",
+  "reparse.selectTitle": "Choose candidate parser",
+  "reparse.selectLabel": "Parser engine",
+  "reparse.start": "Analyze",
+  "reparse.running": "Candidate parser analysis started.",
+  "reparse.failed": "Candidate analysis failed.",
+  "reparse.compareTitle": "Compare parsing results",
+  "reparse.current": "Current",
+  "reparse.candidate": "Candidate",
+  "reparse.problemPages": "Problem pages: {{count}}",
+  "reparse.affected": "Regenerate {{translations}} translations and {{insights}} insights; cancel {{tasks}} running tasks.",
+  "reparse.preserved": "Memos, annotations, and chat history are preserved.",
+  "reparse.apply": "Apply candidate",
+  "reparse.applied": "Reparse applied at revision {{revision}}.",
+  "reparse.noInstalled": "No alternative parser is installed.",
+  "reparse.cancel": "Cancel"
 }

--- a/frontend/src/locales/ko/chat.json
+++ b/frontend/src/locales/ko/chat.json
@@ -9,5 +9,6 @@
   "suggestions.general.summary": "이 문서의 핵심 내용을 요약해줘.",
   "suggestions.general.procedure": "중요한 절차와 전제 조건을 설명해줘.",
   "suggestions.general.cautions": "주의사항과 핵심 수치를 찾아줘.",
-  "retrySameQuestion": "동일 질문 다시 보내기"
+  "retrySameQuestion": "동일 질문 다시 보내기",
+  "staleRevision": "이전 문서 분석 결과 기반"
 }

--- a/frontend/src/locales/ko/library.json
+++ b/frontend/src/locales/ko/library.json
@@ -20,5 +20,21 @@
   "privacy.items.document_metadata": "문서 메타데이터",
   "privacy.items.notes": "메모",
   "privacy.items.document_file": "문서 파일",
-  "privacy.updated": "문서 처리 정책이 저장되었습니다."
+  "privacy.updated": "문서 처리 정책이 저장되었습니다.",
+  "reparse.menu": "PDF 진단·재분석",
+  "reparse.selectTitle": "후보 파서 선택",
+  "reparse.selectLabel": "파서 엔진",
+  "reparse.start": "진단 시작",
+  "reparse.running": "후보 파서 진단을 시작했습니다.",
+  "reparse.failed": "후보 파서 진단에 실패했습니다.",
+  "reparse.compareTitle": "파싱 결과 비교",
+  "reparse.current": "현재 결과",
+  "reparse.candidate": "후보 결과",
+  "reparse.problemPages": "문제 페이지: {{count}}개",
+  "reparse.affected": "번역 {{translations}}개와 인사이트 {{insights}}개를 재생성해야 하며 실행 중 작업 {{tasks}}개를 취소합니다.",
+  "reparse.preserved": "메모·주석·채팅 기록은 보존됩니다.",
+  "reparse.apply": "후보 적용",
+  "reparse.applied": "문서 revision {{revision}}에 재분석 결과를 적용했습니다.",
+  "reparse.noInstalled": "사용 가능한 대체 파서가 설치되어 있지 않습니다.",
+  "reparse.cancel": "취소"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,7 +9,7 @@ import { getModeSetting, normalizeSettingsMode, setModeSetting } from './modeSet
 import { parseStructuredVocabulary, renderStructuredVocabulary } from "./vocabularyView.js"
 import { defaultDocumentType, loadDocumentTypeOptions, saveDocumentTypeOptions, CURRENT_ONBOARDING_VERSION, ONBOARDING_VERSION_KEY } from "./documentModes.js"
 import DOMPurify from 'dompurify'
-import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI, retryDocumentTaskAPI } from './api.js'
+import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI, retryDocumentTaskAPI, createReparsePreviewAPI, getReparsePreviewAPI, applyReparsePreviewAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
 import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
 import { icon } from './icons.js'
@@ -8357,6 +8357,126 @@ let libraryDetailBiblioReqToken = 0
 let libraryGraphCacheForDetail = null // fetchLibraryGraph() 결과 캐시 - 패널을 열 때마다 다시 조회하지 않도록. renderLibrary()가 무효화한다.
 const LIBRARY_DETAIL_TABS = ['overview', 'notes', 'questions', 'related']
 
+
+function chooseReparseEngine(currentEngine) {
+  const choices = (pdfParsersData || []).filter(parser => parser.installed && parser.id !== currentEngine)
+  if (!choices.length && currentEngine !== 'pymupdf') {
+    choices.push({ id: 'pymupdf', name: 'PyMuPDF' })
+  }
+  if (!choices.length) {
+    showToast(t('library:reparse.noInstalled'), 'info')
+    return Promise.resolve(null)
+  }
+  return new Promise(resolve => {
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `
+      <div class="custom-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="reparse-engine-title">
+        <div class="custom-confirm-modal-header">
+          <span id="reparse-engine-title" class="custom-confirm-modal-title">${t('library:reparse.selectTitle')}</span>
+        </div>
+        <div class="custom-confirm-modal-body">
+          <label class="folder-dialog-label">${t('library:reparse.selectLabel')}
+            <select class="folder-dialog-input reparse-engine-select">
+              ${choices.map(parser => `<option value="${escapeHtml(parser.id)}">${escapeHtml(parser.name || parser.id)}</option>`).join('')}
+            </select>
+          </label>
+        </div>
+        <div class="custom-confirm-modal-footer">
+          <button class="custom-confirm-btn cancel-btn">${t('library:reparse.cancel')}</button>
+          <button class="custom-confirm-btn confirm-btn primary-btn">${t('library:reparse.start')}</button>
+        </div>
+      </div>`
+    document.body.appendChild(modal)
+    const select = modal.querySelector('select')
+    const close = value => {
+      modal.classList.remove('active')
+      setTimeout(() => { modal.remove(); resolve(value) }, 180)
+    }
+    modal.querySelector('.cancel-btn').addEventListener('click', () => close(null))
+    modal.querySelector('.confirm-btn').addEventListener('click', () => close(select.value))
+    modal.addEventListener('keydown', event => { if (event.key === 'Escape') close(null) })
+    modal.addEventListener('click', event => { if (event.target === modal) close(null) })
+    setTimeout(() => { modal.classList.add('active'); select.focus() }, 10)
+  })
+}
+
+function showReparseComparison(preview) {
+  return new Promise(resolve => {
+    const current = preview.current_report || {}
+    const candidate = preview.candidate_report || {}
+    const impact = preview.impact || {}
+    const problemPreviews = (candidate.pages || []).filter(page => page.issues?.length).slice(0, 5)
+    const modal = document.createElement('div')
+    modal.className = 'custom-confirm-modal-wrapper'
+    modal.innerHTML = `
+      <div class="custom-confirm-modal reparse-comparison-modal" role="dialog" aria-modal="true" aria-labelledby="reparse-compare-title">
+        <div class="custom-confirm-modal-header">
+          <span id="reparse-compare-title" class="custom-confirm-modal-title">${t('library:reparse.compareTitle')}</span>
+        </div>
+        <div class="custom-confirm-modal-body">
+          <div class="reparse-report-grid">
+            <section><strong>${t('library:reparse.current')}</strong><span>${escapeHtml(current.parser_engine || '')}</span><span>${t('library:reparse.problemPages', { count: current.problem_page_count || 0 })}</span></section>
+            <section><strong>${t('library:reparse.candidate')}</strong><span>${escapeHtml(candidate.parser_engine || '')}</span><span>${t('library:reparse.problemPages', { count: candidate.problem_page_count || 0 })}</span></section>
+          </div>
+          <div class="reparse-problem-previews">
+            ${problemPreviews.map(page => `<article><strong>${escapeHtml(t('viewer:pageLabel', { page: page.page_num }))}</strong><small>${escapeHtml((page.issues || []).join(', '))}</small><p>${escapeHtml(page.preview || '')}</p></article>`).join('')}
+          </div>
+          <p>${escapeHtml(t('library:reparse.affected', {
+            translations: impact.translations_to_regenerate || 0,
+            insights: impact.insights_to_regenerate || 0,
+            tasks: impact.running_tasks_to_cancel || 0,
+          }))}</p>
+          <p>${escapeHtml(t('library:reparse.preserved'))}</p>
+        </div>
+        <div class="custom-confirm-modal-footer">
+          <button class="custom-confirm-btn cancel-btn">${t('library:reparse.cancel')}</button>
+          <button class="custom-confirm-btn confirm-btn primary-btn">${t('library:reparse.apply')}</button>
+        </div>
+      </div>`
+    document.body.appendChild(modal)
+    const close = value => {
+      modal.classList.remove('active')
+      setTimeout(() => { modal.remove(); resolve(value) }, 180)
+    }
+    modal.querySelector('.cancel-btn').addEventListener('click', () => close(false))
+    modal.querySelector('.confirm-btn').addEventListener('click', () => close(true))
+    modal.addEventListener('keydown', event => { if (event.key === 'Escape') close(false) })
+    modal.addEventListener('click', event => { if (event.target === modal) close(false) })
+    setTimeout(() => { modal.classList.add('active'); modal.querySelector('.cancel-btn').focus() }, 10)
+  })
+}
+
+async function runDocumentReparseFlow(doc) {
+  if (!pdfParsersData?.length) {
+    const parserInfo = await fetchPdfParsersInfoAPI()
+    pdfParsersData = parserInfo.parsers || []
+  }
+  const engine = await chooseReparseEngine(doc.parser_engine || 'pymupdf')
+  if (!engine) return
+  showToast(t('library:reparse.running'), 'info')
+  let preview = await createReparsePreviewAPI(doc.id, engine)
+  while (['queued', 'running'].includes(preview.status)) {
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    preview = await getReparsePreviewAPI(doc.id, preview.id)
+  }
+  if (preview.status !== 'succeeded') {
+    throw new Error(preview.last_error_code || t('library:reparse.failed'))
+  }
+  if (!await showReparseComparison(preview)) return
+  const applied = await applyReparsePreviewAPI(doc.id, preview.id)
+  libraryDetailDoc = {
+    ...doc,
+    content_revision: applied.content_revision,
+    parser_engine: applied.parser_engine,
+    parser_version: applied.parser_version,
+    total_pages: applied.total_pages,
+  }
+  showToast(t('library:reparse.applied', { revision: applied.content_revision }), 'success')
+  await renderLibrary()
+}
+
+
 function ensureLibraryDetailPanel() {
   if ($('lib-detail-panel')) return
 
@@ -8393,6 +8513,7 @@ function ensureLibraryDetailPanel() {
         <button id="lib-detail-more-btn" class="lib-detail-icon-btn" title="더보기">${moreIconSvg}</button>
         <div id="lib-detail-more-menu" class="lib-detail-more-menu hidden">
           <button id="lib-detail-classification-btn" class="lib-detail-more-item">${icon('layers', 13)}<span>문서 분류 변경</span></button>
+          <button id="lib-detail-reparse-btn" class="lib-detail-more-item">${icon('refreshCw', 13)}<span>${t('library:reparse.menu')}</span></button>
           <button id="lib-detail-clear-cache-btn" class="lib-detail-more-item">${icon('refreshCw', 13)}<span>PDF 추출 캐시 삭제</span></button>
           <button id="lib-detail-delete-btn" class="lib-detail-more-item danger">${icon('trash2', 13)}<span>삭제 (휴지통으로 이동)</span></button>
         </div>
@@ -8483,6 +8604,18 @@ function ensureLibraryDetailPanel() {
       showToast('문서 분류를 변경했습니다.', 'success')
     } catch (error) {
       showToast(error.message || '문서 분류 변경 실패', 'error')
+    }
+  })
+
+
+  $('lib-detail-reparse-btn')?.addEventListener('click', async () => {
+    if (!libraryDetailDoc) return
+    const doc = libraryDetailDoc
+    moreMenu?.classList.add('hidden')
+    try {
+      await runDocumentReparseFlow(doc)
+    } catch (error) {
+      showToast(error.message || t('library:reparse.failed'), 'error')
     }
   })
 
@@ -9642,7 +9775,10 @@ async function openFromLibrary(doc, shouldPushState = true) {
       for (const msg of chatHistoryList) {
         state.chatHistory.push({ role: msg.role, content: msg.content })
         const isAssistant = msg.role === 'assistant'
-        const renderedContent = isAssistant ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content)
+        let renderedContent = isAssistant ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content)
+        if (isAssistant && msg.stale) {
+          renderedContent = `<span class="chat-stale-revision-badge">${t("chat:staleRevision")}</span>${renderedContent}`
+        }
         appendChatMessage(msg.role, renderedContent, true)
       }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7088,3 +7088,15 @@ body.light-theme .chat-drawer {
 .api-key-delete-btn { margin-top:6px; padding:5px 8px; border:1px solid var(--border-strong); border-radius:7px; background:transparent; color:var(--text-secondary); cursor:pointer; font-size:11px; }
 
 .chat-retry-message-btn { display:block; margin-top:8px; padding:5px 9px; border:1px solid var(--border-strong); border-radius:7px; background:var(--bg-elevated); color:var(--text-primary); cursor:pointer; font-size:11px; }
+
+.chat-stale-revision-badge { display:inline-flex; margin:0 0 7px; padding:2px 6px; border:1px solid var(--border-strong); border-radius:999px; color:var(--text-secondary); font-size:10px; }
+.chat-stale-revision-badge + * { margin-top:0; }
+
+.reparse-comparison-modal { width:min(680px, calc(100vw - 32px)); max-width:680px; }
+.reparse-report-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:12px; }
+.reparse-report-grid section { display:flex; flex-direction:column; gap:4px; padding:10px; border:1px solid var(--border-subtle); border-radius:8px; background:var(--bg-elevated); }
+.reparse-problem-previews { max-height:240px; overflow:auto; display:grid; gap:8px; margin:10px 0; }
+.reparse-problem-previews article { padding:8px; border:1px solid var(--border-subtle); border-radius:7px; }
+.reparse-problem-previews small { margin-left:8px; color:var(--error); }
+.reparse-problem-previews p { margin:5px 0 0; color:var(--text-secondary); font-size:11px; white-space:pre-wrap; }
+@media (max-width:560px) { .reparse-report-grid { grid-template-columns:1fr; } }


### PR DESCRIPTION
# Summary
## 1. PDF 파싱 진단 및 후보 비교
- 페이지별 텍스트 품질, 읽기 순서, 이미지·표, 언어 신뢰도 진단 기능 추가
- 격리된 파서 worker 기반 후보 생성·비교 API와 UI 추가
## 2. 원자적 재분석 적용
- PDF fingerprint 및 content revision 충돌 검증 추가
- 번역·인사이트·채팅 revision 보존과 stale 표시 추가
- 파서 인식 캐시 무효화, FTS·세션·진단 결과 원자 갱신 추가
## 3. 검증
- 백엔드 전체 테스트 546개 통과
- 프론트 단위 테스트 48개, i18n 검증 및 프로덕션 빌드 통과