### PR TITLE
fix(tasks): resume parsing after restart

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -1,8 +1,6 @@
 import uuid
 import os
 import shutil
-import asyncio
-import json
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from fastapi.responses import JSONResponse
 import aiofiles
@@ -10,10 +8,9 @@ from services.auth import get_current_user
 
 from config import UPLOAD_DIR, MAX_FILE_SIZE_MB
 from services.pdf_parser import extract_pages, get_pdf_metadata
-from services.library import save_document, get_document, get_pdf_path as lib_pdf_path, list_documents
+from services.library import get_document, get_pdf_path as lib_pdf_path, list_documents
 from services.translation_job import start_job, resume_incomplete_jobs, get_job_status
 from services.insight_job import start_keyword_job, start_summary_job
-from services.primer import generate_primer
 from services.rate_limiter import enforce_rate_limit
 from models.schemas import UploadResponse
 
@@ -21,7 +18,6 @@ router = APIRouter()
 
 # 메모리 내 세션 저장소
 sessions: dict = {}
-LONG_DOCUMENT_PAGE_THRESHOLD = 50
 
 
 def ensure_session(session_id: str) -> bool:
@@ -218,185 +214,44 @@ async def upload_pdf(
 
     file_size_mb = total_bytes / (1024 * 1024)
 
-    # PDF 파싱
-    from services.document_tasks import create_task, update_task
-    parse_task = create_task(session_id, "parse", {"filename": file.filename}, status="running")
-    try:
-        metadata = get_pdf_metadata(pdf_path)
-        pages = extract_pages(pdf_path)
-        update_task(parse_task["id"], status="succeeded")
-    except Exception as e:
-        update_task(parse_task["id"], status="failed", last_error_code="invalid_pdf")
-        shutil.rmtree(session_dir, ignore_errors=True)
-        raise HTTPException(status_code=422, detail=f"PDF 파싱 실패: {str(e)}")
-
-    from services.languages import detect_document_language
-    detection = detect_document_language(pages)
-    detected_source_language = str(detection["language"])
-    resolved_source_language = source_lang if source_lang != "auto" else detected_source_language
-    source_supported = bool(detection["supported"]) if source_lang == "auto" else True
-
-    # 라이브러리에 영구 저장
-    save_document(
-        session_id, file.filename, pdf_path, len(pages), metadata,
-        username=current_user, document_mode=document_mode, document_type=document_type,
-        source_language=source_lang, detected_source_language=detected_source_language,
-        source_language_confidence=float(detection["confidence"]),
-        preferred_target_language=target_lang,
-        content_revision=1,
-        parser_engine=((pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"),
-        parser_version=__import__("services.pdf_diagnostics", fromlist=["parser_version"]).parser_version(
-            (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
-        ),
-    )
-
-    active_parser_engine = (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
-    from services.pdf_diagnostics import diagnose_pages, parser_version
-    active_parser_version = parser_version(active_parser_engine)
-    persistent_pdf_path = lib_pdf_path(session_id)
-    detected_images = []
-    if persistent_pdf_path:
-        from services.cache import save_images_cache, save_pages_cache
-        save_pages_cache(session_id, persistent_pdf_path, pages, active_parser_engine, active_parser_version)
-        try:
-            from services.pdf_parser import extract_pdf_images
-            detected_images = await asyncio.to_thread(extract_pdf_images, persistent_pdf_path, active_parser_engine)
-            save_images_cache(
-                session_id, persistent_pdf_path, detected_images,
-                active_parser_engine, active_parser_version,
-            )
-        except Exception:
-            detected_images = []
-    initial_report = diagnose_pages(
-        pages, detected_images, active_parser_engine, active_parser_version,
-    )
-    from services.db import get_db
-    from datetime import datetime, timezone
-    with get_db() as conn:
-        conn.execute(
-            """INSERT OR REPLACE INTO parsing_diagnostics
-               (doc_id, content_revision, parser_engine, parser_version, report, created_at)
-               VALUES (?, 1, ?, ?, ?, ?)""",
-            (
-                session_id, active_parser_engine, active_parser_version,
-                json.dumps(initial_report, ensure_ascii=False),
-                datetime.now(timezone.utc).isoformat(),
-            ),
-        )
-        conn.commit()
-
-    from services.context_retrieval import index_document_chunks
-    indexed_chunks = index_document_chunks(session_id, pages)
-    from services.observability import record_document_mode_event
-    record_document_mode_event(
-        current_user, "upload", document_mode, document_type,
-        numeric_value=len(pages), status="indexed" if indexed_chunks else "fallback",
-    )
-
-    # 세션 저장 (메모리)
-    sessions[session_id] = {
-        "pdf_path": pdf_path,
+    # 원본 경로와 업로드 옵션을 먼저 영속 작업에 기록한다. 문서 행이 아직
+    # 생성되지 않은 시점에 서버가 종료되어도 이 정보만으로 실제 파싱과
+    # 라이브러리 최종화를 다시 수행할 수 있다.
+    from services.document_tasks import create_task
+    parse_options = {
         "filename": file.filename,
-        "pages": pages,
-        "total_pages": len(pages),
-        "metadata": metadata,
-        "from_library": False,
+        "file_size_mb": file_size_mb,
         "username": current_user,
+        "target_lang": target_lang,
+        "source_lang": source_lang,
+        "style": style,
+        "ignore_math": ignore_math,
+        "ignore_table": ignore_table,
+        "ignore_refs": ignore_refs,
+        "translation_mode": translation_mode,
+        "keyword_mode": keyword_mode,
+        "summary_mode": summary_mode,
         "document_mode": document_mode,
         "document_type": document_type,
-        "source_language": source_lang,
-        "detected_source_language": detected_source_language,
-        "source_language_confidence": detection["confidence"],
-        "preferred_target_language": target_lang,
-        "processing_policy": "inherit",
-        "content_revision": 1,
-        "parser_engine": (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf",
-        "parser_version": __import__("services.pdf_diagnostics", fromlist=["parser_version"]).parser_version(
-            (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
-        ),
     }
-
-    # translation_mode가 "auto"(기본값)가 아니면 - 페이지 번역 버튼을 누를 때(pane) 또는
-    # 스크롤로 페이지를 볼 때(scroll)만 번역하길 원하는 사용자이므로 - 업로드
-    # 직후 전체 문서를 자동으로 번역하는 백그라운드 잡을 시작하지 않는다.
-    # auto를 선택했더라도 50페이지 이상이면 긴 문서 보호 정책에 따라 전체 잡을
-    # 시작하지 않고, 프런트엔드가 실제로 본 페이지만 지연 번역한다. 이후
-    # 번역은 프런트엔드가 /translate/{id}/{page}를 호출해 페이지별로 트리거한다.
-    #
-    # auto 번역 잡은 선택 기능인 읽기 전 브리핑에 의존하지 않도록
-    # 업로드 응답 전에 즉시 등록한다. 이렇게 해야 primer LLM이 느리거나
-    # 멈춰도 job status가 404로 남지 않고 번역이 진행된다. 문서당 세션을
-    # 재사용하는 CLI provider의 실제 LLM 호출은 llm_client의 세션 락이
-    # 직렬화하므로 동시에 같은 세션을 쓰지 않는다.
-    translation_skipped_reason = None
-    if not source_supported:
-        translation_skipped_reason = "unsupported_source_language"
-    elif resolved_source_language == target_lang:
-        translation_skipped_reason = "same_source_and_target_language"
-    if translation_mode == "auto" and len(pages) < LONG_DOCUMENT_PAGE_THRESHOLD and translation_skipped_reason is None:
-        start_job(
-            session_id,
-            pages,
-            target_lang=target_lang,
-            source_lang=resolved_source_language,
-            style=style,
-            ignore_math=ignore_math,
-            ignore_table=ignore_table,
-            ignore_refs=ignore_refs
+    parse_task = create_task(session_id, "parse", parse_options, status="queued")
+    from services.parse_job import execute_parse_task
+    try:
+        parsed = await execute_parse_task(
+            parse_task["id"], sessions,
+            page_extractor=extract_pages,
+            metadata_reader=get_pdf_metadata,
+            translation_starter=start_job,
+            keyword_starter=start_keyword_job,
+            summary_starter=start_summary_job,
+            upload_root=UPLOAD_DIR,
         )
+    except Exception as exc:
+        shutil.rmtree(session_dir, ignore_errors=True)
+        raise HTTPException(status_code=422, detail=f"PDF 파싱 실패: {exc}") from exc
 
-    async def _run_post_upload_insights():
-        try:
-            if document_mode == "research":
-                await generate_primer(
-                    session_id,
-                    pages,
-                    metadata,
-                    username=current_user,
-                    pdf_path=pdf_path,
-                    target_lang=target_lang,
-                    source_lang=resolved_source_language,
-                    session_id=session_id,
-                )
-        except Exception as e:
-            print(f"[Upload {session_id}] Primer 생성 실패: {e}")
-
-        if keyword_mode == "auto":
-            # 일반 장문 문서는 예상 LLM 호출량을 사용자가 확인한 뒤 별도
-            # insight-jobs API로 시작한다. 20페이지 이하는 기존 자동 흐름 유지.
-            if document_mode != "general" or len(pages) <= 20:
-                start_keyword_job(
-                    session_id, pages, target_lang,
-                    metadata.get("title") or file.filename, document_mode, document_type,
-                )
-
-        if summary_mode == "auto":
-            start_summary_job(
-                session_id,
-                pages,
-                target_lang,
-                metadata.get("title") or file.filename,
-                document_mode,
-                document_type,
-            )
-
-    asyncio.create_task(_run_post_upload_insights())
-
-    return UploadResponse(
-        session_id=session_id,
-        filename=file.filename,
-        total_pages=len(pages),
-        file_size_mb=round(file_size_mb, 2),
-        metadata=metadata,
-        document_mode=document_mode,
-        document_type=document_type,
-        source_language=source_lang,
-        detected_source_language=detected_source_language,
-        source_language_confidence=float(detection["confidence"]),
-        preferred_target_language=target_lang,
-        translation_skipped_reason=translation_skipped_reason,
-    )
-
+    parsed["file_size_mb"] = round(file_size_mb, 2)
+    return UploadResponse(**parsed)
 
 
 @router.get("/session/{session_id}")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -794,6 +794,29 @@ def db_save_document(
         "parser_version": parser_version,
     }
 
+
+def db_finalize_document_parse(
+    doc_id: str, total_pages: int, metadata: dict,
+    detected_source_language: str, source_language_confidence: Optional[float],
+    parser_engine: str, parser_version: Optional[str],
+) -> bool:
+    """Finalize an existing document without replacing its related records."""
+    with get_db() as conn:
+        cursor = conn.execute(
+            """UPDATE documents
+               SET total_pages = ?, metadata = ?, detected_source_language = ?,
+                   source_language_confidence = ?, parser_engine = ?, parser_version = ?
+               WHERE id = ?""",
+            (
+                int(total_pages), json.dumps(metadata, ensure_ascii=False),
+                detected_source_language, source_language_confidence,
+                parser_engine, parser_version, doc_id,
+            ),
+        )
+        conn.commit()
+    return cursor.rowcount == 1
+
+
 def db_get_document(doc_id: str) -> Optional[dict]:
     with get_db() as conn:
         cursor = conn.cursor()

--- a/backend/services/document_tasks.py
+++ b/backend/services/document_tasks.py
@@ -284,7 +284,7 @@ def migrate_legacy_translation(doc_id: str, legacy: dict) -> dict:
 def legacy_translation_view(task: dict) -> dict:
     status_map = {
         "queued": "running", "running": "running", "retry_wait": "running",
-        "succeeded": "completed", "partial_failed": "completed", "failed": "failed", "cancelled": "cancelled",
+        "succeeded": "completed", "partial_failed": "completed_with_errors", "failed": "failed", "cancelled": "cancelled",
     }
     return {
         "task_id": task["id"], "session_id": task["doc_id"],
@@ -300,14 +300,16 @@ def legacy_translation_view(task: dict) -> dict:
 def recover_document_tasks(sessions: dict) -> None:
     """Requeue incomplete durable work after sessions have been restored."""
     for task in recoverable_tasks():
+        if task["kind"] == "parse":
+            from services.parse_job import resume_parse_task
+            resume_parse_task(task["id"], sessions)
+            continue
         session = sessions.get(task["doc_id"])
         if not session:
             continue
         if task["kind"] == "translate":
             continue
-        if task["kind"] == "parse":
-            update_task(task["id"], status="succeeded")
-        elif task["kind"] in {"keywords", "summary"}:
+        if task["kind"] in {"keywords", "summary"}:
             from services.insight_job import start_keyword_job, start_summary_job
             starter = start_keyword_job if task["kind"] == "keywords" else start_summary_job
             options = task["options"]

--- a/backend/services/parse_job.py
+++ b/backend/services/parse_job.py
@@ -1,0 +1,303 @@
+"""Durable PDF parsing and upload finalization."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from config import UPLOAD_DIR
+from services.document_tasks import get_task, update_task
+
+LONG_DOCUMENT_PAGE_THRESHOLD = 50
+_running_parse_tasks: dict[str, asyncio.Task] = {}
+
+
+def _source_path(doc_id: str, configured_path: str | None, upload_root: str) -> str:
+    expected = os.path.realpath(os.path.join(upload_root, doc_id, "document.pdf"))
+    actual = os.path.realpath(configured_path or expected)
+    if actual != expected:
+        raise ValueError("invalid_parse_source_path")
+    if not os.path.isfile(actual):
+        raise FileNotFoundError("parse_source_missing")
+    return actual
+
+
+async def execute_parse_task(
+    task_id: str,
+    sessions: dict,
+    *,
+    page_extractor: Optional[Callable] = None,
+    metadata_reader: Optional[Callable] = None,
+    translation_starter: Optional[Callable] = None,
+    primer_starter: Optional[Callable] = None,
+    keyword_starter: Optional[Callable] = None,
+    summary_starter: Optional[Callable] = None,
+    upload_root: str | None = None,
+) -> dict:
+    """Parse one persisted upload and finish every document-facing artifact."""
+    upload_root = upload_root or UPLOAD_DIR
+    task = get_task(task_id)
+    if not task or task["kind"] != "parse":
+        raise ValueError("parse_task_not_found")
+    if task["cancel_requested"] or task["status"] == "cancelled":
+        raise asyncio.CancelledError
+    if int(task["attempt_count"]) >= int(task["max_attempts"]):
+        update_task(task_id, status="failed", last_error_code="parse_attempts_exhausted")
+        raise RuntimeError("parse_attempts_exhausted")
+
+    options = task["options"]
+    doc_id = task["doc_id"]
+    try:
+        pdf_path = _source_path(doc_id, options.get("pdf_path"), upload_root)
+    except ValueError:
+        update_task(task_id, status="failed", last_error_code="invalid_parse_source_path")
+        raise
+    except FileNotFoundError:
+        update_task(task_id, status="failed", last_error_code="parse_source_missing")
+        raise
+
+    if metadata_reader is None or page_extractor is None:
+        from services.pdf_parser import extract_pages, get_pdf_metadata
+        metadata_reader = metadata_reader or get_pdf_metadata
+        page_extractor = page_extractor or extract_pages
+
+    update_task(
+        task_id, status="running", last_error_code=None,
+        next_retry_at=None, increment_attempt=True,
+    )
+    try:
+        metadata, pages = await asyncio.gather(
+            asyncio.to_thread(metadata_reader, pdf_path),
+            asyncio.to_thread(page_extractor, pdf_path),
+        )
+        if not isinstance(pages, list):
+            raise ValueError("invalid_parser_output")
+    except asyncio.CancelledError:
+        update_task(task_id, status="cancelled", cancel_requested=True)
+        raise
+    except Exception:
+        update_task(task_id, status="failed", last_error_code="invalid_pdf")
+        raise
+
+    from services.languages import detect_document_language
+    detection = detect_document_language(pages)
+    source_lang = options.get("source_lang", "auto")
+    target_lang = options.get("target_lang", "ko")
+    detected_source_language = str(detection["language"])
+    resolved_source_language = source_lang if source_lang != "auto" else detected_source_language
+    source_supported = bool(detection["supported"]) if source_lang == "auto" else True
+    active_parser_engine = (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
+    from services.pdf_diagnostics import diagnose_pages, parser_version
+    active_parser_version = parser_version(active_parser_engine)
+
+    try:
+        from services.library import get_document, get_pdf_path, save_document
+        existing = get_document(doc_id)
+        if existing:
+            from services.db import db_finalize_document_parse
+            db_finalize_document_parse(
+                doc_id, len(pages), metadata, detected_source_language,
+                float(detection["confidence"]), active_parser_engine, active_parser_version,
+            )
+            persistent_pdf_path = get_pdf_path(doc_id)
+            if not persistent_pdf_path or not os.path.isfile(persistent_pdf_path):
+                raise FileNotFoundError("persisted_pdf_missing")
+        else:
+            save_document(
+                doc_id, options.get("filename") or "document.pdf", pdf_path,
+                len(pages), metadata, username=options.get("username", "admin"),
+                document_mode=options.get("document_mode", "research"),
+                document_type=options.get("document_type", "research_paper"),
+                source_language=source_lang,
+                detected_source_language=detected_source_language,
+                source_language_confidence=float(detection["confidence"]),
+                preferred_target_language=target_lang,
+                content_revision=1, parser_engine=active_parser_engine,
+                parser_version=active_parser_version,
+            )
+            persistent_pdf_path = get_pdf_path(doc_id)
+
+        from services.cache import save_images_cache, save_pages_cache
+        save_pages_cache(
+            doc_id, persistent_pdf_path, pages, active_parser_engine,
+            active_parser_version, strict=True,
+        )
+        detected_images = []
+        try:
+            from services.pdf_parser import extract_pdf_images
+            detected_images = await asyncio.to_thread(
+                extract_pdf_images, persistent_pdf_path, active_parser_engine,
+            )
+            save_images_cache(
+                doc_id, persistent_pdf_path, detected_images,
+                active_parser_engine, active_parser_version, strict=True,
+            )
+        except Exception:
+            detected_images = []
+
+        initial_report = diagnose_pages(
+            pages, detected_images, active_parser_engine, active_parser_version,
+        )
+        from services.db import get_db
+        with get_db() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO parsing_diagnostics
+                   (doc_id, content_revision, parser_engine, parser_version, report, created_at)
+                   VALUES (?, 1, ?, ?, ?, ?)""",
+                (
+                    doc_id, active_parser_engine, active_parser_version,
+                    json.dumps(initial_report, ensure_ascii=False),
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            conn.commit()
+
+        from services.context_retrieval import index_document_chunks
+        indexed_chunks = index_document_chunks(doc_id, pages)
+        if not existing:
+            from services.observability import record_document_mode_event
+            record_document_mode_event(
+                options.get("username", "admin"), "upload",
+                options.get("document_mode", "research"),
+                options.get("document_type", "research_paper"),
+                numeric_value=len(pages), status="indexed" if indexed_chunks else "fallback",
+            )
+    except asyncio.CancelledError:
+        update_task(task_id, status="cancelled", cancel_requested=True)
+        raise
+    except Exception:
+        update_task(task_id, status="failed", last_error_code="parse_persistence_failed")
+        raise
+
+    sessions[doc_id] = {
+        "pdf_path": pdf_path,
+        "filename": options.get("filename") or "document.pdf",
+        "pages": pages,
+        "total_pages": len(pages),
+        "metadata": metadata,
+        "from_library": False,
+        "username": options.get("username", "admin"),
+        "document_mode": options.get("document_mode", "research"),
+        "document_type": options.get("document_type", "research_paper"),
+        "source_language": source_lang,
+        "detected_source_language": detected_source_language,
+        "source_language_confidence": detection["confidence"],
+        "preferred_target_language": target_lang,
+        "processing_policy": "inherit",
+        "content_revision": 1,
+        "parser_engine": active_parser_engine,
+        "parser_version": active_parser_version,
+    }
+
+    translation_skipped_reason = None
+    if not source_supported:
+        translation_skipped_reason = "unsupported_source_language"
+    elif resolved_source_language == target_lang:
+        translation_skipped_reason = "same_source_and_target_language"
+
+    from services.document_tasks import latest_task
+    if translation_starter is None:
+        from services.translation_job import start_job
+        translation_starter = start_job
+    if (
+        latest_task(doc_id, "translate") is None
+        and options.get("translation_mode", "auto") == "auto"
+        and len(pages) < LONG_DOCUMENT_PAGE_THRESHOLD
+        and translation_skipped_reason is None
+    ):
+        translation_starter(
+            doc_id, pages, target_lang=target_lang,
+            source_lang=resolved_source_language,
+            style=options.get("style", "academic"),
+            ignore_math=bool(options.get("ignore_math", False)),
+            ignore_table=bool(options.get("ignore_table", True)),
+            ignore_refs=bool(options.get("ignore_refs", False)),
+        )
+
+    if primer_starter is None:
+        from routers.primer import _ensure_generation_started
+        primer_starter = _ensure_generation_started
+    if keyword_starter is None or summary_starter is None:
+        from services.insight_job import start_keyword_job, start_summary_job
+        keyword_starter = keyword_starter or start_keyword_job
+        summary_starter = summary_starter or start_summary_job
+
+    async def _run_followups() -> None:
+        try:
+            if (
+                options.get("document_mode", "research") == "research"
+                and latest_task(doc_id, "primer") is None
+            ):
+                primer_starter(
+                    doc_id, target_lang, resolved_source_language, sessions[doc_id],
+                    options.get("username", "admin"),
+                )
+        except Exception as exc:
+            print(f"[Upload {doc_id}] Primer 생성 실패: {exc}")
+        if (
+            options.get("keyword_mode", "manual") == "auto"
+            and latest_task(doc_id, "keywords") is None
+        ):
+            if options.get("document_mode", "research") != "general" or len(pages) <= 20:
+                keyword_starter(
+                    doc_id, pages, target_lang,
+                    metadata.get("title") or options.get("filename", "document.pdf"),
+                    options.get("document_mode", "research"),
+                    options.get("document_type", "research_paper"),
+                    resolved_source_language,
+                )
+        if (
+            options.get("summary_mode", "manual") == "auto"
+            and latest_task(doc_id, "summary") is None
+        ):
+            summary_starter(
+                doc_id, pages, target_lang,
+                metadata.get("title") or options.get("filename", "document.pdf"),
+                options.get("document_mode", "research"),
+                options.get("document_type", "research_paper"),
+                resolved_source_language,
+            )
+
+    asyncio.create_task(_run_followups())
+    await asyncio.sleep(0)
+    update_task(task_id, status="succeeded", last_error_code=None)
+    return {
+        "session_id": doc_id,
+        "filename": options.get("filename") or "document.pdf",
+        "total_pages": len(pages),
+        "file_size_mb": float(options.get("file_size_mb") or 0),
+        "metadata": metadata,
+        "document_mode": options.get("document_mode", "research"),
+        "document_type": options.get("document_type", "research_paper"),
+        "source_language": source_lang,
+        "detected_source_language": detected_source_language,
+        "source_language_confidence": float(detection["confidence"]),
+        "preferred_target_language": target_lang,
+        "translation_skipped_reason": translation_skipped_reason,
+    }
+
+
+def resume_parse_task(task_id: str, sessions: dict) -> asyncio.Task | None:
+    """Resume an orphaned upload directly from its server-owned source file."""
+    existing = _running_parse_tasks.get(task_id)
+    if existing is not None and not existing.done():
+        return existing
+    task = get_task(task_id)
+    if not task or task["status"] not in {"queued", "running", "retry_wait"}:
+        return None
+    worker = asyncio.create_task(execute_parse_task(task_id, sessions))
+    _running_parse_tasks[task_id] = worker
+
+    def _finished(done: asyncio.Task) -> None:
+        _running_parse_tasks.pop(task_id, None)
+        try:
+            done.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
+    worker.add_done_callback(_finished)
+    return worker

--- a/backend/tests/test_document_tasks.py
+++ b/backend/tests/test_document_tasks.py
@@ -100,6 +100,7 @@ def test_legacy_translation_json_migrates_once(isolated_dirs, monkeypatch):
     first = translation_job.get_job_status(doc_id)
     second = translation_job.get_job_status(doc_id)
     assert first["task_status"] == "partial_failed"
+    assert first["status"] == "completed_with_errors"
     assert first["failed_pages"] == [3]
     assert second["task_id"] == first["task_id"]
     assert len(list_tasks(doc_id)) == 1
@@ -151,3 +152,147 @@ def test_unsupported_retry_does_not_mutate_task(test_client, isolated_dirs):
     current = get_task(task["id"])
     assert current["status"] == "failed"
     assert current["last_error_code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_orphaned_parse_task_rebuilds_document_after_restart(isolated_dirs, monkeypatch):
+    from services import parse_job, pdf_parser
+    from services.document_tasks import create_task, get_task, recover_document_tasks
+    from services.library import get_document
+
+    doc_id = "recover-upload"
+    source_dir = isolated_dirs["upload_dir"] / doc_id
+    source_dir.mkdir()
+    source_path = source_dir / "document.pdf"
+    source_path.write_bytes(b"server-owned-pdf")
+    monkeypatch.setattr(parse_job, "UPLOAD_DIR", str(isolated_dirs["upload_dir"]))
+    monkeypatch.setattr(pdf_parser, "get_pdf_metadata", lambda _path: {"title": "Recovered"})
+    monkeypatch.setattr(
+        pdf_parser, "extract_pages",
+        lambda _path: [{"page_num": 1, "text": "A recoverable English document."}],
+    )
+    monkeypatch.setattr(pdf_parser, "extract_pdf_images", lambda *_args: [])
+    task = create_task(doc_id, "parse", {
+        "filename": "recovered.pdf",
+        "username": "testuser",
+        "translation_mode": "scroll",
+        "document_mode": "general",
+        "document_type": "report",
+        "source_lang": "en",
+        "target_lang": "ko",
+    }, status="running")
+
+    sessions = {}
+    recover_document_tasks(sessions)
+    for _ in range(100):
+        if get_task(task["id"])["status"] not in {"queued", "running", "retry_wait"}:
+            break
+        await asyncio.sleep(0.01)
+
+    recovered = get_task(task["id"])
+    assert recovered["status"] == "succeeded", (recovered["last_error_code"], recovered["options"])
+    assert recovered["attempt_count"] == 1
+    assert get_document(doc_id)["total_pages"] == 1
+    assert sessions[doc_id]["metadata"]["title"] == "Recovered"
+    assert sessions[doc_id]["pages"][0]["text"].startswith("A recoverable")
+
+
+@pytest.mark.asyncio
+async def test_parse_recovery_rejects_task_path_outside_upload_root(isolated_dirs, monkeypatch):
+    from services import parse_job
+    from services.document_tasks import create_task, get_task
+
+    outside = isolated_dirs["upload_dir"].parent / "outside.pdf"
+    outside.write_bytes(b"not-owned")
+    monkeypatch.setattr(parse_job, "UPLOAD_DIR", str(isolated_dirs["upload_dir"]))
+    task = create_task("path-tamper", "parse", {
+        "pdf_path": str(outside), "filename": "outside.pdf", "username": "testuser",
+    })
+
+    with pytest.raises(ValueError, match="invalid_parse_source_path"):
+        await parse_job.execute_parse_task(task["id"], {}, upload_root=str(isolated_dirs["upload_dir"]))
+    current = get_task(task["id"])
+    assert current["status"] == "failed"
+    assert current["last_error_code"] == "invalid_parse_source_path"
+
+
+def test_translation_retry_api_runs_only_failed_pages(test_client, isolated_dirs, monkeypatch):
+    from routers import upload
+    from services import translation_job
+    from services.document_tasks import create_task, finish_from_pages, get_task, update_page
+
+    doc_id = _doc(isolated_dirs, "retry-failed-translation")
+    upload.sessions[doc_id] = {
+        "username": "testuser",
+        "pages": [
+            {"page_num": 1, "text": "done"},
+            {"page_num": 2, "text": "retry"},
+            {"page_num": 3, "text": "done"},
+        ],
+        "metadata": {}, "filename": "paper.pdf",
+        "document_mode": "research", "document_type": "research_paper",
+    }
+    task = create_task(doc_id, "translate", {"target_lang": "ko"}, [1, 2, 3])
+    update_page(task["id"], 1, "succeeded")
+    update_page(task["id"], 2, "failed", last_error_code="generation_failed")
+    update_page(task["id"], 3, "succeeded")
+    finish_from_pages(task["id"])
+    starts = []
+    monkeypatch.setattr(translation_job, "start_job", lambda *args, **kwargs: starts.append((args, kwargs)))
+
+    try:
+        response = test_client.post(f"/api/tasks/{task['id']}/retry")
+        assert response.status_code == 200
+        assert starts[0][1]["page_numbers"] == [2]
+        assert starts[0][1]["durable_task_id"] == task["id"]
+        pages = {page["page_num"]: page["status"] for page in get_task(task["id"])["pages"]}
+        assert pages == {1: "succeeded", 2: "queued", 3: "succeeded"}
+    finally:
+        upload.sessions.pop(doc_id, None)
+
+
+@pytest.mark.asyncio
+async def test_recovered_parse_finalization_preserves_existing_results(isolated_dirs, monkeypatch):
+    from services import parse_job, pdf_parser
+    from services.document_tasks import create_task, update_task
+    from services.library import get_translation, save_translation
+
+    doc_id = "recover-finalize"
+    source_dir = isolated_dirs["upload_dir"] / doc_id
+    source_dir.mkdir()
+    (source_dir / "document.pdf").write_bytes(b"server-owned-pdf")
+    monkeypatch.setattr(parse_job, "UPLOAD_DIR", str(isolated_dirs["upload_dir"]))
+    monkeypatch.setattr(pdf_parser, "extract_pdf_images", lambda *_args: [])
+    task = create_task(doc_id, "parse", {
+        "filename": "recover.pdf", "username": "testuser",
+        "translation_mode": "auto", "document_mode": "general",
+        "document_type": "report", "source_lang": "en", "target_lang": "ko",
+    })
+    translation_starts = []
+
+    def start_translation(*_args, **_kwargs):
+        translation_starts.append(1)
+        create_task(doc_id, "translate", {"target_lang": "ko"}, [1], status="running")
+
+    dependencies = {
+        "page_extractor": lambda _path: [{"page_num": 1, "text": "First parse."}],
+        "metadata_reader": lambda _path: {"title": "First"},
+        "translation_starter": start_translation,
+        "primer_starter": lambda *_args, **_kwargs: None,
+        "keyword_starter": lambda *_args, **_kwargs: None,
+        "summary_starter": lambda *_args, **_kwargs: None,
+        "upload_root": str(isolated_dirs["upload_dir"]),
+    }
+    await parse_job.execute_parse_task(task["id"], {}, **dependencies)
+    save_translation(doc_id, 1, "preserved", "test")
+    update_task(task["id"], status="running")
+    dependencies["metadata_reader"] = lambda _path: {"title": "Recovered"}
+
+    await parse_job.execute_parse_task(task["id"], {}, **dependencies)
+    assert get_translation(doc_id, 1, "test", fallback=False) == "preserved"
+    assert translation_starts == [1]
+    with isolated_dirs["db"].get_db() as conn:
+        metric_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM document_mode_metrics WHERE event = 'upload'"
+        ).fetchone()["count"]
+    assert metric_count == 1

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -8,6 +8,7 @@ MAX_FILE_SIZE_MB를 검사해서, 한도를 아무리 작게 잡아도 큰 업�
 
 import fitz
 import routers.upload as upload_module
+import routers.primer as primer_router
 
 
 def _minimal_pdf_bytes() -> bytes:
@@ -62,13 +63,13 @@ def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, m
         events.append("translation")
         return {"status": "running"}
 
-    async def fake_generate_primer(*args, **kwargs):
+    def fake_generate_primer(*args, **kwargs):
         events.append("primer")
         assert events[0] == "translation"
         return {}
 
     monkeypatch.setattr(upload_module, "start_job", fake_start_job)
-    monkeypatch.setattr(upload_module, "generate_primer", fake_generate_primer)
+    monkeypatch.setattr(primer_router, "_ensure_generation_started", fake_generate_primer)
 
     res = test_client.post(
         "/api/upload?translation_mode=auto&source_lang=en",
@@ -95,11 +96,11 @@ def test_auto_translation_skips_full_job_at_fifty_pages(test_client, isolated_di
         starts.append((args, kwargs))
         return {"status": "running"}
 
-    async def fake_generate_primer(*args, **kwargs):
+    def fake_generate_primer(*args, **kwargs):
         return {}
 
     monkeypatch.setattr(upload_module, "start_job", fake_start_job)
-    monkeypatch.setattr(upload_module, "generate_primer", fake_generate_primer)
+    monkeypatch.setattr(primer_router, "_ensure_generation_started", fake_generate_primer)
 
     response = test_client.post(
         "/api/upload?translation_mode=auto",
@@ -119,10 +120,10 @@ def test_auto_translation_does_not_start_for_undetermined_source(test_client, is
     starts = []
     monkeypatch.setattr(upload_module, "start_job", lambda *args, **kwargs: starts.append(kwargs))
 
-    async def no_primer(*args, **kwargs):
+    def no_primer(*args, **kwargs):
         return {}
 
-    monkeypatch.setattr(upload_module, "generate_primer", no_primer)
+    monkeypatch.setattr(primer_router, "_ensure_generation_started", no_primer)
     response = test_client.post(
         "/api/upload?translation_mode=auto",
         files={"file": ("empty.pdf", _minimal_pdf_bytes(), "application/pdf")},

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3863,6 +3863,9 @@
   "viewer:task.failedPages": {
     "description": "Persistent document task recovery UI text."
   },
+  "viewer:task.retryingFailed": {
+    "description": "Status shown while retrying failed translation pages."
+  },
   "chat:retrySameQuestion": {
     "description": "Persistent document task recovery UI text."
   },

--- a/frontend/src/locales/en/viewer.json
+++ b/frontend/src/locales/en/viewer.json
@@ -18,6 +18,7 @@
   "task.retryWaiting": "Waiting to retry",
   "task.transientError": "Temporary error",
   "task.failedPages": "{{count}} failed pages",
+  "task.retryingFailed": "Retrying failed translation items...",
   "a11y.chatResizer": "Resize AI chat panel",
   "a11y.graphResizer": "Resize graph details panel",
   "a11y.chatPanel": "AI assistant",

--- a/frontend/src/locales/ko/viewer.json
+++ b/frontend/src/locales/ko/viewer.json
@@ -18,6 +18,7 @@
   "task.retryWaiting": "재시도 대기",
   "task.transientError": "일시 오류",
   "task.failedPages": "실패 {{count}}페이지",
+  "task.retryingFailed": "실패한 번역 항목을 다시 시도하는 중...",
   "a11y.chatResizer": "AI 채팅 패널 크기 조절",
   "a11y.graphResizer": "그래프 상세 패널 크기 조절",
   "a11y.chatPanel": "AI 어시스턴트",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,7 @@ import { compareDocsByLastRead } from './readPages.js'
 import { buildScholarSearchUrl, extractCitationTitle } from './citationSearch.js'
 import { changeLocale, getLocale, initI18n, loadFeatureNamespaces, loadNamespaces, t } from './i18n.js'
 import { saveUserLanguagePreferences, saveDocumentLanguageOverride } from './languagePreferences.js'
+import { canRetryTranslationTask, isTranslationTaskRunning, shouldRetryFailedTranslationTask } from './translationTaskState.js'
 
 const i18nReady = initI18n()
 
@@ -69,6 +70,8 @@ const state = {
   translatingPages: new Set(), // 현재 번역 중인 페이지 (폴링 중복 방지용)
   translatedPages: new Set(),  // 번역 완료된 페이지
   pollingTimer: null,          // 잡 폴링 타이머
+  translationTaskId: null,     // 현재 영속 번역 작업 ID
+  translationTaskStatus: null, // queued/running/partial_failed/...
   username: 'admin',           // 현재 로그인한 사용자명 저장
   chatHistory: [],             // AI 채팅 히스토리
   chatActiveStream: null,      // 현재 활성화된 채팅 스트림 abort 함수
@@ -1644,9 +1647,11 @@ function startJobPolling(sessionId) {
         }
       }
 
+      state.translationTaskId = job.task_id || null
+      state.translationTaskStatus = job.task_status || null
       const done  = (job.completed_pages || []).length
       const total = job.total_pages || state.totalPages
-      const isRunning = ['running', 'pending'].includes(job.status) || job.task_status === 'retry_wait'
+      const isRunning = isTranslationTaskRunning(job)
       updateProgressMiniRaw(done, total, isRunning)
       if (job.task_status === 'retry_wait') {
         progressMiniText.textContent = job.next_retry_at ? t('viewer:task.retryAt', { time: new Date(job.next_retry_at).toLocaleTimeString() }) : t('viewer:task.retryWaiting')
@@ -1660,11 +1665,8 @@ function startJobPolling(sessionId) {
         resumeTransBtn.classList.add('hidden')
       } else {
         cancelTransBtn.classList.add('hidden')
-        if (job.status !== 'completed') {
-          resumeTransBtn.classList.remove('hidden')
-        } else {
-          resumeTransBtn.classList.add('hidden')
-        }
+        const canRetry = canRetryTranslationTask(job)
+        resumeTransBtn.classList.toggle('hidden', !canRetry)
         clearInterval(state.pollingTimer)
         state.pollingTimer = null
       }
@@ -2210,8 +2212,12 @@ resumeTransBtn.addEventListener('click', async () => {
   if (!state.sessionId) return
 
   try {
-    showToast('중단된 지점부터 번역을 재개하는 중...', 'info')
-    await restartJobAPI(state.sessionId, { ...getTranslationOptions(), resumeScope: true })
+    const retryFailedTask = shouldRetryFailedTranslationTask(
+      state.translationTaskId, state.translationTaskStatus,
+    )
+    showToast(retryFailedTask ? t('viewer:task.retryingFailed') : '중단된 지점부터 번역을 재개하는 중...', 'info')
+    if (retryFailedTask) await retryDocumentTaskAPI(state.translationTaskId)
+    else await restartJobAPI(state.sessionId, { ...getTranslationOptions(), resumeScope: true })
     startJobPolling(state.sessionId)
     showToast('번역이 이어서 재개되었습니다.', 'success')
   } catch (err) {

--- a/frontend/src/translationTaskState.js
+++ b/frontend/src/translationTaskState.js
@@ -1,0 +1,16 @@
+const ACTIVE_TASK_STATUSES = new Set(['queued', 'running', 'retry_wait'])
+const RETRYABLE_TASK_STATUSES = new Set(['partial_failed', 'failed', 'cancelled'])
+
+export function isTranslationTaskRunning(job = {}) {
+  return ['running', 'pending'].includes(job.status)
+    || ACTIVE_TASK_STATUSES.has(job.task_status)
+}
+
+export function canRetryTranslationTask(job = {}) {
+  return RETRYABLE_TASK_STATUSES.has(job.task_status)
+    || !['completed', 'succeeded'].includes(job.status)
+}
+
+export function shouldRetryFailedTranslationTask(taskId, taskStatus) {
+  return Boolean(taskId && RETRYABLE_TASK_STATUSES.has(taskStatus))
+}

--- a/frontend/tests/translationTaskState.test.js
+++ b/frontend/tests/translationTaskState.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  canRetryTranslationTask,
+  isTranslationTaskRunning,
+  shouldRetryFailedTranslationTask,
+} from '../src/translationTaskState.js'
+
+test('partial translation failure is terminal and retryable', () => {
+  const job = { status: 'completed_with_errors', task_status: 'partial_failed' }
+  assert.equal(isTranslationTaskRunning(job), false)
+  assert.equal(canRetryTranslationTask(job), true)
+  assert.equal(shouldRetryFailedTranslationTask('task-1', job.task_status), true)
+})
+
+test('successful translation is not offered for retry', () => {
+  const job = { status: 'completed', task_status: 'succeeded' }
+  assert.equal(isTranslationTaskRunning(job), false)
+  assert.equal(canRetryTranslationTask(job), false)
+  assert.equal(shouldRetryFailedTranslationTask('task-1', job.task_status), false)
+})
+
+test('queued and retry-wait tasks remain active', () => {
+  assert.equal(isTranslationTaskRunning({ status: 'running', task_status: 'queued' }), true)
+  assert.equal(isTranslationTaskRunning({ status: 'running', task_status: 'retry_wait' }), true)
+})


### PR DESCRIPTION
Adds a durable parse worker that rebuilds orphaned uploads from validated server-owned source paths, preserves existing derived data during replay, and avoids duplicate follow-up work. Exposes partial translation failures distinctly and retries only failed or cancelled pages from the viewer.\n\nTests: 572 backend tests; 52 frontend unit tests; i18n validation; production build.