### PR TITLE
fix: hide processing badges on library cards

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8416,7 +8416,6 @@ function createDocCard(doc) {
         <div class="lib-card-top-body">
           <div class="doc-card-title" title="${escapeHtml(doc.filename)}">${escapeHtml(d.displayTitle)}</div>
           ${documentTypeChipHtml(doc, true)}
-          ${processingBadgeHtml(doc)}
         </div>
       </div>
       ${d.tagsHtml}

--- a/frontend/tests/e2e/library-processing-badge.spec.js
+++ b/frontend/tests/e2e/library-processing-badge.spec.js
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+test('processing badge appears only in the library detail panel', async ({ page }) => {
+  const doc = {
+    id: 'doc-external-transfer',
+    filename: 'external-transfer.pdf',
+    total_pages: 12,
+    created_at: '2026-08-26T00:00:00Z',
+    metadata: { title: 'External Transfer Paper' },
+    translated_pages: [],
+    processing: {
+      badge: 'external_transfer',
+      transfer_items: ['document_text'],
+      document_policy: 'inherit',
+    },
+  }
+  await mockBaseRoutes(page, { documents: [doc] })
+
+  await gotoApp(page)
+
+  const card = page.locator('.doc-card[data-id="doc-external-transfer"]')
+  await expect(card).toBeVisible()
+  await expect(card.locator('.processing-badge')).toHaveCount(0)
+
+  await card.click()
+
+  const detailPanel = page.locator('#lib-detail-panel')
+  await expect(detailPanel).toHaveClass(/open/)
+  await expect(detailPanel.locator('#lib-detail-processing-badge .processing-badge')).toHaveText('외부 전송')
+})


### PR DESCRIPTION
# Summary
## 1. 라이브러리 카드 처리 정책 chip 제거
- 논문 및 문서 카드에서 외부 전송, 로컬 처리, 로컬 전용 chip을 제거함
- 문서 선택 후 우측 상세 사이드바에서 처리 정책 chip을 유지함
## 2. 표시 위치 회귀 테스트 추가
- 처리 정책 chip이 카드에는 없고 우측 상세 사이드바에는 표시되는 E2E 테스트를 추가함