### PR TITLE
fix: remove library card accent bars

### DIFF
--- a/frontend/src/styles/document-modes.css
+++ b/frontend/src/styles/document-modes.css
@@ -88,19 +88,6 @@ button.document-type-chip:hover { background: color-mix(in srgb, var(--document-
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--document-mode-color) 18%, transparent);
 }
 
-.doc-card[data-document-mode="research"], .doc-list-row[data-document-mode="research"] { --document-mode-color: #8b5cf6; }
-.doc-card[data-document-mode="general"], .doc-list-row[data-document-mode="general"] { --document-mode-color: #14b8a6; }
-.doc-card[data-document-mode]::before, .doc-list-row[data-document-mode]::before {
-  content: '';
-  position: absolute;
-  z-index: 2;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 3px;
-  background: var(--document-mode-color);
-  pointer-events: none;
-}
 .document-type-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
 .document-type-option {
   padding: 12px;

--- a/frontend/tests/e2e/document-modes.spec.js
+++ b/frontend/tests/e2e/document-modes.spec.js
@@ -75,7 +75,7 @@ test('워크스페이스 전환은 홈과 데이터 범위를 바꾸고 문서 �
   await expect(manualChip).toHaveText('일반 · 매뉴얼')
   await expect(manualChip).toHaveCSS('white-space', 'nowrap')
   expect(await manualChip.evaluate(el => el.getBoundingClientRect().width > el.getBoundingClientRect().height)).toBe(true)
-  expect(await manualCard.evaluate(el => getComputedStyle(el, '::before').width)).toBe('3px')
+  expect(await manualCard.evaluate(el => getComputedStyle(el, '::before').content)).toBe('none')
 
   await page.locator('#library-grid .document-type-chip.general', { hasText: '매뉴얼' }).click()
   await expect(page.locator('#library-grid').getByText('Setup Manual')).toBeVisible()


### PR DESCRIPTION
# Summary
## 1. 라이브러리 카드 색상 바 제거
- 논문 및 문서 카드 왼쪽의 문서 모드 색상 바를 제거함
- 큰 카드, 작은 카드, 리스트 보기에서 동일하게 색상 바가 나타나지 않도록 수정함
## 2. 문서 모드 회귀 테스트 수정
- 라이브러리 카드의 가상 요소 색상 바가 생성되지 않는지 검증하도록 E2E 테스트를 수정함