### PR TITLE
fix(viewer): remove input focus borders

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3154,6 +3154,10 @@ body.light-theme .chat-input-area {
   border-color: var(--accent-mid);
 }
 
+#chat-sidebar .chat-input-box:focus-within {
+  border-color: var(--border-strong);
+}
+
 #chat-input,
 .chat-input-textarea {
   flex: 1;
@@ -7158,6 +7162,10 @@ body.light-theme .chat-drawer {
 :where(button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
   outline: 3px solid var(--control-accent, #4f8ef7) !important;
   outline-offset: 2px !important;
+}
+#chat-input:focus-visible,
+.floating-memo-textarea:focus-visible {
+  outline: none !important;
 }
 .chat-resizer:focus-visible {
   background: var(--accent-mid);

--- a/frontend/tests/e2e/chat-input-expand.spec.js
+++ b/frontend/tests/e2e/chat-input-expand.spec.js
@@ -32,3 +32,25 @@ test('AI 어시스턴트 입력창을 확장하고 다시 축소할 수 있다',
   await expect(expandButton).toHaveAttribute('aria-expanded', 'false')
   await expect(expandButton).toHaveAttribute('aria-label', '입력창 확장')
 })
+
+test('뷰어 AI 어시스턴트 입력창에 포커스 테두리를 표시하지 않는다', async ({ page }) => {
+  const doc = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-A/pdf', route =>
+    route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
+  await page.waitForTimeout(1000)
+  await page.click('#chat-toggle-btn')
+
+  const input = page.locator('#chat-input')
+  const inputBox = input.locator('..')
+  const borderColor = await inputBox.evaluate(element => getComputedStyle(element).borderColor)
+
+  await input.click()
+
+  await expect(input).toBeFocused()
+  await expect.poll(() => input.evaluate(element => getComputedStyle(element).outlineStyle)).toBe('none')
+  await expect.poll(() => inputBox.evaluate(element => getComputedStyle(element).borderColor)).toBe(borderColor)
+})

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -81,6 +81,17 @@ test('사용자가 조절한 메모 크기를 저장하고 다시 복원한다',
   await expect(memo).toHaveCSS('height', '280px')
 })
 
+test('뷰어 메모 입력창에 포커스 테두리를 표시하지 않는다', async ({ page }) => {
+  await openViewerWithMemo(page)
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+
+  const textarea = memo.locator('.floating-memo-textarea')
+  await expect(textarea).toBeFocused()
+  await expect.poll(() => textarea.evaluate(element => getComputedStyle(element).outlineStyle)).toBe('none')
+})
+
 
 test("키보드로 메모를 이동하고 크기를 조절하면 변경 사항을 알린다", async ({ page }) => {
   await openViewerWithMemo(page)


### PR DESCRIPTION
# Summary\n## 1. 뷰어 AI 어시스턴트 포커스 테두리 제거\n- AI 어시스턴트 텍스트 입력창의 파란 외곽선과 입력 컨테이너의 파란 테두리 전환을 제거함\n## 2. 뷰어 메모 포커스 테두리 제거\n- 플로팅 메모 텍스트 입력창의 파란 외곽선을 제거함\n- AI 입력창과 메모 입력창의 포커스 스타일 회귀 테스트를 추가함