### PR TITLE
fix(upload): prevent stalled and duplicate uploads

### DIFF
--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -195,7 +195,13 @@ async def upload_pdf(
     else:
         session_id = str(uuid.uuid4())
     session_dir = os.path.join(UPLOAD_DIR, session_id)
-    os.makedirs(session_dir, exist_ok=True)
+    # The directory is the atomic reservation for an upload ID. Checking the
+    # in-memory/DB state above is not sufficient because two requests can pass
+    # that check before either one persists its session.
+    try:
+        os.makedirs(session_dir, exist_ok=False)
+    except FileExistsError:
+        raise HTTPException(status_code=409, detail="이미 사용된 업로드 ID입니다.")
     pdf_path = os.path.join(session_dir, "document.pdf")
 
     # 파일 저장 (스트리밍) - await file.read()로 전체를 한 번에 읽으면 크기

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -76,6 +76,24 @@ def test_upload_rejects_invalid_client_upload_id(test_client):
     assert response.status_code == 400
 
 
+def test_upload_rejects_client_id_with_existing_directory(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    upload_id = str(uuid.uuid4())
+    reserved_dir = upload_dir / upload_id
+    reserved_dir.mkdir()
+    marker = reserved_dir / "document.pdf"
+    marker.write_bytes(b"existing upload")
+
+    response = test_client.post(
+        f"/api/upload?upload_id={upload_id}",
+        files={"file": ("duplicate.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    assert response.status_code == 409
+    assert marker.read_bytes() == b"existing upload"
+
+
 def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, monkeypatch):
     """선택 기능인 primer가 느려도 auto 번역 job은 먼저 등록되어야 한다."""
     upload_dir = isolated_dirs["upload_dir"]

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -127,8 +127,13 @@ export async function uploadPDF(file, options, onProgress) {
 
     xhr.addEventListener('load', () => {
       if (xhr.status === 200) {
-        onProgress?.(100, 'processing')
-        resolve(JSON.parse(xhr.responseText))
+        try {
+          const result = JSON.parse(xhr.responseText)
+          onProgress?.(100, 'processing')
+          resolve(result)
+        } catch {
+          reject(new Error(errorMessage({ code: 'unknown' })))
+        }
       } else {
         try {
           const err = JSON.parse(xhr.responseText)

--- a/frontend/tests/api-upload.test.js
+++ b/frontend/tests/api-upload.test.js
@@ -80,3 +80,19 @@ test('connection loss recovers a completed server upload by id', async () => {
     Object.defineProperty(globalThis, 'crypto', { configurable: true, value: originalCrypto })
   }
 })
+
+test('malformed success response rejects instead of leaving upload pending', async () => {
+  const originalXHR = globalThis.XMLHttpRequest
+  globalThis.XMLHttpRequest = MockXHR
+  MockXHR.instances = []
+  try {
+    const promise = uploadPDF(new Blob(['pdf']), options)
+    const xhr = MockXHR.instances[0]
+    xhr.status = 200
+    xhr.responseText = '{invalid json'
+    xhr.emit('load')
+    await assert.rejects(promise)
+  } finally {
+    globalThis.XMLHttpRequest = originalXHR
+  }
+})


### PR DESCRIPTION
# Summary
## 1. 중복 업로드 ID 경쟁 조건 수정
- 업로드 디렉터리를 원자적으로 선점해 동시 요청의 기존 파일 덮어쓰기 방지
- 이미 사용 중인 업로드 ID에 409 응답을 반환하는 회귀 테스트 추가
## 2. 손상된 업로드 성공 응답 처리 수정
- HTTP 200 응답의 JSON 파싱 실패 시 Promise를 명시적으로 거부하도록 수정
- 업로드 UI의 무한 대기를 방지하는 프론트엔드 회귀 테스트 추가