### PR TITLE
fix(login): move locale selector to top right

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,13 @@
       <div class="orb orb-2"></div>
       <div class="orb orb-3"></div>
     </div>
+    <label class="login-language-selector">
+      <span data-i18n="ui.language">화면 언어</span>
+      <select id="login-ui-locale" class="form-select">
+        <option value="ko">한국어</option>
+        <option value="en">English</option>
+      </select>
+    </label>
     <div class="upload-container">
       <div class="logo">
         <span class="logo-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg></span>
@@ -42,9 +49,6 @@
       </div>
       <h1 class="upload-title"><span data-i18n="login.heading">Academic paper translation</span><br /><span class="gradient-text" data-i18n="login.secure">Secure sign-in</span></h1>
       
-      <label style="align-self:flex-end;font-size:12px;color:var(--text-secondary)"><span data-i18n="ui.language">화면 언어</span>
-        <select id="login-ui-locale" class="form-select" style="display:inline-block;width:auto;margin-left:8px"><option value="ko">한국어</option><option value="en">English</option></select>
-      </label>
       <div class="drop-zone" style="max-width: 400px; cursor: default; border: 1px solid var(--border-strong);">
         <form id="login-form" class="drop-zone-inner" style="padding: 36px 32px; gap: 20px; width: 100%;">
           <div style="width: 100%; display: flex; flex-direction: column; gap: 8px;">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2202,6 +2202,39 @@ body.light-theme .toast.error { color: #dc2626; }
   gap: 12px;
 }
 
+.login-language-selector {
+  position: fixed;
+  top: 24px;
+  right: 78px;
+  z-index: 150;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.login-language-selector .form-select {
+  width: auto;
+  min-width: 104px;
+  padding: 11px 36px 11px 12px;
+  background-position: right 12px center;
+  box-shadow: var(--shadow-md);
+}
+
+@media (max-width: 480px) {
+  .global-theme-toggle {
+    top: 16px;
+    right: 16px;
+  }
+
+  .login-language-selector {
+    top: 16px;
+    right: 70px;
+  }
+}
+
 /* 로그인 인풋 포커스 스타일 */
 #login-username:focus, #login-password:focus {
   border-color: var(--control-accent) !important;

--- a/frontend/tests/e2e/i18n.spec.js
+++ b/frontend/tests/e2e/i18n.spec.js
@@ -9,6 +9,12 @@ test('stored locale is applied on the unauthenticated login screen', async ({ pa
   await expect(page.locator('#login-screen')).toHaveClass(/active/)
   await expect(page.locator('#login-ui-locale')).toHaveValue('en')
   await expect(page.locator('#login-form button[type="submit"]')).toHaveText('Sign in')
+  const localeBox = await page.locator('.login-language-selector').boundingBox()
+  const themeBox = await page.locator('#global-theme-toggle-btn').boundingBox()
+  expect(localeBox).not.toBeNull()
+  expect(themeBox).not.toBeNull()
+  expect(Math.abs(localeBox.y - themeBox.y)).toBeLessThanOrEqual(1)
+  expect(localeBox.x + localeBox.width).toBeLessThan(themeBox.x)
   await expect.poll(() => visibleKoreanUi(page)).toEqual([])
 })
 


### PR DESCRIPTION
# Summary
## 1. 로그인 화면 언어 선택기 위치 수정
- 화면 언어 선택 드롭다운을 로그인 카드 상단에서 우측 상단 테마 버튼 왼쪽으로 이동함
- 모바일 화면에서 두 컨트롤이 겹치지 않도록 간격을 조정함
## 2. 위치 회귀 테스트 추가
- 언어 선택기와 테마 버튼의 수평 정렬 및 상대 위치 검증을 추가함