### PR TITLE
fix(viewer): emphasize language status notice

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7144,7 +7144,14 @@ body.light-theme .chat-drawer {
   min-width: 0;
   max-width: 260px;
   box-sizing: border-box;
-  padding: 0 8px;
+  padding: 5px 8px;
+  border-left: 2px solid var(--warning);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
+  color: var(--warning);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.45;
   white-space: normal;
   overflow-wrap: break-word;
 }

--- a/frontend/tests/e2e/i18n.spec.js
+++ b/frontend/tests/e2e/i18n.spec.js
@@ -152,6 +152,18 @@ test('viewer language pickers share the model picker grid and persist custom sel
   })
   expect(labelColumn.firstTrack - labelColumn.widestLabel).toBeLessThan(1)
   await expect(page.locator('#document-language-status')).toContainText('Multiple source languages detected')
+  const statusStyle = await page.locator('#document-language-status').evaluate(status => {
+    const style = getComputedStyle(status)
+    return {
+      bodyColor: getComputedStyle(document.body).color,
+      color: style.color,
+      fontSize: style.fontSize,
+      fontWeight: style.fontWeight,
+    }
+  })
+  expect(statusStyle.fontSize).toBe('12px')
+  expect(Number(statusStyle.fontWeight)).toBeGreaterThanOrEqual(700)
+  expect(statusStyle.color).not.toBe(statusStyle.bodyColor)
 
   await buttons[0].click()
   await expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')


### PR DESCRIPTION
# Summary
## 1. 원문 언어 안내 문구 강조
- 다중 원문 언어 감지 안내 문구의 글자 크기를 케밥 메뉴 라벨과 동일한 크기로 조정함
- 경고 색상, 굵은 글씨, 옅은 배경과 좌측 강조선을 적용해 안내 가시성을 높임
## 2. 회귀 테스트 보강
- 다중 원문 언어 상태에서 안내 문구의 크기, 굵기, 색상이 적용되는지 E2E로 검증함