### PR TITLE
fix(chat): tolerate PDF quote punctuation

### DIFF
--- a/backend/services/context_retrieval.py
+++ b/backend/services/context_retrieval.py
@@ -98,20 +98,46 @@ def _normalized_source_match(source: str, selection: str) -> str | None:
     # from cloneContents().textContent (or vice versa). For a meaningful-length
     # selection, retry without whitespace while still returning server text.
     if match_start < 0:
-        compact_source_chars: list[str] = []
-        compact_source_indexes: list[int] = []
-        for normalized_index, char in enumerate(normalized_source):
-            if not char.isspace():
-                compact_source_chars.append(char)
-                compact_source_indexes.append(normalized_index)
-        compact_selection = "".join(char for char in normalized_selection if not char.isspace())
-        if len(compact_selection) < 8:
+        def compact_match(ignore_punctuation: bool = False) -> tuple[int, int] | None:
+            def retained(char: str) -> bool:
+                if char.isspace():
+                    return False
+                return not (ignore_punctuation and unicodedata.category(char).startswith("P"))
+
+            source_chars: list[str] = []
+            source_indexes: list[int] = []
+            for normalized_index, char in enumerate(normalized_source):
+                if retained(char):
+                    source_chars.append(char)
+                    source_indexes.append(normalized_index)
+            selection_chars = [char for char in normalized_selection if retained(char)]
+            if len(selection_chars) < 8:
+                return None
+            compact_start = "".join(source_chars).find("".join(selection_chars))
+            if compact_start < 0:
+                return None
+            compact_end = compact_start + len(selection_chars) - 1
+            source_start = source_indexes[compact_start]
+            source_end = source_indexes[compact_end] + 1
+            if ignore_punctuation:
+                if unicodedata.category(normalized_selection[0]).startswith("P"):
+                    while source_start > 0 and unicodedata.category(normalized_source[source_start - 1]).startswith("P"):
+                        source_start -= 1
+                if unicodedata.category(normalized_selection[-1]).startswith("P"):
+                    while source_end < len(normalized_source) and unicodedata.category(normalized_source[source_end]).startswith("P"):
+                        source_end += 1
+            return source_start, source_end
+
+        compact_bounds = compact_match()
+        # PyMuPDF and PDF.js do not always agree on whether punctuation at a
+        # text-span boundary is part of the extracted text. Ignore punctuation
+        # only after the stricter whitespace-insensitive match fails. Symbols
+        # (for example mathematical operators) remain significant.
+        if compact_bounds is None:
+            compact_bounds = compact_match(ignore_punctuation=True)
+        if compact_bounds is None:
             return None
-        compact_start = "".join(compact_source_chars).find(compact_selection)
-        if compact_start < 0:
-            return None
-        match_start = compact_source_indexes[compact_start]
-        match_end = compact_source_indexes[compact_start + len(compact_selection) - 1] + 1
+        match_start, match_end = compact_bounds
     else:
         match_end = match_start + match_length
 

--- a/backend/tests/test_grounded_screen_context.py
+++ b/backend/tests/test_grounded_screen_context.py
@@ -282,6 +282,21 @@ def test_selected_text_tolerates_missing_pdf_span_spaces_but_rejects_forgery():
     assert resolve_page_selected_text(pages, 8, "inventedselection") is None
 
 
+def test_selected_text_tolerates_pdf_span_punctuation_differences():
+    from services.context_retrieval import resolve_page_selected_text
+
+    pages = [{
+        "page_num": 9,
+        "text": "The model's two stages—retrieval, then reranking—improve accuracy.",
+    }]
+    assert resolve_page_selected_text(
+        pages, 9, "The models two stages retrieval then reranking improve accuracy.",
+    ) == "The model's two stages—retrieval, then reranking—improve accuracy."
+    assert resolve_page_selected_text(
+        pages, 9, "The models two stages generation then reranking improve accuracy.",
+    ) is None
+
+
 def test_forged_selected_text_is_rejected_before_rate_or_llm(
     test_client, grounded_doc, isolated_dirs, monkeypatch,
 ):


### PR DESCRIPTION
# Summary
## 1. PDF 선택 본문 매칭 오류 수정
- PDF.js와 서버 PDF 추출기 사이의 문장부호 차이를 허용하도록 선택 본문 정규화 로직을 보강함
- 공백 무시 매칭 실패 시 문장부호를 제외한 문자 골격을 비교하고 서버 원문 범위를 반환하도록 수정함
- 수학 연산자 등 의미 있는 기호는 검증 대상으로 유지함
## 2. 회귀 테스트 추가
- 9페이지 선택문에서 문장부호 차이가 있는 경우 정상 매칭되는 테스트를 추가함
- 실제 단어가 변경된 위조 선택문은 계속 거부되는 테스트를 추가함