### PR TITLE
fix: improve multi-document upload reliability

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -143,6 +143,7 @@ def restore_sessions_from_library():
 @router.post("/upload", response_model=UploadResponse)
 async def upload_pdf(
     file: UploadFile = File(...),
+    upload_id: str | None = None,
     target_lang: str = "ko",
     source_lang: str = "auto",
     style: str = "academic",
@@ -181,8 +182,18 @@ async def upload_pdf(
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="PDF 파일만 업로드 가능합니다.")
 
-    # 세션 ID 생성
-    session_id = str(uuid.uuid4())
+    # 클라이언트가 알고 있는 ID를 사용하면 응답 전송이 끊겨도
+    # GET /session/{id}로 실제 저장 성공 여부를 확인할 수 있다.
+    if upload_id:
+        try:
+            session_id = str(uuid.UUID(upload_id))
+        except (ValueError, AttributeError):
+            raise HTTPException(status_code=400, detail="유효하지 않은 업로드 ID입니다.")
+        from services.db import db_get_document
+        if session_id in sessions or db_get_document(session_id):
+            raise HTTPException(status_code=409, detail="이미 사용된 업로드 ID입니다.")
+    else:
+        session_id = str(uuid.uuid4())
     session_dir = os.path.join(UPLOAD_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
     pdf_path = os.path.join(session_dir, "document.pdf")

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -7,6 +7,7 @@ MAX_FILE_SIZE_MB를 검사해서, 한도를 아무리 작게 잡아도 큰 업�
 """
 
 import fitz
+import uuid
 import routers.upload as upload_module
 import routers.primer as primer_router
 
@@ -49,6 +50,30 @@ def test_upload_accepts_file_within_size_limit(test_client, isolated_dirs, monke
     body = res.json()
     assert body["filename"] == "small.pdf"
     assert body["session_id"] in upload_module.sessions
+
+
+def test_upload_uses_valid_client_upload_id(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
+    upload_id = str(uuid.uuid4())
+
+    response = test_client.post(
+        f"/api/upload?translation_mode=scroll&upload_id={upload_id}",
+        files={"file": ("identified.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["session_id"] == upload_id
+
+
+def test_upload_rejects_invalid_client_upload_id(test_client):
+    response = test_client.post(
+        "/api/upload?upload_id=not-a-uuid",
+        files={"file": ("invalid.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert response.status_code == 400
 
 
 def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, monkeypatch):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1473,24 +1473,7 @@
         <button id="upload-popup-close" class="popup-control-btn" title="닫기">&times;</button>
       </div>
     </div>
-    <div class="upload-popup-body" id="upload-popup-body">
-      <div class="upload-item-row">
-        <div class="upload-item-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></div>
-        <div class="upload-item-info">
-          <div class="upload-item-name" id="upload-item-name">filename.pdf</div>
-          <div class="upload-item-status" id="upload-item-status">준비 중...</div>
-          <div class="upload-item-progress-container">
-            <div class="upload-item-progress-bar-wrap">
-              <div class="upload-item-progress-bar" id="upload-item-progress-bar"></div>
-            </div>
-          </div>
-        </div>
-        <div class="upload-item-circle-progress" id="upload-item-circle-progress">
-          <div class="spinner" id="upload-item-spinner" style="width:16px; height:16px;"></div>
-          <span class="upload-success-icon hidden" id="upload-item-success-icon">✓</span>
-        </div>
-      </div>
-    </div>
+    <div class="upload-popup-body" id="upload-popup-body"></div>
   </div>
 
   <!-- 논문 미리보기(빠른 보기) 팝업 -->

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -92,6 +92,22 @@ export async function cancelInsightJobAPI(sessionId, kind) {
   return res.json()
 }
 
+const uploadRecoveryDelays = [400, 800, 1600, 3200, 5000]
+
+async function recoverCompletedUpload(uploadId, onProgress) {
+  onProgress?.(100, 'verifying')
+  for (const delay of uploadRecoveryDelays) {
+    await new Promise(resolve => setTimeout(resolve, delay))
+    try {
+      const session = await getSession(uploadId)
+      return { ...session, file_size_mb: session.file_size_mb || 0 }
+    } catch {
+      // The server may still be finishing parsing after the connection closed.
+    }
+  }
+  return null
+}
+
 export async function uploadPDF(file, options, onProgress) {
   const formData = new FormData()
   formData.append('file', file)
@@ -99,19 +115,19 @@ export async function uploadPDF(file, options, onProgress) {
   const { targetLang, sourceLang = "auto", style, ignoreMath, ignoreTable, ignoreRefs, translationMode, keywordMode, summaryMode, documentMode, documentType } = options
   const query = `?target_lang=${encodeURIComponent(targetLang)}&source_lang=${encodeURIComponent(sourceLang)}&style=${style}&ignore_math=${ignoreMath}&ignore_table=${ignoreTable}&ignore_refs=${ignoreRefs}&translation_mode=${encodeURIComponent(translationMode || 'auto')}&keyword_mode=${encodeURIComponent(keywordMode || 'manual')}&summary_mode=${encodeURIComponent(summaryMode || 'manual')}`
   const classificationQuery = "&document_mode=" + encodeURIComponent(documentMode || "research") + "&document_type=" + encodeURIComponent(documentType || "research_paper")
+  const uploadId = crypto.randomUUID()
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
-    xhr.open('POST', `${API_BASE}/upload${query}${classificationQuery}`)
+    xhr.open('POST', `${API_BASE}/upload${query}${classificationQuery}&upload_id=${encodeURIComponent(uploadId)}`)
 
-    xhr.upload.addEventListener('progress', (e) => {
-      if (e.lengthComputable) {
-        onProgress(Math.round((e.loaded / e.total) * 100))
-      }
+    xhr.upload.addEventListener('progress', (event) => {
+      if (event.lengthComputable) onProgress?.(Math.round((event.loaded / event.total) * 100), 'uploading')
     })
 
     xhr.addEventListener('load', () => {
       if (xhr.status === 200) {
+        onProgress?.(100, 'processing')
         resolve(JSON.parse(xhr.responseText))
       } else {
         try {
@@ -123,7 +139,13 @@ export async function uploadPDF(file, options, onProgress) {
       }
     })
 
-    xhr.addEventListener('error', () => reject(new Error(errorMessage({ code: 'network' }))))
+    const recoverOrReject = async () => {
+      const recovered = await recoverCompletedUpload(uploadId, onProgress)
+      if (recovered) resolve(recovered)
+      else reject(new Error(errorMessage({ code: 'network' })))
+    }
+    xhr.addEventListener('error', recoverOrReject)
+    xhr.addEventListener('timeout', recoverOrReject)
     xhr.send(formData)
   })
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -772,11 +772,7 @@ const uploadPopup        = $('upload-popup')
 const uploadPopupTitle   = $('upload-popup-title')
 const uploadPopupMinimize = $('upload-popup-minimize')
 const uploadPopupClose   = $('upload-popup-close')
-const uploadItemName     = $('upload-item-name')
-const uploadItemStatus   = $('upload-item-status')
-const uploadItemProgressBar = $('upload-item-progress-bar')
-const uploadItemSpinner  = $('upload-item-spinner')
-const uploadItemSuccessIcon = $('upload-item-success-icon')
+const uploadPopupBody    = $('upload-popup-body')
 const docTitle          = $('doc-title')
 const viewerDocumentTypeChip = $("viewer-document-type-chip")
 const docTitleEditBtn   = $('doc-title-edit-btn')
@@ -1140,135 +1136,146 @@ fileInput.addEventListener('change', (e) => {
 
 // ── 파일 처리 ─────────────────────────────────────
 async function beginClassifiedUpload(files, targetFolderId = null) {
-  const selected = await workspaceModeController.chooseUploadClassification(Array.from(files))
-  if (!selected) { fileInput.value = ""; return }
-  await handleFiles(files, targetFolderId, selected)
-}
-
-async function handleFiles(files, targetFolderId = null, classification = null) {
   const pdfFiles = Array.from(files).filter(file => file.name.toLowerCase().endsWith('.pdf'))
-
   if (pdfFiles.length === 0) {
+    fileInput.value = ''
     showToast('PDF 파일만 업로드 가능합니다', 'error')
     return
   }
+  const selected = await workspaceModeController.chooseUploadClassifications(pdfFiles)
+  if (!selected) { fileInput.value = ''; return }
+  await handleFiles(selected, targetFolderId)
+}
 
-  const rememberedTypeOptions = classification?.documentType
-    ? (loadDocumentTypeOptions()[classification.documentType] || {})
-    : {}
+function createUploadPopupRow(file) {
+  const row = document.createElement('div')
+  row.className = 'upload-item-row'
+  row.innerHTML = `
+    <div class="upload-item-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></div>
+    <div class="upload-item-info">
+      <div class="upload-item-name"></div>
+      <div class="upload-item-status">준비 중...</div>
+      <div class="upload-item-progress-container"><div class="upload-item-progress-bar-wrap"><div class="upload-item-progress-bar"></div></div></div>
+    </div>
+    <div class="upload-item-circle-progress"><div class="spinner" style="width:16px;height:16px"></div><span class="upload-success-icon hidden">✓</span><span class="upload-error-icon hidden">!</span></div>`
+  row.querySelector('.upload-item-name').textContent = file.name
+  return {
+    element: row,
+    status: row.querySelector('.upload-item-status'),
+    bar: row.querySelector('.upload-item-progress-bar'),
+    spinner: row.querySelector('.spinner'),
+    success: row.querySelector('.upload-success-icon'),
+    error: row.querySelector('.upload-error-icon'),
+  }
+}
+
+async function handleFiles(uploadItems, targetFolderId = null) {
   const isLibraryActive = libraryScreen.classList.contains('active')
-
-  // Show upload popup
-  uploadPopup.classList.remove('hidden')
-  uploadPopup.classList.remove('minimized')
+  uploadPopup.classList.remove('hidden', 'minimized')
   if (uploadPopupMinimize) uploadPopupMinimize.textContent = '−'
+  uploadPopupBody.replaceChildren()
 
-  let successCount = 0
-  let lastSessionId = null
-  let lastFilename = ""
-  let lastTotalPages = 0
-  let lastTitle = ""
+  const rows = uploadItems.map(({ file }) => {
+    const row = createUploadPopupRow(file)
+    uploadPopupBody.appendChild(row.element)
+    return row
+  })
+  uploadPopupTitle.textContent = `파일 업로드 중 (0/${uploadItems.length})`
 
-  for (let i = 0; i < pdfFiles.length; i++) {
-    const file = pdfFiles[i]
-    uploadPopupTitle.textContent = `파일 업로드 중 (${i + 1}/${pdfFiles.length})`
-    uploadItemName.textContent = file.name
-    uploadItemStatus.textContent = '준비 중...'
-    uploadItemProgressBar.style.width = '0%'
-    uploadItemSpinner.classList.remove('hidden')
-    uploadItemSuccessIcon.classList.add('hidden')
-
+  let completedCount = 0
+  const uploadResults = await Promise.all(uploadItems.map(async (item, index) => {
+    const { file, classification } = item
+    const row = rows[index]
+    const rememberedTypeOptions = loadDocumentTypeOptions()[classification.documentType] || {}
     try {
       const result = await uploadPDF(file, {
-        ...getTranslationOptions(classification?.documentMode || workspaceModeController.getMode()),
+        ...getTranslationOptions(classification.documentMode),
         ...rememberedTypeOptions,
-        translationMode: getTranslationMode(classification?.documentMode || workspaceModeController.getMode()),
-        keywordMode: getKeywordMode(classification?.documentMode || workspaceModeController.getMode()),
-        summaryMode: getSummaryMode(classification?.documentMode || workspaceModeController.getMode()),
-        documentMode: classification?.documentMode || workspaceModeController.getMode(),
-        documentType: classification?.documentType || defaultDocumentType(workspaceModeController.getMode())
-      }, (pct) => {
-        uploadItemProgressBar.style.width = `${pct}%`
-        uploadItemStatus.textContent = `업로드 중... ${pct}%`
+        translationMode: getTranslationMode(classification.documentMode),
+        keywordMode: getKeywordMode(classification.documentMode),
+        summaryMode: getSummaryMode(classification.documentMode),
+        documentMode: classification.documentMode,
+        documentType: classification.documentType,
+      }, (pct, phase) => {
+        row.bar.style.width = `${pct}%`
+        row.status.textContent = phase === 'verifying'
+          ? t('common:legacy.ui.0801')
+          : (pct >= 100 || phase === 'processing' ? '분석 및 저장 중...' : `업로드 중... ${pct}%`)
       })
-
-      uploadItemProgressBar.style.width = '100%'
-      uploadItemStatus.textContent = '분석 및 저장 중...'
-
-      lastSessionId = result.session_id
-      lastFilename = result.filename
-      lastTotalPages = result.total_pages
-      lastTitle = (result.metadata && result.metadata.title) ? result.metadata.title : result.filename
-      const uploadedDocumentMode = classification?.documentMode || workspaceModeController.getMode()
-      if (isLongDocument(result.total_pages) && getTranslationMode(uploadedDocumentMode) === 'auto') {
-        showToast(
-          '50페이지 이상 문서는 전체 자동 번역 대신 보는 페이지부터 번역됩니다.',
-          'info',
-        )
-      }
-      successCount++
-      if (result.document_mode === 'general' && getKeywordMode(result.document_mode) === 'auto' && result.total_pages > 20) {
-        const uploadLanguageOptions = getTranslationOptions(result.document_mode)
-        const estimate = await estimateInsightJobAPI(result.session_id, 'keywords', uploadLanguageOptions.targetLang, uploadLanguageOptions.sourceLang)
-        const confirmed = await showCustomConfirm(
-          `빈 페이지와 기존 캐시를 제외하고 최대 ${estimate.estimated_calls}회의 AI 호출이 예상됩니다. 전체 고급 어휘 생성을 시작할까요?`,
-          { title: '장문 어휘 생성', confirmText: '생성 시작', danger: false },
-        )
-        if (confirmed) {
-          await startInsightJobAPI(result.session_id, 'keywords', uploadLanguageOptions.targetLang, uploadLanguageOptions.sourceLang, true)
-          showInsightJobProgress(result.session_id, 'keywords', `${lastTitle} · 고급 어휘`)
+      if (targetFolderId) {
+        try {
+          await moveLibraryDocuments([result.session_id], targetFolderId)
+        } catch {
+          showToast(t('common:legacy.ui.0751'), 'warning')
         }
       }
-      if (classification?.documentType) {
-        saveDocumentTypeOptions(classification.documentType, { ...rememberedTypeOptions, ...getTranslationOptions(classification.documentMode) })
-        patchWorkspaceSettingsAPI({ document_type_options: loadDocumentTypeOptions() }).catch(() => {
-          showToast('문서 종류별 옵션을 서버에 저장하지 못했습니다.', 'warning')
-        })
-      }
-      if (targetFolderId) await moveLibraryDocuments([result.session_id], targetFolderId)
-
-      if (isLibraryActive) {
-        await renderLibrary()
-      }
-
-      // Mark file upload as success in popup
-      uploadItemStatus.textContent = '업로드 완료'
-      uploadItemSpinner.classList.add('hidden')
-      uploadItemSuccessIcon.classList.remove('hidden')
-    } catch (err) {
-      showToast(`"${file.name}" 업로드 실패: ${err.message}`, 'error')
-      uploadItemStatus.textContent = '업로드 실패'
-      uploadItemSpinner.classList.add('hidden')
+      row.bar.style.width = '100%'
+      row.status.textContent = '업로드 완료'
+      row.spinner.classList.add('hidden')
+      row.success.classList.remove('hidden')
+      return { ...item, result, rememberedTypeOptions }
+    } catch (error) {
+      showToast(`"${file.name}" 업로드 실패: ${error.message}`, 'error')
+      row.status.textContent = '업로드 실패'
+      row.spinner.classList.add('hidden')
+      row.error.classList.remove('hidden')
+      return null
+    } finally {
+      completedCount++
+      uploadPopupTitle.textContent = `파일 업로드 중 (${completedCount}/${uploadItems.length})`
     }
+  }))
+
+  const successes = uploadResults.filter(Boolean)
+  fileInput.value = ''
+
+  for (const uploaded of successes) {
+    const { classification, result, rememberedTypeOptions } = uploaded
+    const title = result.metadata?.title || result.filename
+    if (isLongDocument(result.total_pages) && getTranslationMode(classification.documentMode) === 'auto') {
+      showToast('50페이지 이상 문서는 전체 자동 번역 대신 보는 페이지부터 번역됩니다.', 'info')
+    }
+    if (result.document_mode === 'general' && getKeywordMode(result.document_mode) === 'auto' && result.total_pages > 20) {
+      const languageOptions = getTranslationOptions(result.document_mode)
+      const estimate = await estimateInsightJobAPI(result.session_id, 'keywords', languageOptions.targetLang, languageOptions.sourceLang)
+      const confirmed = await showCustomConfirm(
+        `빈 페이지와 기존 캐시를 제외하고 최대 ${estimate.estimated_calls}회의 AI 호출이 예상됩니다. 전체 고급 어휘 생성을 시작할까요?`,
+        { title: '장문 어휘 생성', confirmText: '생성 시작', danger: false },
+      )
+      if (confirmed) {
+        await startInsightJobAPI(result.session_id, 'keywords', languageOptions.targetLang, languageOptions.sourceLang, true)
+        showInsightJobProgress(result.session_id, 'keywords', `${title} · 고급 어휘`)
+      }
+    }
+    saveDocumentTypeOptions(classification.documentType, { ...rememberedTypeOptions, ...getTranslationOptions(classification.documentMode) })
   }
+  if (successes.length) {
+    patchWorkspaceSettingsAPI({ document_type_options: loadDocumentTypeOptions() }).catch(() => {
+      showToast('문서 종류별 옵션을 서버에 저장하지 못했습니다.', 'warning')
+    })
+  }
+  if (isLibraryActive && successes.length) await renderLibrary()
 
-  fileInput.value = '' // reset input value
+  if (successes.length > 0) {
+    uploadPopupTitle.textContent = `업로드 완료 (${successes.length}/${uploadItems.length})`
+    showToast(`${successes.length}개의 문서가 라이브러리에 추가되었습니다 ✓`, 'success')
+    if (successes.length === uploadItems.length) setTimeout(() => uploadPopup.classList.add('hidden'), 1500)
 
-  if (successCount > 0) {
-    uploadPopupTitle.textContent = `업로드 완료 (${successCount}/${pdfFiles.length})`
-    const uploadedNoun = classification?.documentMode === 'general' ? '문서' : '논문'
-    showToast(`${successCount}개의 ${uploadedNoun}가 라이브러리에 추가되었습니다 ✓`, 'success')
-
-    // 업로드 성공 시 1.5초 후 팝업 자동 닫기
-    setTimeout(() => {
-      uploadPopup.classList.add('hidden')
-    }, 1500)
-
-    if (!isLibraryActive && pdfFiles.length === 1 && successCount === 1) {
-      state.sessionId  = lastSessionId
-      loadDocumentImages(lastSessionId)
-      state.filename   = lastFilename
-      state.totalPages = lastTotalPages
-      state.title      = lastTitle
-      history.pushState({ screen: 'viewer', docId: lastSessionId }, '', `#viewer?id=${lastSessionId}`)
-
-      await loadPDF(`/api/pdf-file/${state.sessionId}`)
-      docTitle.textContent = lastTitle
-      docTitle.title = lastFilename
-      pageTotal.textContent = `/ ${state.totalPages}`
-      pageInput.max   = state.totalPages
+    if (!isLibraryActive && uploadItems.length === 1 && successes.length === 1) {
+      const { result } = successes[0]
+      const title = result.metadata?.title || result.filename
+      state.sessionId = result.session_id
+      loadDocumentImages(result.session_id)
+      state.filename = result.filename
+      state.totalPages = result.total_pages
+      state.title = title
+      history.pushState({ screen: 'viewer', docId: result.session_id }, '', `#viewer?id=${result.session_id}`)
+      await loadPDF(`/api/pdf-file/${result.session_id}`)
+      docTitle.textContent = title
+      docTitle.title = result.filename
+      pageTotal.textContent = `/ ${result.total_pages}`
+      pageInput.max = result.total_pages
       pageInput.value = 1
-
       showViewer()
       await initScrollViewer()
       hideOutlineSidebar()

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3750,7 +3750,7 @@ body.light-theme .provider-picker-panel {
 .upload-popup-body {
   padding: 16px 20px;
   background: rgba(0, 0, 0, 0.15);
-  max-height: 200px;
+  max-height: min(420px, 60vh);
   overflow-y: auto;
   transition: max-height 0.3s;
 }
@@ -3763,6 +3763,16 @@ body.light-theme .provider-picker-panel {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+.upload-item-row + .upload-item-row {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.upload-error-icon {
+  color: var(--error);
+  font-size: 18px;
+  font-weight: 700;
 }
 .upload-item-icon {
   font-size: 24px;

--- a/frontend/src/workspaceModeController.js
+++ b/frontend/src/workspaceModeController.js
@@ -47,6 +47,7 @@ export function createWorkspaceModeController({
   let pendingUpload = null
   let selectedType = null
   let classificationMode = mode
+  let classificationContext = ''
 
   const modal = document.getElementById('document-type-modal')
   const optionRoot = document.getElementById('document-type-options')
@@ -171,7 +172,7 @@ export function createWorkspaceModeController({
     confirmBtn.disabled = true
     modeChip.textContent = classificationMode === 'research' ? '연구 모드' : '일반 문서 모드'
     if (uploadModeSwitch) uploadModeSwitch.textContent = classificationMode === 'research' ? '일반 문서 모드로 전환' : '연구 모드로 전환'
-    summary.textContent = ''
+    summary.textContent = classificationContext
     optionRoot.innerHTML = ''
     getDocumentTypes(registry, classificationMode).forEach(type => {
       const button = document.createElement('button')
@@ -184,16 +185,18 @@ export function createWorkspaceModeController({
         selectedType = type.value
         optionRoot.querySelectorAll('[role="radio"]').forEach(item => item.setAttribute('aria-checked', String(item === button)))
         confirmBtn.disabled = false
-        summary.textContent = `${classificationMode === 'research' ? '연구' : '일반 문서'} · ${type.label}`
+        const classification = `${classificationMode === 'research' ? '연구' : '일반 문서'} · ${type.label}`
+        summary.textContent = classificationContext ? `${classificationContext} · ${classification}` : classification
       })
       optionRoot.appendChild(button)
     })
   }
 
-  function chooseClassification(initialMode, purpose = 'upload', files = []) {
+  function chooseClassification(initialMode, purpose = 'upload', context = '') {
     classificationMode = initialMode === 'general' ? 'general' : 'research'
+    classificationContext = context
     if (!modal || !optionRoot) {
-      return Promise.resolve({ documentMode: classificationMode, documentType: defaultDocumentType(classificationMode), files })
+      return Promise.resolve({ documentMode: classificationMode, documentType: defaultDocumentType(classificationMode) })
     }
     if (pendingUpload) closeUploadModal(null)
     const title = modal.querySelector('.modal-header h2')
@@ -206,7 +209,23 @@ export function createWorkspaceModeController({
     return new Promise(resolve => { pendingUpload = resolve })
   }
 
-  function chooseUploadClassification(files) { return chooseClassification(mode, 'upload', files) }
+  function chooseUploadClassification(files) {
+    const file = Array.from(files || [])[0]
+    return chooseClassification(mode, 'upload', file?.name || '')
+  }
+  async function chooseUploadClassifications(files) {
+    const selected = []
+    const list = Array.from(files)
+    for (let index = 0; index < list.length; index++) {
+      const file = list[index]
+      const pending = chooseClassification(mode, 'upload', `${index + 1}/${list.length} · ${file.name}`)
+      if (confirmBtn) confirmBtn.textContent = index === list.length - 1 ? '업로드' : '다음'
+      const result = await pending
+      if (!result) return null
+      selected.push({ file, classification: result })
+    }
+    return selected
+  }
   function chooseDocumentClassification(currentMode) { return chooseClassification(currentMode, 'change') }
 
   confirmBtn?.addEventListener('click', () => {
@@ -223,7 +242,7 @@ export function createWorkspaceModeController({
   modal?.addEventListener('click', event => { if (event.target === modal) closeUploadModal(null) })
 
   return {
-    initialize, setMode, chooseUploadClassification, chooseDocumentClassification, getPageLabel,
+    initialize, setMode, chooseUploadClassification, chooseUploadClassifications, chooseDocumentClassification, getPageLabel,
     getMode: () => mode,
     getRegistry: () => registry,
     getTypeLabel: (docMode, type) => documentTypeLabel(registry, docMode, type),

--- a/frontend/tests/api-upload.test.js
+++ b/frontend/tests/api-upload.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { uploadPDF } from '../src/api.js'
+
+const options = {
+  targetLang: 'ko', sourceLang: 'auto', style: 'academic',
+  ignoreMath: false, ignoreTable: true, ignoreRefs: false,
+  translationMode: 'auto', keywordMode: 'manual', summaryMode: 'manual',
+  documentMode: 'research', documentType: 'research_paper',
+}
+
+class MockXHR {
+  static instances = []
+  constructor() {
+    this.listeners = new Map()
+    this.upload = { addEventListener: (name, handler) => this.uploadHandler = [name, handler] }
+    MockXHR.instances.push(this)
+  }
+  open(method, url) { this.method = method; this.url = url }
+  addEventListener(name, handler) { this.listeners.set(name, handler) }
+  send(body) { this.body = body }
+  emit(name) { return this.listeners.get(name)?.() }
+}
+
+test('upload sends a client-known id and reports progress phases', async () => {
+  const originalXHR = globalThis.XMLHttpRequest
+  const originalCrypto = globalThis.crypto
+  const uploadId = '123e4567-e89b-42d3-a456-426614174000'
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { randomUUID: () => uploadId } })
+  globalThis.XMLHttpRequest = MockXHR
+  MockXHR.instances = []
+  try {
+    const phases = []
+    const promise = uploadPDF(new Blob(['pdf']), options, (percent, phase) => phases.push([percent, phase]))
+    const xhr = MockXHR.instances[0]
+    assert.equal(xhr.method, 'POST')
+    assert.match(xhr.url, new RegExp(`upload_id=${uploadId}`))
+    xhr.uploadHandler[1]({ lengthComputable: true, loaded: 1, total: 2 })
+    xhr.status = 200
+    xhr.responseText = JSON.stringify({ session_id: uploadId, filename: 'one.pdf', total_pages: 1, metadata: {} })
+    xhr.emit('load')
+    assert.equal((await promise).session_id, uploadId)
+    assert.deepEqual(phases, [[50, 'uploading'], [100, 'processing']])
+  } finally {
+    globalThis.XMLHttpRequest = originalXHR
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: originalCrypto })
+  }
+})
+
+test('connection loss recovers a completed server upload by id', async () => {
+  const originalXHR = globalThis.XMLHttpRequest
+  const originalCrypto = globalThis.crypto
+  const originalFetch = globalThis.fetch
+  const originalSetTimeout = globalThis.setTimeout
+  const uploadId = '123e4567-e89b-42d3-a456-426614174001'
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { randomUUID: () => uploadId } })
+  globalThis.XMLHttpRequest = MockXHR
+  globalThis.setTimeout = handler => { handler(); return 0 }
+  globalThis.fetch = async url => {
+    assert.equal(url, `/api/session/${uploadId}`)
+    return new Response(JSON.stringify({
+      session_id: uploadId, filename: 'recovered.pdf', total_pages: 3, metadata: {},
+      document_mode: 'research', document_type: 'research_paper',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }
+  MockXHR.instances = []
+  try {
+    const phases = []
+    const promise = uploadPDF(new Blob(['pdf']), options, (percent, phase) => phases.push([percent, phase]))
+    await MockXHR.instances[0].emit('error')
+    const result = await promise
+    assert.equal(result.session_id, uploadId)
+    assert.equal(result.filename, 'recovered.pdf')
+    assert.deepEqual(phases, [[100, 'verifying']])
+  } finally {
+    globalThis.XMLHttpRequest = originalXHR
+    globalThis.fetch = originalFetch
+    globalThis.setTimeout = originalSetTimeout
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: originalCrypto })
+  }
+})


### PR DESCRIPTION
# Summary
## 1. 다중 문서 업로드 진행 상태 개선
- Google Drive 스타일 업로드 팝업에 선택한 모든 문서의 파일명, 진행률, 성공·실패 상태를 동시에 표시하도록 수정함
- 문서별 업로드 요청을 병렬 실행하여 직렬 처리로 인한 업로드 지연 현상 수정함
## 2. 문서별 분류 선택 기능 추가
- 다중 업로드 전에 각 문서별로 연구·일반 문서 모드와 문서 종류를 선택하는 다이얼로그 추가
- 마지막 문서 전까지 다음 버튼을 표시하고 문서 순서와 파일명을 분류 요약에 표시함
## 3. 업로드 실패 오탐 복구
- 클라이언트 생성 업로드 ID를 서버 세션 ID로 사용하여 응답 유실 후 실제 저장 여부를 재확인하는 기능 추가
- 업로드 성공 후 폴더 이동 실패를 업로드 실패와 분리하여 경고로 처리함
## 4. 회귀 검증 추가
- 업로드 ID 전달, 진행 단계, 네트워크 응답 유실 복구 테스트 추가
- 유효·무효 업로드 ID 백엔드 테스트 추가