### PR TITLE
fix(viewer): isolate language status layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -500,8 +500,8 @@
                 <span class="kebab-menu-label">번역 모델</span>
                 <div id="viewer-trans-provider"></div>
               </div>
-              <span id="document-language-status" role="status" hidden></span>
             </div>
+            <span id="document-language-status" role="status" hidden></span>
 
             <div class="kebab-menu-divider"></div>
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7135,7 +7135,15 @@ body.light-theme .chat-drawer {
 }
 
 .document-language-controls { font-size:11px; color:var(--text-muted); }
-#document-language-status { grid-column:1 / -1; max-width:100%; white-space:normal; }
+#document-language-status {
+  align-self: stretch;
+  min-width: 0;
+  max-width: 260px;
+  box-sizing: border-box;
+  padding: 0 8px;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
 #document-language-status[hidden] { display:none; }
 
 .processing-badge { display:inline-flex; align-items:center; width:max-content; padding:2px 7px; border-radius:999px; font-size:10px; font-weight:700; border:1px solid var(--border-strong); color:var(--text-secondary); background:var(--bg-elevated); }

--- a/frontend/tests/e2e/i18n.spec.js
+++ b/frontend/tests/e2e/i18n.spec.js
@@ -106,7 +106,7 @@ test('English locale has no visible Korean UI in the PDF viewer', async ({ page 
 test('viewer language pickers share the model picker grid and persist custom selections', async ({ page }) => {
   const doc = {
     id: 'doc-language-picker', filename: 'Languages.pdf', total_pages: 1,
-    source_language: 'en', detected_source_language: 'en', preferred_target_language: 'fr',
+    source_language: 'auto', detected_source_language: 'mul', preferred_target_language: 'fr',
     metadata: { title: 'Language picker document' }, translated_pages: [],
   }
   let languagePayload = null
@@ -144,6 +144,14 @@ test('viewer language pickers share the model picker grid and persist custom sel
   expect(Math.max(...boxes.map(box => box.width)) - Math.min(...boxes.map(box => box.width))).toBeLessThan(1)
   expect(Math.max(...boxes.map(box => box.x)) - Math.min(...boxes.map(box => box.x))).toBeLessThan(1)
   expect(Math.abs((boxes[1].y - boxes[0].y) - (boxes[2].y - boxes[1].y))).toBeLessThan(1)
+  const labelColumn = await page.locator('.kebab-translation-grid').evaluate(grid => {
+    const firstTrack = parseFloat(getComputedStyle(grid).gridTemplateColumns)
+    const widestLabel = Math.max(...[...grid.querySelectorAll('.kebab-menu-label')]
+      .map(label => label.getBoundingClientRect().width))
+    return { firstTrack, widestLabel }
+  })
+  expect(labelColumn.firstTrack - labelColumn.widestLabel).toBeLessThan(1)
+  await expect(page.locator('#document-language-status')).toContainText('Multiple source languages detected')
 
   await buttons[0].click()
   await expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')


### PR DESCRIPTION
# Summary
## 1. 언어 상태 안내 레이아웃 수정
- 다중 원문 언어 감지 안내 문구를 번역 설정 그리드 밖으로 분리함
- 안내 문구가 원문·대상·번역 모델 라벨 열의 너비 계산에 영향을 주지 않도록 수정함
- 메뉴 폭 안에서 안내 문구가 줄바꿈되도록 제한함
## 2. 회귀 테스트 보강
- 다중 원문 언어 상태에서도 첫 번째 그리드 열이 라벨 너비만 사용하도록 E2E 검증을 추가함