### PR TITLE
fix(parser): make reparse apply atomic

### DIFF
--- a/backend/services/cache.py
+++ b/backend/services/cache.py
@@ -81,8 +81,23 @@ def clear_session_cache(session_id: str) -> None:
 _PAGES_CACHE_SUFFIX = "_pages_extract.json"
 
 
-def _pages_cache_path(doc_id: str) -> str:
-    return os.path.join(CACHE_DIR, f"{doc_id}{_PAGES_CACHE_SUFFIX}")
+def _pages_cache_path(doc_id: str, content_revision: int = 1) -> str:
+    revision = max(1, int(content_revision))
+    revision_part = "" if revision == 1 else f"_revision_{revision}"
+    return os.path.join(CACHE_DIR, f"{doc_id}{revision_part}{_PAGES_CACHE_SUFFIX}")
+
+
+def _document_content_revision(doc_id: str, content_revision: int | None) -> int:
+    if content_revision is not None:
+        return max(1, int(content_revision))
+    try:
+        from services.db import db_get_document
+        doc = db_get_document(doc_id)
+        if doc:
+            return max(1, int(doc.get("content_revision") or 1))
+    except Exception:
+        pass
+    return 1
 
 
 
@@ -104,9 +119,11 @@ def _document_parser_identity(doc_id: str, engine: str | None,
 
 
 def get_cached_pages(doc_id: str, pdf_path: str, engine: str | None = None,
-                     version: str | None = None) -> Optional[list]:
-    """Return cached pages only when PDF, parser, version, and schema all match."""
-    path = _pages_cache_path(doc_id)
+                     version: str | None = None,
+                     content_revision: int | None = None) -> Optional[list]:
+    """Return cached pages only when PDF, parser, version, revision, and schema match."""
+    revision = _document_content_revision(doc_id, content_revision)
+    path = _pages_cache_path(doc_id, revision)
     if not os.path.exists(path):
         return None
     try:
@@ -118,6 +135,7 @@ def get_cached_pages(doc_id: str, pdf_path: str, engine: str | None = None,
             data = json.load(f)
         if (
             data.get("cache_schema_version") != PAGES_CACHE_SCHEMA_VERSION
+            or int(data.get("content_revision") or 1) != revision
             or data.get("pdf_fingerprint") != pdf_fingerprint(pdf_path)
             or data.get("parser_engine") != expected_engine
             or data.get("parser_version") != expected_version
@@ -129,9 +147,11 @@ def get_cached_pages(doc_id: str, pdf_path: str, engine: str | None = None,
 
 
 def save_pages_cache(doc_id: str, pdf_path: str, pages: list, engine: str | None = None,
-                     version: str | None = None) -> None:
-    """Persist parser-aware page extraction output."""
+                     version: str | None = None, content_revision: int | None = None,
+                     strict: bool = False) -> None:
+    """Persist parser- and revision-aware page extraction output."""
     try:
+        revision = _document_content_revision(doc_id, content_revision)
         from services.pdf_diagnostics import (
             PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
         )
@@ -141,15 +161,17 @@ def save_pages_cache(doc_id: str, pdf_path: str, pages: list, engine: str | None
         actual_engine, actual_version = parser_identity(actual_engine)
         if version is not None:
             actual_version = version
-        atomic_write_text(_pages_cache_path(doc_id), json.dumps({
+        atomic_write_text(_pages_cache_path(doc_id, revision), json.dumps({
             "cache_schema_version": PAGES_CACHE_SCHEMA_VERSION,
+            "content_revision": revision,
             "pdf_fingerprint": pdf_fingerprint(pdf_path),
             "parser_engine": actual_engine,
             "parser_version": actual_version,
             "pages": pages,
         }, ensure_ascii=False))
     except Exception:
-        pass
+        if strict:
+            raise
 
 
 def clear_all_pages_cache() -> "tuple[int, int]":
@@ -172,14 +194,18 @@ def clear_all_pages_cache() -> "tuple[int, int]":
 _IMAGES_CACHE_SUFFIX = "_images_extract.json"
 
 
-def _images_cache_path(doc_id: str) -> str:
-    return os.path.join(CACHE_DIR, f"{doc_id}{_IMAGES_CACHE_SUFFIX}")
+def _images_cache_path(doc_id: str, content_revision: int = 1) -> str:
+    revision = max(1, int(content_revision))
+    revision_part = "" if revision == 1 else f"_revision_{revision}"
+    return os.path.join(CACHE_DIR, f"{doc_id}{revision_part}{_IMAGES_CACHE_SUFFIX}")
 
 
 def get_cached_images(doc_id: str, pdf_path: str, engine: str | None = None,
-                      version: str | None = None) -> Optional[list]:
-    """Return cached visual regions only for the matching parser identity."""
-    path = _images_cache_path(doc_id)
+                      version: str | None = None,
+                      content_revision: int | None = None) -> Optional[list]:
+    """Return cached visual regions only for the matching parser identity and revision."""
+    revision = _document_content_revision(doc_id, content_revision)
+    path = _images_cache_path(doc_id, revision)
     if not os.path.exists(path):
         return None
     try:
@@ -191,6 +217,7 @@ def get_cached_images(doc_id: str, pdf_path: str, engine: str | None = None,
             data = json.load(f)
         if (
             data.get("cache_schema_version") != PAGES_CACHE_SCHEMA_VERSION
+            or int(data.get("content_revision") or 1) != revision
             or data.get("pdf_fingerprint") != pdf_fingerprint(pdf_path)
             or data.get("parser_engine") != expected_engine
             or data.get("parser_version") != expected_version
@@ -202,24 +229,104 @@ def get_cached_images(doc_id: str, pdf_path: str, engine: str | None = None,
 
 
 def save_images_cache(doc_id: str, pdf_path: str, images: list, engine: str | None = None,
-                      version: str | None = None) -> None:
-    """Persist parser-aware image/table coordinates."""
+                      version: str | None = None, content_revision: int | None = None,
+                      strict: bool = False) -> None:
+    """Persist parser- and revision-aware image/table coordinates."""
     try:
+        revision = _document_content_revision(doc_id, content_revision)
         from services.pdf_diagnostics import (
             PAGES_CACHE_SCHEMA_VERSION, parser_identity, pdf_fingerprint,
         )
         actual_engine, actual_version = parser_identity(engine)
         if version is not None:
             actual_version = version
-        atomic_write_text(_images_cache_path(doc_id), json.dumps({
+        atomic_write_text(_images_cache_path(doc_id, revision), json.dumps({
             "cache_schema_version": PAGES_CACHE_SCHEMA_VERSION,
+            "content_revision": revision,
             "pdf_fingerprint": pdf_fingerprint(pdf_path),
             "parser_engine": actual_engine,
             "parser_version": actual_version,
             "images": images,
         }, ensure_ascii=False))
     except Exception:
-        pass
+        if strict:
+            raise
+
+
+def clear_parser_revision_cache(doc_id: str, content_revision: int) -> None:
+    """Remove only the parser caches staged for one content revision."""
+    for path in (
+        _pages_cache_path(doc_id, content_revision),
+        _images_cache_path(doc_id, content_revision),
+    ):
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+
+def stage_parser_revision_caches(
+    doc_id: str, pdf_path: str, pages: list, images: list,
+    engine: str, version: str, content_revision: int,
+) -> None:
+    """Write and verify an inactive parser cache revision before DB activation."""
+    revision = max(2, int(content_revision))
+    clear_parser_revision_cache(doc_id, revision)
+    try:
+        save_pages_cache(
+            doc_id, pdf_path, pages, engine, version,
+            content_revision=revision, strict=True,
+        )
+        save_images_cache(
+            doc_id, pdf_path, images, engine, version,
+            content_revision=revision, strict=True,
+        )
+        if get_cached_pages(
+            doc_id, pdf_path, engine, version, content_revision=revision,
+        ) != pages:
+            raise RuntimeError("staged_pages_cache_verification_failed")
+        if get_cached_images(
+            doc_id, pdf_path, engine, version, content_revision=revision,
+        ) != images:
+            raise RuntimeError("staged_images_cache_verification_failed")
+    except Exception:
+        clear_parser_revision_cache(doc_id, revision)
+        raise
+
+
+def clear_stale_parser_caches(doc_id: str, keep_revision: int) -> None:
+    """Best-effort cleanup after the DB points at the verified revision."""
+    keep = {
+        _pages_cache_path(doc_id, keep_revision),
+        _images_cache_path(doc_id, keep_revision),
+    }
+    prefix = f"{doc_id}_"
+    for fname in os.listdir(CACHE_DIR):
+        path = os.path.join(CACHE_DIR, fname)
+        if (
+            fname.startswith(prefix)
+            and fname.endswith((_PAGES_CACHE_SUFFIX, _IMAGES_CACHE_SUFFIX))
+            and path not in keep
+        ):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def clear_derived_session_cache(doc_id: str) -> None:
+    """Drop stale translation caches without deleting active parser revision data."""
+    prefix = f"{doc_id}_"
+    for fname in os.listdir(CACHE_DIR):
+        if not fname.startswith(prefix):
+            continue
+        if fname.endswith((_PAGES_CACHE_SUFFIX, _IMAGES_CACHE_SUFFIX)):
+            continue
+        try:
+            os.remove(os.path.join(CACHE_DIR, fname))
+        except OSError:
+            pass
 
 
 def clear_all_images_cache() -> "tuple[int, int]":
@@ -240,28 +347,22 @@ def clear_all_images_cache() -> "tuple[int, int]":
 
 
 def clear_document_cache(doc_id: str) -> "tuple[int, int]":
-    """단일 문서의 PDF 텍스트 및 이미지/표 좌표 추출 디스크 캐시를 삭제합니다.
-    (삭제한 파일 개수, 확보한 바이트 수)를 반환합니다.
-    """
+    """Delete every parser cache revision for one document."""
     count = 0
     freed_bytes = 0
-    pages_path = _pages_cache_path(doc_id)
-    if os.path.exists(pages_path):
+    prefix = f"{doc_id}_"
+    for fname in os.listdir(CACHE_DIR):
+        if not (
+            fname.startswith(prefix)
+            and fname.endswith((_PAGES_CACHE_SUFFIX, _IMAGES_CACHE_SUFFIX))
+        ):
+            continue
+        path = os.path.join(CACHE_DIR, fname)
         try:
-            freed_bytes += os.path.getsize(pages_path)
-            os.remove(pages_path)
+            freed_bytes += os.path.getsize(path)
+            os.remove(path)
             count += 1
-        except Exception:
+        except OSError:
             pass
-
-    images_path = _images_cache_path(doc_id)
-    if os.path.exists(images_path):
-        try:
-            freed_bytes += os.path.getsize(images_path)
-            os.remove(images_path)
-            count += 1
-        except Exception:
-            pass
-
     return count, freed_bytes
 

--- a/backend/services/reparse.py
+++ b/backend/services/reparse.py
@@ -308,6 +308,56 @@ def _cancel_derived_tasks(doc_id: str) -> None:
         pass
 
 
+def _snapshot_derived_tasks(doc_id: str) -> list[dict]:
+    """Capture recoverable task/page state before quiescing derived workers."""
+    from services.document_tasks import recoverable_tasks
+    return [
+        task for task in recoverable_tasks()
+        if task["doc_id"] == doc_id and task["kind"] != "parse"
+    ]
+
+
+async def _restore_derived_tasks(task_snapshots: list[dict], sessions: dict) -> None:
+    """Restore and resume work when the revision transaction did not commit."""
+    if not task_snapshots:
+        return
+
+    # Let CancelledError handlers finish first so they cannot overwrite restoration.
+    await asyncio.sleep(0)
+    with get_db() as conn:
+        for task in task_snapshots:
+            conn.execute(
+                """UPDATE document_tasks
+                   SET status = ?, attempt_count = ?, last_error_code = ?,
+                       next_retry_at = ?, cancel_requested = ?, updated_at = ?
+                   WHERE id = ?""",
+                (
+                    task["status"], int(task["attempt_count"]),
+                    task.get("last_error_code"), task.get("next_retry_at"),
+                    1 if task.get("cancel_requested") else 0,
+                    task["updated_at"], task["id"],
+                ),
+            )
+            for page in task["pages"]:
+                conn.execute(
+                    """UPDATE document_task_pages
+                       SET status = ?, attempt_count = ?, last_error_code = ?,
+                           next_retry_at = ?, updated_at = ?
+                       WHERE task_id = ? AND page_num = ?""",
+                    (
+                        page["status"], int(page["attempt_count"]),
+                        page.get("last_error_code"), page.get("next_retry_at"),
+                        page["updated_at"], task["id"], int(page["page_num"]),
+                    ),
+                )
+        conn.commit()
+
+    from services.translation_job import resume_incomplete_jobs
+    resume_incomplete_jobs(sessions)
+    from services.document_tasks import recover_document_tasks
+    recover_document_tasks(sessions)
+
+
 async def apply_preview(doc_id: str, task_id: str, sessions: dict) -> dict:
     lock = _apply_locks.setdefault(doc_id, asyncio.Lock())
     async with lock:
@@ -349,69 +399,103 @@ async def apply_preview(doc_id: str, task_id: str, sessions: dict) -> dict:
         ):
             raise RuntimeError("content_revision_conflict")
 
-        impact = preview_impact(doc_id, int(preview["source_revision"]))
-        _cancel_derived_tasks(doc_id)
         pages = payload["pages"]
         images = payload.get("images") or []
         report = payload["diagnostics"]
         engine = payload["parser_engine"]
         version = payload["parser_version"]
+        new_revision = int(preview["source_revision"]) + 1
         from services.languages import detect_document_language
         detection = detect_document_language(pages)
         from services.context_retrieval import chunk_pages
         chunks = chunk_pages(pages)
+
+        impact = preview_impact(doc_id, int(preview["source_revision"]))
+        task_snapshots = _snapshot_derived_tasks(doc_id)
+
+        # Write and verify revision-addressed caches while the current document still
+        # points at the previous revision. A staging failure has no active-state effect.
+        from services.cache import clear_parser_revision_cache, stage_parser_revision_caches
+        try:
+            stage_parser_revision_caches(
+                doc_id, pdf_path, pages, images, engine, version, new_revision,
+            )
+        except Exception as exc:
+            raise RuntimeError("reparse_cache_staging_failed") from exc
+
+        try:
+            _cancel_derived_tasks(doc_id)
+        except Exception:
+            clear_parser_revision_cache(doc_id, new_revision)
+            await _restore_derived_tasks(task_snapshots, sessions)
+            raise
         now = _now()
 
-        with get_db() as conn:
-            conn.execute("BEGIN IMMEDIATE")
-            doc = conn.execute(
-                "SELECT content_revision, metadata FROM documents WHERE id = ?", (doc_id,)
-            ).fetchone()
-            if not doc or int(doc["content_revision"]) != int(preview["source_revision"]):
-                conn.rollback()
-                raise RuntimeError("content_revision_conflict")
-            new_revision = int(doc["content_revision"]) + 1
-            try:
-                metadata = json.loads(doc["metadata"]) if doc["metadata"] else {}
-            except (TypeError, json.JSONDecodeError):
-                metadata = {}
-            for key in ("bibliography", "references", "reference_list"):
-                metadata.pop(key, None)
-            conn.execute(
-                """UPDATE documents
-                   SET total_pages = ?, metadata = ?, content_revision = ?,
-                       parser_engine = ?, parser_version = ?,
-                       detected_source_language = ?, source_language_confidence = ?
-                   WHERE id = ?""",
-                (
-                    len(pages), json.dumps(metadata, ensure_ascii=False), new_revision,
-                    engine, version, str(detection["language"]), float(detection["confidence"]), doc_id,
-                ),
-            )
-            conn.execute(
-                """INSERT INTO parsing_diagnostics
-                   (doc_id, content_revision, parser_engine, parser_version, report, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (doc_id, new_revision, engine, version, json.dumps(report, ensure_ascii=False), now),
-            )
-            conn.execute(
-                "UPDATE reparse_previews SET status = 'applied', updated_at = ? WHERE id = ?",
-                (now, task_id),
-            )
-            conn.execute("DELETE FROM document_chunks_fts WHERE doc_id = ?", (doc_id,))
-            conn.executemany(
-                "INSERT INTO document_chunks_fts(doc_id,page_num,ordinal,section,content) VALUES(?,?,?,?,?)",
-                [(doc_id, chunk["page_num"], chunk["ordinal"], chunk["section"], chunk["content"])
-                 for chunk in chunks],
-            )
-            conn.commit()
+        try:
+            with get_db() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                doc = conn.execute(
+                    "SELECT content_revision, metadata FROM documents WHERE id = ?", (doc_id,)
+                ).fetchone()
+                if not doc or int(doc["content_revision"]) != int(preview["source_revision"]):
+                    conn.rollback()
+                    raise RuntimeError("content_revision_conflict")
+                if new_revision != int(doc["content_revision"]) + 1:
+                    conn.rollback()
+                    raise RuntimeError("content_revision_conflict")
+                try:
+                    metadata = json.loads(doc["metadata"]) if doc["metadata"] else {}
+                except (TypeError, json.JSONDecodeError):
+                    metadata = {}
+                for key in ("bibliography", "references", "reference_list"):
+                    metadata.pop(key, None)
+                conn.execute(
+                    """UPDATE documents
+                       SET total_pages = ?, metadata = ?, content_revision = ?,
+                           parser_engine = ?, parser_version = ?,
+                           detected_source_language = ?, source_language_confidence = ?
+                       WHERE id = ?""",
+                    (
+                        len(pages), json.dumps(metadata, ensure_ascii=False), new_revision,
+                        engine, version, str(detection["language"]), float(detection["confidence"]), doc_id,
+                    ),
+                )
+                conn.execute(
+                    """INSERT INTO parsing_diagnostics
+                       (doc_id, content_revision, parser_engine, parser_version, report, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (doc_id, new_revision, engine, version, json.dumps(report, ensure_ascii=False), now),
+                )
+                conn.execute(
+                    "UPDATE reparse_previews SET status = 'applied', updated_at = ? WHERE id = ?",
+                    (now, task_id),
+                )
+                conn.execute("DELETE FROM document_chunks_fts WHERE doc_id = ?", (doc_id,))
+                conn.executemany(
+                    "INSERT INTO document_chunks_fts(doc_id,page_num,ordinal,section,content) VALUES(?,?,?,?,?)",
+                    [(doc_id, chunk["page_num"], chunk["ordinal"], chunk["section"], chunk["content"])
+                     for chunk in chunks],
+                )
+                conn.commit()
 
-        from services.cache import clear_session_cache, save_images_cache, save_pages_cache
-        clear_session_cache(doc_id)
-        save_pages_cache(doc_id, pdf_path, pages, engine, version)
-        save_images_cache(doc_id, pdf_path, images, engine, version)
-        from services.pdf_parser import clear_parser_memory_cache
-        clear_parser_memory_cache()
+        except Exception as apply_exc:
+            clear_parser_revision_cache(doc_id, new_revision)
+            try:
+                await _restore_derived_tasks(task_snapshots, sessions)
+            except Exception as restore_exc:
+                apply_exc.add_note(f"derived task restoration failed: {restore_exc}")
+            raise
+
+        # DB activation is authoritative. Cleanup failures must not turn a committed
+        # revision into an error response; inactive files are safe to remove later.
+        try:
+            from services.cache import clear_derived_session_cache, clear_stale_parser_caches
+            clear_derived_session_cache(doc_id)
+            clear_stale_parser_caches(doc_id, new_revision)
+            from services.pdf_parser import clear_parser_memory_cache
+            clear_parser_memory_cache()
+        except Exception:
+            pass
         indexed_chunks = len(chunks)
 
         existing = sessions.get(doc_id, {})

--- a/backend/tests/test_pdf_reparse.py
+++ b/backend/tests/test_pdf_reparse.py
@@ -296,3 +296,253 @@ def test_document_cache_clear_removes_memory_session(test_client, isolated_dirs)
     response = test_client.post("/api/library/clear-memory/clear-cache")
     assert response.status_code == 200
     assert "clear-memory" not in sessions
+
+
+
+def _candidate_staging_payload(isolated_dirs, doc_id: str, pdf_path: Path):
+    from services.pdf_diagnostics import diagnose_pages, pdf_fingerprint
+
+    pages = [{
+        "page_num": 1,
+        "text": "Verified candidate text",
+        "parser_engine": "pdfplumber",
+    }]
+    images = [{"page": 1, "label": "Figure 1"}]
+    staging_path = isolated_dirs["library_dir"] / f"{doc_id}-candidate.json"
+    staging_path.write_text(json.dumps({
+        "pdf_fingerprint": pdf_fingerprint(str(pdf_path)),
+        "parser_engine": "pdfplumber",
+        "parser_version": "test-new",
+        "pages": pages,
+        "images": images,
+        "diagnostics": diagnose_pages(
+            pages, images, "pdfplumber", "test-new",
+        ),
+    }), encoding="utf-8")
+    return staging_path, pages, images
+
+
+def test_parser_cache_revision_activates_only_after_document_switch(isolated_dirs):
+    from services.cache import (
+        clear_document_cache, get_cached_images, get_cached_pages,
+        save_images_cache, save_pages_cache, stage_parser_revision_caches,
+    )
+
+    doc_id = "revision-cache"
+    pdf_path = _make_document(isolated_dirs, doc_id)
+    old_pages = [{"page_num": 1, "text": "old", "parser_engine": "pymupdf"}]
+    old_images = [{"page": 1, "label": "Old Figure"}]
+    new_pages = [{"page_num": 1, "text": "new", "parser_engine": "pdfplumber"}]
+    new_images = [{"page": 1, "label": "New Figure"}]
+    save_pages_cache(
+        doc_id, str(pdf_path), old_pages, "pymupdf", "test-old",
+        content_revision=1, strict=True,
+    )
+    save_images_cache(
+        doc_id, str(pdf_path), old_images, "pymupdf", "test-old",
+        content_revision=1, strict=True,
+    )
+    stage_parser_revision_caches(
+        doc_id, str(pdf_path), new_pages, new_images,
+        "pdfplumber", "test-new", 2,
+    )
+
+    assert get_cached_pages(doc_id, str(pdf_path)) == old_pages
+    assert get_cached_images(doc_id, str(pdf_path)) == old_images
+
+    with isolated_dirs["db"].get_db() as conn:
+        conn.execute(
+            """UPDATE documents SET content_revision = 2,
+               parser_engine = 'pdfplumber', parser_version = 'test-new'
+               WHERE id = ?""",
+            (doc_id,),
+        )
+        conn.commit()
+
+    assert get_cached_pages(doc_id, str(pdf_path)) == new_pages
+    assert get_cached_images(doc_id, str(pdf_path)) == new_images
+    assert clear_document_cache(doc_id)[0] == 4
+    assert get_cached_pages(
+        doc_id, str(pdf_path), "pdfplumber", "test-new", content_revision=2,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_reparse_cache_staging_failure_preserves_active_state(
+    isolated_dirs, monkeypatch,
+):
+    from services import cache, reparse
+    from services.document_tasks import create_task, get_task, update_task
+
+    doc_id = "cache-stage-failure"
+    pdf_path = _make_document(isolated_dirs, doc_id)
+    staging_path, _pages, _images = _candidate_staging_payload(
+        isolated_dirs, doc_id, pdf_path,
+    )
+    preview_id = _insert_preview(isolated_dirs, doc_id, staging_path)
+    task = create_task(doc_id, "summary", {}, [1])
+    update_task(task["id"], status="running")
+    sessions = {
+        doc_id: {
+            "pages": [{"page_num": 1, "text": "active old text"}],
+            "username": "testuser",
+        },
+    }
+    cancelled = []
+    monkeypatch.setattr(
+        cache, "stage_parser_revision_caches",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(
+        reparse, "_cancel_derived_tasks", lambda value: cancelled.append(value),
+    )
+
+    with pytest.raises(RuntimeError, match="reparse_cache_staging_failed"):
+        await reparse.apply_preview(doc_id, preview_id, sessions)
+
+    document = isolated_dirs["db"].db_get_document(doc_id)
+    assert document["content_revision"] == 1
+    assert document["parser_engine"] == "pymupdf"
+    assert sessions[doc_id]["pages"][0]["text"] == "active old text"
+    assert get_task(task["id"])["status"] == "running"
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_reparse_transaction_conflict_restores_cancelled_tasks(
+    isolated_dirs, monkeypatch,
+):
+    from services import cache, reparse
+    from services.document_tasks import (
+        create_task, get_task, request_cancel, update_task,
+    )
+    import services.document_tasks as document_tasks
+    import services.translation_job as translation_job
+
+    doc_id = "transaction-conflict"
+    pdf_path = _make_document(isolated_dirs, doc_id)
+    staging_path, _pages, _images = _candidate_staging_payload(
+        isolated_dirs, doc_id, pdf_path,
+    )
+    preview_id = _insert_preview(isolated_dirs, doc_id, staging_path)
+    task = create_task(doc_id, "summary", {}, [1])
+    update_task(task["id"], status="running")
+    sessions = {
+        doc_id: {
+            "pages": [{"page_num": 1, "text": "active old text"}],
+            "username": "testuser",
+        },
+    }
+
+    def cancel_then_conflict(value):
+        assert value == doc_id
+        request_cancel(task["id"])
+        with isolated_dirs["db"].get_db() as conn:
+            conn.execute(
+                "UPDATE documents SET content_revision = 2 WHERE id = ?",
+                (doc_id,),
+            )
+            conn.commit()
+
+    monkeypatch.setattr(reparse, "_cancel_derived_tasks", cancel_then_conflict)
+    monkeypatch.setattr(
+        translation_job, "resume_incomplete_jobs", lambda _sessions: None,
+    )
+    monkeypatch.setattr(
+        document_tasks, "recover_document_tasks", lambda _sessions: None,
+    )
+
+    with pytest.raises(RuntimeError, match="content_revision_conflict"):
+        await reparse.apply_preview(doc_id, preview_id, sessions)
+
+    restored = get_task(task["id"])
+    assert restored["status"] == "running"
+    assert restored["cancel_requested"] is False
+    assert restored["pages"][0]["status"] == "queued"
+    assert sessions[doc_id]["pages"][0]["text"] == "active old text"
+    assert cache.get_cached_pages(
+        doc_id, str(pdf_path), "pdfplumber", "test-new", content_revision=2,
+    ) is None
+
+
+
+@pytest.mark.asyncio
+async def test_reparse_cancel_failure_restores_tasks_and_discards_stage(
+    isolated_dirs, monkeypatch,
+):
+    from services import cache, reparse
+    from services.document_tasks import (
+        create_task, get_task, request_cancel, update_task,
+    )
+    import services.document_tasks as document_tasks
+    import services.translation_job as translation_job
+
+    doc_id = "cancel-failure"
+    pdf_path = _make_document(isolated_dirs, doc_id)
+    staging_path, _pages, _images = _candidate_staging_payload(
+        isolated_dirs, doc_id, pdf_path,
+    )
+    preview_id = _insert_preview(isolated_dirs, doc_id, staging_path)
+    task = create_task(doc_id, "summary", {}, [1])
+    update_task(task["id"], status="running")
+    sessions = {
+        doc_id: {
+            "pages": [{"page_num": 1, "text": "active old text"}],
+            "username": "testuser",
+        },
+    }
+
+    def partial_cancel_then_fail(_doc_id):
+        request_cancel(task["id"])
+        raise RuntimeError("worker cancellation failed")
+
+    monkeypatch.setattr(reparse, "_cancel_derived_tasks", partial_cancel_then_fail)
+    monkeypatch.setattr(
+        translation_job, "resume_incomplete_jobs", lambda _sessions: None,
+    )
+    monkeypatch.setattr(
+        document_tasks, "recover_document_tasks", lambda _sessions: None,
+    )
+
+    with pytest.raises(RuntimeError, match="worker cancellation failed"):
+        await reparse.apply_preview(doc_id, preview_id, sessions)
+
+    restored = get_task(task["id"])
+    assert restored["status"] == "running"
+    assert restored["cancel_requested"] is False
+    assert isolated_dirs["db"].db_get_document(doc_id)["content_revision"] == 1
+    assert cache.get_cached_pages(
+        doc_id, str(pdf_path), "pdfplumber", "test-new", content_revision=2,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_reparse_cleanup_failure_does_not_mask_committed_apply(
+    isolated_dirs, monkeypatch,
+):
+    from services import cache, reparse
+
+    doc_id = "cleanup-failure"
+    pdf_path = _make_document(isolated_dirs, doc_id)
+    staging_path, pages, _images = _candidate_staging_payload(
+        isolated_dirs, doc_id, pdf_path,
+    )
+    preview_id = _insert_preview(isolated_dirs, doc_id, staging_path)
+    sessions = {
+        doc_id: {
+            "pages": [{"page_num": 1, "text": "active old text"}],
+            "username": "testuser",
+        },
+    }
+    monkeypatch.setattr(reparse, "_cancel_derived_tasks", lambda _doc_id: None)
+    monkeypatch.setattr(
+        cache, "clear_derived_session_cache",
+        lambda _doc_id: (_ for _ in ()).throw(OSError("cleanup failed")),
+    )
+
+    result = await reparse.apply_preview(doc_id, preview_id, sessions)
+
+    assert result["status"] == "applied"
+    assert result["content_revision"] == 2
+    assert isolated_dirs["db"].db_get_document(doc_id)["content_revision"] == 2
+    assert sessions[doc_id]["pages"] == pages


### PR DESCRIPTION
Makes reparse application atomic across revision-addressed parser caches, document metadata, diagnostics, and FTS activation. Restores derived task state if cancellation or the database transaction fails, while keeping post-commit cleanup best-effort.\n\nTests: 568 backend tests passed.