### PR TITLE
fix: stabilize viewer text quotes

### DIFF
--- a/backend/services/context_retrieval.py
+++ b/backend/services/context_retrieval.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -15,6 +16,12 @@ _TOKEN_RE = re.compile(r"[A-Za-z0-9가-힣_]{2,}")
 _PAGE_RE = re.compile(r"(?:page|pages|p\.?|페이지)\s*(\d+)(?:\s*[-–~]\s*(\d+))?", re.I)
 _CITATION_RE = re.compile(r"\[(p|pp)\.(\d+)(?:\s*[-–]\s*(\d+))?\]", re.I)
 _STOP = {"the", "and", "for", "that", "with", "this", "from", "what", "which", "문서", "페이지", "내용", "대한"}
+_PDF_PUNCTUATION = str.maketrans({
+    "‘": "'", "’": "'", "‚": "'", "‛": "'",
+    "“": '"', "”": '"', "„": '"', "‟": '"',
+    "‐": "-", "‑": "-", "‒": "-", "–": "-", "—": "-", "―": "-",
+})
+_IGNORED_PDF_CHARS = {"\u00ad", "\u200b", "\u200c", "\u200d", "\ufeff"}
 
 
 @dataclass(frozen=True)
@@ -28,6 +35,87 @@ class ContextResult:
 
 def _tokens(text: str) -> list[str]:
     return [t.casefold() for t in _TOKEN_RE.findall(text or "") if t.casefold() not in _STOP]
+
+
+def _normalized_pdf_text(text: str) -> tuple[str, list[int], list[int]]:
+    """Normalize common PDF extractor differences while retaining source offsets."""
+    normalized: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char in _IGNORED_PDF_CHARS:
+            index += 1
+            continue
+
+        # One extractor may preserve a line-end hyphen while another joins the
+        # word. Only dehyphenate when an actual line break follows the hyphen.
+        if char in "-‐‑‒–—―":
+            next_index = index + 1
+            while next_index < len(text) and text[next_index].isspace():
+                next_index += 1
+            separator = text[index + 1:next_index]
+            if ("\n" in separator or "\r" in separator) and next_index < len(text):
+                if index > 0 and text[index - 1].isalnum() and text[next_index].isalnum():
+                    index = next_index
+                    continue
+
+        transformed = unicodedata.normalize("NFKC", char).translate(_PDF_PUNCTUATION)
+        for output_char in transformed:
+            if output_char in _IGNORED_PDF_CHARS or unicodedata.category(output_char) == "Cf":
+                continue
+            if output_char.isspace():
+                if normalized and normalized[-1] != " ":
+                    normalized.append(" ")
+                    starts.append(index)
+                    ends.append(index + 1)
+                elif normalized:
+                    ends[-1] = index + 1
+                continue
+            normalized.append(output_char)
+            starts.append(index)
+            ends.append(index + 1)
+        index += 1
+
+    while normalized and normalized[-1] == " ":
+        normalized.pop()
+        starts.pop()
+        ends.pop()
+    return "".join(normalized), starts, ends
+
+
+def _normalized_source_match(source: str, selection: str) -> str | None:
+    normalized_source, starts, ends = _normalized_pdf_text(source)
+    normalized_selection, _, _ = _normalized_pdf_text(selection)
+    if not normalized_selection:
+        return None
+
+    match_start = normalized_source.find(normalized_selection)
+    match_length = len(normalized_selection)
+
+    # PDF.js can visually insert spacing between adjacent spans that is absent
+    # from cloneContents().textContent (or vice versa). For a meaningful-length
+    # selection, retry without whitespace while still returning server text.
+    if match_start < 0:
+        compact_source_chars: list[str] = []
+        compact_source_indexes: list[int] = []
+        for normalized_index, char in enumerate(normalized_source):
+            if not char.isspace():
+                compact_source_chars.append(char)
+                compact_source_indexes.append(normalized_index)
+        compact_selection = "".join(char for char in normalized_selection if not char.isspace())
+        if len(compact_selection) < 8:
+            return None
+        compact_start = "".join(compact_source_chars).find(compact_selection)
+        if compact_start < 0:
+            return None
+        match_start = compact_source_indexes[compact_start]
+        match_end = compact_source_indexes[compact_start + len(compact_selection) - 1] + 1
+    else:
+        match_end = match_start + match_length
+
+    return source[starts[match_start]:ends[match_end - 1]]
 
 
 def _section_name(text: str, fallback: str) -> str:
@@ -169,7 +257,9 @@ def resolve_page_selected_text(
     if not parts:
         return None
     match = re.search(r"\s+".join(re.escape(part) for part in parts), source)
-    return match.group(0) if match else None
+    if match:
+        return match.group(0)
+    return _normalized_source_match(source, selection)
 
 
 def retrieve_context(doc_id: str, pages: list[dict], question: str, current_page: int | None = None,

--- a/backend/tests/test_grounded_screen_context.py
+++ b/backend/tests/test_grounded_screen_context.py
@@ -260,6 +260,28 @@ def test_selected_text_is_resolved_to_canonical_page_source():
     assert resolve_page_selected_text(pages, 2, "invented statement") is None
 
 
+def test_selected_text_tolerates_common_pdf_extractor_differences():
+    from services.context_retrieval import resolve_page_selected_text
+
+    pages = [{
+        "page_num": 8,
+        "text": "The ﬁnal docu-\nment uses “grounded evidence” safely.",
+    }]
+    assert resolve_page_selected_text(
+        pages, 8, 'The final document uses "grounded evidence" safely.',
+    ) == "The ﬁnal docu-\nment uses “grounded evidence” safely."
+
+
+def test_selected_text_tolerates_missing_pdf_span_spaces_but_rejects_forgery():
+    from services.context_retrieval import resolve_page_selected_text
+
+    pages = [{"page_num": 8, "text": "Grounded evidence remains server canonical."}]
+    assert resolve_page_selected_text(
+        pages, 8, "Groundedevidenceremainsservercanonical.",
+    ) == "Grounded evidence remains server canonical."
+    assert resolve_page_selected_text(pages, 8, "inventedselection") is None
+
+
 def test_forged_selected_text_is_rejected_before_rate_or_llm(
     test_client, grounded_doc, isolated_dirs, monkeypatch,
 ):

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11736,7 +11736,16 @@ function createSelectionMenu() {
     const selection = window.getSelection()
     const text = extractSelectionText(selection).trim()
     if (text) {
-      askAIAssistant(text)
+      const range = selection.getRangeAt(0)
+      const commonNode = range.commonAncestorContainer
+      const commonEl = commonNode.nodeType === Node.ELEMENT_NODE
+        ? commonNode
+        : commonNode.parentElement
+      const pageWrapper = commonEl?.closest('.textLayer')?.closest('.pdf-page-wrapper')
+      const sourcePage = pageWrapper ? Number.parseInt(pageWrapper.dataset.page, 10) : null
+      askAIAssistant(text, {
+        sourcePage: Number.isInteger(sourcePage) ? sourcePage : null,
+      })
     }
     selection.removeAllRanges()
     hideSelectionMenu()
@@ -11970,7 +11979,7 @@ function createAnnHoverTooltip() {
     e.preventDefault(); e.stopPropagation()
     const text = activeHoveredSpan ? activeHoveredSpan.textContent.trim() : activeHoveredText
     if (text) {
-      askAIAssistant(text)
+      askAIAssistant(text, { sourcePage: activeHoveredPageNum })
     }
     hideAnnHoverTooltip()
   })
@@ -14247,13 +14256,19 @@ async function sendChatMessage() {
   // 텍스트 placeholder만 저장되고, 이건 이번 요청에서만 사용된다.
   let imageForThisTurn = null
   let selectedTextForThisTurn = null
+  let contextPageForThisTurn = state.currentPage
 
   if (state.quotedText) {
-    selectedTextForThisTurn = typeof state.quotedText === 'string' ? state.quotedText : state.quotedText?.text
-    const fullPayload = `[인용된 본문 내용]:\n"${state.quotedText}"\n\n[질문]:\n${text}`
+    const quotedText = typeof state.quotedText === 'string' ? state.quotedText : state.quotedText?.text
+    const sourcePage = typeof state.quotedText === 'object' ? state.quotedText?.sourcePage : null
+    if (quotedText && Number.isInteger(sourcePage) && sourcePage > 0) {
+      selectedTextForThisTurn = quotedText
+      contextPageForThisTurn = sourcePage
+    }
+    const fullPayload = `[인용된 본문 내용]:\n"${quotedText}"\n\n[질문]:\n${text}`
 
     // UI에 답장/인용구 레이아웃으로 표시
-    const userMsgHtml = `<div class="message-quote"><span class="quote-symbol">❝</span><span class="quote-body">${escapeHtml(state.quotedText)}</span></div><div class="message-text">${escapeHtml(text)}</div>`
+    const userMsgHtml = `<div class="message-quote"><span class="quote-symbol">❝</span><span class="quote-body">${escapeHtml(quotedText)}</span></div><div class="message-text">${escapeHtml(text)}</div>`
     appendChatMessage('user', userMsgHtml, true)
     state.chatHistory.push({ role: 'user', content: fullPayload })
 
@@ -14353,11 +14368,11 @@ async function sendChatMessage() {
     },
     imageForThisTurn,
     {
-      currentPage: state.currentPage,
+      currentPage: contextPageForThisTurn,
       selectedText: selectedTextForThisTurn,
       screenContext: {
         mode: "viewer",
-        page_num: state.currentPage,
+        page_num: contextPageForThisTurn,
         include_visual: null,
       },
       verifyEvidence: /근거\s*검증|verify\s+(?:the\s+)?evidence/i.test(text),
@@ -14596,14 +14611,19 @@ function initChatListeners() {
 // AI Chat Sidebar 리스너 초기화 실행
 initChatListeners()
 
-function askAIAssistant(text) {
+function askAIAssistant(text, { sourcePage = null } = {}) {
   if (!state.sessionId) {
     showToast('논문을 먼저 업로드하거나 선택해주세요.', 'error');
     return;
   }
 
   // 인용구 보관 및 영역 업데이트
-  state.quotedText = text;
+  // 원문 선택만 서버의 selected_text 검증 대상으로 보낸다. 번역문과 AI 답변은
+  // 현재 PDF 페이지 원문에 존재하지 않으므로 질문의 인용 문맥으로만 유지한다.
+  state.quotedText = {
+    text,
+    sourcePage: Number.isInteger(sourcePage) && sourcePage > 0 ? sourcePage : null,
+  };
   state.quotedImage = null;
   state.quotedImagePage = null;
 

--- a/frontend/tests/e2e/chat-quote.spec.js
+++ b/frontend/tests/e2e/chat-quote.spec.js
@@ -6,11 +6,14 @@ import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
 test('AI 채팅 답변 텍스트를 선택하면 Ask AI로 인용할 수 있다', async ({ page }) => {
   const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
   await mockBaseRoutes(page, { documents: [docA] })
+  const chatRequests = []
 
   await page.route('**/api/library/doc-A/pdf', route =>
     route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
-  await page.route('**/api/chat/stream', route =>
-    route.fulfill({ status: 200, contentType: 'text/plain', body: '트랜스포머 아키텍처는 셀프 어텐션 메커니즘을 핵심으로 사용하는 딥러닝 모델입니다.' }))
+  await page.route('**/api/chat/stream', async route => {
+    chatRequests.push(await route.request().postDataJSON())
+    return route.fulfill({ status: 200, contentType: 'text/plain', body: '트랜스포머 아키텍처는 셀프 어텐션 메커니즘을 핵심으로 사용하는 딥러닝 모델입니다.' })
+  })
 
   await gotoApp(page)
   await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
@@ -69,6 +72,13 @@ test('AI 채팅 답변 텍스트를 선택하면 Ask AI로 인용할 수 있다'
 
   await expect(page.locator('#chat-quote-area')).not.toHaveClass(/hidden/)
   await expect(page.locator('#chat-quote-text')).toHaveText('셀프 어텐션')
+
+  await page.fill('#chat-input', '이 부분을 더 설명해줘')
+  await page.click('#chat-send-btn')
+  await expect.poll(() => chatRequests.length).toBe(2)
+
+  expect(chatRequests[1].selected_text).toBeUndefined()
+  expect(chatRequests[1].messages.at(-1).content).toContain('셀프 어텐션')
 })
 
 // 사용자 자신이 보낸 메시지는 인용 대상에서 제외되어야 한다


### PR DESCRIPTION
# Summary
## 1. 뷰어 본문 인용 검증 안정화
- 원문 선택 페이지를 인용 상태에 보존해 해당 페이지 원문으로 검증하도록 수정함
- 번역문·AI 답변 인용은 원문 검증 대상에서 제외해 질문 문맥으로만 전달하도록 수정함
## 2. PDF 추출 차이 대응
- ligature, soft hyphen, 줄바꿈 하이픈, 공백, 따옴표 차이를 정규화해 서버 원문과 매칭하도록 수정함
- 서버 원문에 없는 위조 선택문은 기존처럼 거부하도록 유지함
## 3. 회귀 테스트 추가
- AI 답변 인용이 selected_text로 전송되지 않는 E2E 테스트를 추가함
- PDF 추출 차이와 위조 선택문 거부를 검증하는 백엔드 테스트를 추가함