### PR TITLE
fix: 메모·하이라이트 다중 기기 동기화 개선

### DIFF
--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -9,7 +9,7 @@ from services.library import (
     patch_document_metadata,
     get_chat_quote_image_path, list_folders, create_folder, update_folder, delete_folder, move_documents_to_folder
 )
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 import json
 import re
 
@@ -26,7 +26,7 @@ def _document_translation_suffix(doc, target_lang, style, ignore_math, ignore_ta
     )
 
 
-from typing import Optional
+from typing import Literal, Optional
 
 class FolderCreateRequest(BaseModel):
     name: str
@@ -92,6 +92,37 @@ class LibraryMirrorPayload(BaseModel):
         encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         if len(encoded) > MAX_LIBRARY_MIRROR_JSON_BYTES:
             raise ValueError("주석 또는 메모 데이터는 5MiB 이하여야 합니다.")
+        return value
+
+
+class LibrarySyncMutation(BaseModel):
+    mutation_id: str = Field(min_length=1, max_length=128)
+    operation: Literal["upsert", "delete"]
+    item_id: str = Field(min_length=1, max_length=128)
+    page_key: str = Field(min_length=1, max_length=64)
+    base_version: int = Field(default=0, ge=0)
+    item: Optional[dict] = None
+
+    @model_validator(mode="after")
+    def require_upsert_item(self):
+        if self.operation == "upsert" and not isinstance(self.item, dict):
+            raise ValueError("upsert 작업에는 item이 필요합니다.")
+        return self
+
+
+class LibrarySyncPayload(BaseModel):
+    client_id: str = Field(min_length=1, max_length=128)
+    mutations: list[LibrarySyncMutation] = Field(min_length=1, max_length=1000)
+
+    @field_validator("mutations")
+    @classmethod
+    def limit_serialized_size(cls, value):
+        encoded = json.dumps(
+            [mutation.model_dump() for mutation in value], ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(encoded) > MAX_LIBRARY_MIRROR_JSON_BYTES:
+            raise ValueError("주석 또는 메모 동기화 데이터는 5MiB 이하여야 합니다.")
         return value
 
 
@@ -1072,42 +1103,56 @@ async def resolve_library_reference(doc_id: str, ref_num: str, current_user: str
 
 @router.get("/library/{doc_id}/annotations")
 async def get_library_annotations(doc_id: str, current_user: str = Depends(get_current_user)):
-    """문서의 하이라이트/주석 서버 미러 데이터를 반환합니다.
-
-    localStorage가 원본(source of truth)이며 이 데이터는 다중 기기 동기화를
-    위한 best-effort 백업일 뿐이다. 저장된 적이 없으면 빈 데이터를 반환한다.
-    """
+    """서버 기준 하이라이트/주석 snapshot을 반환합니다."""
     require_owned_document(doc_id, current_user)
     from services.db import db_get_annotations
     result = db_get_annotations(doc_id)
-    return result or {"data": {}, "updated_at": None}
+    return result or {"data": {}, "updated_at": None, "revision": 0,
+                      "item_versions": {}, "tombstones": {}}
 
 
 @router.put("/library/{doc_id}/annotations")
 async def put_library_annotations(doc_id: str, payload: LibraryMirrorPayload, current_user: str = Depends(get_current_user)):
-    """하이라이트/주석 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
+    """구버전 클라이언트 데이터를 삭제 없이 안전하게 병합합니다."""
     require_owned_document(doc_id, current_user)
     from services.db import db_put_annotations
     db_put_annotations(doc_id, payload.data)
     return {"status": "ok"}
 
 
+@router.patch("/library/{doc_id}/annotations")
+async def patch_library_annotations(doc_id: str, payload: LibrarySyncPayload, current_user: str = Depends(get_current_user)):
+    require_owned_document(doc_id, current_user)
+    from services.annotation_sync import apply_mutations
+    return apply_mutations("annotations", doc_id, payload.client_id,
+                           [mutation.model_dump() for mutation in payload.mutations])
+
+
 @router.get("/library/{doc_id}/memos")
 async def get_library_memos(doc_id: str, current_user: str = Depends(get_current_user)):
-    """문서의 메모 서버 미러 데이터를 반환합니다. (annotations와 동일한 성격)"""
+    """서버 기준 메모 snapshot을 반환합니다."""
     require_owned_document(doc_id, current_user)
     from services.db import db_get_memos
     result = db_get_memos(doc_id)
-    return result or {"data": {}, "updated_at": None}
+    return result or {"data": {}, "updated_at": None, "revision": 0,
+                      "item_versions": {}, "tombstones": {}}
 
 
 @router.put("/library/{doc_id}/memos")
 async def put_library_memos(doc_id: str, payload: LibraryMirrorPayload, current_user: str = Depends(get_current_user)):
-    """메모 서버 미러를 통째로 덮어씁니다(전체 블롭 upsert)."""
+    """구버전 클라이언트 데이터를 삭제 없이 안전하게 병합합니다."""
     require_owned_document(doc_id, current_user)
     from services.db import db_put_memos
     db_put_memos(doc_id, payload.data)
     return {"status": "ok"}
+
+
+@router.patch("/library/{doc_id}/memos")
+async def patch_library_memos(doc_id: str, payload: LibrarySyncPayload, current_user: str = Depends(get_current_user)):
+    require_owned_document(doc_id, current_user)
+    from services.annotation_sync import apply_mutations
+    return apply_mutations("memos", doc_id, payload.client_id,
+                           [mutation.model_dump() for mutation in payload.mutations])
 
 
 @router.get("/library/tags/ontology")

--- a/backend/services/annotation_sync.py
+++ b/backend/services/annotation_sync.py
@@ -1,0 +1,240 @@
+"""Versioned, item-level synchronization for annotations and memos."""
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from services.db import get_db
+
+
+RESOURCES = {"annotations", "memos"}
+
+
+def _check_resource(resource: str) -> None:
+    if resource not in RESOURCES:
+        raise ValueError("Unsupported sync resource")
+
+
+def _legacy_id(resource: str, page_key: str, item: dict, index: int) -> str:
+    identity = {key: value for key, value in item.items() if key not in {"id", "version"}}
+    encoded = json.dumps(
+        [resource, page_key, identity, index], ensure_ascii=False, sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"legacy_{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def normalize_data(resource: str, data: dict) -> tuple[dict, bool]:
+    normalized: dict = {}
+    changed = False
+    for page_key, raw_items in (data or {}).items():
+        if not isinstance(raw_items, list):
+            continue
+        items = []
+        for index, raw_item in enumerate(raw_items):
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            if not item.get("id"):
+                item["id"] = _legacy_id(resource, page_key, item, index)
+                changed = True
+            items.append(item)
+        normalized[page_key] = items
+    return normalized, changed
+
+
+def empty_snapshot() -> dict:
+    return {"data": {}, "updated_at": None, "revision": 0, "item_versions": {}, "tombstones": {}}
+
+
+def _write(conn, resource: str, doc_id: str, snapshot: dict) -> str:
+    updated_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        f"""INSERT INTO {resource} (doc_id, data, updated_at, revision, item_versions, tombstones)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(doc_id) DO UPDATE SET
+          data = excluded.data, updated_at = excluded.updated_at,
+          revision = excluded.revision, item_versions = excluded.item_versions,
+          tombstones = excluded.tombstones""",
+        (doc_id, json.dumps(snapshot["data"], ensure_ascii=False), updated_at,
+         snapshot["revision"], json.dumps(snapshot["item_versions"]),
+         json.dumps(snapshot["tombstones"])),
+    )
+    snapshot["updated_at"] = updated_at
+    return updated_at
+
+
+def _read(conn, resource: str, doc_id: str) -> Optional[dict]:
+    row = conn.execute(
+        f"SELECT data, updated_at, revision, item_versions, tombstones FROM {resource} WHERE doc_id = ?",
+        (doc_id,),
+    ).fetchone()
+    if not row:
+        return None
+    data, normalized = normalize_data(resource, json.loads(row["data"]))
+    snapshot = {
+        "data": data,
+        "updated_at": row["updated_at"],
+        "revision": int(row["revision"] or 0),
+        "item_versions": json.loads(row["item_versions"] or "{}"),
+        "tombstones": json.loads(row["tombstones"] or "{}"),
+    }
+    if normalized or (data and snapshot["revision"] == 0):
+        snapshot["revision"] = max(1, snapshot["revision"])
+        for items in data.values():
+            for item in items:
+                snapshot["item_versions"].setdefault(item["id"], snapshot["revision"])
+        _write(conn, resource, doc_id, snapshot)
+    return snapshot
+
+
+def _find(data: dict, item_id: str):
+    for page_key, items in data.items():
+        for index, item in enumerate(items):
+            if item.get("id") == item_id:
+                return page_key, index, item
+    return None, None, None
+
+
+def _remove(data: dict, item_id: str):
+    page_key, index, item = _find(data, item_id)
+    if page_key is not None:
+        del data[page_key][index]
+        if not data[page_key]:
+            del data[page_key]
+    return item
+
+
+def _has_conflict_copy(data: dict, item_id: str, incoming: dict) -> bool:
+    comparable = {key: value for key, value in incoming.items() if key not in {"id", "conflict_of"}}
+    for items in data.values():
+        for item in items:
+            if item.get("conflict_of") != item_id:
+                continue
+            existing = {key: value for key, value in item.items() if key not in {"id", "conflict_of"}}
+            if existing == comparable:
+                return True
+    return False
+
+
+def get_snapshot(resource: str, doc_id: str) -> Optional[dict]:
+    _check_resource(resource)
+    with get_db() as conn:
+        snapshot = _read(conn, resource, doc_id)
+        conn.commit()
+        return snapshot
+
+
+def legacy_merge(resource: str, doc_id: str, incoming: dict) -> dict:
+    """Merge legacy PUT data; a missing item never means delete."""
+    _check_resource(resource)
+    incoming, _ = normalize_data(resource, incoming)
+    with get_db() as conn:
+        snapshot = _read(conn, resource, doc_id) or empty_snapshot()
+        for page_key, items in incoming.items():
+            for incoming_item in items:
+                item = incoming_item
+                item_id = item["id"]
+                if item_id in snapshot["tombstones"]:
+                    continue
+                _, _, existing = _find(snapshot["data"], item_id)
+                if existing == item:
+                    continue
+                if existing is not None:
+                    if _has_conflict_copy(snapshot["data"], item_id, item):
+                        continue
+                    item = {**item, "id": str(uuid.uuid4()), "conflict_of": item_id}
+                    item_id = item["id"]
+                snapshot["revision"] += 1
+                snapshot["data"].setdefault(page_key, []).append(item)
+                snapshot["item_versions"][item_id] = snapshot["revision"]
+        _write(conn, resource, doc_id, snapshot)
+        conn.commit()
+        return snapshot
+
+
+def apply_mutations(resource: str, doc_id: str, client_id: str, mutations: list[dict]) -> dict:
+    _check_resource(resource)
+    results = []
+    with get_db() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        snapshot = _read(conn, resource, doc_id) or empty_snapshot()
+        changed = False
+        for mutation in mutations:
+            mutation_id = mutation["mutation_id"]
+            prior = conn.execute(
+                """SELECT result FROM annotation_mutations
+                   WHERE resource = ? AND doc_id = ? AND client_id = ? AND mutation_id = ?""",
+                (resource, doc_id, client_id, mutation_id),
+            ).fetchone()
+            if prior:
+                result = json.loads(prior["result"])
+                result["already_applied"] = True
+                results.append(result)
+                continue
+
+            item_id = mutation["item_id"]
+            base_version = int(mutation.get("base_version") or 0)
+            tombstone = snapshot["tombstones"].get(item_id) or {}
+            current_version = int(snapshot["item_versions"].get(item_id) or tombstone.get("version", 0))
+            page_key, _, current_item = _find(snapshot["data"], item_id)
+            result = {"mutation_id": mutation_id, "item_id": item_id, "applied": False,
+                      "already_applied": False, "conflict_copy": False,
+                      "delete_conflict_preserved": False}
+
+            if mutation["operation"] == "delete":
+                if item_id in snapshot["tombstones"]:
+                    result["already_applied"] = True
+                elif current_item is not None and base_version == current_version:
+                    _remove(snapshot["data"], item_id)
+                    snapshot["revision"] += 1
+                    snapshot["item_versions"][item_id] = snapshot["revision"]
+                    snapshot["tombstones"][item_id] = {"version": snapshot["revision"], "page_key": page_key}
+                    result["applied"], changed = True, True
+                elif current_item is not None:
+                    result["delete_conflict_preserved"] = True
+                else:
+                    snapshot["revision"] += 1
+                    snapshot["item_versions"][item_id] = snapshot["revision"]
+                    snapshot["tombstones"][item_id] = {
+                        "version": snapshot["revision"], "page_key": mutation.get("page_key")}
+                    result["applied"], changed = True, True
+            else:
+                item = {**(mutation.get("item") or {}), "id": item_id}
+                if current_item == item:
+                    result["already_applied"] = True
+                elif current_item is None and item_id not in snapshot["tombstones"] and base_version == 0:
+                    snapshot["revision"] += 1
+                    snapshot["data"].setdefault(mutation["page_key"], []).append(item)
+                    snapshot["item_versions"][item_id] = snapshot["revision"]
+                    result["applied"], changed = True, True
+                elif current_item is not None and base_version == current_version:
+                    _remove(snapshot["data"], item_id)
+                    snapshot["revision"] += 1
+                    snapshot["data"].setdefault(mutation["page_key"], []).append(item)
+                    snapshot["item_versions"][item_id] = snapshot["revision"]
+                    result["applied"], changed = True, True
+                else:
+                    copy_id = str(uuid.uuid4())
+                    copy_item = {**item, "id": copy_id, "conflict_of": item_id}
+                    snapshot["revision"] += 1
+                    snapshot["data"].setdefault(mutation["page_key"], []).append(copy_item)
+                    snapshot["item_versions"][copy_id] = snapshot["revision"]
+                    result.update({"conflict_copy": True, "conflict_copy_id": copy_id})
+                    changed = True
+
+            conn.execute(
+                """INSERT INTO annotation_mutations
+                   (resource, doc_id, client_id, mutation_id, result, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (resource, doc_id, client_id, mutation_id, json.dumps(result),
+                 datetime.now(timezone.utc).isoformat()),
+            )
+            results.append(result)
+
+        if changed:
+            _write(conn, resource, doc_id, snapshot)
+        conn.commit()
+    return {**snapshot, "results": results}

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -406,6 +406,9 @@ def init_db():
             doc_id TEXT PRIMARY KEY,
             data TEXT NOT NULL,
             updated_at TEXT NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 0,
+            item_versions TEXT NOT NULL DEFAULT '{}',
+            tombstones TEXT NOT NULL DEFAULT '{}',
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
         )
         """)
@@ -414,6 +417,31 @@ def init_db():
             doc_id TEXT PRIMARY KEY,
             data TEXT NOT NULL,
             updated_at TEXT NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 0,
+            item_versions TEXT NOT NULL DEFAULT '{}',
+            tombstones TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
+        )
+        """)
+        for table in ("annotations", "memos"):
+            for column_sql in (
+                f"ALTER TABLE {table} ADD COLUMN revision INTEGER NOT NULL DEFAULT 0",
+                f"ALTER TABLE {table} ADD COLUMN item_versions TEXT NOT NULL DEFAULT '{{}}'",
+                f"ALTER TABLE {table} ADD COLUMN tombstones TEXT NOT NULL DEFAULT '{{}}'",
+            ):
+                try:
+                    cursor.execute(column_sql)
+                except sqlite3.OperationalError:
+                    pass
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS annotation_mutations (
+            resource TEXT NOT NULL,
+            doc_id TEXT NOT NULL,
+            client_id TEXT NOT NULL,
+            mutation_id TEXT NOT NULL,
+            result TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (resource, doc_id, client_id, mutation_id),
             FOREIGN KEY (doc_id) REFERENCES documents (id) ON DELETE CASCADE
         )
         """)
@@ -2008,53 +2036,23 @@ def db_search_graph_nodes(doc_ids: List[str], query: str) -> Dict[str, List[str]
 # ── 메모 / 하이라이트 서버 미러 ───────────────────────────────────────────────
 
 def db_get_annotations(doc_id: str) -> Optional[Dict[str, Any]]:
-    with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute("SELECT data, updated_at FROM annotations WHERE doc_id = ?", (doc_id,))
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {"data": json.loads(row["data"]), "updated_at": row["updated_at"]}
+    from services.annotation_sync import get_snapshot
+    return get_snapshot("annotations", doc_id)
 
 
 def db_put_annotations(doc_id: str, data: dict) -> None:
-    updated_at = datetime.now(timezone.utc).isoformat()
-    data_str = json.dumps(data, ensure_ascii=False)
-    with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO annotations (doc_id, data, updated_at) VALUES (?, ?, ?)
-            ON CONFLICT(doc_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
-            """,
-            (doc_id, data_str, updated_at)
-        )
-        conn.commit()
+    from services.annotation_sync import legacy_merge
+    legacy_merge("annotations", doc_id, data)
 
 
 def db_get_memos(doc_id: str) -> Optional[Dict[str, Any]]:
-    with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute("SELECT data, updated_at FROM memos WHERE doc_id = ?", (doc_id,))
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {"data": json.loads(row["data"]), "updated_at": row["updated_at"]}
+    from services.annotation_sync import get_snapshot
+    return get_snapshot("memos", doc_id)
 
 
 def db_put_memos(doc_id: str, data: dict) -> None:
-    updated_at = datetime.now(timezone.utc).isoformat()
-    data_str = json.dumps(data, ensure_ascii=False)
-    with get_db() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO memos (doc_id, data, updated_at) VALUES (?, ?, ?)
-            ON CONFLICT(doc_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
-            """,
-            (doc_id, data_str, updated_at)
-        )
-        conn.commit()
+    from services.annotation_sync import legacy_merge
+    legacy_merge("memos", doc_id, data)
 
 
 def db_get_memo_counts_for_docs(doc_ids: List[str]) -> Dict[str, int]:

--- a/backend/tests/test_annotation_sync.py
+++ b/backend/tests/test_annotation_sync.py
@@ -1,0 +1,160 @@
+def _doc(isolated_dirs, doc_id="sync-doc", username="testuser"):
+    isolated_dirs["db"].db_save_document(doc_id, username, "paper.pdf", "/x/paper.pdf", 2, {})
+
+
+def _mutation(mid, operation, item_id, page_key="page_1", base_version=0, item=None):
+    value = {"mutation_id": mid, "operation": operation, "item_id": item_id,
+             "page_key": page_key, "base_version": base_version}
+    if item is not None:
+        value["item"] = item
+    return value
+
+
+def _patch(client, resource, client_id, mutations, doc_id="sync-doc"):
+    return client.patch(f"/api/library/{doc_id}/{resource}", json={
+        "client_id": client_id, "mutations": mutations,
+    })
+
+
+def test_init_db_adds_sync_columns_to_legacy_tables(isolated_dirs):
+    db = isolated_dirs["db"]
+    with db.get_db() as conn:
+        conn.execute("DROP TABLE annotation_mutations")
+        conn.execute("DROP TABLE annotations")
+        conn.execute("DROP TABLE memos")
+        conn.execute("CREATE TABLE annotations (doc_id TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        conn.execute("CREATE TABLE memos (doc_id TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        conn.commit()
+
+    db.init_db()
+
+    with db.get_db() as conn:
+        annotation_columns = {row[1] for row in conn.execute("PRAGMA table_info(annotations)")}
+        memo_columns = {row[1] for row in conn.execute("PRAGMA table_info(memos)")}
+        mutation_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'annotation_mutations'"
+        ).fetchone()
+    assert {"revision", "item_versions", "tombstones"}.issubset(annotation_columns)
+    assert {"revision", "item_versions", "tombstones"}.issubset(memo_columns)
+    assert mutation_table is not None
+
+
+def test_schema_migrates_existing_blob_and_assigns_ids(isolated_dirs):
+    db = isolated_dirs["db"]
+    _doc(isolated_dirs)
+    with db.get_db() as conn:
+        conn.execute("INSERT INTO annotations (doc_id, data, updated_at) VALUES (?, ?, ?)",
+                     ("sync-doc", '{"page_1":[{"text":"old","startOffset":1}]}', "old"))
+        conn.commit()
+    snapshot = db.db_get_annotations("sync-doc")
+    item = snapshot["data"]["page_1"][0]
+    assert item["id"].startswith("legacy_")
+    assert snapshot["revision"] == 1
+    assert snapshot["item_versions"][item["id"]] == 1
+
+
+def test_independent_items_merge_and_retry_is_idempotent(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    first = _mutation("m1", "upsert", "a", item={"id": "a", "text": "A"})
+    second = _mutation("m2", "upsert", "b", item={"id": "b", "text": "B"})
+    assert _patch(test_client, "annotations", "mac", [first]).status_code == 200
+    response = _patch(test_client, "annotations", "windows", [second]).json()
+    assert {item["id"] for item in response["data"]["page_1"]} == {"a", "b"}
+    retry = _patch(test_client, "annotations", "windows", [second]).json()
+    assert retry["revision"] == response["revision"]
+    assert retry["results"][0]["already_applied"] is True
+
+
+def test_stale_update_creates_conflict_copy(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    created = _patch(test_client, "memos", "mac", [
+        _mutation("create", "upsert", "memo", item={"id": "memo", "content": "original"})
+    ]).json()
+    version = created["item_versions"]["memo"]
+    updated = _patch(test_client, "memos", "mac", [
+        _mutation("edit", "upsert", "memo", base_version=version,
+                  item={"id": "memo", "content": "server edit"})
+    ]).json()
+    conflict = _patch(test_client, "memos", "windows", [
+        _mutation("stale", "upsert", "memo", base_version=version,
+                  item={"id": "memo", "content": "local edit"})
+    ]).json()
+    assert conflict["results"][0]["conflict_copy"] is True
+    assert {item["content"] for item in conflict["data"]["page_1"]} == {"server edit", "local edit"}
+    assert updated["revision"] + 1 == conflict["revision"]
+
+
+def test_stale_delete_preserves_newer_server_item(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    created = _patch(test_client, "memos", "one", [
+        _mutation("create", "upsert", "memo", item={"id": "memo", "content": "v1"})
+    ]).json()
+    old_version = created["item_versions"]["memo"]
+    _patch(test_client, "memos", "one", [
+        _mutation("update", "upsert", "memo", base_version=old_version,
+                  item={"id": "memo", "content": "v2"})
+    ])
+    response = _patch(test_client, "memos", "two", [
+        _mutation("delete", "delete", "memo", base_version=old_version)
+    ]).json()
+    assert response["results"][0]["delete_conflict_preserved"] is True
+    assert response["data"]["page_1"][0]["content"] == "v2"
+
+
+def test_stale_update_after_delete_is_preserved_as_conflict_copy(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    created = _patch(test_client, "memos", "one", [
+        _mutation("create", "upsert", "memo", item={"id": "memo", "content": "v1"})
+    ]).json()
+    version = created["item_versions"]["memo"]
+    _patch(test_client, "memos", "one", [
+        _mutation("delete", "delete", "memo", base_version=version)
+    ])
+    conflict = _patch(test_client, "memos", "two", [
+        _mutation("stale-edit", "upsert", "memo", base_version=version,
+                  item={"id": "memo", "content": "offline edit"})
+    ]).json()
+    assert conflict["results"][0]["conflict_copy"] is True
+    assert conflict["data"]["page_1"][0]["content"] == "offline edit"
+    assert "memo" in conflict["tombstones"]
+
+
+def test_retried_legacy_conflict_does_not_duplicate_copy(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    payload = {"data": {"page_1": [{"id": "memo", "content": "server"}]}}
+    assert test_client.put("/api/library/sync-doc/memos", json=payload).status_code == 200
+    stale = {"data": {"page_1": [{"id": "memo", "content": "local"}]}}
+    assert test_client.put("/api/library/sync-doc/memos", json=stale).status_code == 200
+    first = test_client.get("/api/library/sync-doc/memos").json()
+    assert test_client.put("/api/library/sync-doc/memos", json=stale).status_code == 200
+    retried = test_client.get("/api/library/sync-doc/memos").json()
+    assert len(retried["data"]["page_1"]) == 2
+    assert retried["revision"] == first["revision"]
+
+
+def test_delete_tombstone_blocks_legacy_resurrection(test_client, isolated_dirs):
+    _doc(isolated_dirs)
+    created = _patch(test_client, "annotations", "one", [
+        _mutation("create", "upsert", "a", item={"id": "a", "text": "old"})
+    ]).json()
+    deleted = _patch(test_client, "annotations", "one", [
+        _mutation("delete", "delete", "a", base_version=created["item_versions"]["a"])
+    ]).json()
+    assert "a" in deleted["tombstones"]
+    assert test_client.put("/api/library/sync-doc/annotations", json={
+        "data": {"page_1": [{"id": "a", "text": "old"}]},
+    }).status_code == 200
+    assert test_client.get("/api/library/sync-doc/annotations").json()["data"] == {}
+
+
+def test_patch_enforces_ownership_and_payload_limit(test_client, isolated_dirs):
+    _doc(isolated_dirs, "other-doc", "otheruser")
+    denied = _patch(test_client, "memos", "client", [
+        _mutation("m", "upsert", "x", item={"id": "x"})
+    ], "other-doc")
+    assert denied.status_code == 404
+    _doc(isolated_dirs, "large-doc")
+    large = _patch(test_client, "memos", "client", [
+        _mutation("large", "upsert", "x", item={"id": "x", "content": "x" * (5 * 1024 * 1024)})
+    ], "large-doc")
+    assert large.status_code == 422

--- a/backend/tests/test_library_annotations_memos_api.py
+++ b/backend/tests/test_library_annotations_memos_api.py
@@ -17,14 +17,16 @@ def test_get_annotations_with_no_saved_data_returns_empty_shape(test_client, iso
     _create_doc_owned_by(isolated_dirs, "doc-anno-empty", "testuser")
     res = test_client.get("/api/library/doc-anno-empty/annotations")
     assert res.status_code == 200
-    assert res.json() == {"data": {}, "updated_at": None}
+    assert res.json() == {"data": {}, "updated_at": None, "revision": 0,
+                          "item_versions": {}, "tombstones": {}}
 
 
 def test_get_memos_with_no_saved_data_returns_empty_shape(test_client, isolated_dirs):
     _create_doc_owned_by(isolated_dirs, "doc-memo-empty", "testuser")
     res = test_client.get("/api/library/doc-memo-empty/memos")
     assert res.status_code == 200
-    assert res.json() == {"data": {}, "updated_at": None}
+    assert res.json() == {"data": {}, "updated_at": None, "revision": 0,
+                          "item_versions": {}, "tombstones": {}}
 
 
 def test_put_then_get_annotations_round_trips(test_client, isolated_dirs):

--- a/frontend/src/annotationSync.js
+++ b/frontend/src/annotationSync.js
@@ -1,0 +1,272 @@
+import {
+  fetchLibraryAnnotations, fetchLibraryMemos,
+  patchLibraryAnnotations, patchLibraryMemos,
+} from './library.js'
+
+const RESOURCE_CONFIG = {
+  annotations: {
+    storagePrefix: 'easypaper_annotations_',
+    fetchSnapshot: fetchLibraryAnnotations,
+    patchMutations: patchLibraryAnnotations,
+  },
+  memos: {
+    storagePrefix: 'easypaper_memos_',
+    fetchSnapshot: fetchLibraryMemos,
+    patchMutations: patchLibraryMemos,
+  },
+}
+
+const CLIENT_ID_KEY = 'easypaper_annotation_sync_client_id'
+const QUEUE_PREFIX = 'easypaper_annotation_sync_queue_'
+const META_PREFIX = 'easypaper_annotation_sync_meta_'
+
+function randomId(prefix = '') {
+  const value = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+  return `${prefix}${value}`
+}
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map(key => [key, stableValue(value[key])]))
+  }
+  return value
+}
+
+function comparableItem(item) {
+  const value = { ...item }
+  delete value.version
+  return value
+}
+
+export function itemFingerprint(resource, pageKey, item) {
+  const value = { ...comparableItem(item) }
+  delete value.id
+  delete value.conflict_of
+  return JSON.stringify(stableValue([resource, pageKey, value]))
+}
+
+function parse(storage, key, fallback) {
+  try {
+    const value = JSON.parse(storage.getItem(key))
+    return value ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+function resourceKey(resource, docId) {
+  return `${RESOURCE_CONFIG[resource].storagePrefix}${docId}`
+}
+
+function queueKey(resource, docId) {
+  return `${QUEUE_PREFIX}${resource}_${docId}`
+}
+
+function metaKey(resource, docId) {
+  return `${META_PREFIX}${resource}_${docId}`
+}
+
+export function getSyncClientId(storage = localStorage) {
+  let clientId = storage.getItem(CLIENT_ID_KEY)
+  if (!clientId) {
+    clientId = randomId('client_')
+    storage.setItem(CLIENT_ID_KEY, clientId)
+  }
+  return clientId
+}
+
+function flatten(data) {
+  const result = new Map()
+  Object.entries(data || {}).forEach(([pageKey, items]) => {
+    ;(items || []).forEach(item => {
+      if (item?.id) result.set(item.id, { pageKey, item })
+    })
+  })
+  return result
+}
+
+export function normalizeResourceData(resource, data, referenceData = {}) {
+  const references = new Map()
+  Object.entries(referenceData || {}).forEach(([pageKey, items]) => {
+    ;(items || []).forEach(item => {
+      if (!item?.id) return
+      const key = itemFingerprint(resource, pageKey, item)
+      if (!references.has(key)) references.set(key, [])
+      references.get(key).push(item.id)
+    })
+  })
+  const used = new Set()
+  let changed = false
+  const normalized = {}
+  Object.entries(data || {}).forEach(([pageKey, items]) => {
+    if (!Array.isArray(items)) return
+    normalized[pageKey] = items.filter(item => item && typeof item === 'object').map(item => {
+      if (item.id) {
+        used.add(item.id)
+        return { ...item }
+      }
+      const candidates = references.get(itemFingerprint(resource, pageKey, item)) || []
+      const matched = candidates.find(id => !used.has(id))
+      const id = matched || randomId(resource === 'memos' ? 'memo_' : 'annotation_')
+      used.add(id)
+      changed = true
+      return { ...item, id }
+    })
+  })
+  return { data: normalized, changed }
+}
+
+export function ensureLocalResourceIds(resource, docId, data, storage = localStorage) {
+  const normalized = normalizeResourceData(resource, data)
+  if (normalized.changed) {
+    storage.setItem(resourceKey(resource, docId), JSON.stringify(normalized.data))
+  }
+  return normalized.data
+}
+
+function readQueue(resource, docId, storage) {
+  return parse(storage, queueKey(resource, docId), [])
+}
+
+function writeQueue(resource, docId, queue, storage) {
+  if (queue.length) storage.setItem(queueKey(resource, docId), JSON.stringify(queue))
+  else storage.removeItem(queueKey(resource, docId))
+}
+
+function enqueue(queue, mutation) {
+  const index = queue.findIndex(entry => entry.item_id === mutation.item_id)
+  if (index < 0) return [...queue, mutation]
+  const existing = queue[index]
+  if (existing.operation === 'upsert' && existing.base_version === 0 && mutation.operation === 'delete') {
+    return queue.filter((_, itemIndex) => itemIndex !== index)
+  }
+  const next = queue.slice()
+  next[index] = { ...mutation, base_version: existing.base_version }
+  return next
+}
+
+export function recordLocalResourceChange(resource, docId, nextData, storage = localStorage) {
+  const key = resourceKey(resource, docId)
+  const previousRaw = parse(storage, key, {})
+  const previous = normalizeResourceData(resource, previousRaw).data
+  const normalized = normalizeResourceData(resource, nextData, previous).data
+  const before = flatten(previous)
+  const after = flatten(normalized)
+  const meta = parse(storage, metaKey(resource, docId), { item_versions: {} })
+  let queue = readQueue(resource, docId, storage)
+
+  after.forEach(({ pageKey, item }, itemId) => {
+    const old = before.get(itemId)
+    if (old && JSON.stringify(stableValue(comparableItem(old.item))) === JSON.stringify(stableValue(comparableItem(item)))
+        && old.pageKey === pageKey) return
+    queue = enqueue(queue, {
+      mutation_id: randomId('mutation_'), operation: 'upsert', item_id: itemId,
+      page_key: pageKey, base_version: Number(meta.item_versions?.[itemId] || 0), item,
+    })
+  })
+  before.forEach(({ pageKey }, itemId) => {
+    if (after.has(itemId)) return
+    queue = enqueue(queue, {
+      mutation_id: randomId('mutation_'), operation: 'delete', item_id: itemId,
+      page_key: pageKey, base_version: Number(meta.item_versions?.[itemId] || 0),
+    })
+  })
+  storage.setItem(key, JSON.stringify(normalized))
+  writeQueue(resource, docId, queue, storage)
+  return normalized
+}
+
+function overlayPending(snapshotData, queue) {
+  const data = Object.fromEntries(Object.entries(snapshotData || {}).map(([key, items]) => [key, [...items]]))
+  queue.forEach(mutation => {
+    Object.keys(data).forEach(pageKey => {
+      data[pageKey] = data[pageKey].filter(item => item.id !== mutation.item_id)
+      if (!data[pageKey].length) delete data[pageKey]
+    })
+    if (mutation.operation === 'upsert') {
+      data[mutation.page_key] ||= []
+      data[mutation.page_key].push(mutation.item)
+    }
+  })
+  return data
+}
+
+function seedUpgradeQueue(resource, localData, snapshot, queue) {
+  const local = flatten(localData)
+  const server = flatten(snapshot.data)
+  const tombstones = snapshot.tombstones || {}
+  let next = queue
+  local.forEach(({ pageKey, item }, itemId) => {
+    if (tombstones[itemId]) return
+    const remote = server.get(itemId)
+    if (remote && JSON.stringify(stableValue(comparableItem(remote.item))) === JSON.stringify(stableValue(comparableItem(item)))) return
+    if (next.some(entry => entry.item_id === itemId)) return
+    next = enqueue(next, {
+      mutation_id: randomId('mutation_'), operation: 'upsert', item_id: itemId,
+      page_key: pageKey, base_version: 0, item,
+    })
+  })
+  return next
+}
+
+function requireSnapshot(value) {
+  if (!value || !value.data || typeof value.data !== 'object' || Array.isArray(value.data)) {
+    throw new Error('Invalid annotation sync snapshot')
+  }
+  return value
+}
+
+export async function syncResource(resource, docId, options = {}) {
+  const storage = options.storage || localStorage
+  const config = options.config || RESOURCE_CONFIG[resource]
+  const key = resourceKey(resource, docId)
+  const localRaw = parse(storage, key, {})
+  const snapshot = requireSnapshot(await config.fetchSnapshot(docId))
+  const normalized = normalizeResourceData(resource, localRaw, snapshot.data || {})
+  let local = normalized.data
+  const tombstones = snapshot.tombstones || {}
+  Object.keys(local).forEach(pageKey => {
+    local[pageKey] = local[pageKey].filter(item => !tombstones[item.id])
+    if (!local[pageKey].length) delete local[pageKey]
+  })
+  let queue = readQueue(resource, docId, storage)
+  const meta = parse(storage, metaKey(resource, docId), null)
+  if (!meta) queue = seedUpgradeQueue(resource, local, snapshot, queue)
+  writeQueue(resource, docId, queue, storage)
+
+  let latest = snapshot
+  const sentIds = new Set(queue.map(item => item.mutation_id))
+  if (queue.length) {
+    latest = requireSnapshot(await config.patchMutations(docId, {
+      client_id: getSyncClientId(storage), mutations: queue,
+    }, { keepalive: options.keepalive === true }))
+    queue = readQueue(resource, docId, storage).filter(item => !sentIds.has(item.mutation_id))
+    writeQueue(resource, docId, queue, storage)
+  }
+  const merged = overlayPending(latest.data || {}, queue)
+  storage.setItem(key, JSON.stringify(merged))
+  storage.setItem(metaKey(resource, docId), JSON.stringify({
+    revision: latest.revision || 0,
+    item_versions: latest.item_versions || {},
+    tombstones: latest.tombstones || {},
+  }))
+  return {
+    data: merged,
+    snapshot: latest,
+    conflicts: (latest.results || []).filter(result => result.conflict_copy || result.delete_conflict_preserved),
+  }
+}
+
+export async function syncDocumentAnnotations(docId, options = {}) {
+  const [annotations, memos] = await Promise.all([
+    syncResource('annotations', docId, options),
+    syncResource('memos', docId, options),
+  ])
+  return { annotations, memos }
+}
+
+export function hasPendingAnnotationSync(docId, storage = localStorage) {
+  return ['annotations', 'memos'].some(resource => readQueue(resource, docId, storage).length > 0)
+}

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -250,6 +250,35 @@ export async function putLibraryMemos(docId, data) {
   return res.json()
 }
 
+export async function patchLibraryAnnotations(docId, payload, options = {}) {
+  return patchLibrarySyncResource(docId, 'annotations', payload, options)
+}
+
+export async function patchLibraryMemos(docId, payload, options = {}) {
+  return patchLibrarySyncResource(docId, 'memos', payload, options)
+}
+
+async function patchLibrarySyncResource(docId, resource, payload, options = {}) {
+  const res = await fetch(`${API_BASE}/library/${docId}/${resource}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    keepalive: options.keepalive === true,
+  })
+  if (!res.ok) {
+    let message = resource === 'annotations' ? 'Annotation sync failed' : 'Memo sync failed'
+    try {
+      const err = await res.json()
+      message = err.detail || message
+    } catch {
+      // JSON이 아닌 경우 기본 메시지 사용
+    }
+    throw new Error(message)
+  }
+  invalidateLibraryGetCache()
+  return res.json()
+}
+
 export async function searchLibrary(query, documentMode = null) {
   const params = new URLSearchParams({ q: query })
   if (documentMode) params.set("document_mode", documentMode)

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -4010,6 +4010,12 @@
   "viewer:a11y.previewSize": {
     "description": "Live announcement of a resized figure preview."
   },
+  "viewer:sync.conflict": {
+    "description": "Toast shown when concurrent edits require preserving a conflict copy."
+  },
+  "viewer:sync.delayed": {
+    "description": "Toast shown when annotation mutations remain queued due to a network failure."
+  },
   "errors:selected_text_requires_viewer_page": {
     "description": "Selected-text requests without an active viewer page."
   },

--- a/frontend/src/locales/en/viewer.json
+++ b/frontend/src/locales/en/viewer.json
@@ -42,5 +42,7 @@
   "a11y.green": "Green",
   "a11y.blue": "Blue",
   "a11y.red": "Red",
-  "a11y.previewSize": "Preview size {{width}} by {{height}} pixels"
+  "a11y.previewSize": "Preview size {{width}} by {{height}} pixels",
+  "sync.conflict": "A sync conflict occurred, so both versions were preserved.",
+  "sync.delayed": "Annotation sync is delayed due to a network problem."
 }

--- a/frontend/src/locales/ko/viewer.json
+++ b/frontend/src/locales/ko/viewer.json
@@ -42,5 +42,7 @@
   "a11y.green": "초록",
   "a11y.blue": "파랑",
   "a11y.red": "빨강",
-  "a11y.previewSize": "미리보기 크기 너비 {{width}}픽셀, 높이 {{height}}픽셀"
+  "a11y.previewSize": "미리보기 크기 너비 {{width}}픽셀, 높이 {{height}}픽셀",
+  "sync.conflict": "동기화 충돌이 있어 두 버전을 모두 보존했습니다.",
+  "sync.delayed": "네트워크 문제로 주석 동기화가 지연되고 있습니다."
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,7 +11,8 @@ import { defaultDocumentType, loadDocumentTypeOptions, saveDocumentTypeOptions, 
 import DOMPurify from 'dompurify'
 import { uploadPDF, checkHealth, streamTranslation, getJobStatus, getPageTranslation, loginAPI, logoutAPI, checkAuthAPI, changeCredentialsAPI, getSkipLoginAPI, setSkipLoginAPI, getSystemSettingsAPI, saveSystemSettingsAPI, restartJobAPI, streamPullModelAPI, deleteModelAPI, streamChatAPI, clearTranslationCacheAPI, clearPagesCacheAPI, clearSingleDocCacheAPI, getChatHistoryAPI, cancelJobAPI, triggerSystemUpdateAPI, checkForUpdateAPI, streamPageInsightAPI, getOllamaStatusAPI, streamInstallOllamaAPI, fetchCliAvailability, getUpdateCheckConfigAPI, setUpdateCheckConfigAPI, getPostUpdateNoticeAPI, streamCompareChatAPI, getCompareChatHistoryAPI, getFullChangelogAPI, getChatSessionsAPI, getCompareChatSessionsAPI, getSuggestedQuestionsAPI, fetchPdfParsersInfoAPI, installPdfParserAPI, uninstallPdfParserAPI, fetchDocumentTypesAPI, getWorkspaceSettingsAPI, patchWorkspaceSettingsAPI, patchDocumentClassificationAPI, estimateInsightJobAPI, startInsightJobAPI, getInsightJobStatusAPI, cancelInsightJobAPI, getLanguagesAPI, getLanguageSettingsAPI, saveLanguageSettingsAPI, patchDocumentLanguagesAPI, patchDocumentProcessingPolicyAPI, retryDocumentTaskAPI, createReparsePreviewAPI, getReparsePreviewAPI, applyReparsePreviewAPI } from './api.js'
 import { loadPDF, renderScrollView, scrollToPage, reRenderAll, getScale, getTotalPages, getPDFOutline, renderFigureCrop } from './pdfViewer.js'
-import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryAnnotations, putLibraryAnnotations, fetchLibraryMemos, putLibraryMemos, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
+import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder, updateLibraryFolder, deleteLibraryFolder, moveLibraryDocuments, deleteLibraryDoc, fetchLibraryTranslation, fetchLibraryDocImages, updateLibraryDocMetadata, updateLibraryDocTitle, updateLibraryTranslation, fetchLibraryTrash, restoreLibraryDoc, emptyLibraryTrash, deleteLibraryDocPermanently, searchLibrary, exportAnnotatedPdf, fetchLibraryReferences, resolveLibraryReference, fetchPrimer, regeneratePrimer, fetchLibraryBibliography, fetchLibraryGraph, fetchGraphNodeQuestions, searchGraphNodes, fetchReadingRecommendations, fetchCachedReadingRecommendations, fetchLibraryHeatmapMatrix, sendReadingHeartbeat, fetchPaperTagOntology, updatePaperTags, reclassifyPaperTags } from './library.js'
+import { ensureLocalResourceIds, hasPendingAnnotationSync, recordLocalResourceChange, syncDocumentAnnotations } from './annotationSync.js'
 import { icon } from './icons.js'
 import { formatTranslationHtml, applyKatexToElement, linkPageCitations } from './textFormat.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
@@ -4971,7 +4972,22 @@ async function flushReadingHeartbeat({ keepalive = false } = {}) {
 
 setInterval(tickReadingHeartbeat, READING_HEARTBEAT_TICK_SECONDS * 1000)
 setInterval(flushReadingHeartbeat, READING_HEARTBEAT_FLUSH_MS)
-window.addEventListener('beforeunload', () => { flushReadingHeartbeat({ keepalive: true }); globalAnalyticsTracker.stopSession() })
+window.addEventListener('beforeunload', () => {
+  flushReadingHeartbeat({ keepalive: true })
+  if (state.sessionId && hasPendingAnnotationSync(state.sessionId)) {
+    syncAnnotationsNow(state.sessionId, { keepalive: true, refresh: false })
+  }
+  globalAnalyticsTracker.stopSession()
+})
+window.addEventListener('pagehide', () => {
+  if (state.sessionId && hasPendingAnnotationSync(state.sessionId)) {
+    syncAnnotationsNow(state.sessionId, { keepalive: true, refresh: false })
+  }
+})
+window.addEventListener('online', () => { if (state.sessionId) syncAnnotationsNow(state.sessionId) })
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible' && state.sessionId) syncAnnotationsNow(state.sessionId)
+})
 
 // ── 초기화 ────────────────────────────────────────
 i18nReady.then(() => checkAuthentication()).catch(console.error)
@@ -9837,31 +9853,69 @@ async function loadDocumentReferences(docId) {
 // 것과 동일한 패턴으로, 같은 문서를 여는 재진입 호출을 걸러낸다.
 let docOpeningId = null
 
-// 하이라이트/메모는 localStorage가 원본이고 서버 저장은 다중 기기 동기화를
-// 위한 best-effort 백업일 뿐이다. 로컬에 이미 데이터가 있으면(가장 흔한
-// 케이스: 같은 브라우저에서 계속 쓰던 문서) 절대 덮어쓰지 않고, 로컬에 해당
-// 키가 아예 없을 때만(다른 브라우저/설치에서 처음 여는 경우) 서버 데이터를
-// 채워 넣는다 - 병합 로직 없음, 로컬이 있으면 항상 로컬이 우선한다. 문서당
-// 한 번만 시도하도록 마커를 남긴다(매번 열 때마다 재조회하지 않기 위함).
-async function hydrateAnnotationsAndMemosFromServer(docId) {
-  const marker = `easypaper_hydrated_${docId}`
-  if (localStorage.getItem(marker)) return
-  try {
-    if (!localStorage.getItem(`easypaper_annotations_${docId}`)) {
-      const server = await fetchLibraryAnnotations(docId).catch(() => null)
-      if (server?.data && Object.keys(server.data).length) {
-        localStorage.setItem(`easypaper_annotations_${docId}`, JSON.stringify(server.data))
-      }
-    }
-    if (!localStorage.getItem(`easypaper_memos_${docId}`)) {
-      const server = await fetchLibraryMemos(docId).catch(() => null)
-      if (server?.data && Object.keys(server.data).length) {
-        localStorage.setItem(`easypaper_memos_${docId}`, JSON.stringify(server.data))
-      }
-    }
-  } finally {
-    localStorage.setItem(marker, '1')
+const annotationSyncTimers = new Map()
+const annotationSyncInFlight = new Map()
+let deferredAnnotationRefresh = false
+let annotationSyncDelayNotified = false
+
+function refreshSyncedAnnotationView() {
+  const active = document.activeElement
+  if (active?.classList?.contains('floating-memo-textarea')) {
+    deferredAnnotationRefresh = true
+    return
   }
+  deferredAnnotationRefresh = false
+  document.querySelectorAll('.pdf-page-wrapper[data-page]').forEach(wrapper => {
+    const pageNum = Number(wrapper.dataset.page)
+    const textLayer = wrapper.querySelector('.textLayer')
+    if (textLayer) reRenderPageAnnotations(textLayer, pageNum)
+    renderPageMemos(pageNum)
+  })
+  document.dispatchEvent(new CustomEvent('easypaper:annotations-synced'))
+}
+
+async function syncAnnotationsNow(docId, { keepalive = false, refresh = true } = {}) {
+  if (!docId) return null
+  if (!navigator.onLine && !keepalive) {
+    if (!annotationSyncDelayNotified && state.sessionId === docId) {
+      annotationSyncDelayNotified = true
+      showToast(t('viewer:sync.delayed'), 'warning')
+    }
+    return null
+  }
+  if (annotationSyncInFlight.has(docId)) return annotationSyncInFlight.get(docId)
+  const promise = syncDocumentAnnotations(docId, { keepalive })
+    .then(result => {
+      annotationSyncDelayNotified = false
+      const conflicts = [...result.annotations.conflicts, ...result.memos.conflicts]
+      if (conflicts.length) showToast(t('viewer:sync.conflict'), 'warning')
+      if (refresh && state.sessionId === docId) refreshSyncedAnnotationView()
+      return result
+    })
+    .catch(error => {
+      console.warn('Annotation sync delayed; local queue retained:', error)
+      if (!annotationSyncDelayNotified && state.sessionId === docId) {
+        annotationSyncDelayNotified = true
+        showToast(t('viewer:sync.delayed'), 'warning')
+      }
+      return null
+    })
+    .finally(() => annotationSyncInFlight.delete(docId))
+  annotationSyncInFlight.set(docId, promise)
+  return promise
+}
+
+function scheduleAnnotationSync(docId) {
+  if (!docId) return
+  clearTimeout(annotationSyncTimers.get(docId))
+  annotationSyncTimers.set(docId, setTimeout(() => {
+    annotationSyncTimers.delete(docId)
+    syncAnnotationsNow(docId)
+  }, 1000))
+}
+
+async function hydrateAnnotationsAndMemosFromServer(docId) {
+  await syncAnnotationsNow(docId, { refresh: false })
 }
 
 async function openFromLibrary(doc, shouldPushState = true) {
@@ -9876,6 +9930,10 @@ async function openFromLibrary(doc, shouldPushState = true) {
     // 섞여 들어가는 경쟁 조건이 있었다.
     if (state.chatActiveStream) { state.chatActiveStream(); state.chatActiveStream = null }
 
+    const previousDocId = state.sessionId
+    if (previousDocId && previousDocId !== doc.id && hasPendingAnnotationSync(previousDocId)) {
+      syncAnnotationsNow(previousDocId, { keepalive: true, refresh: false })
+    }
     if (shouldPushState) {
       history.pushState({ screen: 'viewer', docId: doc.id }, '', `#viewer?id=${doc.id}`)
     }
@@ -10296,27 +10354,17 @@ function applyModeTheme(mode) {
 function loadAnnotations(sessionId) {
   try {
     const data = localStorage.getItem(`easypaper_annotations_${sessionId}`)
-    return data ? JSON.parse(data) : {}
+    return ensureLocalResourceIds('annotations', sessionId, data ? JSON.parse(data) : {})
   } catch {
     return {}
   }
 }
 
 // 로컬 스토리지에 어노테이션 정보 저장하기
-// localStorage 쓰기는 항상 동기로 즉시 수행하고(이 함수의 호출부 다수가
-// mousemove/keydown 같은 동기 이벤트 핸들러라 async로 바꾸면 입력 지연이
-// 생긴다), 서버 미러 동기화는 디바운스해 fire-and-forget으로 보낸다. 서버는
-// 항상 전체 블롭을 덮어쓰므로(시퀀스 번호 불필요) 마지막에 도착한 요청이
-// 이기고 다음 저장 때 자연히 정합성이 맞춰진다.
-const _annotationMirrorTimers = {}
 function saveAnnotations(sessionId, annotations) {
-  localStorage.setItem(`easypaper_annotations_${sessionId}`, JSON.stringify(annotations))
   if (!sessionId) return
-  clearTimeout(_annotationMirrorTimers[sessionId])
-  _annotationMirrorTimers[sessionId] = setTimeout(() => {
-    delete _annotationMirrorTimers[sessionId]
-    putLibraryAnnotations(sessionId, annotations).catch(err => console.warn('서버 동기화 실패(로컬은 유지됨):', err))
-  }, 1000)
+  recordLocalResourceChange('annotations', sessionId, annotations)
+  scheduleAnnotationSync(sessionId)
 }
 
 // textLayer 내 텍스트 전체에 대한 선택 위치(Character Offset) 구하기
@@ -10713,22 +10761,16 @@ function loadMemos(sessionId) {
   if (!sessionId) return {}
   const key = `easypaper_memos_${sessionId}`
   try {
-    return JSON.parse(localStorage.getItem(key)) || {}
+    return ensureLocalResourceIds('memos', sessionId, JSON.parse(localStorage.getItem(key)) || {})
   } catch (e) {
     return {}
   }
 }
 
-const _memoMirrorTimers = {}
 function saveMemos(sessionId, memos) {
   if (!sessionId) return
-  const key = `easypaper_memos_${sessionId}`
-  localStorage.setItem(key, JSON.stringify(memos))
-  clearTimeout(_memoMirrorTimers[sessionId])
-  _memoMirrorTimers[sessionId] = setTimeout(() => {
-    delete _memoMirrorTimers[sessionId]
-    putLibraryMemos(sessionId, memos).catch(err => console.warn('서버 동기화 실패(로컬은 유지됨):', err))
-  }, 1000)
+  recordLocalResourceChange('memos', sessionId, memos)
+  scheduleAnnotationSync(sessionId)
 }
 
 // ── 하이라이트/밑줄/메모 삭제 실행취소(Ctrl+Z) ──────────────────────
@@ -11139,6 +11181,10 @@ function renderPageMemos(pageNum) {
               isEditing = false
               updateCardContent()
               updateMemoConnectorLine(pageWrapper, memo)
+              if (deferredAnnotationRefresh) {
+                deferredAnnotationRefresh = false
+                syncAnnotationsNow(state.sessionId)
+              }
             }
           }, 150)
         })

--- a/frontend/src/pages/notesPage.js
+++ b/frontend/src/pages/notesPage.js
@@ -3,17 +3,12 @@
 // 보여준다. 이 페이지에서는 주석을 새로 만들거나 편집할 수 없다 - 오직
 // 뷰어에서 이미 만든 것을 조회하고, 클릭하면 해당 논문 뷰어로 이동한다.
 //
-// 데이터 출처: 메모/하이라이트/언더라인은 서버 DB가 아니라 문서(세션)별
-// localStorage(`easypaper_annotations_<id>`, `easypaper_memos_<id>`)에만
-// 저장된다(main.js의 loadAnnotations/loadMemos/saveAnnotations/saveMemos와
-// 동일한 키·형태를 그대로 읽는다 - import는 하지 않고 패턴만 따라한다).
-// 로컬이 비어있는 문서에 한해서만 서버 미러(fetchLibraryAnnotations/
-// fetchLibraryMemos)로 폴백한다("로컬이 있으면 항상 로컬 우선, 병합 없음"
-// - main.js의 hydrateAnnotationsAndMemosFromServer와 동일한 정책이지만,
-// 여기서는 표시 전용이라 로컬에 다시 써넣지는 않는다).
+// 데이터 출처는 서버 snapshot이며 localStorage는 즉시 표시와 오프라인 작업
+// 보존에 사용한다. 화면을 열 때 각 문서를 동기화한 결과를 집계한다.
 
 import '../styles/notes.css'
-import { fetchLibrary, fetchLibraryAnnotations, fetchLibraryMemos, fetchPrimer } from '../library.js'
+import { fetchLibrary, fetchPrimer } from '../library.js'
+import { syncDocumentAnnotations } from '../annotationSync.js'
 import { icon } from '../icons.js'
 import { lastActivityIso } from '../readPages.js'
 import { formatTranslationHtml, formatMarkdownLatexHtml, applyKatexToElement } from '../textFormat.js'
@@ -90,26 +85,15 @@ function readLocalMemos(docId) {
 }
 
 async function getDocAnnotationsAndMemos(docId) {
-  let annotationsByPage = readLocalAnnotations(docId)
-  let memosByPage = readLocalMemos(docId)
-
-  if (Object.keys(annotationsByPage).length === 0) {
-    try {
-      const server = await fetchLibraryAnnotations(docId)
-      if (server && server.data && Object.keys(server.data).length) annotationsByPage = server.data
-    } catch {
-      // best-effort - 조회 실패해도 목록 표시는 계속 진행
+  try {
+    const synced = await syncDocumentAnnotations(docId)
+    return {
+      annotationsByPage: synced.annotations.data,
+      memosByPage: synced.memos.data,
     }
+  } catch {
+    return { annotationsByPage: readLocalAnnotations(docId), memosByPage: readLocalMemos(docId) }
   }
-  if (Object.keys(memosByPage).length === 0) {
-    try {
-      const server = await fetchLibraryMemos(docId)
-      if (server && server.data && Object.keys(server.data).length) memosByPage = server.data
-    } catch {
-      // best-effort
-    }
-  }
-  return { annotationsByPage, memosByPage }
 }
 
 // 새 데이터는 createdAt을 사용하고, 구버전 메모는 `memo_${Date.now()}` ID에서

--- a/frontend/tests/annotationSync.test.js
+++ b/frontend/tests/annotationSync.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  hasPendingAnnotationSync, normalizeResourceData,
+  recordLocalResourceChange, syncResource,
+} from '../src/annotationSync.js'
+
+
+class MemoryStorage {
+  constructor(entries = {}) { this.values = new Map(Object.entries(entries)) }
+  getItem(key) { return this.values.has(key) ? this.values.get(key) : null }
+  setItem(key, value) { this.values.set(key, String(value)) }
+  removeItem(key) { this.values.delete(key) }
+}
+
+function snapshot(data = {}, extras = {}) {
+  return {
+    data, updated_at: null, revision: 0, item_versions: {}, tombstones: {},
+    ...extras,
+  }
+}
+
+test('기존 ID 없는 항목을 fingerprint로 서버 항목과 매칭한다', () => {
+  const local = { page_1: [{ type: 'highlight', text: 'same', startOffset: 1, endOffset: 5 }] }
+  const server = { page_1: [{ id: 'server-id', type: 'highlight', text: 'same', startOffset: 1, endOffset: 5 }] }
+  const result = normalizeResourceData('annotations', local, server)
+  assert.equal(result.data.page_1[0].id, 'server-id')
+})
+
+test('로컬 변경은 즉시 저장되고 오프라인 큐에 유지된 뒤 재전송된다', async () => {
+  const storage = new MemoryStorage()
+  const saved = recordLocalResourceChange('memos', 'doc', {
+    page_1: [{ content: 'offline memo', x: 10, y: 20 }],
+  }, storage)
+  assert.ok(saved.page_1[0].id)
+  assert.equal(JSON.parse(storage.getItem('easypaper_memos_doc')).page_1[0].content, 'offline memo')
+  assert.equal(hasPendingAnnotationSync('doc', storage), true)
+
+  const failingConfig = {
+    fetchSnapshot: async () => snapshot(),
+    patchMutations: async () => { throw new Error('offline') },
+  }
+  await assert.rejects(syncResource('memos', 'doc', { storage, config: failingConfig }), /offline/)
+  assert.equal(hasPendingAnnotationSync('doc', storage), true)
+
+  let sent
+  const onlineConfig = {
+    fetchSnapshot: async () => snapshot(),
+    patchMutations: async (_docId, payload) => {
+      sent = payload.mutations
+      const item = payload.mutations[0].item
+      return snapshot({ page_1: [item] }, {
+        revision: 1, item_versions: { [item.id]: 1 },
+        results: [{ mutation_id: payload.mutations[0].mutation_id, applied: true }],
+      })
+    },
+  }
+  await syncResource('memos', 'doc', { storage, config: onlineConfig })
+  assert.equal(sent[0].operation, 'upsert')
+  assert.equal(hasPendingAnnotationSync('doc', storage), false)
+})
+
+test('최초 업그레이드는 서버와 로컬의 합집합을 저장한다', async () => {
+  const local = { page_1: [{ type: 'highlight', text: 'shared', startOffset: 0, endOffset: 6 }] }
+  const storage = new MemoryStorage({ easypaper_annotations_doc: JSON.stringify(local) })
+  const serverData = { page_1: [
+    { id: 'shared-id', type: 'highlight', text: 'shared', startOffset: 0, endOffset: 6 },
+    { id: 'remote-id', type: 'underline', text: 'remote', startOffset: 8, endOffset: 14 },
+  ] }
+  let patchCalls = 0
+  const config = {
+    fetchSnapshot: async () => snapshot(serverData, {
+      revision: 2, item_versions: { 'shared-id': 1, 'remote-id': 2 },
+    }),
+    patchMutations: async () => { patchCalls += 1 },
+  }
+  const result = await syncResource('annotations', 'doc', { storage, config })
+  assert.equal(patchCalls, 0)
+  assert.deepEqual(result.data.page_1.map(item => item.id), ['shared-id', 'remote-id'])
+})
+
+test('최초 이관 중 같은 ID의 다른 내용은 stale upsert로 전송한다', async () => {
+  const storage = new MemoryStorage({
+    easypaper_memos_doc: JSON.stringify({ page_1: [{ id: 'memo', content: 'local' }] }),
+  })
+  let mutation
+  const config = {
+    fetchSnapshot: async () => snapshot({ page_1: [{ id: 'memo', content: 'server' }] }, {
+      revision: 1, item_versions: { memo: 1 },
+    }),
+    patchMutations: async (_docId, payload) => {
+      mutation = payload.mutations[0]
+      return snapshot({ page_1: [
+        { id: 'memo', content: 'server' },
+        { id: 'copy', conflict_of: 'memo', content: 'local' },
+      ] }, { revision: 2, item_versions: { memo: 1, copy: 2 },
+        results: [{ mutation_id: payload.mutations[0].mutation_id, conflict_copy: true }] })
+    },
+  }
+  const result = await syncResource('memos', 'doc', { storage, config })
+  assert.equal(mutation.base_version, 0)
+  assert.deepEqual(result.data.page_1.map(item => item.content), ['server', 'local'])
+  assert.equal(result.conflicts.length, 1)
+})
+
+test('서버 tombstone은 오래된 로컬 항목의 부활을 막는다', async () => {
+  const storage = new MemoryStorage({
+    easypaper_annotations_doc: JSON.stringify({ page_1: [{ id: 'deleted', text: 'old' }] }),
+  })
+  let patched = false
+  const config = {
+    fetchSnapshot: async () => snapshot({}, {
+      revision: 3, item_versions: { deleted: 3 }, tombstones: { deleted: { version: 3, page_key: 'page_1' } },
+    }),
+    patchMutations: async () => { patched = true },
+  }
+  const result = await syncResource('annotations', 'doc', { storage, config })
+  assert.deepEqual(result.data, {})
+  assert.equal(patched, false)
+})

--- a/frontend/tests/e2e/cross-device-annotation-sync.spec.js
+++ b/frontend/tests/e2e/cross-device-annotation-sync.spec.js
@@ -1,0 +1,179 @@
+import { test, expect } from '@playwright/test'
+import { gotoApp, mockBaseRoutes } from './helpers.js'
+
+const doc = {
+  id: 'doc-sync', filename: 'sync.pdf', total_pages: 1,
+  created_at: '2026-01-01T00:00:00Z', metadata: { title: 'Sync' }, translated_pages: [],
+}
+
+function createSyncServer() {
+  const resources = Object.fromEntries(['annotations', 'memos'].map(resource => [resource, {
+    data: {}, updated_at: null, revision: 0, item_versions: {}, tombstones: {},
+  }]))
+  const processed = new Map()
+  let copySequence = 0
+
+  function find(snapshot, itemId) {
+    for (const [pageKey, items] of Object.entries(snapshot.data)) {
+      const index = items.findIndex(item => item.id === itemId)
+      if (index >= 0) return { pageKey, index, item: items[index] }
+    }
+    return null
+  }
+
+  function remove(snapshot, itemId) {
+    const found = find(snapshot, itemId)
+    if (!found) return null
+    snapshot.data[found.pageKey].splice(found.index, 1)
+    if (!snapshot.data[found.pageKey].length) delete snapshot.data[found.pageKey]
+    return found
+  }
+
+  async function routeHandler(route) {
+    const request = route.request()
+    const match = new URL(request.url()).pathname.match(/\/api\/library\/doc-sync\/(annotations|memos)$/)
+    if (!match) return route.fallback()
+    const snapshot = resources[match[1]]
+    if (request.method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(snapshot) })
+    }
+    const payload = request.postDataJSON()
+    const results = []
+    for (const mutation of payload.mutations) {
+      const mutationKey = `${match[1]}:${payload.client_id}:${mutation.mutation_id}`
+      if (processed.has(mutationKey)) {
+        results.push({ ...processed.get(mutationKey), already_applied: true })
+        continue
+      }
+      const found = find(snapshot, mutation.item_id)
+      const tombstone = snapshot.tombstones[mutation.item_id]
+      const currentVersion = snapshot.item_versions[mutation.item_id] || tombstone?.version || 0
+      const result = { mutation_id: mutation.mutation_id, item_id: mutation.item_id,
+        applied: false, already_applied: false, conflict_copy: false,
+        delete_conflict_preserved: false }
+      if (mutation.operation === 'delete') {
+        if (tombstone) result.already_applied = true
+        else if (found && mutation.base_version === currentVersion) {
+          remove(snapshot, mutation.item_id)
+          snapshot.revision += 1
+          snapshot.item_versions[mutation.item_id] = snapshot.revision
+          snapshot.tombstones[mutation.item_id] = { version: snapshot.revision, page_key: found.pageKey }
+          result.applied = true
+        } else if (found) result.delete_conflict_preserved = true
+      } else if (!found && !tombstone && mutation.base_version === 0) {
+        snapshot.revision += 1
+        snapshot.data[mutation.page_key] ||= []
+        snapshot.data[mutation.page_key].push(mutation.item)
+        snapshot.item_versions[mutation.item_id] = snapshot.revision
+        result.applied = true
+      } else if (found && mutation.base_version === currentVersion) {
+        remove(snapshot, mutation.item_id)
+        snapshot.revision += 1
+        snapshot.data[mutation.page_key] ||= []
+        snapshot.data[mutation.page_key].push(mutation.item)
+        snapshot.item_versions[mutation.item_id] = snapshot.revision
+        result.applied = true
+      } else {
+        const copyId = `conflict-copy-${++copySequence}`
+        snapshot.revision += 1
+        snapshot.data[mutation.page_key] ||= []
+        snapshot.data[mutation.page_key].push({ ...mutation.item, id: copyId, conflict_of: mutation.item_id })
+        snapshot.item_versions[copyId] = snapshot.revision
+        Object.assign(result, { conflict_copy: true, conflict_copy_id: copyId })
+      }
+      processed.set(mutationKey, result)
+      results.push(result)
+    }
+    snapshot.updated_at = new Date().toISOString()
+    return route.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify({ ...snapshot, results }) })
+  }
+  return { routeHandler }
+}
+
+async function installPage(page, server) {
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/doc-sync/{annotations,memos}', server.routeHandler)
+  await gotoApp(page)
+}
+
+async function record(page, resource, data) {
+  await page.evaluate(({ resource, data }) => {
+    const dataKey = `easypaper_${resource}_doc-sync`
+    const queueKey = `easypaper_annotation_sync_queue_${resource}_doc-sync`
+    const metaKey = `easypaper_annotation_sync_meta_${resource}_doc-sync`
+    const before = JSON.parse(localStorage.getItem(dataKey) || '{}')
+    const meta = JSON.parse(localStorage.getItem(metaKey) || '{"item_versions":{}}')
+    const flatten = value => new Map(Object.entries(value).flatMap(([pageKey, items]) =>
+      (items || []).map(item => [item.id, { pageKey, item }])))
+    const oldItems = flatten(before)
+    const newItems = flatten(data)
+    const queue = []
+    newItems.forEach(({ pageKey, item }, itemId) => {
+      const old = oldItems.get(itemId)
+      if (old && JSON.stringify(old.item) === JSON.stringify(item) && old.pageKey === pageKey) return
+      queue.push({ mutation_id: crypto.randomUUID(), operation: 'upsert', item_id: itemId,
+        page_key: pageKey, base_version: meta.item_versions?.[itemId] || 0, item })
+    })
+    oldItems.forEach(({ pageKey }, itemId) => {
+      if (!newItems.has(itemId)) queue.push({ mutation_id: crypto.randomUUID(), operation: 'delete',
+        item_id: itemId, page_key: pageKey, base_version: meta.item_versions?.[itemId] || 0 })
+    })
+    localStorage.setItem(dataKey, JSON.stringify(data))
+    localStorage.setItem(queueKey, JSON.stringify(queue))
+  }, { resource, data })
+}
+
+async function synchronize(page) {
+  await page.locator('.sidebar-nav-item[data-page="dashboard"]').click()
+  await page.locator('.sidebar-nav-item[data-page="notes"]').click()
+  await expect(page.locator('#page-notes.active')).toBeVisible()
+  await expect.poll(() => page.evaluate(() => ({
+    annotationsMeta: !!localStorage.getItem('easypaper_annotation_sync_meta_annotations_doc-sync'),
+    memosMeta: !!localStorage.getItem('easypaper_annotation_sync_meta_memos_doc-sync'),
+    annotationsQueued: !!localStorage.getItem('easypaper_annotation_sync_queue_annotations_doc-sync'),
+    memosQueued: !!localStorage.getItem('easypaper_annotation_sync_queue_memos_doc-sync'),
+  }))).toEqual({ annotationsMeta: true, memosMeta: true,
+    annotationsQueued: false, memosQueued: false })
+}
+
+async function localData(page, resource) {
+  return page.evaluate(resource => JSON.parse(localStorage.getItem(`easypaper_${resource}_doc-sync`) || '{}'), resource)
+}
+
+test('Mac/Windows 컨텍스트가 항목을 병합하고 충돌·삭제를 보존한다', async ({ browser }) => {
+  const server = createSyncServer()
+  const macContext = await browser.newContext({ userAgent: 'EasyPaper E2E macOS' })
+  const windowsContext = await browser.newContext({ userAgent: 'EasyPaper E2E Windows' })
+  const mac = await macContext.newPage()
+  const windows = await windowsContext.newPage()
+  await installPage(mac, server)
+  await installPage(windows, server)
+  await synchronize(mac)
+  await synchronize(windows)
+
+  await record(mac, 'annotations', { page_1: [{ id: 'mac-highlight', type: 'highlight', text: 'Mac' }] })
+  await record(windows, 'memos', { page_1: [{ id: 'shared-memo', content: 'Windows memo' }] })
+  await synchronize(mac)
+  await synchronize(windows)
+  await synchronize(mac)
+  await synchronize(windows)
+  expect((await localData(mac, 'memos')).page_1[0].content).toBe('Windows memo')
+  expect((await localData(windows, 'annotations')).page_1[0].text).toBe('Mac')
+
+  await record(mac, 'memos', { page_1: [{ id: 'shared-memo', content: 'Mac edit' }] })
+  await record(windows, 'memos', { page_1: [{ id: 'shared-memo', content: 'Windows edit' }] })
+  await synchronize(mac)
+  await synchronize(windows)
+  await synchronize(mac)
+  const contents = (await localData(mac, 'memos')).page_1.map(item => item.content).sort()
+  expect(contents).toEqual(['Mac edit', 'Windows edit'])
+
+  await record(mac, 'annotations', {})
+  await synchronize(mac)
+  await synchronize(windows)
+  expect(await localData(windows, 'annotations')).toEqual({})
+
+  await macContext.close()
+  await windowsContext.close()
+})

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -93,6 +93,41 @@ test('뷰어 메모 입력창에 포커스 테두리를 표시하지 않는다',
 })
 
 
+test('메모 편집 중 원격 snapshot은 입력 DOM 교체를 편집 종료까지 미룬다', async ({ page }) => {
+  await openViewerWithMemo(page)
+  await page.route('**/api/library/doc-memo/annotations', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ data: {}, updated_at: null, revision: 0, item_versions: {}, tombstones: {} }),
+  }))
+  await page.route('**/api/library/doc-memo/memos', route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({
+      data: { page_1: [{
+        id: 'memo-regression', pageNum: 1, sentenceIdx: 0, sentenceText: 'memo anchor',
+        content: '다른 기기 메모', x: 10, y: 10,
+      }] },
+      updated_at: '2026-08-27T00:00:00Z', revision: 2,
+      item_versions: { 'memo-regression': 2 }, tombstones: {},
+    }),
+  }))
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+  await expect(textarea).toBeFocused()
+  await page.evaluate(() => window.dispatchEvent(new Event('online')))
+  await expect.poll(() => page.evaluate(() => {
+    const saved = JSON.parse(localStorage.getItem('easypaper_memos_doc-memo') || '{}')
+    return saved.page_1?.[0]?.content
+  })).toBe('다른 기기 메모')
+  await expect(textarea).toBeVisible()
+  await expect(textarea).toHaveValue('메모 내용')
+
+  await textarea.blur()
+  await expect(memo.locator('.floating-memo-render')).toContainText('다른 기기 메모')
+})
+
+
 test("키보드로 메모를 이동하고 크기를 조절하면 변경 사항을 알린다", async ({ page }) => {
   await openViewerWithMemo(page)
 


### PR DESCRIPTION
# Summary
## 1. 서버 기준 항목별 동기화 추가
- annotations·memos snapshot에 revision, item_versions, tombstones 메타데이터 추가
- client_id와 mutation_id를 사용하는 멱등 PATCH API 및 소유권·5MiB 제한 적용
- 기존 PUT 요청을 누락 항목 삭제 없이 병합하는 legacy 호환 처리
## 2. 로컬 캐시와 오프라인 큐 개선
- localStorage 변경 즉시 반영 및 항목별 upsert/delete 작업 큐 저장
- 문서 열기, 탭 복귀, 온라인 복구, 문서 이탈 시 서버 동기화와 재시도 추가
- 최초 업그레이드 시 서버·브라우저 기존 데이터 합집합 이관 및 fingerprint 매칭
## 3. 충돌과 삭제 보존 처리
- stale 수정 시 서버본 유지 및 새 ID의 충돌 복사본 생성
- stale 삭제와 최신 수정 충돌 시 서버본 보존 및 tombstone을 통한 삭제 항목 부활 방지
- 메모 편집 중 DOM 갱신 지연과 동기화 지연·충돌 안내 토스트 추가
## 4. 동기화 회귀 검증 추가
- 마이그레이션, 멱등 재시도, 충돌 복사본, 수정-삭제 충돌, payload·소유권 백엔드 테스트 추가
- 오프라인 큐, 최초 합집합 이관, tombstone 프런트 단위 테스트 추가
- 두 브라우저 컨텍스트 간 생성·충돌·삭제와 편집 중 원격 갱신 E2E 추가