### PR TITLE
feat(viewer): add auto-sizing rich memos

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -15,6 +15,7 @@ import { fetchLibrary, fetchLibraryDoc, fetchLibraryFolders, createLibraryFolder
 import { ensureLocalResourceIds, hasPendingAnnotationSync, recordLocalResourceChange, syncDocumentAnnotations } from './annotationSync.js'
 import { icon } from './icons.js'
 import { formatTranslationHtml, applyKatexToElement, linkPageCitations } from './textFormat.js'
+import { prepareMemoMarkdown } from './memoMarkdown.js'
 import { createSelectionRect, resolveDragSelection } from './library-selection.js'
 import { globalAnalyticsTracker } from './readingAnalytics.js'
 import { globalReadingTimeActivityTracker } from './readingTimeActivity.js'
@@ -11141,15 +11142,66 @@ function renderPageMemos(pageNum) {
 
     if (isHidden) return // 카드/커넥터는 그리지 않고 하이라이트만 남긴다
 
+    // 높이를 저장한 기존 메모는 사용자가 직접 조절한 것으로 간주해 그대로
+    // 복원한다. 높이 저장값이 없는 기존/신규 메모는 자동 크기 모드로 시작한다.
+    let memoAutoSize = memo.autoSize === true
+      || (memo.autoSize !== false && !Number.isFinite(memo.height))
     const memoEl = document.createElement('div')
-    memoEl.className = `floating-memo color-${memo.color || 'default'}${memo.collapsed ? ' collapsed' : ''}`
+    memoEl.className = `floating-memo color-${memo.color || 'default'}${memo.collapsed ? ' collapsed' : ''}${memoAutoSize ? ' auto-size' : ''}`
     memoEl.setAttribute('data-id', memo.id)
     memoEl.style.left = `${memo.x}%`
     memoEl.style.top = `${memo.y}%`
-    if (Number.isFinite(memo.width)) memoEl.style.width = `${memo.width}px`
-    if (!memo.collapsed && Number.isFinite(memo.height)) memoEl.style.height = `${memo.height}px`
+    if (!memoAutoSize && Number.isFinite(memo.width)) memoEl.style.width = `${memo.width}px`
+    if (!memoAutoSize && !memo.collapsed && Number.isFinite(memo.height)) memoEl.style.height = `${memo.height}px`
 
     let isEditing = !memo.content.trim()
+
+    function persistMemoChange() {
+      const allMemosObj = loadMemos(state.sessionId)
+      allMemosObj[`page_${pageNum}`] = pageMemos
+      saveMemos(state.sessionId, allMemosObj)
+    }
+
+    function resizeTextareaToContent(textarea) {
+      if (!memoAutoSize || !textarea) return
+      textarea.style.height = '0px'
+      textarea.style.height = `${textarea.scrollHeight}px`
+    }
+
+    function updateAutoSizeButton() {
+      const button = memoEl.querySelector('.auto-size-btn')
+      if (!button) return
+      const label = memoAutoSize ? '수동 크기 조절 사용' : '내용에 맞게 자동 조절'
+      button.classList.toggle('active', memoAutoSize)
+      button.setAttribute('aria-pressed', String(memoAutoSize))
+      button.setAttribute('aria-label', label)
+      button.title = label
+      button.innerHTML = icon(memoAutoSize ? 'shrink' : 'expand', 12)
+    }
+
+    function setMemoAutoSize(enabled, { save = true } = {}) {
+      if (memoAutoSize === enabled) return
+      const currentWidth = memoEl.offsetWidth
+      const currentHeight = memoEl.offsetHeight
+      memoAutoSize = enabled
+      memo.autoSize = enabled
+      memoEl.classList.toggle('auto-size', enabled)
+      if (enabled) {
+        delete memo.width
+        delete memo.height
+        memoEl.style.width = ''
+        memoEl.style.height = ''
+        resizeTextareaToContent(memoEl.querySelector('.floating-memo-textarea'))
+      } else {
+        memo.width = currentWidth
+        memo.height = currentHeight
+        memoEl.style.width = `${currentWidth}px`
+        memoEl.style.height = `${currentHeight}px`
+      }
+      updateAutoSizeButton()
+      if (save) persistMemoChange()
+      requestAnimationFrame(() => updateMemoConnectorLine(pageWrapper, memo))
+    }
 
     function updateCardContent() {
       const body = memoEl.querySelector('.floating-memo-body')
@@ -11165,13 +11217,13 @@ function renderPageMemos(pageNum) {
 
         const textarea = body.querySelector('.floating-memo-textarea')
         textarea.focus()
+        resizeTextareaToContent(textarea)
 
         textarea.addEventListener('input', () => {
           memo.content = textarea.value
-          const allMemosObj = loadMemos(state.sessionId)
-          allMemosObj[`page_${pageNum}`] = pageMemos
-          saveMemos(state.sessionId, allMemosObj)
-          updateMemoConnectorLine(pageWrapper, memo)
+          resizeTextareaToContent(textarea)
+          persistMemoChange()
+          requestAnimationFrame(() => updateMemoConnectorLine(pageWrapper, memo))
         })
 
         textarea.addEventListener('blur', () => {
@@ -11210,7 +11262,7 @@ function renderPageMemos(pageNum) {
         let renderedHtml = memo.content
         if (marked && typeof marked.parse === 'function') {
           try {
-            renderedHtml = marked.parse(memo.content)
+            renderedHtml = marked.parse(prepareMemoMarkdown(memo.content))
           } catch (e) {
             console.error("Markdown parsing failed:", e)
           }
@@ -11297,6 +11349,9 @@ function renderPageMemos(pageNum) {
           <button type="button" class="color-dot red ${memo.color === 'red' ? 'selected' : ''}" data-color="red" title="${t('viewer:a11y.red')}" aria-label="${t('viewer:a11y.color', { color: t('viewer:a11y.red') })}" aria-pressed="${String(memo.color === 'red')}"></button>
         </div>
         <div class="floating-memo-toggles">
+          <button type="button" class="floating-memo-action-btn auto-size-btn${memoAutoSize ? ' active' : ''}" aria-pressed="${String(memoAutoSize)}">
+            ${icon(memoAutoSize ? 'shrink' : 'expand', 12)}
+          </button>
           <button type="button" class="floating-memo-action-btn collapse-btn" title="${memo.collapsed ? '메모 펼치기' : '메모 접기'}">
             ${icon(memo.collapsed ? 'chevronDown' : 'chevronUp', 12)}
           </button>
@@ -11310,7 +11365,14 @@ function renderPageMemos(pageNum) {
       <button type="button" class="floating-memo-resize-handle" aria-label="${t('viewer:a11y.memoResize')}" title="${t('viewer:a11y.memoResize')}"></button>
     `
 
+    updateAutoSizeButton()
     updateCardContent()
+
+    const autoSizeBtn = memoEl.querySelector('.auto-size-btn')
+    autoSizeBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      setMemoAutoSize(!memoAutoSize)
+    })
 
     const collapseBtn = memoEl.querySelector('.collapse-btn')
     collapseBtn.addEventListener('click', (e) => {
@@ -11321,7 +11383,9 @@ function renderPageMemos(pageNum) {
       saveMemos(state.sessionId, allMemosObj)
 
       memoEl.classList.toggle('collapsed', memo.collapsed)
-      memoEl.style.height = memo.collapsed || !Number.isFinite(memo.height) ? '' : `${memo.height}px`
+      memoEl.style.height = memo.collapsed || memoAutoSize || !Number.isFinite(memo.height)
+        ? ''
+        : `${memo.height}px`
       collapseBtn.innerHTML = icon(memo.collapsed ? 'chevronDown' : 'chevronUp', 12)
       collapseBtn.title = memo.collapsed ? '메모 펼치기' : '메모 접기'
       setTimeout(() => updateMemoConnectorLine(pageWrapper, memo), 0)
@@ -11379,6 +11443,10 @@ function renderPageMemos(pageNum) {
         if (nextWidth === observedWidth && nextHeight === observedHeight) return
         observedWidth = nextWidth
         observedHeight = nextHeight
+        if (memoAutoSize) {
+          updateMemoConnectorLine(pageWrapper, memo)
+          return
+        }
         memo.width = nextWidth
         memo.height = nextHeight
         updateMemoConnectorLine(pageWrapper, memo)
@@ -11396,9 +11464,13 @@ function renderPageMemos(pageNum) {
     }
 
     const resizeHandle = memoEl.querySelector('.floating-memo-resize-handle')
+    resizeHandle.addEventListener('pointerdown', () => {
+      setMemoAutoSize(false)
+    })
     resizeHandle.addEventListener('keydown', (event) => {
       if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return
       event.preventDefault(); event.stopPropagation()
+      setMemoAutoSize(false, { save: false })
       const step = event.shiftKey ? 20 : 4
       let width = memoEl.offsetWidth
       let height = memoEl.offsetHeight

--- a/frontend/src/memoMarkdown.js
+++ b/frontend/src/memoMarkdown.js
@@ -1,0 +1,45 @@
+const CALLOUT_TITLES = {
+  note: 'Note',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  caution: 'Caution',
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * GitHub/Obsidian 스타일의 `> [!NOTE]` 블록을 marked가 렌더링할 수 있는
+ * 안전한 인라인 마커로 바꾼다. blockquote 구조는 그대로 두므로 내부의 목록,
+ * 코드, 강조 표시도 일반 Markdown과 동일하게 파싱된다.
+ */
+export function prepareMemoMarkdown(markdown) {
+  const lines = String(markdown || '').split('\n')
+  let fence = null
+
+  return lines.map(line => {
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      const marker = fenceMatch[1]
+      if (!fence) fence = { char: marker[0], length: marker.length }
+      else if (marker[0] === fence.char && marker.length >= fence.length) fence = null
+      return line
+    }
+    if (fence) return line
+
+    return line.replace(
+      /^((?:[ \t]*>[ \t]*)+)\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\](?:[+-])?(?:[ \t]+(.*))?$/i,
+      (_, prefix, typeText, titleText) => {
+        const type = typeText.toLowerCase()
+        const title = titleText?.trim() || CALLOUT_TITLES[type]
+        return `${prefix}<span class="memo-callout-marker" data-callout="${type}">${escapeHtml(title)}</span>`
+      },
+    )
+  }).join('\n')
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5086,6 +5086,27 @@ body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-red {
   color: var(--text-primary);
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+.floating-memo.auto-size {
+  width: fit-content;
+  max-width: min(420px, 90vw);
+  height: auto;
+  min-height: 0;
+  max-height: none;
+}
+.floating-memo.auto-size .floating-memo-body {
+  flex: none;
+  overflow-y: visible;
+}
+.floating-memo.auto-size .floating-memo-textarea {
+  flex: none;
+  width: min(360px, calc(90vw - 20px));
+  height: auto;
+  overflow: hidden;
+}
+.floating-memo-action-btn.active {
+  color: var(--accent-mid);
+  background: color-mix(in srgb, var(--accent-mid) 16%, transparent);
+}
 .floating-memo::after {
   content: '';
   position: absolute;
@@ -5195,10 +5216,18 @@ body.light-theme .floating-memo-header {
 .floating-memo-render p {
   margin: 0 0 8px 0;
 }
-.floating-memo-render p:last-child {
+.floating-memo-render > :first-child {
+  margin-top: 0;
+}
+.floating-memo-render > :last-child {
   margin-bottom: 0;
 }
-.floating-memo-render h1, .floating-memo-render h2, .floating-memo-render h3 {
+.floating-memo-render h1,
+.floating-memo-render h2,
+.floating-memo-render h3,
+.floating-memo-render h4,
+.floating-memo-render h5,
+.floating-memo-render h6 {
   margin: 6px 0;
   font-weight: 600;
   color: var(--text-primary);
@@ -5206,19 +5235,124 @@ body.light-theme .floating-memo-header {
 .floating-memo-render h1 { font-size: 16px; }
 .floating-memo-render h2 { font-size: 14px; }
 .floating-memo-render h3 { font-size: 13px; }
+.floating-memo-render h4,
+.floating-memo-render h5,
+.floating-memo-render h6 { font-size: 12px; }
 .floating-memo-render code {
   background: rgba(255,255,255,0.08);
   padding: 1px 4px;
   border-radius: var(--radius-xs);
-  font-family: monospace;
+  font-family: var(--font-mono, monospace);
   font-size: 11px;
+  overflow-wrap: anywhere;
 }
 body.light-theme .floating-memo-render code {
   background: rgba(0,0,0,0.06);
 }
-.floating-memo-render ul, .floating-memo-render ol {
+.floating-memo-render pre {
+  max-width: 100%;
+  margin: 8px 0;
+  padding: 8px 10px;
+  overflow-x: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.floating-memo-render pre code {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+}
+.floating-memo-render ul,
+.floating-memo-render ol {
   margin: 0 0 8px 0;
   padding-left: 18px;
+}
+.floating-memo-render li > ul,
+.floating-memo-render li > ol {
+  margin: 3px 0 0;
+}
+.floating-memo-render ul ul { list-style-type: circle; }
+.floating-memo-render ul ul ul { list-style-type: square; }
+.floating-memo-render ol ol { list-style-type: lower-alpha; }
+.floating-memo-render ol ol ol { list-style-type: lower-roman; }
+.floating-memo-render input[type="checkbox"] {
+  margin: 0 5px 0 0;
+  vertical-align: -1px;
+}
+.floating-memo-render blockquote {
+  margin: 8px 0;
+  padding: 6px 10px;
+  border-left: 3px solid var(--border-strong);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
+  color: var(--text-secondary);
+}
+.floating-memo-render blockquote:has(.memo-callout-marker) {
+  --memo-callout-color: var(--accent-mid);
+  border: 1px solid color-mix(in srgb, var(--memo-callout-color) 45%, transparent);
+  border-left-width: 4px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--memo-callout-color) 11%, var(--bg-panel));
+  color: var(--text-primary);
+}
+.floating-memo-render blockquote:has(.memo-callout-marker[data-callout="tip"]) {
+  --memo-callout-color: #10b981;
+}
+.floating-memo-render blockquote:has(.memo-callout-marker[data-callout="important"]) {
+  --memo-callout-color: #8b5cf6;
+}
+.floating-memo-render blockquote:has(.memo-callout-marker[data-callout="warning"]) {
+  --memo-callout-color: #f59e0b;
+}
+.floating-memo-render blockquote:has(.memo-callout-marker[data-callout="caution"]) {
+  --memo-callout-color: #ef4444;
+}
+.floating-memo-render .memo-callout-marker {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--memo-callout-color);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+.floating-memo-render table {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 8px 0;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 11.5px;
+}
+.floating-memo-render th,
+.floating-memo-render td {
+  min-width: 72px;
+  padding: 5px 7px;
+  border: 1px solid var(--border-strong);
+  text-align: left;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+.floating-memo-render th {
+  background: var(--bg-hover);
+  font-weight: 600;
+}
+.floating-memo-render hr {
+  margin: 10px 0;
+  border: 0;
+  border-top: 1px solid var(--border-strong);
+}
+.floating-memo-render a {
+  color: var(--accent-mid);
+  overflow-wrap: anywhere;
+}
+.floating-memo-render img {
+  max-width: 100%;
+  height: auto;
 }
 
 .memo-connector-svg {

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
 
-async function openViewerWithMemo(page) {
+async function openViewerWithMemo(page, memoOverrides = {}) {
   const doc = {
     id: 'doc-memo',
     filename: 'Memo.pdf',
@@ -26,7 +26,7 @@ async function openViewerWithMemo(page) {
   })
 
   await gotoApp(page)
-  await page.evaluate(() => {
+  await page.evaluate((overrides) => {
     localStorage.setItem('easypaper_hydrated_doc-memo', '1')
     localStorage.setItem('easypaper_memos_doc-memo', JSON.stringify({
       page_1: [{
@@ -37,10 +37,11 @@ async function openViewerWithMemo(page) {
         content: '메모 내용',
         x: 10,
         y: 10,
+        ...overrides,
       }],
     }))
     location.hash = '#viewer?id=doc-memo'
-  })
+  }, memoOverrides)
 
   await expect(page.locator('.floating-memo[data-id="memo-regression"]')).toBeVisible()
   await expect(page.locator('#trans-content-1 .trans-text')).toContainText('Cached translation')
@@ -64,6 +65,7 @@ test('사용자가 조절한 메모 크기를 저장하고 다시 복원한다',
   await openViewerWithMemo(page)
 
   const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.auto-size-btn').click()
   await memo.evaluate(el => {
     el.style.width = '360px'
     el.style.height = '280px'
@@ -146,4 +148,51 @@ test("키보드로 메모를 이동하고 크기를 조절하면 변경 사항�
   await resizeHandle.press("Shift+ArrowRight")
   await expect.poll(async () => (await memo.boundingBox()).width).toBeGreaterThan(beforeResize.width + 15)
   await expect(page.locator("#a11y-live-region")).toContainText("메모 크기")
+})
+
+test('자동 크기 모드에서 입력 내용에 맞춰 높이를 늘리고 줄인다', async ({ page }) => {
+  await openViewerWithMemo(page, { content: '짧은 메모' })
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await expect(memo).toHaveClass(/auto-size/)
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+  const initialHeight = (await memo.boundingBox()).height
+
+  await textarea.fill(Array.from({ length: 12 }, (_, index) => `길이가 긴 자동 크기 메모 ${index + 1}`).join('\n'))
+  await expect.poll(async () => (await memo.boundingBox()).height).toBeGreaterThan(initialHeight + 80)
+  await expect.poll(async () => (await memo.boundingBox()).width).toBeLessThanOrEqual(422)
+
+  const expandedHeight = (await memo.boundingBox()).height
+  await textarea.fill('다시 짧게')
+  await expect.poll(async () => (await memo.boundingBox()).height).toBeLessThan(expandedHeight - 80)
+})
+
+test('코드블록, 콜아웃, 중첩 목록과 표를 메모에서 렌더링한다', async ({ page }) => {
+  await openViewerWithMemo(page, {
+    content: [
+      '> [!WARNING] 확인 필요',
+      '> 중요한 내용입니다.',
+      '',
+      '```js',
+      'const answer = 42',
+      '```',
+      '',
+      '- 상위 항목',
+      '  - 하위 항목',
+      '1. 첫 단계',
+      '   1. 하위 단계',
+      '',
+      '| 항목 | 값 |',
+      '| --- | --- |',
+      '| 정답 | 42 |',
+    ].join('\n'),
+  })
+
+  const rendered = page.locator('.floating-memo-render')
+  await expect(rendered.locator('pre code')).toContainText('const answer = 42')
+  await expect(rendered.locator('blockquote .memo-callout-marker')).toContainText('확인 필요')
+  await expect(rendered.locator('ul ul')).toContainText('하위 항목')
+  await expect(rendered.locator('ol ol')).toContainText('하위 단계')
+  await expect(rendered.locator('table')).toContainText('정답')
 })

--- a/frontend/tests/textFormat.test.js
+++ b/frontend/tests/textFormat.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { formatMarkdownLatexHtml, linkPageCitations } from '../src/textFormat.js'
+import { prepareMemoMarkdown } from '../src/memoMarkdown.js'
 
 const passthrough = html => html
 
@@ -67,4 +68,26 @@ test('유효한 단일·범위 페이지 인용만 이동 버튼으로 만든다
   assert.match(html, /data-page-citation="4" data-page-citation-end="6"/)
   assert.match(html, /\[p\.12\]/)
   assert.match(html, /\[pp\.8-7\]/)
+})
+
+test('메모 콜아웃 마커를 blockquote 안의 안전한 HTML로 변환한다', () => {
+  const source = [
+    '> [!WARNING] 직접 지정한 제목 <script>',
+    '> - 첫 항목',
+    '>   1. 중첩 항목',
+  ].join('\n')
+  const prepared = prepareMemoMarkdown(source)
+
+  assert.match(prepared, /class="memo-callout-marker" data-callout="warning"/)
+  assert.match(prepared, /직접 지정한 제목 &lt;script&gt;/)
+  assert.match(prepared, /> - 첫 항목/)
+  assert.match(prepared, />   1\. 중첩 항목/)
+})
+
+test('코드 블록 안의 콜아웃 문법은 변환하지 않는다', () => {
+  const source = '```md\n> [!NOTE] 예시\n```\n\n> [!TIP] 실제 팁'
+  const prepared = prepareMemoMarkdown(source)
+
+  assert.match(prepared, /```md\n> \[!NOTE\] 예시\n```/)
+  assert.match(prepared, /data-callout="tip"/)
 })


### PR DESCRIPTION
# Summary
## 1. 메모 자동 크기 조절 기능 추가
- 내용 길이에 따라 메모 높이를 자동 조절하고, 너비 상한 이후 줄바꿈을 적용함
- 자동·수동 크기 모드 전환 및 기존 수동 크기 복원 기능을 추가함
## 2. 메모 Markdown 렌더링 확장
- 코드블록, 콜아웃, 중첩 목록·숫자 목록, 표 렌더링과 전용 스타일을 추가함
- 메모 자동 크기 및 Markdown 렌더링 E2E 테스트를 추가함