### PR TITLE
fix(primer): restore unknown-language summaries

### DIFF
--- a/backend/routers/primer.py
+++ b/backend/routers/primer.py
@@ -16,8 +16,7 @@ router = APIRouter()
 
 def _validated_languages(session: dict, target_value: str) -> tuple[str, str]:
     from services.languages import (
-        DOCUMENT_LANGUAGE_CODES, api_language_error, normalize_document_language,
-        resolve_source_language,
+        api_language_error, normalize_document_language, resolve_source_language,
     )
     try:
         target = normalize_document_language(target_value, allow_legacy=True)
@@ -28,12 +27,11 @@ def _validated_languages(session: dict, target_value: str) -> tuple[str, str]:
         source = resolve_source_language(session, requested_source)
     except ValueError:
         raise HTTPException(status_code=400, detail=api_language_error(requested_source, source=True))
-    if source not in DOCUMENT_LANGUAGE_CODES:
-        raise HTTPException(status_code=409, detail={
-            "code": "source_language_not_translatable",
-            "params": {"language": source},
-            "fallback": "The source language cannot be used for briefing generation.",
-        })
+    # Primer/overview prompts include the source excerpts themselves, so unlike
+    # translation they can safely let the LLM infer an undetermined or mixed
+    # source language. Upload-time generation already uses ``und``/``mul``;
+    # rejecting those values here made the generated cache impossible to read
+    # from both the Library and Viewer.
     return target, source
 
 # 캐시가 없는 문서(구버전 등)는 이 자리에서 생성해야 하는데, 계보/실험 흐름/

--- a/backend/tests/test_primer_router.py
+++ b/backend/tests/test_primer_router.py
@@ -113,7 +113,7 @@ def test_does_not_restart_generation_within_cooldown_after_a_recent_failure():
     assert task_key not in primer_router._pending_generations
 
 
-def test_rejects_invalid_target_and_unresolved_source(test_client, monkeypatch):
+def test_rejects_invalid_target(test_client, monkeypatch):
     monkeypatch.setattr(primer_router, "require_session_owner", lambda *_: {
         "pages": [], "metadata": {}, "pdf_path": "/x",
         "source_language": "auto", "detected_source_language": "und",
@@ -121,6 +121,24 @@ def test_rejects_invalid_target_and_unresolved_source(test_client, monkeypatch):
     invalid = test_client.get("/api/library/doc/primer?target_lang=xx")
     assert invalid.status_code == 400
     assert invalid.json()["code"] == "unsupported_target_language"
-    unresolved = test_client.get("/api/library/doc/primer?target_lang=fr")
-    assert unresolved.status_code == 409
-    assert unresolved.json()["code"] == "source_language_not_translatable"
+
+
+@pytest.mark.parametrize("detected", ["und", "mul"])
+def test_returns_cached_primer_for_unresolved_or_mixed_source(
+    test_client, isolated_dirs, monkeypatch, detected,
+):
+    monkeypatch.setattr(primer_router, "require_session_owner", lambda *_: {
+        "pages": [], "metadata": {}, "pdf_path": "/x",
+        "source_language": "auto", "detected_source_language": detected,
+    })
+    isolated_dirs["library"].save_page_insight(
+        "doc-special-source", 0, "primer_v2", '{"hook": "cached hook"}',
+        suffix=f"document-insights-v1:{detected}:fr",
+    )
+
+    response = test_client.get(
+        "/api/library/doc-special-source/primer?target_lang=fr"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"hook": "cached hook"}


### PR DESCRIPTION
Allow Library and Viewer primer requests to serve summaries for undetermined or mixed source languages.