### PR TITLE
fix: sync document search placeholder

### DIFF
--- a/frontend/src/workspaceModeController.js
+++ b/frontend/src/workspaceModeController.js
@@ -84,6 +84,13 @@ export function createWorkspaceModeController({
       if (tooltip) tooltip.textContent = label
     })
     const search = document.getElementById('workspace-search-input')
+    const librarySearch = document.getElementById('library-search-input')
+    if (librarySearch) {
+      librarySearch.placeholder = mode === 'general'
+        ? '문서 제목, 파일명, 번역된 내용 검색...'
+        : '논문 제목, 파일명, 번역된 내용 검색...'
+    }
+
     if (search) {
       search.dataset.i18nPlaceholder = copy.search.key
       search.placeholder = copy.search.value


### PR DESCRIPTION
# Summary
## 1. 문서 모드 라이브러리 검색창 초기 표기 수정
- 워크스페이스 모드 초기화 시 라이브러리 검색창 플레이스홀더를 현재 모드에 맞게 갱신하도록 수정함
- 문서 모드 전환 시 검색창을 "문서 제목, 파일명, 번역된 내용 검색..."으로 즉시 표시하도록 수정함