### PR TITLE
fix(a11y): correct viewer popover roles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -469,10 +469,10 @@
         <!-- 추가 메뉴(케밥): 번역 상태/모델, 번역 관리(다시 번역/중지/이어서/다운로드),
              메모 숨기기, 테마 전환을 한데 모아 툴바를 간결하게 유지한다. -->
         <div class="kebab-wrapper">
-          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴" aria-haspopup="menu" aria-expanded="false" aria-controls="toolbar-kebab-menu">
+          <button id="toolbar-kebab-btn" class="icon-btn" title="추가 메뉴" aria-haspopup="dialog" aria-expanded="false" aria-controls="toolbar-kebab-menu">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="12" cy="5" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="12" cy="19" r="1.8"/></svg>
           </button>
-          <div id="toolbar-kebab-menu" class="kebab-menu hidden" role="menu" aria-label="Viewer more menu" data-i18n-aria-label="viewer:a11y.toolbarMenu">
+          <div id="toolbar-kebab-menu" class="kebab-menu hidden" role="dialog" aria-modal="false" aria-label="Viewer more menu" data-i18n-aria-label="viewer:a11y.toolbarMenu">
             <!-- 번역 작업 상태 정보 -->
             <div id="translation-progress-mini" class="progress-mini hidden">
               <div class="progress-mini-bar" id="progress-mini-bar"></div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1975,7 +1975,6 @@ exportBtn.addEventListener('click', (e) => {
 // 잡혀 그때 케밥 메뉴도 함께 닫힌다.
 if (toolbarKebabBtn && toolbarKebabMenu) {
   const getMenuItems = () => Array.from(toolbarKebabMenu.querySelectorAll('button:not([disabled]), select, [tabindex]:not([tabindex="-1"])'))
-  toolbarKebabMenu.querySelectorAll('button').forEach(item => item.setAttribute('role', 'menuitem'))
   const syncMenuState = () => toolbarKebabBtn.setAttribute('aria-expanded', String(!toolbarKebabMenu.classList.contains('hidden')))
   const closeMenu = (restoreFocus = false) => {
     toolbarKebabMenu.classList.add('hidden')

--- a/frontend/tests/e2e/accessibility.spec.js
+++ b/frontend/tests/e2e/accessibility.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test"
 import AxeBuilder from "@axe-core/playwright"
-import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from "./helpers.js"
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A, SAMPLE_PDF_CITATION } from "./helpers.js"
 
 const documentFixture = {
   id: "doc-accessibility",
@@ -26,6 +26,56 @@ async function openViewer(page) {
 
 test("뷰어 핵심 화면이 WCAG 2.2 AA 자동 검사를 통과한다", async ({ page }) => {
   await openViewer(page)
+
+  const results = await new AxeBuilder({ page })
+    .include("#viewer-screen")
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+    .analyze()
+
+  expect(results.violations).toEqual([])
+})
+
+test("뷰어 툴바를 Tab만으로 논리적인 순서로 이동하고 포커스를 식별한다", async ({ page }) => {
+  await openViewer(page)
+
+  const tabOrder = [
+    "#back-btn",
+    "#logo-btn",
+    "#viewer-read-toggle-btn",
+    "#outline-toggle-btn",
+    "#doc-title-edit-btn",
+    "#page-input",
+    "#zoom-out-btn",
+    "#zoom-in-btn",
+    "#capture-area-btn",
+    "#chat-toggle-btn",
+    "#toolbar-kebab-btn",
+  ]
+
+  await page.locator(tabOrder[0]).focus()
+  for (let index = 0; index < tabOrder.length; index += 1) {
+    const control = page.locator(tabOrder[index])
+    await expect(control).toBeFocused()
+    if (index < tabOrder.length - 1) await page.keyboard.press("Tab")
+  }
+
+  const focusStyle = await page.locator("#toolbar-kebab-btn").evaluate(element => {
+    const style = getComputedStyle(element)
+    return { style: style.outlineStyle, width: style.outlineWidth }
+  })
+  expect(focusStyle.style).not.toBe("none")
+  expect(focusStyle.width).not.toBe("0px")
+})
+
+test("열린 채팅 패널과 메뉴도 WCAG 2.2 AA 자동 검사를 통과한다", async ({ page }) => {
+  await openViewer(page)
+
+  await page.locator("#chat-toggle-btn").press("Enter")
+  await expect(page.locator("#chat-sidebar")).toBeVisible()
+  await page.locator("#toolbar-kebab-btn").press("Space")
+  await expect(page.locator("#toolbar-kebab-menu")).toBeVisible()
+  await expect(page.locator("#toolbar-kebab-btn")).toHaveAttribute("aria-haspopup", "dialog")
+  await expect(page.locator("#toolbar-kebab-menu")).toHaveAttribute("role", "dialog")
 
   const results = await new AxeBuilder({ page })
     .include("#viewer-screen")
@@ -76,4 +126,42 @@ test("채팅 패널과 리사이저를 키보드로 조작하고 닫을 때 포�
   await page.locator("#chat-input").press("Escape")
   await expect(page.locator("#chat-sidebar")).toBeHidden()
   await expect(toggle).toBeFocused()
+})
+
+test("인용 오버레이를 키보드로 열고 Escape로 트리거에 복귀한다", async ({ page }) => {
+  const citationDocument = {
+    id: "doc-C",
+    filename: "Citation.pdf",
+    total_pages: 1,
+    metadata: { title: "Citation Sample Paper" },
+    translated_pages: [],
+  }
+  await mockBaseRoutes(page, { documents: [citationDocument] })
+  await page.route("**/api/library/doc-C/pdf", route => {
+    route.fulfill({ status: 200, contentType: "application/pdf", body: SAMPLE_PDF_CITATION })
+  })
+  await page.route("**/api/library/doc-C/references", route => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ references: { "1": "Vaswani et al. Attention Is All You Need. 2017." } }),
+    })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = "#viewer?id=doc-C" })
+  const trigger = page.locator(".citation-marker-box").first()
+  await expect(trigger).toBeVisible()
+  await trigger.focus()
+  await trigger.press("Space")
+
+  const tooltip = page.locator(".citation-tooltip")
+  await expect(tooltip).toBeVisible()
+  await expect(trigger).toHaveAttribute("aria-expanded", "true")
+  await expect(tooltip.locator(".citation-tooltip-resolve-btn")).toBeFocused()
+
+  await page.keyboard.press("Escape")
+  await expect(tooltip).toBeHidden()
+  await expect(trigger).toHaveAttribute("aria-expanded", "false")
+  await expect(trigger).toBeFocused()
 })


### PR DESCRIPTION
## Summary
- models the mixed-control viewer toolbar popover as a non-modal dialog instead of an invalid ARIA menu
- removes dynamically assigned menuitem roles that lacked valid menu parents
- adds Tab-order and visible-focus coverage across viewer toolbar and page navigation
- runs axe against active chat and toolbar popovers
- verifies keyboard citation activation and Escape focus restoration

## Tests
- frontend unit: 53 passed
- locale validation: passed
- production build: passed
- accessibility Playwright: 6 passed
- full Playwright: 68 passed