### PR TITLE
fix(chat): validate grounded context

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -102,6 +102,28 @@ def _sse(event: str, payload: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
+def _validated_selected_text(
+    pages: list[dict], current_page: int | None, selected_text: str | None,
+) -> str | None:
+    if not (selected_text or "").strip():
+        return None
+    if not current_page:
+        raise HTTPException(status_code=400, detail={
+            "code": "selected_text_requires_viewer_page",
+            "params": {},
+            "fallback": "Selected text requires an active viewer page.",
+        })
+    from services.context_retrieval import resolve_page_selected_text
+    canonical = resolve_page_selected_text(pages, current_page, selected_text)
+    if canonical is None:
+        raise HTTPException(status_code=400, detail={
+            "code": "selected_text_not_on_page",
+            "params": {"page_num": current_page},
+            "fallback": "Selected text was not found on the current document page.",
+        })
+    return canonical
+
+
 async def _semantic_verify_answer(answer: str, evidence: list[dict], session_id: str) -> dict:
     if not evidence:
         return {"mode": "structural_only", "status": "no_cited_evidence"}
@@ -151,13 +173,14 @@ async def chat_stream(data: ChatRequest, current_user: str = Depends(get_current
             "params": {"page_num": current_page, "total_pages": total_pages},
             "fallback": "The requested viewer page is outside this document.",
         })
+    selected_text = _validated_selected_text(pages, current_page, data.selected_text)
     enforce_rate_limit("chat", current_user)
     from time import perf_counter
     from services.context_retrieval import retrieve_context
     retrieval_started = perf_counter()
     context_result = retrieve_context(
         session_id, pages, latest_question, current_page=current_page,
-        selected_text=data.selected_text,
+        selected_text=selected_text,
         content_revision=int(session.get("content_revision") or 1),
     )
     paper_text = context_result.text
@@ -296,15 +319,23 @@ async def chat_suggestions(data: ChatRequest, current_user: str = Depends(get_cu
     session = require_session_owner(session_id, current_user)
     from services.processing_policy import ensure_processing_allowed
     ensure_processing_allowed(session, "chat")
-    enforce_rate_limit("chat", current_user)
 
     pages = session.get("pages", [])
+    total_pages = max((int(page.get("page_num") or 0) for page in pages), default=0)
+    if data.current_page and data.current_page > total_pages:
+        raise HTTPException(status_code=400, detail={
+            "code": "screen_page_out_of_range",
+            "params": {"page_num": data.current_page, "total_pages": total_pages},
+            "fallback": "The requested viewer page is outside this document.",
+        })
+    selected_text = _validated_selected_text(pages, data.current_page, data.selected_text)
+    enforce_rate_limit("chat", current_user)
     history_messages = [{"role": msg.role, "content": msg.content} for msg in data.messages]
     latest_question = data.messages[-1].content if data.messages else ""
     from services.context_retrieval import retrieve_context
     paper_text = retrieve_context(
         session_id, pages, latest_question, current_page=data.current_page,
-        selected_text=data.selected_text, budget=6000, max_chunks=5,
+        selected_text=selected_text, budget=6000, max_chunks=5,
     ).text
 
     filename = session.get("filename", "알 수 없음")

--- a/backend/services/context_retrieval.py
+++ b/backend/services/context_retrieval.py
@@ -144,6 +144,34 @@ def _chunk_evidence(doc_id: str, revision: int, chunk: dict, page: dict) -> dict
     }
 
 
+def resolve_page_selected_text(
+    pages: list[dict], page_num: int, selected_text: str | None,
+) -> str | None:
+    """Return the canonical source substring only when it exists on the page."""
+    selection = (selected_text or "").strip()
+    if not selection:
+        return None
+    page = next(
+        (item for item in pages if int(item.get("page_num") or 0) == int(page_num)),
+        None,
+    )
+    if page is None:
+        return None
+    source = str(page.get("text") or "")
+    exact_start = source.find(selection)
+    if exact_start >= 0:
+        return source[exact_start:exact_start + len(selection)]
+
+    # Browser text selection and PDF extraction commonly disagree only on line
+    # breaks or repeated spaces. Match those boundaries flexibly, but return the
+    # original server-side substring rather than any client-provided characters.
+    parts = re.split(r"\s+", selection)
+    if not parts:
+        return None
+    match = re.search(r"\s+".join(re.escape(part) for part in parts), source)
+    return match.group(0) if match else None
+
+
 def retrieve_context(doc_id: str, pages: list[dict], question: str, current_page: int | None = None,
                      selected_text: str | None = None, budget: int = 40000, max_chunks: int = 14,
                      content_revision: int = 1) -> ContextResult:

--- a/backend/tests/test_grounded_screen_context.py
+++ b/backend/tests/test_grounded_screen_context.py
@@ -248,3 +248,103 @@ def test_screen_page_range_is_validated_before_rate_accounting(test_client, grou
     assert response.status_code == 400
     assert response.json()["code"] == "screen_page_out_of_range"
     assert calls == []
+
+
+def test_selected_text_is_resolved_to_canonical_page_source():
+    from services.context_retrieval import resolve_page_selected_text
+
+    pages = [{"page_num": 2, "text": "Grounded accuracy\n  improves by 12 percent."}]
+    assert resolve_page_selected_text(
+        pages, 2, "Grounded accuracy improves by 12 percent.",
+    ) == "Grounded accuracy\n  improves by 12 percent."
+    assert resolve_page_selected_text(pages, 2, "invented statement") is None
+
+
+def test_forged_selected_text_is_rejected_before_rate_or_llm(
+    test_client, grounded_doc, isolated_dirs, monkeypatch,
+):
+    import routers.chat as chat_router
+    calls = []
+    monkeypatch.setattr(chat_router, "enforce_rate_limit", lambda *_args: calls.append("rate"))
+
+    async def forbidden_stream(*_args, **_kwargs):
+        calls.append("llm")
+        yield "unexpected"
+
+    monkeypatch.setattr(chat_router, "stream_chat", forbidden_stream)
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "question"}],
+        "selected_text": "This forged text is not in the PDF.",
+        "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": False},
+    })
+    assert response.status_code == 400
+    assert response.json()["code"] == "selected_text_not_on_page"
+    assert calls == []
+    assert isolated_dirs["db"].db_get_chat_history("grounded-doc", include_revision=True) == []
+
+
+def test_standalone_chat_rejects_selected_text_without_viewer_page(
+    test_client, grounded_doc, monkeypatch,
+):
+    import routers.chat as chat_router
+    calls = []
+    monkeypatch.setattr(chat_router, "enforce_rate_limit", lambda *_args: calls.append(True))
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "question"}],
+        "selected_text": "Figure 1 shows the grounded accuracy result.",
+        "screen_context": {"mode": "standalone", "include_visual": False},
+    })
+    assert response.status_code == 400
+    assert response.json()["code"] == "selected_text_requires_viewer_page"
+    assert calls == []
+
+
+def test_valid_selected_text_uses_server_canonical_quote(
+    test_client, grounded_doc, monkeypatch,
+):
+    import routers.chat as chat_router
+    prompts = []
+
+    async def fake_stream(system_prompt, messages, session_id=None, page_image_b64=None):
+        prompts.append(system_prompt)
+        evidence_id = re.search(r"\[E:(ev_[A-Za-z0-9_-]+)\]", system_prompt).group(1)
+        yield "Supported [E:" + evidence_id + "]."
+
+    monkeypatch.setattr(chat_router, "stream_chat", fake_stream)
+    monkeypatch.setattr("config.get_chat_provider", lambda: "openai")
+    monkeypatch.setattr("config.get_chat_model", lambda: "model")
+    response = test_client.post("/api/chat/stream", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "explain selection"}],
+        "selected_text": "Figure 1   shows the grounded accuracy result.",
+        "screen_context": {"mode": "viewer", "page_num": 1, "include_visual": False},
+    })
+    events = dict(_events(response))
+    assert response.status_code == 200
+    assert "Figure 1 shows the grounded accuracy result." in prompts[0]
+    assert events["evidence"]["items"][0]["quote"] == "Figure 1 shows the grounded accuracy result."
+
+
+def test_suggestions_reject_forged_selection_before_rate_accounting(
+    test_client, grounded_doc, monkeypatch,
+):
+    import routers.chat as chat_router
+    calls = []
+    monkeypatch.setattr(chat_router, "enforce_rate_limit", lambda *_args: calls.append("rate"))
+
+    async def forbidden_suggestions(*_args, **_kwargs):
+        calls.append("llm")
+        return []
+
+    monkeypatch.setattr(chat_router, "generate_suggested_questions", forbidden_suggestions)
+    response = test_client.post("/api/chat/suggestions", json={
+        "session_id": "grounded-doc",
+        "messages": [{"role": "user", "content": "question"}],
+        "current_page": 1,
+        "selected_text": "This forged text is not in the PDF.",
+    })
+    assert response.status_code == 400
+    assert response.json()["code"] == "selected_text_not_on_page"
+    assert calls == []

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -4024,5 +4024,11 @@
   },
   "viewer:a11y.previewSize": {
     "description": "Live announcement of a resized figure preview."
+  },
+  "errors:selected_text_requires_viewer_page": {
+    "description": "Selected-text requests without an active viewer page."
+  },
+  "errors:selected_text_not_on_page": {
+    "description": "Selected text that cannot be verified against the server-side page source."
   }
 }

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -8,5 +8,7 @@
   "generation_failed": "Generation failed. Please try again.",
   "network": "Could not connect to the server.",
   "external_processing_blocked": "This document allows local processing only. Select a loopback Ollama provider for {{operation}}.",
-  "invalid_processing_policy": "Unsupported document processing policy."
+  "invalid_processing_policy": "Unsupported document processing policy.",
+  "selected_text_requires_viewer_page": "Selected text can only be used from the current document viewer page.",
+  "selected_text_not_on_page": "Selected text was not found in the source of page {{page_num}}."
 }

--- a/frontend/src/locales/ko/errors.json
+++ b/frontend/src/locales/ko/errors.json
@@ -8,5 +8,7 @@
   "generation_failed": "생성하지 못했습니다. 다시 시도해 주세요.",
   "network": "서버에 연결할 수 없습니다.",
   "external_processing_blocked": "이 문서는 로컬 처리만 허용합니다. {{operation}} 작업에는 loopback 주소의 Ollama를 선택하세요.",
-  "invalid_processing_policy": "지원하지 않는 문서 처리 정책입니다."
+  "invalid_processing_policy": "지원하지 않는 문서 처리 정책입니다.",
+  "selected_text_requires_viewer_page": "선택한 본문은 문서 뷰어의 현재 페이지에서만 사용할 수 있습니다.",
+  "selected_text_not_on_page": "선택한 본문을 현재 {{page_num}}페이지 원문에서 찾을 수 없습니다."
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5707,7 +5707,7 @@ if (compareBackBtn) {
 // 떠 있고, 드로어만 그 위에 열고 닫는다.
 let chatDrawerState = { docId: null, doc: null, history: [], activeStream: null, currentText: '' }
 
-function renderChatDrawerMessage(role, content, isHtml = false) {
+function renderChatDrawerMessage(role, content, isHtml = false, showActions = true) {
   const msgEl = document.createElement('div')
   msgEl.className = `chat-message ${role}`
 
@@ -5717,7 +5717,7 @@ function renderChatDrawerMessage(role, content, isHtml = false) {
   else bubbleEl.textContent = content
   msgEl.appendChild(bubbleEl)
 
-  if (content) appendChatDrawerActionButtons(msgEl, role, content)
+  if (content && showActions) appendChatDrawerActionButtons(msgEl, role, content)
 
   chatDrawerMessages.appendChild(msgEl)
   chatDrawerMessages.scrollTop = chatDrawerMessages.scrollHeight
@@ -5751,6 +5751,20 @@ function appendChatDrawerActionButtons(msgEl, role, content) {
     }
   })
   actionsEl.appendChild(copyBtn)
+
+  if (role === 'assistant') {
+    const verifyBtn = document.createElement('button')
+    verifyBtn.type = 'button'
+    verifyBtn.className = 'msg-action-btn'
+    verifyBtn.innerHTML = icon('checkCircle', 12) + escapeHtml(t('chat:evidence.verifyAction'))
+    verifyBtn.title = t('chat:evidence.verifyAction')
+    verifyBtn.addEventListener('click', () => {
+      if (chatDrawerState.activeStream) return
+      chatDrawerInput.value = t('chat:evidence.verifyPrompt')
+      sendChatDrawerMessage()
+    })
+    actionsEl.appendChild(verifyBtn)
+  }
   msgEl.appendChild(actionsEl)
 }
 
@@ -5787,7 +5801,7 @@ function renderChatDrawerGreeting(doc) {
     `<strong>${escapeHtml(title)}</strong>에 대해 무엇이든 물어보세요.<br><br>` +
     `<strong>${icon('info', 13, 'style="vertical-align:-2px;margin-right:3px"')}질문 예시:</strong>` +
     `<ul><li>이 논문의 핵심 기여는 무엇인가요?</li><li>실험 설정을 요약해줄 수 있나요?</li><li>이 방법론의 한계점은 뭔가요?</li></ul>`,
-    true)
+    true, false)
 }
 
 // location.hash 대입은 popstate/hashchange를 둘 다 발생시킬 수 있어(openCompareScreen과
@@ -5820,8 +5834,16 @@ async function openChatDrawer(doc) {
       renderChatDrawerGreeting(doc)
     } else {
       savedHistory.forEach(msg => {
-        const renderedContent = msg.role === 'assistant' ? formatChatHtml(msg.content) : formatUserChatHtml(msg.content, doc.id)
-        renderChatDrawerMessage(msg.role, renderedContent, true)
+        const isAssistant = msg.role === 'assistant'
+        let renderedContent = isAssistant ? formatChatHtml(msg.content, Number(doc.total_pages) || 0) : formatUserChatHtml(msg.content, doc.id)
+        if (isAssistant && msg.stale) {
+          renderedContent = `<span class="chat-stale-revision-badge">${t("chat:staleRevision")}</span>${renderedContent}`
+        }
+        const messageElement = renderChatDrawerMessage(msg.role, renderedContent, true)
+        if (isAssistant && msg.evidence?.length) {
+          attachEvidenceToBubble(messageElement.querySelector('.message-bubble'), msg.evidence)
+        }
+        if (isAssistant && msg.verification) renderVerificationBadge(messageElement, msg.verification)
         chatDrawerState.history.push({ role: msg.role, content: msg.content })
       })
     }
@@ -5874,6 +5896,8 @@ async function sendChatDrawerMessage() {
   let accumulatedText = ''
   let replyBubble = null
   let firstToken = true
+  let responseEvidence = []
+  let responseVerification = null
   chatDrawerState.currentText = ''
 
   chatDrawerState.activeStream = streamChatAPI(
@@ -5889,7 +5913,7 @@ async function sendChatDrawerMessage() {
       }
       accumulatedText += token
       chatDrawerState.currentText = accumulatedText
-      replyBubble.innerHTML = formatChatHtml(accumulatedText)
+      replyBubble.innerHTML = formatChatHtml(accumulatedText, Number(chatDrawerState.doc?.total_pages) || 0)
       chatDrawerMessages.scrollTop = chatDrawerMessages.scrollHeight
     },
     // onDone
@@ -5897,8 +5921,12 @@ async function sendChatDrawerMessage() {
       chatDrawerState.activeStream = null
       chatDrawerState.history.push({ role: 'assistant', content: accumulatedText })
       if (replyBubble) {
-        replyBubble.innerHTML = formatChatHtml(accumulatedText)
-        if (replyBubble.parentElement) appendChatDrawerActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+        replyBubble.innerHTML = formatChatHtml(accumulatedText, Number(chatDrawerState.doc?.total_pages) || 0)
+        attachEvidenceToBubble(replyBubble, responseEvidence)
+        if (replyBubble.parentElement) {
+          renderVerificationBadge(replyBubble.parentElement, responseVerification)
+          appendChatDrawerActionButtons(replyBubble.parentElement, 'assistant', accumulatedText)
+        }
       }
       chatDrawerInput.disabled = false
       updateChatDrawerSendBtnIcon(false)
@@ -5908,16 +5936,57 @@ async function sendChatDrawerMessage() {
     (err) => {
       removeChatDrawerTypingIndicator()
       chatDrawerState.activeStream = null
+      const retryButton = `<button type="button" class="chat-retry-message-btn" data-chat-drawer-retry="${encodeURIComponent(text)}">${t('chat:retrySameQuestion')}</button>`
       if (firstToken) {
-        renderChatDrawerMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>`, true)
+        renderChatDrawerMessage('assistant', `<span class="chat-error-text">${icon('alertTriangle', 13, 'style="vertical-align:-2px;margin-right:3px"')}답변 중 오류가 발생했습니다: ${escapeHtml(err.message)}</span>${retryButton}`, true)
       } else if (replyBubble) {
-        replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${err.message}]</span>`
+        replyBubble.innerHTML += `<br><br><span style="color: var(--error);">[오류: ${escapeHtml(err.message)}]</span>${retryButton}`
       }
       chatDrawerInput.disabled = false
       updateChatDrawerSendBtnIcon(false)
       chatDrawerInput.focus()
+    },
+    null,
+    {
+      screenContext: { mode: 'standalone', include_visual: false },
+      verifyEvidence: /근거\s*검증|verify\s+(?:the\s+)?evidence/i.test(text),
+    },
+    (eventName, payload) => {
+      if (eventName === 'evidence') responseEvidence = payload?.items || []
+      if (eventName === 'verification') responseVerification = payload
     }
   )
+}
+
+if (chatDrawerMessages) {
+  chatDrawerMessages.addEventListener('click', event => {
+    const retryButton = event.target.closest('[data-chat-drawer-retry]')
+    if (retryButton) {
+      const question = decodeURIComponent(retryButton.dataset.chatDrawerRetry || '')
+      const errorMessage = retryButton.closest('.chat-message')
+      const userMessage = errorMessage?.previousElementSibling
+      const lastHistory = chatDrawerState.history.at(-1)
+      if (lastHistory?.role === 'user' && lastHistory.content === question) {
+        chatDrawerState.history.pop()
+        if (userMessage?.classList.contains('user')) userMessage.remove()
+      }
+      errorMessage?.remove()
+      chatDrawerInput.value = question
+      sendChatDrawerMessage()
+      return
+    }
+    const citation = event.target.closest('[data-page-citation]')
+    if (!citation || !chatDrawerState.docId) return
+    const page = Number(citation.dataset.pageCitation)
+    if (!Number.isInteger(page) || page < 1) return
+    const docId = chatDrawerState.docId
+    const params = new URLSearchParams({ id: docId, page: String(page) })
+    const quote = citation.dataset.evidenceQuote
+    if (quote) params.set('quote', quote)
+    params.set('occurrence', citation.dataset.evidenceOccurrence || '1')
+    closeChatDrawer()
+    location.hash = 'viewer?' + params.toString()
+  })
 }
 
 if (chatDrawerSendBtn) {
@@ -13589,7 +13658,7 @@ function resetChatUI() {
   chatInput.style.height = 'auto'
 }
 
-function formatChatHtml(text) {
+function formatChatHtml(text, totalPages = state.totalPages) {
   if (!text) return ''
 
   // 0. 문장 정렬용 태그([S0], [S1] 등) 제거
@@ -13661,7 +13730,7 @@ function formatChatHtml(text) {
   })
 
   // sanitizer를 통과한 뒤 숫자로 검증한 단일·범위 페이지 근거만 링크한다.
-  return linkPageCitations(html, state.totalPages)
+  return linkPageCitations(html, totalPages)
 }
 
 // 인용 이미지를 로컬/서버 어디서도 복원하지 못했을 때(<img onerror>에서 호출)
@@ -16645,6 +16714,8 @@ function viewerAnnotationTargetFromParams(params) {
     memoId: params.get('memoId') || null,
     startOffset: toOptionalInt('start'),
     endOffset: toOptionalInt('end'),
+    quote: params.get('quote') || null,
+    occurrence: Math.max(1, parseInt(params.get('occurrence'), 10) || 1),
   }
 }
 
@@ -16670,6 +16741,10 @@ function findViewerAnnotationElement(target) {
 async function navigateToViewerAnnotation(target) {
   if (!target || target.page > state.totalPages) return
   scrollToPage(viewerScrollContainer, target.page, { instant: true })
+  if (target.quote) {
+    await locateTermInPdf(target.page, target.quote, target.occurrence)
+    return
+  }
 
   const hasExactAnchor = target.memoId || target.startOffset !== null
   if (!hasExactAnchor) return

--- a/frontend/tests/api-install-stream.test.js
+++ b/frontend/tests/api-install-stream.test.js
@@ -63,3 +63,28 @@ test("document chat parses named SSE events across chunk boundaries", async () =
   const body = JSON.parse(requests[0].options.body)
   assert.deepEqual(body.screen_context, { mode: "viewer", page_num: 2, include_visual: null })
 })
+
+
+test('standalone document chat sends no viewer page or visual context', async () => {
+  const requests = []
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options })
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: done\ndata: {}\n\n'))
+        controller.close()
+      },
+    })
+    return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+  }
+
+  await new Promise((resolve, reject) => {
+    streamChatAPI('doc', [{ role: 'user', content: 'question' }],
+      () => {}, resolve, reject, null,
+      { screenContext: { mode: 'standalone', include_visual: false } })
+  })
+  const body = JSON.parse(requests[0].options.body)
+  assert.deepEqual(body.screen_context, { mode: 'standalone', include_visual: false })
+  assert.equal(body.current_page, undefined)
+  assert.equal(body.selected_text, undefined)
+})

--- a/frontend/tests/e2e/chat-grounding-parity.spec.js
+++ b/frontend/tests/e2e/chat-grounding-parity.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+const documentRecord = {
+  id: 'grounded-chat-doc', filename: 'grounded.pdf', total_pages: 1,
+  created_at: '2026-01-01T00:00:00Z', metadata: { title: 'Grounded Paper' },
+  translated_pages: [], document_mode: 'research', document_type: 'research_paper',
+  source_language: 'en', detected_source_language: 'en', preferred_target_language: 'ko',
+  processing_policy: 'inherit', content_revision: 1,
+}
+
+function sse(frames) {
+  return frames.map(([name, payload]) =>
+    'event: ' + name + '\ndata: ' + JSON.stringify(payload) + '\n\n'
+  ).join('')
+}
+
+test('standalone chat renders evidence and retries one failed question without duplication', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [documentRecord] })
+  await page.route('**/api/chat/sessions*', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ sessions: [{
+      doc_id: documentRecord.id, title: 'Grounded Paper', filename: 'grounded.pdf',
+      created_at: documentRecord.created_at, last_message_at: documentRecord.created_at,
+      document_mode: 'research', document_type: 'research_paper',
+    }] }),
+  }))
+  await page.route('**/api/library/grounded-chat-doc/pdf', route => route.fulfill({
+    status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A,
+  }))
+  await page.route('**/api/chat/grounded-chat-doc/history', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ history: [
+      { role: 'user', content: 'saved question', content_revision: 1, stale: false },
+      {
+        role: 'assistant', content: 'Saved answer [p.1]', content_revision: 1, stale: false,
+        evidence: [{ evidence_id: 'ev_saved', page_num: 1, section: 'Saved', quote: 'Saved source.', occurrence: 1 }],
+        verification: { status: 'verified_structure', risks: [] },
+      },
+    ] }),
+  }))
+
+  const requests = []
+  let failedOnce = false
+  await page.route('**/api/chat/stream', async route => {
+    const body = route.request().postDataJSON()
+    requests.push(body)
+    const question = body.messages.at(-1)?.content
+    if (question === 'fail once' && !failedOnce) {
+      failedOnce = true
+      return route.fulfill({
+        status: 200, contentType: 'text/event-stream',
+        body: sse([
+          ['context', { mode: 'standalone', page_num: null, visual_included: false }],
+          ['error', { code: 'chat_stream_failed', message: 'temporary failure' }],
+          ['done', { failed: true }],
+        ]),
+      })
+    }
+    const answer = question === 'fail once' ? 'Recovered answer [p.1]' : 'Grounded answer [p.1]'
+    return route.fulfill({
+      status: 200, contentType: 'text/event-stream',
+      body: sse([
+        ['context', { mode: 'standalone', page_num: null, visual_included: false }],
+        ['answer', { delta: answer }],
+        ['evidence', { items: [{
+          evidence_id: 'ev_grounded', page_num: 1, section: 'Results',
+          quote: 'Grounded source quote.', translation_quote: '근거 원문 번역.', occurrence: 1,
+        }] }],
+        ['verification', { status: 'verified_structure', risks: [] }],
+        ['done', { answer_message_id: 7 }],
+      ]),
+    })
+  })
+
+  await gotoApp(page)
+  await page.click('.sidebar-nav-item[data-page="chats"]')
+  await page.click('.aic-action-btn[data-action="chat"]')
+  await expect(page.locator('#chat-drawer')).toHaveClass(/open/)
+  await expect(page.locator('#chat-drawer-messages [data-evidence-id="ev_saved"]')).toBeVisible()
+  await expect(page.locator('#chat-drawer-messages .chat-verification-badge').first()).toBeVisible()
+
+  await page.fill('#chat-drawer-input', 'ground this')
+  await page.click('#chat-drawer-send-btn')
+  const citation = page.locator('#chat-drawer-messages [data-page-citation="1"]').last()
+  await expect(citation).toBeVisible()
+  await expect(citation.locator('.chat-evidence-card')).toHaveCount(1)
+  await expect(page.locator('#chat-drawer-messages .chat-verification-badge').last()).toBeVisible()
+  expect(requests[0].screen_context).toEqual({ mode: 'standalone', include_visual: false })
+  expect(requests[0].current_page).toBeUndefined()
+  expect(requests[0].selected_text).toBeUndefined()
+
+  await page.fill('#chat-drawer-input', 'fail once')
+  await page.click('#chat-drawer-send-btn')
+  const retry = page.locator('#chat-drawer-messages [data-chat-drawer-retry]')
+  await expect(retry).toBeVisible()
+  await retry.click()
+  await expect(page.locator('#chat-drawer-messages .message-bubble').filter({ hasText: 'Recovered answer' })).toBeVisible()
+  const retriedBody = requests.at(-1)
+  expect(retriedBody.messages.filter(message => message.role === 'user' && message.content === 'fail once')).toHaveLength(1)
+
+  await citation.click()
+  await expect.poll(() => new URL(page.url()).hash).toContain('#viewer?id=grounded-chat-doc&page=1')
+  expect(new URL(page.url()).hash).toContain('quote=Grounded+source+quote.')
+})


### PR DESCRIPTION
## Summary
- validates viewer selections against canonical server-side page text before retrieval and rate accounting
- rejects forged or standalone selections with localized structured errors
- brings standalone chat evidence cards, verification state, stale revision badges, retry, and citation navigation in line with viewer chat
- adds backend, frontend unit, and Playwright regression coverage

## Tests
- backend: 577 passed
- frontend unit: 53 passed
- locale validation: passed
- production build: passed
- Playwright: 65 passed