### PR TITLE
fix(privacy): block secondary external calls

### DIFF
--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -118,6 +118,11 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
         return
     username = doc["username"]
 
+    # Graph sync starts with the analysis provider. Similarity linking below uses
+    # the library provider and is checked only when that secondary call is needed.
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(doc, "insight")
+
     from services.llm_client import extract_paper_concepts, find_similar_concepts
     from services.db import db_upsert_concept, db_link_paper_concept, db_get_all_concepts, db_upsert_concept_edge
     concepts = await extract_paper_concepts(
@@ -142,6 +147,7 @@ async def sync_document_for_graph(doc_id: str, pages: list, doc_title: str) -> N
 
         if is_new and existing_by_normalized:
             try:
+                ensure_processing_allowed(doc, "recommendation")
                 candidate_names = [c2["name"] for c2 in existing_by_normalized.values()]
                 matches = await find_similar_concepts(name, candidate_names, session_id=doc_id)
                 for m in matches:
@@ -194,6 +200,16 @@ async def sync_question_for_graph(chat_id: int, doc_id_or_compare_id: str, quest
 
     concept_links = db_get_concepts_for_docs(doc_ids)
     if concept_links:
+        from fastapi import HTTPException
+        from services.library import get_document
+        from services.processing_policy import ensure_documents_processing_allowed
+        documents = [doc for doc_id in doc_ids if (doc := get_document(doc_id))]
+        try:
+            ensure_documents_processing_allowed(documents, "chat")
+        except HTTPException as exc:
+            if isinstance(exc.detail, dict) and exc.detail.get("code") == "external_processing_blocked":
+                return
+            raise
         from services.llm_client import match_question_to_concepts
         seen_concept_ids = set()
         concept_by_name = {}
@@ -897,6 +913,12 @@ async def _score_one_paper(doc_id: str, title: str, concept_names: List[str]) ->
     추출 실패, LLM 오류, 응답 파싱 실패 등 어떤 이유로든 실패하면 조용히 빈
     dict를 반환해 호출부가 등장 여부 기반 값으로 대체하게 한다 - 이 함수 하나가
     실패해도 나머지 논문의 채점이나 매트릭스 자체가 막히면 안 된다."""
+    from services.library import get_document
+    from services.processing_policy import ensure_processing_allowed
+    document = get_document(doc_id)
+    if not document:
+        return {}
+    ensure_processing_allowed(document, "recommendation")
     from services.llm_client import score_paper_concept_relevance
     text = await _get_paper_text_for_scoring(doc_id)
     try:
@@ -1164,6 +1186,10 @@ async def get_ai_insights(username: str) -> List[dict]:
     rule_based_gaps = await get_knowledge_gaps(username)
     if not docs:
         return rule_based_gaps
+
+    # Cached insights cause no transfer; enforce only before generating fresh data.
+    from services.processing_policy import ensure_documents_processing_allowed
+    ensure_documents_processing_allowed(docs, "recommendation")
 
     # get_activity_timeline의 summary는 UI 카드용으로 80자로 잘려있어, 질문에서
     # 이해 부족/개념 공백을 실제로 진단하기엔 근거가 너무 짧다. 여기서는 같은

--- a/backend/services/paper_tags.py
+++ b/backend/services/paper_tags.py
@@ -227,6 +227,8 @@ async def classify_and_store_paper_tags(
     abstract = extract_abstract_text(pages)
     if not abstract:
         return {}
+    from services.processing_policy import ensure_processing_allowed
+    ensure_processing_allowed(before, "insight")
     paper_tags = await classify_paper_tags(title, abstract, session_id=doc_id)
     if not paper_tags:
         return {}

--- a/backend/tests/test_processing_privacy.py
+++ b/backend/tests/test_processing_privacy.py
@@ -184,3 +184,176 @@ def test_all_document_ai_entrypoints_block_external_processing(test_client, isol
             assert response.json()["code"] == "external_processing_blocked"
     finally:
         upload_router.sessions.pop(session_id, None)
+
+
+def _save_local_only_document(isolated_dirs, doc_id: str) -> None:
+    isolated_dirs["db"].db_save_document(
+        doc_id, "testuser", f"{doc_id}.pdf", "/x/nonexistent.pdf", 1,
+        {"title": f"{doc_id} title"}, processing_policy="local_only",
+    )
+
+
+@pytest.mark.asyncio
+async def test_secondary_tag_classification_enforces_analysis_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services.paper_tags import classify_and_store_paper_tags
+
+    _save_local_only_document(isolated_dirs, "privacy-secondary-tags")
+    monkeypatch.setattr("config.get_analysis_provider", lambda: "openai")
+    calls = []
+
+    async def fake_classify(*_args, **_kwargs):
+        calls.append(True)
+        return {}
+
+    monkeypatch.setattr(llm_client, "classify_paper_tags", fake_classify)
+    pages = [{"page_num": 1, "text": "Abstract\n" + ("meaningful research text " * 12)}]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await classify_and_store_paper_tags(
+            "privacy-secondary-tags", pages, "Private paper", force=True,
+        )
+
+    assert exc_info.value.detail["code"] == "external_processing_blocked"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_graph_sync_enforces_analysis_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services.knowledge_graph import sync_document_for_graph
+
+    _save_local_only_document(isolated_dirs, "privacy-secondary-graph")
+    monkeypatch.setattr("config.get_analysis_provider", lambda: "claude")
+    calls = []
+
+    async def fake_extract(*_args, **_kwargs):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(llm_client, "extract_paper_concepts", fake_extract)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sync_document_for_graph(
+            "privacy-secondary-graph",
+            [{"page_num": 1, "text": "private document text"}],
+            "Private graph paper",
+        )
+
+    assert exc_info.value.detail["code"] == "external_processing_blocked"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_question_sync_skips_external_chat_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services import db
+    from services.knowledge_graph import sync_question_for_graph
+
+    doc_id = "privacy-secondary-question"
+    _save_local_only_document(isolated_dirs, doc_id)
+    concept_id = db.db_upsert_concept("Private Concept", "private concept", "method")
+    db.db_link_paper_concept(doc_id, concept_id)
+    chat_id = db.db_save_chat_message(doc_id, "user", "Explain the private concept")
+    monkeypatch.setattr("config.get_chat_provider", lambda: "gemini")
+    calls = []
+
+    async def fake_match(*_args, **_kwargs):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(llm_client, "match_question_to_concepts", fake_match)
+    await sync_question_for_graph(chat_id, doc_id, "Explain the private concept")
+
+    assert calls == []
+    with db.get_db() as conn:
+        row = conn.execute(
+            "SELECT graph_synced_at FROM chats WHERE id = ?", (chat_id,),
+        ).fetchone()
+    assert row["graph_synced_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_secondary_heatmap_scoring_enforces_library_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services.knowledge_graph import _score_one_paper
+
+    doc_id = "privacy-secondary-heatmap"
+    _save_local_only_document(isolated_dirs, doc_id)
+    monkeypatch.setattr("config.get_library_provider", lambda: "codex")
+    calls = []
+
+    async def fake_score(*_args, **_kwargs):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(llm_client, "score_paper_concept_relevance", fake_score)
+    with pytest.raises(HTTPException) as exc_info:
+        await _score_one_paper(doc_id, "Private paper", ["Private Concept"])
+
+    assert exc_info.value.detail["code"] == "external_processing_blocked"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_dashboard_insights_enforce_library_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services.knowledge_graph import get_ai_insights
+
+    _save_local_only_document(isolated_dirs, "privacy-secondary-dashboard")
+    monkeypatch.setattr("config.get_library_provider", lambda: "openai")
+    calls = []
+
+    async def fake_generate(*_args, **_kwargs):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(llm_client, "generate_dashboard_insights", fake_generate)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_ai_insights("testuser")
+
+    assert exc_info.value.detail["code"] == "external_processing_blocked"
+    assert calls == []
+
+
+
+@pytest.mark.asyncio
+async def test_secondary_graph_similarity_skips_external_library_provider(
+    isolated_dirs, monkeypatch,
+):
+    import services.llm_client as llm_client
+    from services import db
+    from services.knowledge_graph import sync_document_for_graph
+
+    doc_id = "privacy-secondary-similarity"
+    _save_local_only_document(isolated_dirs, doc_id)
+    db.db_upsert_concept("Existing Concept", "existing concept", "method")
+    monkeypatch.setattr("config.get_analysis_provider", lambda: "ollama")
+    monkeypatch.setattr("config.get_ollama_host", lambda: "http://127.0.0.1:11434")
+    monkeypatch.setattr("config.get_library_provider", lambda: "openai")
+    calls = []
+
+    async def fake_extract(*_args, **_kwargs):
+        return [{"concept": "New Private Concept", "kind": "method"}]
+
+    async def fake_similar(*_args, **_kwargs):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(llm_client, "extract_paper_concepts", fake_extract)
+    monkeypatch.setattr(llm_client, "find_similar_concepts", fake_similar)
+    await sync_document_for_graph(
+        doc_id, [{"page_num": 1, "text": "private text"}], "Private paper",
+    )
+
+    assert calls == []


### PR DESCRIPTION
Enforce document policy at tag, graph, heatmap, and dashboard model boundaries so local-only data cannot reach a differently configured provider.
