### PR TITLE
feat(chat): ground viewer answers in evidence

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,10 +1,11 @@
 import asyncio
 import hashlib
+import json
 import re
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Literal
 
 from routers.upload import sessions, ensure_session, require_session_owner
 from services.ownership import require_owned_documents
@@ -12,6 +13,9 @@ from services.llm_client import stream_chat, generate_suggested_questions
 from services.db import (
     db_save_chat_message,
     db_get_chat_history,
+    db_get_translation,
+    db_save_chat_evidence,
+    db_save_chat_verification,
     db_list_assistant_chat_sessions,
     db_upsert_compare_session,
     db_list_compare_chat_sessions,
@@ -44,6 +48,17 @@ class ChatRequest(BaseModel):
     image_base64: Optional[str] = Field(default=None, max_length=MAX_CHAT_IMAGE_BASE64_CHARS)
     current_page: Optional[int] = Field(default=None, ge=1)
     selected_text: Optional[str] = Field(default=None, max_length=20_000)
+    screen_context: Optional["ScreenContext"] = None
+    verify_evidence: bool = False
+
+
+class ScreenContext(BaseModel):
+    mode: Literal["viewer", "standalone"] = "viewer"
+    page_num: Optional[int] = Field(default=None, ge=1)
+    include_visual: Optional[bool] = None
+
+
+ChatRequest.model_rebuild()
 
 # ── 여러 논문 간 비교 채팅 ──────────────────────────────
 MIN_COMPARE_DOCS = 2
@@ -66,110 +81,210 @@ def _build_compare_id(doc_ids: List[str]) -> str:
 def _dedupe_preserve_order(items: List[str]) -> List[str]:
     return list(dict.fromkeys(items))
 
+_VISUAL_QUESTION_RE = re.compile(
+    r"(?:이 페이지|그림|도표|(?<![가-힣])표(?:\s*\d+|[을를이가의에서])?(?![가-힣])|차트|수식|이미지|figure|diagram|table|chart|equation|this page)",
+    re.IGNORECASE,
+)
+_MAX_RENDERED_PAGE_IMAGE_CHARS = 12 * 1024 * 1024
+
+
+def _provider_supports_vision(provider: str, model: str) -> bool:
+    provider = (provider or "").lower()
+    if provider in {"openai", "gemini", "claude", "antigravity", "claude_code", "codex"}:
+        return True
+    if provider != "ollama":
+        return False
+    normalized_model = (model or "").lower().replace("-", "").replace("_", "")
+    return any(name in normalized_model for name in ("llava", "gemma3", "qwen2.5vl", "qwen25vl", "minicpmv", "bakllava"))
+
+
+def _sse(event: str, payload: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+async def _semantic_verify_answer(answer: str, evidence: list[dict], session_id: str) -> dict:
+    if not evidence:
+        return {"mode": "structural_only", "status": "no_cited_evidence"}
+    evidence_lines = []
+    for item in evidence:
+        evidence_id = item.get("evidence_id")
+        page_num = item.get("page_num")
+        quote = item.get("quote") or ""
+        evidence_lines.append(f"[{evidence_id}] Page {page_num}: {quote[:1200]}")
+    evidence_text = "\n\n".join(evidence_lines)
+    prompt = (
+        "Check whether each factual claim in the answer is supported by the supplied evidence. "
+        "Return a compact JSON object with status (supported, mixed, or unsupported) and issues.\n\n"
+        f"ANSWER:\n{answer[:12000]}\n\nEVIDENCE:\n{evidence_text}"
+    )
+    chunks = []
+    try:
+        async for token in stream_chat(
+            "You are an evidence verification model. Do not use outside knowledge.",
+            [{"role": "user", "content": prompt}],
+            session_id=f"{session_id}/evidence_verification",
+        ):
+            chunks.append(token)
+            if sum(len(chunk) for chunk in chunks) > 8000:
+                break
+        return {"mode": "semantic_model", "status": "completed", "result": "".join(chunks).strip()}
+    except Exception as exc:
+        return {"mode": "structural_only", "status": "semantic_unavailable", "detail": str(exc)[:300]}
+
+
 @router.post("/chat/stream")
 async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current_user)):
-    """
-    논문 내용을 기반으로 AI 전문가와 챗을 진행하고 실시간 스트리밍 답변을 반환합니다.
-    """
     session_id = data.session_id
     session = require_session_owner(session_id, current_user)
-    from services.processing_policy import ensure_processing_allowed
+    from services.processing_policy import ensure_processing_allowed, provider_is_local
     ensure_processing_allowed(session, "chat")
-    enforce_rate_limit("chat", current_user)
 
-    # 질문 관련 문단을 FTS5로 찾고 명시 페이지·현재 페이지·선택 영역을
-    # 우선 재순위화한다. 장/절이 이어지는 인접 문단도 함께 확장한다.
-    pages = session.get("pages", [])
     latest_question = data.messages[-1].content if data.messages else ""
+    screen = data.screen_context
+    viewer_mode = bool(screen and screen.mode == "viewer") or (screen is None and data.current_page is not None)
+    current_page = ((screen.page_num or data.current_page) if screen else data.current_page) if viewer_mode else None
+    pages = session.get("pages", [])
+    total_pages = max((int(page.get("page_num") or 0) for page in pages), default=0)
+    if current_page and current_page > total_pages:
+        raise HTTPException(status_code=400, detail={
+            "code": "screen_page_out_of_range",
+            "params": {"page_num": current_page, "total_pages": total_pages},
+            "fallback": "The requested viewer page is outside this document.",
+        })
+    enforce_rate_limit("chat", current_user)
     from time import perf_counter
     from services.context_retrieval import retrieve_context
     retrieval_started = perf_counter()
     context_result = retrieve_context(
-        session_id, pages, latest_question,
-        current_page=data.current_page, selected_text=data.selected_text,
+        session_id, pages, latest_question, current_page=current_page,
+        selected_text=data.selected_text,
+        content_revision=int(session.get("content_revision") or 1),
     )
     paper_text = context_result.text
     from services.observability import record_document_mode_event
+    document_mode = session.get("document_mode", "research")
+    document_type = session.get("document_type", "research_paper")
     record_document_mode_event(
-        current_user, "chat_retrieval",
-        session.get("document_mode", "research"),
-        session.get("document_type", "research_paper"),
+        current_user, "chat_retrieval", document_mode, document_type,
         duration_ms=round((perf_counter() - retrieval_started) * 1000),
         numeric_value=context_result.retrieval_count, status=context_result.strategy,
     )
 
-    filename = session.get("filename", "알 수 없음")
+    from config import get_chat_model, get_chat_provider
+    provider = get_chat_provider()
+    model = get_chat_model()
+    visual_requested = bool(screen and screen.include_visual is True)
+    visual_auto = bool(screen and screen.include_visual is None and _VISUAL_QUESTION_RE.search(latest_question))
+    should_attach_visual = viewer_mode and bool(current_page) and (visual_requested or visual_auto)
+    page_image = data.image_base64
+    visual_included = bool(page_image)
+    visual_reason = "quoted_image" if page_image else None
+    if should_attach_visual and not page_image:
+        if not _provider_supports_vision(provider, model):
+            visual_reason = "vision_not_supported"
+        else:
+            from services.pdf_parser import render_page_image_base64
+            rendered = await asyncio.to_thread(
+                render_page_image_base64, session["pdf_path"], int(current_page), 1.25,
+            )
+            if rendered and len(rendered) <= _MAX_RENDERED_PAGE_IMAGE_CHARS:
+                page_image = rendered
+                visual_included = True
+                visual_reason = "manual" if visual_requested else "visual_question"
+            else:
+                visual_reason = "image_too_large" if rendered else "render_failed"
 
     from services.document_policy import build_assistant_prompt
-    document_mode = session.get("document_mode", "research")
-    document_type = session.get("document_type", "research_paper")
-    system_prompt = build_assistant_prompt(
-        document_mode, document_type, filename, paper_text,
+    filename = session.get("filename", "알 수 없음")
+    system_prompt = build_assistant_prompt(document_mode, document_type, filename, paper_text)
+    system_prompt += (
+        "\n\n[EVIDENCE CITATION RULES]\n"
+        "Every factual claim based on the document must cite one or more supplied evidence IDs exactly as [E:ev_...]. "
+        "Never invent an evidence ID. Numeric claims always require a citation. If evidence is insufficient, say so."
     )
-
     history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
 
-    # Save user message to database
     question_chat_id = None
     if data.messages:
         latest_msg = data.messages[-1]
         question_chat_id = db_save_chat_message(session_id, latest_msg.role, latest_msg.content)
-
-        # 이미지 인용 메시지라면, 이번 요청에 실려온 이미지를 문서별 디렉터리에도
-        # 저장한다(브라우저 localStorage에만 있으면 다른 기기/브라우저에서 이
-        # 히스토리를 다시 열었을 때 이미지가 사라지고 텍스트 placeholder만
-        # 남는 문제가 있었음). 저장에 실패해도 채팅 자체는 그대로 진행된다.
         if data.image_base64:
             marker_match = _QUOTE_IMAGE_MARKER_RE.match(latest_msg.content)
             if marker_match:
                 try:
                     save_chat_quote_image(session_id, marker_match.group(1), data.image_base64)
-                except Exception as e:
-                    print(f"[chat_stream] 인용 이미지 서버 저장 실패 ({session_id}): {e}")
+                except Exception as exc:
+                    print(f"[chat_stream] quoted image save failed ({session_id}): {exc}")
 
     async def event_generator():
-        yield " "
-        full_response = []
+        context_payload = {
+            "mode": "viewer" if viewer_mode else "standalone",
+            "page_num": current_page,
+            "current_page_text_included": bool(viewer_mode and current_page in context_result.evidence_pages),
+            "visual_included": visual_included,
+            "visual_reason": visual_reason,
+            "provider": provider,
+            "evidence_count": len(context_result.evidence),
+        }
+        yield _sse("context", context_payload)
         try:
+            full_response = []
             async for token in stream_chat(
-                system_prompt, history_messages, session_id=session_id,
-                page_image_b64=data.image_base64
+                system_prompt, history_messages, session_id=session_id, page_image_b64=page_image,
             ):
                 full_response.append(token)
-
-            # 응답 전체에서 실제 제공된 근거 페이지 밖 인용을 제거한 뒤에만
-            # 클라이언트와 채팅 기록에 노출한다.
-            from services.context_retrieval import validate_page_citations
-            assistant_content, invalid_citations = validate_page_citations(
-                "".join(full_response).strip(), context_result.evidence_pages,
+            from services.context_retrieval import validate_evidence_citations
+            assistant_content, cited_evidence, verification = validate_evidence_citations(
+                "".join(full_response).strip(), context_result.evidence,
             )
+            for item in cited_evidence:
+                translated_page = db_get_translation(
+                    session_id, int(item["page_num"]), fallback=True,
+                    content_revision=int(item["content_revision"]),
+                )
+                if translated_page:
+                    item["translation_quote"] = translated_page.strip()[:800]
+            verify_requested = data.verify_evidence or bool(verification["risks"]) or bool(
+                re.search(r"근거\s*검증|verify\s+(?:the\s+)?evidence", latest_question, re.IGNORECASE)
+            )
+            if verify_requested:
+                local_only = session.get("processing_policy") == "local_only"
+                if local_only and (not provider_is_local(provider) or not model):
+                    verification["semantic"] = {
+                        "mode": "structural_only",
+                        "status": "no_allowed_local_verifier",
+                    }
+                else:
+                    verification["semantic"] = await _semantic_verify_answer(
+                        assistant_content, cited_evidence, session_id,
+                    )
+            else:
+                verification["semantic"] = {"mode": "not_run", "status": "not_required"}
             record_document_mode_event(
                 current_user, "chat_citation", document_mode, document_type,
-                status="invalid_removed" if invalid_citations else "valid",
-                numeric_value=len(invalid_citations),
+                status=verification["status"], numeric_value=len(verification["risks"]),
             )
             for offset in range(0, len(assistant_content), 240):
-                yield assistant_content[offset:offset + 240]
+                yield _sse("answer", {"delta": assistant_content[offset:offset + 240]})
+            answer_chat_id = None
             if assistant_content:
-                db_save_chat_message(session_id, "assistant", assistant_content)
-                # 지식 그래프: 이 질문을 논문의 기존 개념과 연결한다(fire-and-forget -
-                # 실패해도 채팅 응답 자체에는 영향 없음).
+                answer_chat_id = db_save_chat_message(session_id, "assistant", assistant_content)
+                if answer_chat_id is not None:
+                    db_save_chat_verification(answer_chat_id, verification)
+                    db_save_chat_evidence(answer_chat_id, session_id, cited_evidence, verification)
                 if question_chat_id is not None and document_mode == "research":
                     from services.knowledge_graph import sync_question_for_graph
-                    asyncio.create_task(
-                        sync_question_for_graph(question_chat_id, session_id, latest_msg.content)
-                    )
-        except Exception as e:
-            yield f"\n[오류 발생: {str(e)}]"
+                    asyncio.create_task(sync_question_for_graph(question_chat_id, session_id, latest_msg.content))
+            yield _sse("evidence", {"answer_message_id": answer_chat_id, "items": cited_evidence})
+            yield _sse("verification", verification)
+            yield _sse("done", {"answer_message_id": answer_chat_id})
+        except Exception as exc:
+            yield _sse("error", {"code": "chat_stream_failed", "message": str(exc)})
+            yield _sse("done", {"failed": True})
 
     return StreamingResponse(
-        event_generator(),
-        media_type="text/plain",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
-        }
+        event_generator(), media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no", "Connection": "keep-alive"},
     )
 
 

--- a/backend/services/context_retrieval.py
+++ b/backend/services/context_retrieval.py
@@ -6,6 +6,7 @@ is sent to telemetry or external embedding services.
 """
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 from typing import Iterable
@@ -22,6 +23,7 @@ class ContextResult:
     evidence_pages: frozenset[int]
     retrieval_count: int
     strategy: str
+    evidence: tuple[dict, ...] = ()
 
 
 def _tokens(text: str) -> list[str]:
@@ -108,8 +110,43 @@ def _fts_rows(doc_id: str, query: str) -> list[dict]:
         return []
 
 
+def _chunk_evidence(doc_id: str, revision: int, chunk: dict, page: dict) -> dict:
+    content = str(chunk.get("content") or "").strip()
+    page_text = str(page.get("text") or "")
+    char_start = page_text.find(content)
+    if char_start < 0:
+        probe = content[:120]
+        char_start = page_text.find(probe) if probe else -1
+    char_end = char_start + len(content) if char_start >= 0 else None
+    occurrence = 1
+    if char_start >= 0 and content:
+        occurrence = page_text[:char_start].count(content) + 1
+    bbox = None
+    for block in page.get("blocks") or []:
+        block_text = str(block.get("text") or "") if isinstance(block, dict) else ""
+        if content[:80] and content[:80] in block_text:
+            bbox = block.get("bbox")
+            break
+    chunk_page_num = chunk.get("page_num")
+    chunk_ordinal = chunk.get("ordinal")
+    identity = f"{doc_id}:{revision}:{chunk_page_num}:{chunk_ordinal}:{char_start}:{content}"
+    evidence_id = "ev_" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+    return {
+        "evidence_id": evidence_id,
+        "content_revision": int(revision),
+        "page_num": int(chunk.get("page_num") or 0),
+        "section": str(chunk.get("section") or ""),
+        "quote": content,
+        "char_start": char_start if char_start >= 0 else None,
+        "char_end": char_end,
+        "occurrence": occurrence,
+        "bbox": bbox,
+    }
+
+
 def retrieve_context(doc_id: str, pages: list[dict], question: str, current_page: int | None = None,
-                     selected_text: str | None = None, budget: int = 40000, max_chunks: int = 14) -> ContextResult:
+                     selected_text: str | None = None, budget: int = 40000, max_chunks: int = 14,
+                     content_revision: int = 1) -> ContextResult:
     all_chunks = chunk_pages(pages)
     total_pages = max((int(p.get("page_num") or 0) for p in pages), default=0)
     from services.document_policy import feature_enabled
@@ -152,7 +189,7 @@ def retrieve_context(doc_id: str, pages: list[dict], question: str, current_page
     for row in ranked:
         key = (int(row["page_num"]), int(row.get("ordinal") or 0))
         if key not in seen:
-            selected.append(row); seen.add(key)
+            selected.append(by_key.get(key, row)); seen.add(key)
         # Extend within the same section by one adjacent paragraph.
         neighbor = by_key.get((key[0], key[1] + 1))
         if neighbor and neighbor.get("section") == row.get("section"):
@@ -165,21 +202,44 @@ def retrieve_context(doc_id: str, pages: list[dict], question: str, current_page
         selected = all_chunks[:min(4, max_chunks)]
 
     blocks = []
-    evidence = set()
+    evidence_items = []
+    pages_by_num = {int(page.get("page_num") or 0): page for page in pages}
     if selected_text:
-        page = current_page if current_page and current_page > 0 else 0
-        blocks.append(f"--- Selected text, Page {page or '?'} ---\n{selected_text.strip()}")
-        if page:
-            evidence.add(page)
+        page_num = current_page if current_page and current_page > 0 else 0
+        selected_chunk = {
+            "page_num": page_num, "ordinal": -1,
+            "section": "Selected text", "content": selected_text.strip(),
+        }
+        selected_evidence = _chunk_evidence(
+            doc_id, content_revision, selected_chunk, pages_by_num.get(page_num, {}),
+        )
+        evidence_items.append(selected_evidence)
+        selected_id = selected_evidence["evidence_id"]
+        page_label = page_num or "?"
+        blocks.append(
+            f"[E:{selected_id}] Page {page_label} · Selected text\n"
+            f"{selected_text.strip()}"
+        )
     for row in selected:
-        page = int(row["page_num"])
-        block = f"--- Page {page} · {row.get('section') or 'Document'} ---\n{row['content'].strip()}"
-        if sum(len(b) + 2 for b in blocks) + len(block) > budget:
+        page_num = int(row["page_num"])
+        evidence_item = _chunk_evidence(
+            doc_id, content_revision, row, pages_by_num.get(page_num, {}),
+        )
+        evidence_id = evidence_item["evidence_id"]
+        section = row.get("section") or "Document"
+        content = row["content"].strip()
+        block_text = (
+            f"[E:{evidence_id}] Page {page_num} · {section}\n{content}"
+        )
+        if sum(len(item) + 2 for item in blocks) + len(block_text) > budget:
             continue
-        blocks.append(block)
-        evidence.add(page)
+        blocks.append(block_text)
+        evidence_items.append(evidence_item)
     strategy = "fts5+page-proximity+section" if fts_enabled else "lexical+page-proximity+section"
-    return ContextResult("\n\n".join(blocks), frozenset(evidence), len(selected), strategy)
+    evidence_pages = frozenset(item["page_num"] for item in evidence_items if item["page_num"] > 0)
+    return ContextResult(
+        "\n\n".join(blocks), evidence_pages, len(selected), strategy, tuple(evidence_items),
+    )
 
 
 def validate_page_citations(answer: str, evidence_pages: set[int] | frozenset[int]) -> tuple[str, list[str]]:
@@ -192,3 +252,50 @@ def validate_page_citations(answer: str, evidence_pages: set[int] | frozenset[in
         invalid.append(match.group(0))
         return "[제공된 근거에서 확인되지 않은 페이지 인용 제거]"
     return _CITATION_RE.sub(replace, answer or ""), invalid
+
+
+_EVIDENCE_CITATION_RE = re.compile(r"\[E:([A-Za-z0-9_-]+)\]")
+_NUMBER_RE = re.compile(r"(?<![A-Za-z])\d+(?:[.,]\d+)?%?")
+
+
+def validate_evidence_citations(answer: str, evidence: tuple[dict, ...] | list[dict]) -> tuple[str, list[dict], dict]:
+    """Allow only supplied evidence IDs and expose page citations to the UI."""
+    by_id = {item["evidence_id"]: item for item in evidence}
+    cited_ids = []
+    invalid_ids = []
+
+    def replace(match: re.Match) -> str:
+        evidence_id = match.group(1)
+        item = by_id.get(evidence_id)
+        if item is None:
+            invalid_ids.append(evidence_id)
+            return "[제공되지 않은 근거 ID 제거]"
+        cited_ids.append(evidence_id)
+        page_num = item["page_num"]
+        return f"[p.{page_num}]"
+
+    displayed = _EVIDENCE_CITATION_RE.sub(replace, answer or "")
+    cited = [by_id[evidence_id] for evidence_id in dict.fromkeys(cited_ids)]
+    sentences = [part.strip() for part in re.split(r"(?<=[.!?。！？])\s+|\n+", answer or "") if part.strip()]
+    numeric_without_citation = [
+        sentence[:240] for sentence in sentences
+        if _NUMBER_RE.search(sentence) and not _EVIDENCE_CITATION_RE.search(sentence)
+    ]
+    claim_count = sum(1 for sentence in sentences if len(sentence) >= 24)
+    insufficient = claim_count >= 3 and len(set(cited_ids)) * 2 < claim_count
+    risks = []
+    if invalid_ids:
+        risks.append("invalid_evidence_id")
+    if numeric_without_citation:
+        risks.append("uncited_numeric_claim")
+    if insufficient:
+        risks.append("insufficient_citation_coverage")
+    verification = {
+        "status": "risk" if risks else "verified_structure",
+        "risks": risks,
+        "invalid_evidence_ids": list(dict.fromkeys(invalid_ids)),
+        "uncited_numeric_claims": numeric_without_citation,
+        "claim_count": claim_count,
+        "citation_count": len(set(cited_ids)),
+    }
+    return displayed, cited, verification

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -83,6 +83,7 @@ def init_db():
             role TEXT NOT NULL,
             content TEXT NOT NULL,
             content_revision INTEGER NOT NULL DEFAULT 1,
+            evidence_verification TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
         )
@@ -168,6 +169,29 @@ def init_db():
         )
         """)
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_reparse_previews_doc ON reparse_previews(doc_id, created_at DESC)")
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS chat_evidence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            answer_message_id INTEGER NOT NULL,
+            doc_id TEXT NOT NULL,
+            evidence_id TEXT NOT NULL,
+            content_revision INTEGER NOT NULL,
+            page_num INTEGER NOT NULL,
+            section TEXT,
+            quote TEXT NOT NULL,
+            translation_quote TEXT,
+            char_start INTEGER,
+            char_end INTEGER,
+            occurrence INTEGER NOT NULL DEFAULT 1,
+            bbox TEXT,
+            verification TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (answer_message_id) REFERENCES chats (id) ON DELETE CASCADE,
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE,
+            UNIQUE(answer_message_id, evidence_id)
+        )
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_chat_evidence_answer ON chat_evidence(answer_message_id)")
 
         # 문서 채팅용 페이지·문단 전문 검색 인덱스. PDF 원문을 문단 단위로
         # 저장해 재시작 후에도 후반부 질문을 검색할 수 있다.
@@ -227,6 +251,7 @@ def init_db():
             "ALTER TABLE translations ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
             "ALTER TABLE page_insights ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
             "ALTER TABLE chats ADD COLUMN content_revision INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE chats ADD COLUMN evidence_verification TEXT",
         ):
             try:
                 cursor.execute(column_sql)
@@ -235,6 +260,11 @@ def init_db():
 
         try:
             cursor.execute("ALTER TABLE reparse_previews ADD COLUMN source_pdf_fingerprint TEXT")
+        except sqlite3.OperationalError:
+            pass
+
+        try:
+            cursor.execute("ALTER TABLE chat_evidence ADD COLUMN translation_quote TEXT")
         except sqlite3.OperationalError:
             pass
 
@@ -913,6 +943,7 @@ def db_delete_document(doc_id: str) -> bool:
         except sqlite3.OperationalError:
             pass
         cursor.execute("DELETE FROM translations WHERE doc_id = ?", (doc_id,))
+        cursor.execute("DELETE FROM chat_evidence WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM chats WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
         cursor.execute("DELETE FROM document_folders WHERE doc_id = ?", (doc_id,))
@@ -1067,28 +1098,97 @@ def db_save_chat_message(doc_id: str, role: str, content: str) -> Optional[int]:
         conn.commit()
         return cursor.lastrowid
 
+def db_save_chat_verification(answer_message_id: int, verification: Dict[str, Any]) -> None:
+    if not answer_message_id:
+        return
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE chats SET evidence_verification = ? WHERE id = ?",
+            (json.dumps(verification, ensure_ascii=False), int(answer_message_id)),
+        )
+        conn.commit()
+
+
+def db_save_chat_evidence(answer_message_id: int, doc_id: str, evidence: List[Dict[str, Any]],
+                          verification: Dict[str, Any]) -> None:
+    if not answer_message_id or not evidence:
+        return
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        conn.executemany(
+            """INSERT OR REPLACE INTO chat_evidence
+               (answer_message_id, doc_id, evidence_id, content_revision, page_num, section, quote,
+                translation_quote, char_start, char_end, occurrence, bbox, verification, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [(
+                int(answer_message_id), doc_id, item["evidence_id"],
+                int(item.get("content_revision") or 1), int(item["page_num"]),
+                item.get("section"), item.get("quote") or "",
+                item.get("translation_quote"), item.get("char_start"), item.get("char_end"),
+                int(item.get("occurrence") or 1),
+                json.dumps(item.get("bbox"), ensure_ascii=False) if item.get("bbox") is not None else None,
+                json.dumps(verification, ensure_ascii=False), created_at,
+            ) for item in evidence],
+        )
+        conn.commit()
+
+
+def db_get_chat_evidence(answer_message_id: int) -> List[Dict[str, Any]]:
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT evidence_id, content_revision, page_num, section, quote, translation_quote, char_start,
+                      char_end, occurrence, bbox, verification
+               FROM chat_evidence WHERE answer_message_id = ? ORDER BY id""",
+            (int(answer_message_id),),
+        ).fetchall()
+    result = []
+    for row in rows:
+        item = dict(row)
+        item["bbox"] = json.loads(item["bbox"]) if item.get("bbox") else None
+        item["verification"] = json.loads(item["verification"]) if item.get("verification") else None
+        result.append(item)
+    return result
+
+
 def db_get_chat_history(doc_id: str, include_revision: bool = False) -> List[Dict[str, Any]]:
     with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """SELECT c.role, c.content, c.content_revision,
+        rows = conn.execute(
+            """SELECT c.id, c.role, c.content, c.content_revision, c.evidence_verification,
                       COALESCE(d.content_revision, c.content_revision) AS current_revision
                FROM chats c LEFT JOIN documents d ON d.id = c.doc_id
                WHERE c.doc_id = ? ORDER BY c.id ASC""",
             (doc_id,),
-        )
-        rows = cursor.fetchall()
+        ).fetchall()
         if not include_revision:
-            return [{"role": r["role"], "content": r["content"]} for r in rows]
-        return [{
-            "role": r["role"], "content": r["content"],
-            "content_revision": int(r["content_revision"]),
-            "stale": int(r["content_revision"]) < int(r["current_revision"]),
-        } for r in rows]
+            return [{"role": row["role"], "content": row["content"]} for row in rows]
+        answer_ids = [int(row["id"]) for row in rows if row["role"] == "assistant"]
+        evidence_by_answer = {answer_id: [] for answer_id in answer_ids}
+        if answer_ids:
+            placeholders = ",".join("?" for _ in answer_ids)
+            evidence_rows = conn.execute(
+                f"""SELECT answer_message_id, evidence_id, content_revision, page_num, section, quote,
+                           translation_quote, char_start, char_end, occurrence, bbox, verification
+                    FROM chat_evidence WHERE answer_message_id IN ({placeholders}) ORDER BY id""",
+                answer_ids,
+            ).fetchall()
+            for evidence_row in evidence_rows:
+                item = dict(evidence_row)
+                answer_id = int(item.pop("answer_message_id"))
+                item["bbox"] = json.loads(item["bbox"]) if item.get("bbox") else None
+                item["verification"] = json.loads(item["verification"]) if item.get("verification") else None
+                evidence_by_answer[answer_id].append(item)
+    return [{
+        "id": int(row["id"]), "role": row["role"], "content": row["content"],
+        "content_revision": int(row["content_revision"]),
+        "stale": int(row["content_revision"]) < int(row["current_revision"]),
+        "evidence": evidence_by_answer.get(int(row["id"]), []),
+        "verification": json.loads(row["evidence_verification"]) if row["evidence_verification"] else None,
+    } for row in rows]
 
 def db_clear_chat_history(doc_id: str) -> None:
     with get_db() as conn:
         cursor = conn.cursor()
+        cursor.execute("DELETE FROM chat_evidence WHERE doc_id = ?", (doc_id,))
         cursor.execute("DELETE FROM chats WHERE doc_id = ?", (doc_id,))
         conn.commit()
 

--- a/backend/tests/test_grounded_screen_context.py
+++ b/backend/tests/test_grounded_screen_context.py
@@ -1,0 +1,250 @@
+import json
+import re
+import fitz
+import pytest
+
+
+def _events(response):
+    result = []
+    for frame in response.text.replace("\r\n", "\n").split("\n\n"):
+        if not frame.strip():
+            continue
+        event, data = "message", []
+        for line in frame.splitlines():
+            if line.startswith("event:"):
+                event = line[6:].strip()
+            elif line.startswith("data:"):
+                data.append(line[5:].lstrip())
+        if data:
+            result.append((event, json.loads("\n".join(data))))
+    return result
+
+
+def _chat_document(isolated_dirs, doc_id="grounded-doc", policy="inherit"):
+    from routers.upload import sessions
+    pdf_path = isolated_dirs["library_dir"] / (doc_id + ".pdf")
+    pdf = fitz.open()
+    page = pdf.new_page()
+    page.insert_text((72, 72), "Figure 1 shows the grounded accuracy result.")
+    pdf.save(pdf_path)
+    pdf.close()
+    isolated_dirs["db"].db_save_document(
+        doc_id, "testuser", "paper.pdf", str(pdf_path), 1, {"title": "Paper"},
+        processing_policy=policy,
+    )
+    isolated_dirs["db"].db_save_translation(doc_id, 1, "그림 1은 근거 정확도 결과를 보여준다.")
+    sessions[doc_id] = {
+        "pdf_path": str(pdf_path), "filename": "paper.pdf",
+        "pages": [{"page_num": 1, "text": "Figure 1 shows the grounded accuracy result.",
+                   "blocks": [{"bbox": [70, 60, 350, 90], "text": "Figure 1 shows the grounded accuracy result."}]}],
+        "total_pages": 1, "metadata": {"title": "Paper"}, "username": "testuser",
+        "document_mode": "research", "document_type": "research_paper",
+        "processing_policy": policy, "content_revision": 1,
+    }
+    return sessions
+
+
+@pytest.fixture()
+def grounded_doc(isolated_dirs):
+    sessions = _chat_document(isolated_dirs)
+    try:
+        yield sessions
+    finally:
+        sessions.pop("grounded-doc", None)
+
+
+def test_visual_question_detection_avoids_korean_false_positive():
+    from routers.chat import _VISUAL_QUESTION_RE
+    assert _VISUAL_QUESTION_RE.search("이 표를 설명해줘")
+    assert not _VISUAL_QUESTION_RE.search("연구 목표를 설명해줘")
+
+
+def test_evidence_ids_are_deterministic_and_invalid_ids_are_removed(isolated_dirs):
+    from services.context_retrieval import retrieve_context, validate_evidence_citations
+    pages = [{"page_num": 3, "text": "# Results\n\nAccuracy improved by 12 percent."}]
+    first = retrieve_context("doc", pages, "accuracy", content_revision=4)
+    second = retrieve_context("doc", pages, "accuracy", content_revision=4)
+    assert first.evidence == second.evidence
+    item = first.evidence[0]
+    assert item["content_revision"] == 4 and item["page_num"] == 3
+    assert item["char_start"] is not None and item["evidence_id"].startswith("ev_")
+    answer, cited, verification = validate_evidence_citations(
+        "Improved [E:" + item["evidence_id"] + "]. Invented [E:ev_missing].", first.evidence,
+    )
+    assert "[p.3]" in answer and "ev_missing" not in answer
+    assert cited[0]["evidence_id"] == item["evidence_id"]
+    assert "invalid_evidence_id" in verification["risks"]
+
+
+@pytest.mark.parametrize("question,screen_context,expect_visual", [
+    ("이 페이지 그림을 설명해줘", {"mode": "viewer", "page_num": 1, "include_visual": None}, True),
+    ("핵심 내용을 설명해줘", {"mode": "viewer", "page_num": 1, "include_visual": None}, False),
+    ("이 페이지 그림을 설명해줘", {"mode": "standalone", "include_visual": True}, False),
+])
+def test_screen_context_visual_attachment_rules(
+    test_client, grounded_doc, isolated_dirs, monkeypatch, question, screen_context, expect_visual,
+):
+    import routers.chat as chat_router
+    captures = []
+
+    async def fake_stream(system_prompt, messages, session_id=None, page_image_b64=None):
+        evidence_id = re.search(r"\[E:(ev_[A-Za-z0-9_-]+)\]", system_prompt).group(1)
+        captures.append(page_image_b64)
+        yield "Supported claim [E:" + evidence_id + "]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    monkeypatch.setattr("config.get_chat_model", lambda: "gpt-vision")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc", "messages": [{"role": "user", "content": question}],
+        "screen_context": screen_context,
+    })
+    assert response.status_code == 200
+    events = _events(response)
+    assert [name for name, _ in events] == ["context", "answer", "evidence", "verification", "done"]
+    context = events[0][1]
+    assert context["visual_included"] is expect_visual
+    assert bool(captures[0]) is expect_visual
+    assert context["current_page_text_included"] is (screen_context["mode"] == "viewer")
+    assert "[p.1]" in events[1][1]["delta"]
+    evidence = events[2][1]["items"]
+    assert evidence and evidence[0]["quote"].startswith("Figure 1")
+    assert evidence[0]["translation_quote"].startswith("그림 1")
+    history = isolated_dirs["db"].db_get_chat_history("grounded-doc", include_revision=True)
+    assert history[-1]["evidence"][0]["content_revision"] == 1
+    assert history[-1]["evidence"][0]["translation_quote"].startswith("그림 1")
+
+
+def test_unsupported_vision_model_reports_reason_without_render(test_client, grounded_doc, monkeypatch):
+    import routers.chat as chat_router
+    captures = []
+
+    async def fake_stream(system_prompt, messages, session_id=None, page_image_b64=None):
+        evidence_id = re.search(r"\[E:(ev_[A-Za-z0-9_-]+)\]", system_prompt).group(1)
+        captures.append(page_image_b64)
+        yield "Supported [E:" + evidence_id + "]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "ollama")
+    monkeypatch.setattr("config.get_chat_model", lambda: "llama3")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc", "messages": [{"role": "user", "content": "이 페이지 그림을 설명해줘"}],
+        "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": True},
+    })
+    context = _events(response)[0][1]
+    assert context["visual_included"] is False
+    assert context["visual_reason"] == "vision_not_supported"
+    assert captures == [None]
+
+
+def test_local_only_external_provider_blocks_before_page_render(test_client, isolated_dirs, monkeypatch):
+    from routers.upload import sessions
+    _chat_document(isolated_dirs, "local-grounded", policy="local_only")
+    rendered = []
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    monkeypatch.setattr("services.pdf_parser.render_page_image_base64", lambda *_args: rendered.append(True))
+    try:
+        response = test_client.post("/api/chat/stream", json={
+            "session_id": "local-grounded", "messages": [{"role": "user", "content": "이 페이지 그림을 설명해줘"}],
+            "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": True},
+        })
+    finally:
+        sessions.pop("local-grounded", None)
+    assert response.status_code == 409
+    assert response.json()["code"] == "external_processing_blocked"
+    assert rendered == []
+
+
+def test_invalid_evidence_id_emits_risk_and_is_not_persisted(
+    test_client, grounded_doc, isolated_dirs, monkeypatch,
+):
+    import routers.chat as chat_router
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "Unsupported statement [E:ev_not_supplied]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    monkeypatch.setattr("config.get_chat_model", lambda: "model")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc", "messages": [{"role": "user", "content": "question"}],
+        "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": False},
+    })
+    events = dict(_events(response))
+    assert "ev_not_supplied" not in events["answer"]["delta"]
+    assert "invalid_evidence_id" in events["verification"]["risks"]
+    history = isolated_dirs["db"].db_get_chat_history("grounded-doc", include_revision=True)
+    assert history[-1]["evidence"] == []
+    assert "invalid_evidence_id" in history[-1]["verification"]["risks"]
+
+
+def test_explicit_verification_runs_separate_semantic_pass(test_client, grounded_doc, monkeypatch):
+    import routers.chat as chat_router
+    calls = []
+
+    async def fake_stream(system_prompt, messages, session_id=None, page_image_b64=None):
+        calls.append(session_id)
+        if "evidence verification model" in system_prompt:
+            yield "{\"status\":\"supported\"}"
+            return
+        evidence_id = re.search(r"\[E:(ev_[A-Za-z0-9_-]+)\]", system_prompt).group(1)
+        yield "Supported [E:" + evidence_id + "]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    monkeypatch.setattr("config.get_chat_model", lambda: "model")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "Verify the evidence"}],
+        "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": False},
+        "verify_evidence": True,
+    })
+    verification = dict(_events(response))["verification"]
+    assert verification["semantic"]["mode"] == "semantic_model"
+    assert len(calls) == 2
+
+
+def test_local_only_without_model_limits_verification_to_structure(test_client, isolated_dirs, monkeypatch):
+    import routers.chat as chat_router
+    from routers.upload import sessions
+    _chat_document(isolated_dirs, "local-verify", policy="local_only")
+    calls = []
+
+    async def fake_stream(system_prompt, messages, session_id=None, page_image_b64=None):
+        calls.append(session_id)
+        evidence_id = re.search(r"\[E:(ev_[A-Za-z0-9_-]+)\]", system_prompt).group(1)
+        yield "Supported [E:" + evidence_id + "]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "ollama")
+    monkeypatch.setattr("config.get_chat_model", lambda: "")
+    monkeypatch.setattr("config.get_ollama_host", lambda: "http://127.0.0.1:11434")
+    try:
+        response = test_client.post("/api/chat/stream", json={
+            "session_id": "local-verify",
+            "messages": [{"role": "user", "content": "근거 검증"}],
+            "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": False},
+            "verify_evidence": True,
+        })
+    finally:
+        sessions.pop("local-verify", None)
+    verification = dict(_events(response))["verification"]
+    assert verification["semantic"] == {
+        "mode": "structural_only", "status": "no_allowed_local_verifier",
+    }
+    assert len(calls) == 1
+
+
+def test_screen_page_range_is_validated_before_rate_accounting(test_client, grounded_doc, monkeypatch):
+    import routers.chat as chat_router
+    calls = []
+    monkeypatch.setattr(chat_router, "enforce_rate_limit", lambda *_args: calls.append(True))
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "question"}],
+        "screen_context": {"mode": "viewer", "page_num": 9, "include_visual": False},
+    })
+    assert response.status_code == 400
+    assert response.json()["code"] == "screen_page_out_of_range"
+    assert calls == []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -598,6 +598,13 @@
               <img id="chat-quote-img" class="chat-quote-img hidden" alt="Quoted Figure" />
               <button id="chat-quote-close-btn" class="chat-quote-close-btn" title="인용 취소">&times;</button>
             </div>
+            <div class="chat-screen-context" aria-live="polite">
+              <span id="chat-page-context-chip" class="chat-context-chip"></span>
+              <label class="chat-visual-toggle">
+                <input id="chat-include-visual" type="checkbox" />
+                <span data-i18n="chat:screenContext.includeVisual">현재 페이지 이미지 포함</span>
+              </label>
+            </div>
             <textarea id="chat-input" class="chat-input-textarea" placeholder="논문에 대해 궁금한 점을 질문하세요..." data-i18n-placeholder="chat:placeholder" rows="1"></textarea>
             <div class="chat-input-footer">
               <div id="chat-sidebar-provider"></div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -589,40 +589,89 @@ export async function deleteModelAPI(modelName) {
  *   provider가 캡처 영역을 직접 보고 답한다.
  * @returns {function} abort - 중단 함수
  */
-export function streamChatAPI(sessionId, messages, onToken, onDone, onError, imageBase64, context = {}) {
+export function streamChatAPI(sessionId, messages, onToken, onDone, onError, imageBase64, context = {}, onEvent = null) {
   const controller = new AbortController()
+  let completed = false
+  let failed = false
 
-  fetch(`${API_BASE}/chat/stream`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  const dispatchEvent = (eventName, payload) => {
+    if (typeof onEvent === "function") onEvent(eventName, payload)
+    if (eventName === "answer") {
+      if (payload?.delta) onToken(payload.delta)
+    } else if (eventName === "error") {
+      failed = true
+      onError(new Error(payload?.message || "Chat stream failed"))
+    } else if (eventName === "done" && !completed) {
+      completed = true
+      if (!failed && !payload?.failed) onDone(payload)
+    }
+  }
+
+  fetch(API_BASE + "/chat/stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       session_id: sessionId,
       messages: messages,
       image_base64: imageBase64 || undefined,
       current_page: context.currentPage || undefined,
-      selected_text: context.selectedText || undefined
+      selected_text: context.selectedText || undefined,
+      screen_context: context.screenContext || undefined,
+      verify_evidence: Boolean(context.verifyEvidence),
     }),
     signal: controller.signal
   })
     .then(async (res) => {
-      if (!res.ok) { onError(await apiError(res)); return }
-
+      if (!res.ok) { failed = true; onError(await apiError(res)); return }
+      const contentType = res.headers?.get?.("content-type") || ""
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
+      if (!contentType.includes("text/event-stream")) {
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          const token = decoder.decode(value, { stream: true })
+          if (token) onToken(token)
+        }
+        if (!completed && !failed) { completed = true; onDone() }
+        return
+      }
 
+      let buffer = ""
+      const consume = () => {
+        let boundary
+        while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+          const frame = buffer.slice(0, boundary).replace(/\r/g, "")
+          buffer = buffer.slice(boundary + 2)
+          if (!frame.trim()) continue
+          let eventName = "message"
+          const dataLines = []
+          frame.split("\n").forEach(line => {
+            if (line.startsWith("event:")) eventName = line.slice(6).trim()
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart())
+          })
+          if (!dataLines.length) continue
+          try {
+            dispatchEvent(eventName, JSON.parse(dataLines.join("\n")))
+          } catch (error) {
+            failed = true
+            onError(error)
+          }
+        }
+      }
       while (true) {
         const { value, done } = await reader.read()
         if (done) break
-
-        const token = decoder.decode(value, { stream: true })
-        if (token) {
-          onToken(token)
-        }
+        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n")
+        consume()
       }
-      onDone()
+      buffer += decoder.decode().replace(/\r\n/g, "\n")
+      consume()
+      if (!completed && !failed) { completed = true; onDone() }
     })
     .catch((err) => {
-      if (err.name !== 'AbortError') {
+      if (err.name !== "AbortError") {
+        failed = true
         onError(err)
       }
     })

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3916,5 +3916,38 @@
   },
   "library:reparse.cancel": {
     "description": "Cancel PDF reparse dialog."
+  },
+  "chat:screenContext.includeVisual": {
+    "description": "Label for manually including the current PDF page image in viewer chat."
+  },
+  "chat:screenContext.pageIncluded": {
+    "description": "Context chip showing that current-page text is included."
+  },
+  "chat:screenContext.pageWithVisual": {
+    "description": "Context chip showing that current-page text and image are included."
+  },
+  "chat:screenContext.visionUnsupported": {
+    "description": "Tooltip when the selected chat model cannot inspect page images."
+  },
+  "chat:screenContext.textDescription": {
+    "description": "Tooltip explaining default current-page text context."
+  },
+  "chat:evidence.source": {
+    "description": "Fallback heading for a document evidence hover card."
+  },
+  "chat:evidence.verified": {
+    "description": "Badge for structurally verified evidence citations."
+  },
+  "chat:evidence.risk": {
+    "description": "Badge showing the number of evidence verification risk signals."
+  },
+  "chat:evidence.translation": {
+    "description": "Heading for the translated excerpt in an evidence hover card."
+  },
+  "chat:evidence.verifyAction": {
+    "description": "Assistant message action that requests semantic evidence verification."
+  },
+  "chat:evidence.verifyPrompt": {
+    "description": "Question inserted when the user requests evidence verification."
   }
 }

--- a/frontend/src/locales/en/chat.json
+++ b/frontend/src/locales/en/chat.json
@@ -10,5 +10,16 @@
   "suggestions.general.procedure": "Explain the important procedures and prerequisites.",
   "suggestions.general.cautions": "Identify the cautions and key figures.",
   "retrySameQuestion": "Send same question again",
-  "staleRevision": "Based on an earlier document analysis"
+  "staleRevision": "Based on an earlier document analysis",
+  "screenContext.includeVisual": "Include page image",
+  "screenContext.pageIncluded": "Page {{page}} included",
+  "screenContext.pageWithVisual": "Page {{page}} and image included",
+  "screenContext.visionUnsupported": "The selected model does not support page images.",
+  "screenContext.textDescription": "The current page text is included automatically.",
+  "evidence.source": "Document evidence",
+  "evidence.verified": "Evidence structure verified",
+  "evidence.risk": "{{count}} evidence risk signals",
+  "evidence.translation": "Translation evidence",
+  "evidence.verifyAction": "Verify evidence",
+  "evidence.verifyPrompt": "Verify the evidence for the previous answer."
 }

--- a/frontend/src/locales/ko/chat.json
+++ b/frontend/src/locales/ko/chat.json
@@ -10,5 +10,16 @@
   "suggestions.general.procedure": "중요한 절차와 전제 조건을 설명해줘.",
   "suggestions.general.cautions": "주의사항과 핵심 수치를 찾아줘.",
   "retrySameQuestion": "동일 질문 다시 보내기",
-  "staleRevision": "이전 문서 분석 결과 기반"
+  "staleRevision": "이전 문서 분석 결과 기반",
+  "screenContext.includeVisual": "현재 페이지 이미지 포함",
+  "screenContext.pageIncluded": "현재 {{page}}페이지 포함됨",
+  "screenContext.pageWithVisual": "현재 {{page}}페이지·이미지 포함됨",
+  "screenContext.visionUnsupported": "선택한 모델은 페이지 이미지를 지원하지 않습니다.",
+  "screenContext.textDescription": "현재 페이지 텍스트가 자동으로 포함됩니다.",
+  "evidence.source": "문서 원문 근거",
+  "evidence.verified": "근거 구조 검증됨",
+  "evidence.risk": "근거 위험 신호 {{count}}개",
+  "evidence.translation": "번역 근거",
+  "evidence.verifyAction": "근거 검증",
+  "evidence.verifyPrompt": "직전 답변의 근거를 검증해줘."
 }

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -1111,5 +1111,6 @@
   "–페이지로 이동": "common:legacy.ui.1110",
   "페이지로 이동": "common:legacy.ui.1111",
   "화면 테마": "settings:themeHeading",
-  "저장된 키 삭제": "settings:deleteApiKey"
+  "저장된 키 삭제": "settings:deleteApiKey",
+  "현재 페이지 이미지 포함": "chat:screenContext.includeVisual"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1521,6 +1521,7 @@ function updatePageDisplay(pageNum) {
   if (pageNum === state.currentPage) return
   state.currentPage = pageNum
   pageInput.value = pageNum
+  updateChatScreenContext()
   scheduleSaveLastReadPage(pageNum)
 }
 
@@ -9749,6 +9750,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
       : 1
     pageInput.value = restorePage
     state.currentPage = restorePage
+    updateChatScreenContext()
 
     showViewer()
     hideOutlineSidebar()
@@ -9779,7 +9781,13 @@ async function openFromLibrary(doc, shouldPushState = true) {
         if (isAssistant && msg.stale) {
           renderedContent = `<span class="chat-stale-revision-badge">${t("chat:staleRevision")}</span>${renderedContent}`
         }
-        appendChatMessage(msg.role, renderedContent, true)
+        const messageElement = appendChatMessage(msg.role, renderedContent, true)
+        if (isAssistant && msg.evidence?.length) {
+          attachEvidenceToBubble(messageElement.querySelector(".message-bubble"), msg.evidence)
+        }
+        if (isAssistant && msg.verification) {
+          renderVerificationBadge(messageElement, msg.verification)
+        }
       }
 
       // 마지막 답변이 여전히 어시스턴트 것이라면(그 뒤로 새 질문을 보내지
@@ -13291,6 +13299,66 @@ function buildChatWelcomeHtml() {
   return `<div class="chat-message assistant"><div class="message-bubble">${escapeHtml(welcome)}<br><br><strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}${escapeHtml(t('chat:suggestions.label'))}</strong><ul>${examples.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul></div></div>`
 }
 
+function updateChatScreenContext(contextEvent = null) {
+  if (!chatPageContextChip) return
+  const page = Number(contextEvent?.page_num || state.currentPage || 1)
+  const visual = contextEvent?.visual_included
+  chatPageContextChip.textContent = visual
+    ? t("chat:screenContext.pageWithVisual", { page })
+    : t("chat:screenContext.pageIncluded", { page })
+  chatPageContextChip.classList.toggle("visual-included", Boolean(visual))
+  if (contextEvent?.visual_reason === "vision_not_supported") {
+    chatPageContextChip.title = t("chat:screenContext.visionUnsupported")
+  } else {
+    chatPageContextChip.title = t("chat:screenContext.textDescription")
+  }
+}
+
+function attachEvidenceToBubble(bubble, evidenceItems = []) {
+  if (!bubble || !evidenceItems.length) return
+  const byPage = new Map()
+  evidenceItems.forEach(item => {
+    const page = Number(item.page_num)
+    if (!byPage.has(page)) byPage.set(page, [])
+    byPage.get(page).push(item)
+  })
+  bubble.querySelectorAll("[data-page-citation]").forEach(button => {
+    const page = Number(button.dataset.pageCitation)
+    const item = byPage.get(page)?.shift()
+    if (!item) return
+    button.dataset.evidenceId = item.evidence_id
+    button.dataset.evidenceQuote = item.quote || ""
+    button.dataset.evidenceOccurrence = String(item.occurrence || 1)
+    const card = document.createElement("span")
+    card.className = "chat-evidence-card"
+    const heading = document.createElement("strong")
+    heading.textContent = item.section || t("chat:evidence.source")
+    const quote = document.createElement("span")
+    quote.textContent = (item.quote || "").slice(0, 360)
+    card.append(heading, quote)
+    if (item.translation_quote) {
+      const translationHeading = document.createElement("strong")
+      translationHeading.className = "chat-evidence-translation-heading"
+      translationHeading.textContent = t("chat:evidence.translation")
+      const translation = document.createElement("span")
+      translation.textContent = item.translation_quote.slice(0, 360)
+      card.append(translationHeading, translation)
+    }
+    button.appendChild(card)
+  })
+}
+
+function renderVerificationBadge(messageElement, verification) {
+  if (!messageElement || !verification) return
+  const badge = document.createElement("div")
+  const hasRisk = Array.isArray(verification.risks) && verification.risks.length > 0
+  badge.className = "chat-verification-badge " + (hasRisk ? "risk" : "verified")
+  badge.textContent = hasRisk
+    ? t("chat:evidence.risk", { count: verification.risks.length })
+    : t("chat:evidence.verified")
+  messageElement.appendChild(badge)
+}
+
 function resetChatUI() {
   chatMessages.innerHTML = buildChatWelcomeHtml()
   chatInput.value = ''
@@ -13494,6 +13562,8 @@ function regenerateResponse(assistantMsgEl) {
   let accumulatedText = '';
   let replyBubble = null;
   let firstToken = true;
+  let responseEvidence = [];
+  let responseVerification = null;
 
   state.chatActiveStream = streamChatAPI(
     state.sessionId,
@@ -13516,8 +13586,10 @@ function regenerateResponse(assistantMsgEl) {
 
       if (replyBubble) {
         replyBubble.innerHTML = formatChatHtml(accumulatedText);
+        attachEvidenceToBubble(replyBubble, responseEvidence);
         applyKatexToElement(replyBubble);
         if (replyBubble.parentElement) {
+          renderVerificationBadge(replyBubble.parentElement, responseVerification);
           appendActionButtons(replyBubble.parentElement, 'assistant', accumulatedText);
           renderSuggestedQuestions(replyBubble.parentElement);
         }
@@ -13538,6 +13610,19 @@ function regenerateResponse(assistantMsgEl) {
       chatInput.disabled = false;
       updateChatSendBtnIcon(false);
       chatInput.focus();
+    },
+    null,
+    {
+      currentPage: state.currentPage,
+      screenContext: {
+        mode: "viewer", page_num: state.currentPage,
+        include_visual: state.chatIncludeVisual ? true : null,
+      },
+    },
+    (eventName, payload) => {
+      if (eventName === "context") updateChatScreenContext(payload);
+      if (eventName === "evidence") responseEvidence = payload?.items || [];
+      if (eventName === "verification") responseVerification = payload;
     }
   );
 }
@@ -13603,6 +13688,18 @@ function appendActionButtons(msgEl, role, content) {
       regenerateResponse(msgEl)
     })
     actionsEl.appendChild(regenBtn)
+
+    const verifyBtn = document.createElement("button")
+    verifyBtn.type = "button"
+    verifyBtn.className = "msg-action-btn"
+    verifyBtn.innerHTML = icon("checkCircle", 12) + escapeHtml(t("chat:evidence.verifyAction"))
+    verifyBtn.title = t("chat:evidence.verifyAction")
+    verifyBtn.addEventListener("click", () => {
+      if (state.chatActiveStream) return
+      chatInput.value = t("chat:evidence.verifyPrompt")
+      sendChatMessage()
+    })
+    actionsEl.appendChild(verifyBtn)
   }
 
   msgEl.appendChild(actionsEl)
@@ -13810,6 +13907,8 @@ async function sendChatMessage() {
   let accumulatedText = ''
   let replyBubble = null
   let firstToken = true
+  let responseEvidence = []
+  let responseVerification = null
   state.chatCurrentText = ''
 
   state.chatActiveStream = streamChatAPI(
@@ -13836,7 +13935,9 @@ async function sendChatMessage() {
 
       if (replyBubble) {
         replyBubble.innerHTML = formatChatHtml(accumulatedText)
+        attachEvidenceToBubble(replyBubble, responseEvidence)
         if (replyBubble.parentElement) {
+          renderVerificationBadge(replyBubble.parentElement, responseVerification)
           appendActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
           renderSuggestedQuestions(replyBubble.parentElement)
         }
@@ -13862,7 +13963,21 @@ async function sendChatMessage() {
       chatInput.focus()
     },
     imageForThisTurn,
-    { currentPage: state.currentPage, selectedText: selectedTextForThisTurn }
+    {
+      currentPage: state.currentPage,
+      selectedText: selectedTextForThisTurn,
+      screenContext: {
+        mode: "viewer",
+        page_num: state.currentPage,
+        include_visual: state.chatIncludeVisual ? true : null,
+      },
+      verifyEvidence: /근거\s*검증|verify\s+(?:the\s+)?evidence/i.test(text),
+    },
+    (eventName, payload) => {
+      if (eventName === "context") updateChatScreenContext(payload)
+      if (eventName === "evidence") responseEvidence = payload?.items || []
+      if (eventName === "verification") responseVerification = payload
+    }
   )
 }
 
@@ -13878,7 +13993,10 @@ function initChatListeners() {
     if (!citation) return
     const page = Number(citation.dataset.pageCitation)
     if (Number.isInteger(page) && page >= 1 && page <= state.totalPages) {
-      scrollToPage(viewerScrollContainer, page)
+      const quote = citation.dataset.evidenceQuote
+      const occurrence = Number(citation.dataset.evidenceOccurrence || 1)
+      if (quote) locateTermInPdf(page, quote, occurrence)
+      else scrollToPage(viewerScrollContainer, page)
     }
   })
 
@@ -13900,6 +14018,14 @@ function initChatListeners() {
   if (chatCloseBtn) {
     chatCloseBtn.addEventListener('click', toggleChatSidebar)
   }
+
+  if (chatIncludeVisual) {
+    chatIncludeVisual.addEventListener("change", () => {
+      state.chatIncludeVisual = chatIncludeVisual.checked
+      updateChatScreenContext()
+    })
+  }
+  updateChatScreenContext()
 
   if (chatSendBtn) {
     chatSendBtn.addEventListener('click', () => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -589,6 +589,8 @@ const primerContinueBtn    = $('primer-continue-btn')
 const chatInput          = $('chat-input')
 const chatInputExpandBtn = $('chat-input-expand-btn')
 const chatSendBtn        = $('chat-send-btn')
+const chatPageContextChip = $('chat-page-context-chip')
+const chatIncludeVisual   = $('chat-include-visual')
 
 
 // ── 설정 기본값 및 옵션 헬퍼 ──────────────────────────

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7100,3 +7100,16 @@ body.light-theme .chat-drawer {
 .reparse-problem-previews small { margin-left:8px; color:var(--error); }
 .reparse-problem-previews p { margin:5px 0 0; color:var(--text-secondary); font-size:11px; white-space:pre-wrap; }
 @media (max-width:560px) { .reparse-report-grid { grid-template-columns:1fr; } }
+
+.chat-screen-context { display:flex; align-items:center; gap:8px; padding:8px 10px 0; flex-wrap:wrap; }
+.chat-context-chip, .chat-visual-toggle { display:inline-flex; align-items:center; gap:5px; min-height:24px; padding:2px 8px; border:1px solid var(--border); border-radius:999px; color:var(--text-secondary); background:var(--bg-elevated); font-size:10px; }
+.chat-context-chip.visual-included { border-color:var(--accent-mid); color:var(--accent); }
+.chat-visual-toggle { cursor:pointer; user-select:none; }
+.chat-visual-toggle input { accent-color:var(--accent); }
+.chat-page-citation { position:relative; }
+.chat-evidence-card { display:none; position:absolute; z-index:40; left:50%; bottom:calc(100% + 8px); width:min(320px, 70vw); padding:9px; border:1px solid var(--border-strong); border-radius:8px; background:var(--bg-panel); color:var(--text-primary); box-shadow:var(--shadow-lg); text-align:left; white-space:normal; pointer-events:none; transform:translateX(-50%); }
+.chat-evidence-card strong, .chat-evidence-card span { display:block; }
+.chat-evidence-card span { margin-top:5px; color:var(--text-secondary); font-size:10px; line-height:1.45; }
+.chat-page-citation:hover .chat-evidence-card, .chat-page-citation:focus-visible .chat-evidence-card { display:block; }
+.chat-verification-badge { align-self:flex-start; margin:4px 0 0; padding:3px 7px; border:1px solid var(--success); border-radius:999px; color:var(--success); font-size:10px; }
+.chat-verification-badge.risk { border-color:var(--warning); color:var(--warning); }

--- a/frontend/tests/api-install-stream.test.js
+++ b/frontend/tests/api-install-stream.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { streamInstallOllamaAPI } from '../src/api.js'
+import { streamChatAPI, streamInstallOllamaAPI } from '../src/api.js'
 
 test('CLI install stream uses POST and parses SSE events', async () => {
   const requests = []
@@ -28,4 +28,38 @@ test('CLI install stream uses POST and parses SSE events', async () => {
   assert.equal(requests[0].url, '/api/settings/install-ollama')
   assert.equal(requests[0].options.method, 'POST')
   assert.deepEqual(progress, ['installing'])
+})
+
+
+test("document chat parses named SSE events across chunk boundaries", async () => {
+  const requests = []
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options })
+    const chunks = [
+      "event: context\ndata: {\"page_num\":2,\"visual_included\":false}\n\nevent: ans",
+      "wer\ndata: {\"delta\":\"Grounded \"}\n\nevent: answer\ndata: {\"delta\":\"answer [p.2]\"}\n\n",
+      "event: evidence\ndata: {\"items\":[{\"evidence_id\":\"ev_1\",\"page_num\":2}]}\n\nevent: verification\ndata: {\"status\":\"verified_structure\"}\n\nevent: done\ndata: {\"answer_message_id\":7}\n\n",
+    ]
+    const body = new ReadableStream({
+      start(controller) {
+        chunks.forEach(chunk => controller.enqueue(new TextEncoder().encode(chunk)))
+        controller.close()
+      },
+    })
+    return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } })
+  }
+
+  const tokens = []
+  const events = []
+  await new Promise((resolve, reject) => {
+    streamChatAPI("doc", [{ role: "user", content: "question" }],
+      token => tokens.push(token), resolve, reject, null,
+      { screenContext: { mode: "viewer", page_num: 2, include_visual: null } },
+      (name, payload) => events.push([name, payload]))
+  })
+
+  assert.deepEqual(tokens, ["Grounded ", "answer [p.2]"])
+  assert.deepEqual(events.map(item => item[0]), ["context", "answer", "answer", "evidence", "verification", "done"])
+  const body = JSON.parse(requests[0].options.body)
+  assert.deepEqual(body.screen_context, { mode: "viewer", page_num: 2, include_visual: null })
 })


### PR DESCRIPTION
# Summary
## 1. 화면 컨텍스트 및 시각 질문
- 뷰어 현재 페이지 텍스트 기본 포함과 이미지 수동 토글 추가
- 시각 질문 감지 시 서버 원본 PDF 렌더링 이미지 자동 첨부 추가
- local-only, 비전 지원 모델, 이미지 크기, standalone 화면 검사 추가
## 2. 근거 인용 및 검증
- revision·페이지·절·원문 offset·occurrence·bbox 기반 결정적 evidence ID 추가
- 허용되지 않은 ID 제거, 숫자 무인용·인용 부족 위험 신호 및 선택적 semantic 검증 추가
- 원문·번역 근거 hover 카드와 페이지 이동·occurrence 강조 추가
## 3. 영속화 및 스트리밍
- chat_evidence와 answer-level 검증 결과 영속화 및 stale revision 연계 추가
- context·answer·evidence·verification·error·done named SSE로 전환
- 백엔드 556개, 프론트 49개 테스트 및 프로덕션 빌드 통과