### PR TITLE
feat(viewer): expand memo markdown editing

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11533,7 +11533,8 @@ function renderPageMemos(pageNum) {
         textarea.addEventListener('blur', () => {
           setTimeout(() => {
             const exists = memoEl.parentNode !== null
-            if (exists) {
+            const currentTextarea = memoEl.querySelector('.floating-memo-textarea')
+            if (exists && isEditing && currentTextarea === textarea) {
               isEditing = false
               updateCardContent()
               updateMemoConnectorLine(pageWrapper, memo)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9986,6 +9986,21 @@ function refreshSyncedAnnotationView() {
   document.dispatchEvent(new CustomEvent('easypaper:annotations-synced'))
 }
 
+function getAnnotationViewFingerprint(docId) {
+  const withoutVersions = data => Object.fromEntries(Object.entries(data).map(([pageKey, items]) => [
+    pageKey,
+    items.map(item => {
+      const value = { ...item }
+      delete value.version
+      return value
+    }),
+  ]))
+  return JSON.stringify({
+    annotations: withoutVersions(loadAnnotations(docId)),
+    memos: withoutVersions(loadMemos(docId)),
+  })
+}
+
 async function syncAnnotationsNow(docId, { keepalive = false, refresh = true } = {}) {
   if (!docId) return null
   if (!navigator.onLine && !keepalive) {
@@ -9995,13 +10010,21 @@ async function syncAnnotationsNow(docId, { keepalive = false, refresh = true } =
     }
     return null
   }
+  const annotationViewBeforeSync = refresh && state.sessionId === docId
+    ? getAnnotationViewFingerprint(docId)
+    : null
   if (annotationSyncInFlight.has(docId)) return annotationSyncInFlight.get(docId)
   const promise = syncDocumentAnnotations(docId, { keepalive })
     .then(result => {
       annotationSyncDelayNotified = false
       const conflicts = [...result.annotations.conflicts, ...result.memos.conflicts]
       if (conflicts.length) showToast(t('viewer:sync.conflict'), 'warning')
-      if (refresh && state.sessionId === docId) refreshSyncedAnnotationView()
+      const annotationViewAfterSync = annotationViewBeforeSync === null
+        ? null
+        : getAnnotationViewFingerprint(docId)
+      if (refresh && state.sessionId === docId && annotationViewBeforeSync !== annotationViewAfterSync) {
+        refreshSyncedAnnotationView()
+      }
       return result
     })
     .catch(error => {
@@ -11173,6 +11196,8 @@ function renderPageMemos(pageNum) {
   const pageMemos = allMemos[`page_${pageNum}`] || []
 
   pageMemos.forEach(memo => {
+    if (!Number.isFinite(memo.x)) memo.x = 10
+    if (!Number.isFinite(memo.y)) memo.y = 10
     // 개별 "숨기기"(memo.hidden) 또는 툴바의 "전체 숨기기"(allMemosHidden) 중
     // 하나라도 켜져 있으면 카드는 그리지 않고 PDF 본문의 하이라이트만 남긴다.
     // 전체 숨기기는 순수 화면 표시 상태라 하이라이트를 클릭해도 개별 메모만
@@ -11279,6 +11304,23 @@ function renderPageMemos(pageNum) {
       textarea.style.height = `${textarea.scrollHeight}px`
     }
 
+    function applyMemoMarkdownShortcut(event, textarea) {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) return false
+      const shortcuts = { b: ["**", "**", "굵은 텍스트"], i: ["*", "*", "기울임 텍스트"], k: ["[", "](url)", "링크 텍스트"], e: ["`", "`", "코드"] }
+      const shortcut = !event.shiftKey && shortcuts[event.key.toLowerCase()]
+      if (!shortcut) return false
+      event.preventDefault()
+      event.stopPropagation()
+      const start = textarea.selectionStart
+      const end = textarea.selectionEnd
+      const content = textarea.value.slice(start, end) || shortcut[2]
+      textarea.setRangeText(shortcut[0] + content + shortcut[1], start, end, "select")
+      const contentStart = start + shortcut[0].length
+      textarea.setSelectionRange(contentStart, contentStart + content.length)
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      return true
+    }
+
     function updateAutoSizeButton() {
       const button = memoEl.querySelector('.auto-size-btn')
       if (!button) return
@@ -11337,6 +11379,10 @@ function renderPageMemos(pageNum) {
           requestAnimationFrame(() => updateMemoConnectorLine(pageWrapper, memo))
         })
 
+        textarea.addEventListener('keydown', (event) => {
+          applyMemoMarkdownShortcut(event, textarea)
+        })
+
         textarea.addEventListener('blur', () => {
           setTimeout(() => {
             const exists = memoEl.parentNode !== null
@@ -11346,7 +11392,7 @@ function renderPageMemos(pageNum) {
               updateMemoConnectorLine(pageWrapper, memo)
               if (deferredAnnotationRefresh) {
                 deferredAnnotationRefresh = false
-                syncAnnotationsNow(state.sessionId)
+                refreshSyncedAnnotationView()
               }
             }
           }, 150)
@@ -11480,6 +11526,9 @@ function renderPageMemos(pageNum) {
     updateCardContent()
 
     const autoSizeBtn = memoEl.querySelector('.auto-size-btn')
+    memoEl.querySelectorAll('button').forEach(button => {
+      button.addEventListener('mousedown', (event) => event.stopPropagation())
+    })
     autoSizeBtn.addEventListener('click', (e) => {
       e.stopPropagation()
       setMemoAutoSize(!memoAutoSize)
@@ -11624,6 +11673,7 @@ function renderPageMemos(pageNum) {
       announceA11y(t('viewer:a11y.memoPosition', { x: Math.round(memoEl.offsetLeft), y: Math.round(memoEl.offsetTop) }))
     })
     header.addEventListener('mousedown', (e) => {
+      if (e.target.closest('button, input, textarea, a')) return
       e.preventDefault(); e.stopPropagation()
       const startMouseX = e.clientX
       const startMouseY = e.clientY

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11291,6 +11291,7 @@ function renderPageMemos(pageNum) {
     if (!memoAutoSize && !memo.collapsed && Number.isFinite(memo.height)) memoEl.style.height = `${memo.height}px`
 
     let isEditing = !memo.content.trim()
+    let memoEditStartContent = memo.content
 
     function persistMemoChange() {
       const allMemosObj = loadMemos(state.sessionId)
@@ -11304,21 +11305,147 @@ function renderPageMemos(pageNum) {
       textarea.style.height = `${textarea.scrollHeight}px`
     }
 
-    function applyMemoMarkdownShortcut(event, textarea) {
-      if (!(event.ctrlKey || event.metaKey) || event.altKey) return false
-      const shortcuts = { b: ["**", "**", "굵은 텍스트"], i: ["*", "*", "기울임 텍스트"], k: ["[", "](url)", "링크 텍스트"], e: ["`", "`", "코드"] }
-      const shortcut = !event.shiftKey && shortcuts[event.key.toLowerCase()]
-      if (!shortcut) return false
-      event.preventDefault()
-      event.stopPropagation()
+    function dispatchMemoTextareaInput(textarea) {
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+
+    function toggleMemoInlineFormat(textarea, prefix, suffix, placeholder) {
       const start = textarea.selectionStart
       const end = textarea.selectionEnd
-      const content = textarea.value.slice(start, end) || shortcut[2]
-      textarea.setRangeText(shortcut[0] + content + shortcut[1], start, end, "select")
-      const contentStart = start + shortcut[0].length
-      textarea.setSelectionRange(contentStart, contentStart + content.length)
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-      return true
+      const selected = textarea.value.slice(start, end)
+      const outside = start >= prefix.length
+        && textarea.value.slice(start - prefix.length, start) === prefix
+        && textarea.value.slice(end, end + suffix.length) === suffix
+        && textarea.value.slice(start - prefix.length - 1, start - prefix.length) !== prefix[0]
+        && textarea.value.slice(end + suffix.length, end + suffix.length + 1) !== suffix[suffix.length - 1]
+      if (selected.startsWith(prefix) && selected.endsWith(suffix)) {
+        const content = selected.slice(prefix.length, -suffix.length)
+        textarea.setRangeText(content, start, end, 'select')
+        textarea.setSelectionRange(start, start + content.length)
+      } else if (outside) {
+        textarea.setRangeText(selected, start - prefix.length, end + suffix.length, 'select')
+        textarea.setSelectionRange(start - prefix.length, end - prefix.length)
+      } else {
+        const content = selected || placeholder
+        textarea.setRangeText(prefix + content + suffix, start, end, 'select')
+        textarea.setSelectionRange(start + prefix.length, start + prefix.length + content.length)
+      }
+      dispatchMemoTextareaInput(textarea)
+    }
+
+    function memoSelectedLineRange(textarea) {
+      const start = textarea.selectionStart
+      const end = textarea.selectionEnd
+      const lineStart = textarea.value.lastIndexOf('\n', Math.max(0, start - 1)) + 1
+      const nextNewline = textarea.value.indexOf('\n', end)
+      return [lineStart, nextNewline === -1 ? textarea.value.length : nextNewline]
+    }
+
+    function transformMemoLines(textarea, transform) {
+      const [start, end] = memoSelectedLineRange(textarea)
+      const lines = textarea.value.slice(start, end).split('\n')
+      textarea.setRangeText(lines.map(transform).join('\n'), start, end, 'select')
+      dispatchMemoTextareaInput(textarea)
+    }
+
+    function toggleMemoLinePrefix(textarea, createPrefix, pattern) {
+      const [start, end] = memoSelectedLineRange(textarea)
+      const lines = textarea.value.slice(start, end).split('\n')
+      const remove = lines.every(line => !line.trim() || pattern.test(line))
+      textarea.setRangeText(lines.map((line, index) => {
+        pattern.lastIndex = 0
+        if (remove) return line.replace(pattern, '$1')
+        const indent = line.match(/^\s*/)[0]
+        return indent + createPrefix(index) + line.slice(indent.length)
+      }).join('\n'), start, end, 'select')
+      dispatchMemoTextareaInput(textarea)
+    }
+
+    function applyMemoMarkdownShortcut(event, textarea) {
+      const caret = textarea.selectionStart
+      if (event.key === '[' && !event.ctrlKey && !event.metaKey && !event.altKey
+          && caret === textarea.selectionEnd && textarea.value.slice(caret - 1, caret) === '[') {
+        event.preventDefault()
+        textarea.setRangeText('[]]', caret, caret, 'end')
+        textarea.setSelectionRange(caret + 1, caret + 1)
+        dispatchMemoTextareaInput(textarea)
+        return 'handled'
+      }
+      if (event.key === 'Enter' && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey
+          && caret === textarea.selectionEnd) {
+        const lineStart = textarea.value.lastIndexOf('\n', Math.max(0, caret - 1)) + 1
+        const match = textarea.value.slice(lineStart, caret).match(/^(\s*)(?:(\d+)\.|([-+*])|(-\s+\[[ xX]\]))\s+(.*)$/)
+        if (match) {
+          event.preventDefault()
+          if (!match[5].trim()) textarea.setRangeText('', lineStart, caret, 'end')
+          else {
+            const marker = match[2] ? String(Number(match[2]) + 1) + '.' : match[4] ? '- [ ]' : match[3]
+            textarea.setRangeText('\n' + match[1] + marker + ' ', caret, caret, 'end')
+          }
+          dispatchMemoTextareaInput(textarea)
+          return 'handled'
+        }
+      }
+      if (event.key === 'Tab' && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault()
+        transformMemoLines(textarea, line => event.shiftKey
+          ? (line.startsWith('  ') ? line.slice(2) : line.replace(/^ /, ''))
+          : '  ' + line)
+        return 'handled'
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        return 'cancel'
+      }
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) return null
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        const [start, end] = memoSelectedLineRange(textarea)
+        const line = textarea.value.slice(start, end)
+        if (/^\s*-\s+\[[ xX]\]/.test(line)) {
+          textarea.setRangeText(line.replace(/^(\s*-\s+\[)([ xX])(\])/, (_, before, mark, after) => (
+            before + (mark === ' ' ? 'x' : ' ') + after
+          )), start, end, 'end')
+          dispatchMemoTextareaInput(textarea)
+          return 'handled'
+        }
+        return 'finish'
+      }
+      const key = event.key.toLowerCase()
+      let format = null
+      if (!event.shiftKey && key === 'b') format = ['**', '**', '굵은 텍스트']
+      else if (!event.shiftKey && key === 'i') format = ['*', '*', '기울임 텍스트']
+      else if (!event.shiftKey && key === 'k') format = ['[', '](url)', '링크 텍스트']
+      else if (!event.shiftKey && key === 'e') format = ['`', '`', '코드']
+      else if (event.shiftKey && key === 'x') format = ['~~', '~~', '취소선']
+      else if (event.shiftKey && key === 'c') format = ['```\n', '\n```', '코드 블록']
+      if (format) {
+        event.preventDefault()
+        event.stopPropagation()
+        toggleMemoInlineFormat(textarea, ...format)
+        return 'handled'
+      }
+      if (event.shiftKey && event.code === 'Digit7') {
+        event.preventDefault()
+        toggleMemoLinePrefix(textarea, index => String(index + 1) + '. ', /^(\s*)\d+\.\s+/)
+        return 'handled'
+      }
+      if (event.shiftKey && event.code === 'Digit8') {
+        event.preventDefault()
+        toggleMemoLinePrefix(textarea, () => '- ', /^(\s*)[-+*]\s+/)
+        return 'handled'
+      }
+      if (event.shiftKey && key === 'l') {
+        event.preventDefault()
+        toggleMemoLinePrefix(textarea, () => '- [ ] ', /^(\s*)-\s+\[[ xX]\]\s+/)
+        return 'handled'
+      }
+      if (event.shiftKey && event.code === 'Period') {
+        event.preventDefault()
+        toggleMemoLinePrefix(textarea, () => '> ', /^(\s*)>\s+/)
+        return 'handled'
+      }
+      return null
     }
 
     function updateAutoSizeButton() {
@@ -11380,7 +11507,27 @@ function renderPageMemos(pageNum) {
         })
 
         textarea.addEventListener('keydown', (event) => {
-          applyMemoMarkdownShortcut(event, textarea)
+          const action = applyMemoMarkdownShortcut(event, textarea)
+          if (action === 'cancel') {
+            memo.content = memoEditStartContent
+            persistMemoChange()
+            isEditing = false
+            updateCardContent()
+          } else if (action === 'finish') {
+            isEditing = false
+            updateCardContent()
+          }
+        })
+
+        textarea.addEventListener('paste', (event) => {
+          const pasted = event.clipboardData?.getData('text/plain')?.trim()
+          const start = textarea.selectionStart
+          const end = textarea.selectionEnd
+          const selected = textarea.value.slice(start, end)
+          if (!selected || !/^https?:\/\/\S+$/i.test(pasted || '')) return
+          event.preventDefault()
+          textarea.setRangeText('[' + selected + '](' + pasted + ')', start, end, 'end')
+          dispatchMemoTextareaInput(textarea)
         })
 
         textarea.addEventListener('blur', () => {
@@ -11465,6 +11612,7 @@ function renderPageMemos(pageNum) {
             allMemosObj[`page_${pageNum}`] = pageMemos
             saveMemos(state.sessionId, allMemosObj)
           }
+          memoEditStartContent = memo.content
           isEditing = true
           updateCardContent()
         })
@@ -11566,6 +11714,7 @@ function renderPageMemos(pageNum) {
       if (isEditing) return
       if (e.target.closest('a')) return
       e.stopPropagation()
+      memoEditStartContent = memo.content
       isEditing = true
       updateCardContent()
     })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5097,7 +5097,7 @@ body.light-theme .pdf-sentence.pdf-sentence-has-memo.color-red {
   animation: popupScale 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .floating-memo.auto-size {
-  width: fit-content;
+  width: min(380px, calc(90vw - 20px));
   max-width: min(420px, 90vw);
   height: auto;
   min-height: 0;

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -181,6 +181,92 @@ test('자동 크기 모드에서 입력 내용에 맞춰 높이를 늘리고 줄
   await expect.poll(async () => (await memo.boundingBox()).height).toBeLessThan(expandedHeight - 80)
 })
 
+test('메모 Markdown 서식과 줄 단축키를 토글한다', async ({ page }) => {
+  await openViewerWithMemo(page)
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+
+  await textarea.fill('서식')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+x')
+  await expect(textarea).toHaveValue('~~서식~~')
+  await textarea.press('ControlOrMeta+Shift+x')
+  await expect(textarea).toHaveValue('서식')
+
+  await textarea.fill('첫째\n둘째')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+8')
+  await expect(textarea).toHaveValue('- 첫째\n- 둘째')
+  await textarea.press('ControlOrMeta+Shift+8')
+  await expect(textarea).toHaveValue('첫째\n둘째')
+
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+7')
+  await expect(textarea).toHaveValue('1. 첫째\n2. 둘째')
+
+  await textarea.fill('할 일')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+l')
+  await expect(textarea).toHaveValue('- [ ] 할 일')
+
+  await textarea.fill('인용')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+.')
+  await expect(textarea).toHaveValue('> 인용')
+
+  await textarea.fill('코드')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+Shift+c')
+  await expect(textarea).toHaveValue('```\n코드\n```')
+
+  await textarea.fill('[')
+  await textarea.press('[')
+  await expect(textarea).toHaveValue('[[]]')
+})
+
+test('메모 목록 자동 편집과 완료 및 취소를 지원한다', async ({ page }) => {
+  await openViewerWithMemo(page)
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+
+  await textarea.fill('- 첫 항목')
+  await textarea.press('End')
+  await textarea.press('Enter')
+  await expect(textarea).toHaveValue('- 첫 항목\n- ')
+  await textarea.press('Enter')
+  await expect(textarea).toHaveValue('- 첫 항목\n')
+
+  await textarea.fill('- [ ] 확인')
+  await textarea.press('Home')
+  await textarea.press('Tab')
+  await expect(textarea).toHaveValue('  - [ ] 확인')
+  await textarea.press('Shift+Tab')
+  await expect(textarea).toHaveValue('- [ ] 확인')
+  await textarea.press('ControlOrMeta+Enter')
+  await expect(textarea).toHaveValue('- [x] 확인')
+  await textarea.press('ControlOrMeta+Enter')
+  await expect(textarea).toHaveValue('- [ ] 확인')
+
+  await textarea.fill('OpenAI')
+  await textarea.selectText()
+  await textarea.evaluate(element => {
+    const data = new DataTransfer()
+    data.setData('text/plain', 'https://openai.com')
+    element.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true }))
+  })
+  await expect(textarea).toHaveValue('[OpenAI](https://openai.com)')
+  await textarea.press('ControlOrMeta+Enter')
+  await expect(memo.locator('.floating-memo-render a')).toHaveAttribute('href', 'https://openai.com')
+
+  await memo.locator('.edit-btn').click()
+  await textarea.fill('취소할 변경')
+  await textarea.press('Escape')
+  await expect(memo.locator('.floating-memo-render')).toContainText('OpenAI')
+  await expect(memo.locator('.floating-memo-render')).not.toContainText('취소할 변경')
+})
+
 test('코드블록, 콜아웃, 중첩 목록과 표를 메모에서 렌더링한다', async ({ page }) => {
   await openViewerWithMemo(page, {
     content: [

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -66,6 +66,7 @@ test('사용자가 조절한 메모 크기를 저장하고 다시 복원한다',
 
   const memo = page.locator('.floating-memo[data-id="memo-regression"]')
   await memo.locator('.auto-size-btn').click()
+  await expect(page.locator('.floating-memo')).toHaveCount(1)
   await memo.evaluate(el => {
     el.style.width = '360px'
     el.style.height = '280px'
@@ -91,6 +92,12 @@ test('뷰어 메모 입력창에 포커스 테두리를 표시하지 않는다',
 
   const textarea = memo.locator('.floating-memo-textarea')
   await expect(textarea).toBeFocused()
+  await textarea.fill('굵게')
+  await textarea.selectText()
+  await textarea.press('ControlOrMeta+b')
+  await expect(textarea).toHaveValue('**굵게**')
+  await textarea.press('ControlOrMeta+i')
+  await expect(textarea).toHaveValue('***굵게***')
   await expect.poll(() => textarea.evaluate(element => getComputedStyle(element).outlineStyle)).toBe('none')
 })
 
@@ -138,10 +145,13 @@ test("키보드로 메모를 이동하고 크기를 조절하면 변경 사항�
   const resizeHandle = memo.locator(".floating-memo-resize-handle")
   const beforeMove = await memo.boundingBox()
 
+  await memo.evaluate(el => { el.dataset.instanceMarker = 'before-move' })
   await header.focus()
   await header.press("ArrowRight")
   await expect.poll(async () => (await memo.boundingBox()).x).toBeGreaterThan(beforeMove.x + 3)
   await expect(page.locator("#a11y-live-region")).toContainText("메모 위치")
+  await page.waitForTimeout(1500)
+  await expect(memo).toHaveAttribute('data-instance-marker', 'before-move')
 
   const beforeResize = await memo.boundingBox()
   await resizeHandle.focus()
@@ -157,7 +167,10 @@ test('자동 크기 모드에서 입력 내용에 맞춰 높이를 늘리고 줄
   await expect(memo).toHaveClass(/auto-size/)
   await memo.locator('.edit-btn').click()
   const textarea = memo.locator('.floating-memo-textarea')
-  const initialHeight = (await memo.boundingBox()).height
+  const initialBox = await memo.boundingBox()
+  const initialHeight = initialBox.height
+  await memo.evaluate(el => { el.style.left = '150%' })
+  await expect.poll(async () => (await memo.boundingBox()).width).toBe(initialBox.width)
 
   await textarea.fill(Array.from({ length: 12 }, (_, index) => `길이가 긴 자동 크기 메모 ${index + 1}`).join('\n'))
   await expect.poll(async () => (await memo.boundingBox()).height).toBeGreaterThan(initialHeight + 80)


### PR DESCRIPTION
# Summary
## 1. 뷰어 메모 상호작용 오류 수정
- 자동 크기 버튼 클릭 시 메모 복제 및 드래그 이벤트가 함께 발생하는 문제 수정함
- 위치 저장 동기화 후 메모 DOM이 재생성되는 현상 수정함
- 번역 패널 방향 이동 시 자동 크기 폭 축소 및 잘못된 위치 좌표 처리 수정함
## 2. Markdown 편집 단축키 확장
- 볼드, 이탤릭, 링크, 인라인 코드, 취소선, 코드 블록 단축키 기능을 추가
- 글머리·번호·체크박스 목록과 인용문 토글 단축키 기능을 추가
## 3. Obsidian 스타일 자동 편집 동작 추가
- 목록 연속 생성·종료·번호 증가 및 들여쓰기·내어쓰기 기능을 추가
- 체크박스 전환, 편집 완료·취소, URL 링크 변환, 위키 링크 괄호 자동 완성 기능을 추가
## 4. 회귀 테스트 보강
- 메모 복제·동기화·자동 크기 및 Markdown 편집 E2E 검증을 추가