### PR TITLE
fix(viewer): unify language picker layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -478,16 +478,23 @@
               <div class="progress-mini-bar" id="progress-mini-bar"></div>
               <span id="progress-mini-text">0%</span>
             </div>
-            <div id="document-language-controls" class="document-language-controls" hidden>
-              <label><span data-i18n="viewer:source.label">Source</span><select id="document-source-lang" aria-label="Document source language" data-i18n-aria-label="viewer:source.aria"></select></label>
-              <span aria-hidden="true">→</span>
-              <label><span data-i18n="viewer:target.label">Target</span><select id="document-target-lang" aria-label="Document target language" data-i18n-aria-label="viewer:target.aria"></select></label>
-              <span id="document-language-status" role="status"></span>
-            </div>
-            <!-- AI 번역 모델 선택 드롭다운 -->
-            <div class="kebab-menu-row">
-              <span class="kebab-menu-label">번역 모델</span>
-              <div id="viewer-trans-provider"></div>
+            <div class="kebab-translation-grid">
+              <div id="document-language-controls" class="document-language-controls" hidden>
+                <div class="kebab-menu-row">
+                  <span id="document-source-lang-label" class="kebab-menu-label" data-i18n="viewer:source.label">Source</span>
+                  <select id="document-source-lang" aria-label="Document source language" data-i18n-aria-label="viewer:source.aria"></select>
+                </div>
+                <div class="kebab-menu-row">
+                  <span id="document-target-lang-label" class="kebab-menu-label" data-i18n="viewer:target.label">Target</span>
+                  <select id="document-target-lang" aria-label="Document target language" data-i18n-aria-label="viewer:target.aria"></select>
+                </div>
+              </div>
+              <!-- AI 번역 모델 선택 드롭다운 -->
+              <div class="kebab-menu-row">
+                <span class="kebab-menu-label">번역 모델</span>
+                <div id="viewer-trans-provider"></div>
+              </div>
+              <span id="document-language-status" role="status" hidden></span>
             </div>
 
             <div class="kebab-menu-divider"></div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -119,6 +119,113 @@ const $ = (id) => document.getElementById(id)
 
 let languageCatalog = []
 
+// Native select values and change events remain the source of truth while the viewer
+// menu presents the same button-and-popover pattern as the model picker.
+class LanguageSelectPicker {
+  constructor(select) {
+    if (!select) return
+    this.select = select
+    this.container = document.createElement('div')
+    this.container.className = 'provider-picker language-picker'
+    select.parentNode.insertBefore(this.container, select)
+    this.container.appendChild(select)
+    select.classList.add('sr-only')
+    select.setAttribute('aria-hidden', 'true')
+    select.tabIndex = -1
+    this.button = document.createElement('button')
+    this.button.type = 'button'
+    this.button.className = 'provider-picker-btn'
+    this.button.setAttribute('aria-haspopup', 'listbox')
+    this.button.setAttribute('aria-expanded', 'false')
+    this.button.setAttribute('aria-labelledby', select.id + '-label ' + select.id + '-picker-value')
+    this.button.innerHTML = '<span id="' + select.id + '-picker-value" class="picker-label"></span><span class="picker-arrow" aria-hidden="true">▾</span>'
+    this.panel = document.createElement('div')
+    this.panel.id = select.id + '-picker-panel'
+    this.panel.className = 'provider-picker-panel'
+    this.panel.setAttribute('role', 'listbox')
+    this.button.setAttribute('aria-controls', this.panel.id)
+    this.container.append(this.button, this.panel)
+    this.button.addEventListener('click', (event) => {
+      event.stopPropagation()
+      this.container.classList.contains('open') ? this.close() : this.open()
+    })
+    this.button.addEventListener('keydown', (event) => {
+      if (!['ArrowDown', 'ArrowUp'].includes(event.key)) return
+      event.preventDefault()
+      this.open()
+      const items = [...this.panel.querySelectorAll('.picker-model-item')]
+      const selectedIndex = Math.max(0, items.findIndex(item => item.getAttribute('aria-selected') === 'true'))
+      items[event.key === 'ArrowUp' ? Math.max(0, items.length - 1) : selectedIndex]?.focus()
+    })
+    select.addEventListener('change', () => this.refresh())
+    document.addEventListener('click', (event) => {
+      if (!this.container.contains(event.target)) this.close()
+    })
+    this.refresh()
+  }
+  open() {
+    document.querySelectorAll('.language-picker.open .provider-picker-btn').forEach(button => {
+      button.setAttribute('aria-expanded', 'false')
+    })
+    document.querySelectorAll('.provider-picker.open').forEach(picker => picker.classList.remove('open'))
+    this.rebuildPanel()
+    this.container.classList.add('open')
+    this.button.setAttribute('aria-expanded', 'true')
+  }
+  close({ focus = false } = {}) {
+    this.container.classList.remove('open')
+    this.button.setAttribute('aria-expanded', 'false')
+    if (focus) this.button.focus()
+  }
+  refresh() {
+    const selected = this.select.selectedOptions[0]
+    this.button.querySelector('.picker-label').textContent = selected?.textContent || ''
+    this.button.title = this.select.getAttribute('aria-label') || selected?.textContent || ''
+    if (this.container.classList.contains('open')) this.rebuildPanel()
+  }
+  rebuildPanel() {
+    this.panel.innerHTML = ''
+    ;[...this.select.options].forEach(option => {
+      const item = document.createElement('button')
+      item.type = 'button'
+      item.className = 'picker-model-item language-picker-item' + (option.selected ? ' selected' : '')
+      item.textContent = option.textContent
+      item.dataset.value = option.value
+      item.setAttribute('role', 'option')
+      item.setAttribute('aria-selected', String(option.selected))
+      item.addEventListener('click', (event) => {
+        event.stopPropagation()
+        if (this.select.value !== option.value) {
+          this.select.value = option.value
+          this.select.dispatchEvent(new Event('change', { bubbles: true }))
+        }
+        this.close({ focus: true })
+      })
+      item.addEventListener('keydown', (event) => {
+        const items = [...this.panel.querySelectorAll('.picker-model-item')]
+        const index = items.indexOf(item)
+        let nextIndex = null
+        if (event.key === 'ArrowDown') nextIndex = Math.min(items.length - 1, index + 1)
+        else if (event.key === 'ArrowUp') nextIndex = Math.max(0, index - 1)
+        else if (event.key === 'Home') nextIndex = 0
+        else if (event.key === 'End') nextIndex = items.length - 1
+        else if (event.key === 'Escape') {
+          event.preventDefault()
+          this.close({ focus: true })
+          return
+        }
+        if (nextIndex !== null) {
+          event.preventDefault()
+          items[nextIndex]?.focus()
+        }
+      })
+      this.panel.appendChild(item)
+    })
+  }
+}
+const documentLanguagePickers = ['document-source-lang', 'document-target-lang']
+  .map(id => new LanguageSelectPicker($(id)))
+
 function populateLanguageControls(settings = {}) {
   const sourceSelect = $('setting-source-lang')
   const targetSelect = $('setting-target-lang')
@@ -145,6 +252,7 @@ function populateLanguageControls(settings = {}) {
     documentTarget.innerHTML = options
     documentTarget.value = state.preferredTargetLanguage || targetValue
   }
+  documentLanguagePickers.forEach(picker => picker.refresh())
   renderDocumentLanguageStatus()
   for (const id of ['login-ui-locale', 'onboarding-ui-locale', 'setting-ui-locale']) {
     const select = $(id)
@@ -161,6 +269,7 @@ function renderDocumentLanguageStatus() {
   const controls = $('document-language-controls')
   if (!status || !controls) return
   controls.hidden = !state.sessionId
+  status.hidden = !state.sessionId
   if (!state.sessionId) return
   const source = state.sourceLanguage === 'auto' ? state.detectedSourceLanguage : state.sourceLanguage
   const target = state.preferredTargetLanguage || getModeSetting('targetLang', state.currentDocumentMode)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4713,12 +4713,19 @@ body.toolbar-pos-bottom .kebab-menu {
   box-sizing: border-box;
   justify-content: center;
 }
-.kebab-menu-row {
-  display: flex;
+.kebab-translation-grid {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 160px);
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  gap: 8px 10px;
   padding: 4px 8px;
+}
+.kebab-translation-grid .kebab-menu-row,
+.kebab-translation-grid .document-language-controls {
+  display: contents;
+}
+.kebab-translation-grid .document-language-controls[hidden] {
+  display: none;
 }
 .kebab-menu-label {
   flex-shrink: 0;
@@ -4727,11 +4734,27 @@ body.toolbar-pos-bottom .kebab-menu {
   font-weight: 500;
   white-space: nowrap;
 }
-.kebab-menu-row .provider-picker {
+.kebab-translation-grid .provider-picker {
+  width: 100%;
   min-width: 0;
 }
-.kebab-menu-row .provider-picker-btn {
+.kebab-translation-grid .provider-picker-btn {
+  width: 100%;
   min-width: 0;
+}
+.language-picker-item {
+  width: 100%;
+  border: 0;
+  position: relative;
+  background: transparent;
+  font-family: var(--font-sans);
+  text-align: left;
+}
+.language-picker-item:hover {
+  background: var(--bg-hover);
+}
+.language-picker-item.selected {
+  background: rgba(126, 196, 232, 0.15);
 }
 .kebab-menu-divider {
   height: 1px;
@@ -7073,11 +7096,9 @@ body.light-theme .chat-drawer {
   text-transform: uppercase;
 }
 
-.document-language-controls { display:flex; flex-direction:column; align-items:stretch; gap:6px; padding:6px 0; font-size:11px; color:var(--text-muted); }
-.document-language-controls > span[aria-hidden] { display:none; }
-.document-language-controls label { display:flex; align-items:center; justify-content:space-between; gap:8px; }
-.document-language-controls select { max-width:150px; background:var(--bg-elevated); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 5px; }
-#document-language-status { max-width:230px; white-space:normal; }
+.document-language-controls { font-size:11px; color:var(--text-muted); }
+#document-language-status { grid-column:1 / -1; max-width:100%; white-space:normal; }
+#document-language-status[hidden] { display:none; }
 
 .processing-badge { display:inline-flex; align-items:center; width:max-content; padding:2px 7px; border-radius:999px; font-size:10px; font-weight:700; border:1px solid var(--border-strong); color:var(--text-secondary); background:var(--bg-elevated); }
 .processing-badge.local_only { color:#166534; background:#dcfce7; border-color:#86efac; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4708,6 +4708,11 @@ body.toolbar-pos-bottom .kebab-menu {
   backdrop-filter: blur(3px);
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+/* 상·하단 툴바에서 채팅 패널과 케밥 메뉴가 같은 우측 영역을 쓰면
+   메뉴 안의 선택기와 채팅 닫기 버튼이 겹친다. 실측 패널 폭만큼 메뉴를 옮긴다. */
+body:not(.toolbar-pos-left):not(.toolbar-pos-right):has(.chat-sidebar:not(.hidden)) .kebab-menu {
+  right: calc(var(--chat-sidebar-offset, 0px) + 8px);
+}
 .kebab-menu .progress-mini {
   width: 100%;
   box-sizing: border-box;

--- a/frontend/tests/e2e/i18n.spec.js
+++ b/frontend/tests/e2e/i18n.spec.js
@@ -97,6 +97,60 @@ test('English locale has no visible Korean UI in the PDF viewer', async ({ page 
   await expect.poll(() => visibleKoreanUi(page)).toEqual([])
 })
 
+test('viewer language pickers share the model picker grid and persist custom selections', async ({ page }) => {
+  const doc = {
+    id: 'doc-language-picker', filename: 'Languages.pdf', total_pages: 1,
+    source_language: 'en', detected_source_language: 'en', preferred_target_language: 'fr',
+    metadata: { title: 'Language picker document' }, translated_pages: [],
+  }
+  let languagePayload = null
+  await mockBaseRoutes(page, {
+    documents: [doc],
+    languageSettings: { ui_locale: 'en', default_source_language: 'auto', target_language: 'fr' },
+  })
+  await page.route('**/api/library/doc-language-picker/pdf', route => route.fulfill({
+    status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A,
+  }))
+  await page.route('**/api/library/doc-language-picker/languages', route => {
+    languagePayload = route.request().postDataJSON()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        source_language: languagePayload.source_language,
+        preferred_target_language: languagePayload.preferred_target_language,
+      }),
+    })
+  })
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-language-picker' })
+  await expect(page.locator('#viewer-screen')).toHaveClass(/active/)
+  await page.locator('#toolbar-kebab-btn').click()
+
+  const buttons = [
+    page.locator('#document-source-lang').locator('..').locator('.provider-picker-btn'),
+    page.locator('#document-target-lang').locator('..').locator('.provider-picker-btn'),
+    page.locator('#viewer-trans-provider .provider-picker-btn'),
+  ]
+  const boxes = await Promise.all(buttons.map(button => button.boundingBox()))
+  expect(boxes.every(Boolean)).toBe(true)
+  expect(Math.max(...boxes.map(box => box.width)) - Math.min(...boxes.map(box => box.width))).toBeLessThan(1)
+  expect(Math.max(...boxes.map(box => box.x)) - Math.min(...boxes.map(box => box.x))).toBeLessThan(1)
+  expect(Math.abs((boxes[1].y - boxes[0].y) - (boxes[2].y - boxes[1].y))).toBeLessThan(1)
+
+  await buttons[0].click()
+  await expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+  await page.locator('#document-source-lang-picker-panel [data-value="ja"]').click()
+  await expect(buttons[0]).toContainText('Japanese')
+  await expect(buttons[0]).toHaveAttribute('aria-expanded', 'false')
+  await expect.poll(() => languagePayload).toEqual({
+    source_language: 'ja',
+    preferred_target_language: 'fr',
+  })
+})
+
+
 test('Korean locale renders every workspace route in Korean', async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem('easypaper_ui_locale', 'en'))
   await mockBaseRoutes(page, { documents: [], languageSettings: { ui_locale: 'ko', default_source_language: 'auto', target_language: 'ko' } })


### PR DESCRIPTION
# Summary
## 1. 뷰어 언어 드롭다운 커스텀화
- 원문 및 대상 언어 선택기를 번역 모델 선택기와 동일한 버튼·팝오버 방식으로 변경함
- 기존 select 값과 change 이벤트를 유지해 문서 언어 저장 로직 호환성을 보존함
- 키보드 탐색과 ARIA 확장 상태를 지원함
## 2. 번역 설정 그리드 정렬
- 원문, 대상, 번역 모델 항목을 공통 2열 그리드로 배치함
- 세 드롭다운의 너비, 좌우 마진, 행 간격을 동일하게 조정함
## 3. 회귀 테스트 추가
- 드롭다운 너비·간격과 커스텀 언어 선택 및 저장 요청을 검증하는 E2E 테스트를 추가함