### PR TITLE
fix(viewer): prevent stale interaction state

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1648,11 +1648,11 @@ function renderInsightContent(contentEl, kind, text) {
 function translatePage(pageNum) {
   if (state.translatingPages.has(pageNum) || state.translatedPages.has(pageNum)) return
   if (!state.sessionId) return
-  state.translatingPages.add(pageNum)
 
   const statusEl  = $(`trans-status-${pageNum}`)
   const contentEl = $(`trans-content-${pageNum}`)
   if (!contentEl) return
+  state.translatingPages.add(pageNum)
 
   // 스피너 + 대기 상태 표시
   contentEl.innerHTML = `
@@ -1857,11 +1857,12 @@ function startJobPolling(sessionId) {
     pollInFlight = true
     try {
       const job = await getJobStatus(sessionId)
-      if (!job) return
+      if (!job || state.sessionId !== sessionId) return
 
       for (const pageNum of (job.completed_pages || [])) {
         if (state.translatedPages.has(pageNum)) continue
         const data = await getPageTranslation(sessionId, pageNum, getTranslationOptions())
+        if (state.sessionId !== sessionId) return
         if (data?.translation) {
           state.translationCache[pageNum] = data.translation
           state.translationSentences[pageNum] = data.sentences || []
@@ -9964,6 +9965,7 @@ async function loadDocumentReferences(docId) {
 // 두 번 렌더링되는 등의 중복 문제가 생겼다. 비교 화면의 openCompareScreen에 적용한
 // 것과 동일한 패턴으로, 같은 문서를 여는 재진입 호출을 걸러낸다.
 let docOpeningId = null
+let documentOpenGeneration = 0
 
 const annotationSyncTimers = new Map()
 const annotationSyncInFlight = new Map()
@@ -10056,6 +10058,8 @@ async function hydrateAnnotationsAndMemosFromServer(docId) {
 async function openFromLibrary(doc, shouldPushState = true) {
   await loadFeatureNamespaces('viewer')
   if (docOpeningId === doc.id) return
+  const myOpenGeneration = ++documentOpenGeneration
+  const isCurrentOpen = () => myOpenGeneration === documentOpenGeneration
   docOpeningId = doc.id
   try {
     // 이전 문서에서 진행 중이던 채팅 스트림이 있으면 반드시 먼저 취소한다.
@@ -10111,6 +10115,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
           updateLibraryDocMetadata(doc.id, { primer_shown: true }).catch(() => {})
         } else {
           const gateResult = await showPrimerModal(doc, { mode: 'gate' })
+          if (!isCurrentOpen()) return
           state.currentDocMetadata.primer_shown = true
           updateLibraryDocMetadata(doc.id, { primer_shown: true }).catch(() => {})
           // 브리핑의 인용 그래프에서 내 라이브러리의 다른 논문으로 바로 이동한
@@ -10130,6 +10135,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
     // (아래 loadPDF에서 페이지를 렌더링하며 바로 참조한다) 서버 미러 데이터를
     // 먼저 끌어와야 다른 기기에서 저장한 하이라이트/메모가 반영된다.
     await hydrateAnnotationsAndMemosFromServer(doc.id)
+    if (!isCurrentOpen()) return
 
     // 논문을 여는 시점 자체를 "마지막으로 읽은 시각"으로 기록한다(fire-and-forget).
     // 스크롤로 페이지가 바뀔 때만 last_read_at이 갱신되면, 열자마자 바로 나가거나
@@ -10165,7 +10171,8 @@ async function openFromLibrary(doc, shouldPushState = true) {
       return null
     })
 
-    await loadPDF(`/api/library/${doc.id}/pdf`)
+    const loadedPages = await loadPDF(`/api/library/${doc.id}/pdf`)
+    if (!isCurrentOpen() || loadedPages === null) return
     docTitle.textContent  = displayTitle
     docTitle.title        = doc.filename
     if (viewerDocumentTypeChip) {
@@ -10200,12 +10207,14 @@ async function openFromLibrary(doc, shouldPushState = true) {
       })(),
       loadPDFOutline(),
     ])
+    if (!isCurrentOpen()) return
 
     // 채팅 기록 반영 (PDF 로딩과 병렬로 이미 완료됐을 가능성이 높음)
     // 주의: 변수명을 "history"로 쓰면 이 함수 맨 위에서 쓰는 전역 history(window.history)
     // 객체를 가려버려("Cannot access 'history' before initialization") 함수 전체가
     // 조용히 실패하므로 반드시 다른 이름을 사용해야 한다.
     const chatRes = await chatHistoryPromise
+    if (!isCurrentOpen()) return
     const chatHistoryList = chatRes?.history || []
     if (chatHistoryList.length > 0) {
       for (const msg of chatHistoryList) {

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -14,6 +14,7 @@ let currentScale = 1.5
 let pageObserver = null
 let pageVisibilityObserver = null
 let visiblePageHeights = {}
+let loadGeneration = 0
 // renderScrollView가 호출될 때마다(문서 전환, 줌 변경) 증가하는 세대 카운터.
 // pdf-page-wrapper DOM 노드는 문서를 바꿔도 새로 만들지 않고 재사용하는데,
 // 이전 문서/줌에 대한 _renderPage 호출이 비동기 대기 중일 때 사용자가 빠르게
@@ -34,7 +35,19 @@ async function loadPDFJS() {
 
 export async function loadPDF(url) {
   await loadPDFJS()
-  pdfDoc = await pdfjsLib.getDocument(url).promise
+  const myGeneration = ++loadGeneration
+  const loadingTask = pdfjsLib.getDocument(url)
+  const nextPdfDoc = await loadingTask.promise
+  if (myGeneration !== loadGeneration) {
+    await nextPdfDoc.destroy().catch(() => {})
+    return null
+  }
+  const previousPdfDoc = pdfDoc
+  renderGeneration++
+  pdfDoc = nextPdfDoc
+  if (previousPdfDoc && previousPdfDoc !== nextPdfDoc) {
+    previousPdfDoc.destroy().catch(() => {})
+  }
   figureCropCache.clear()
   return pdfDoc.numPages
 }
@@ -101,6 +114,13 @@ export async function renderScrollView(container, zoom, { onPageVisible } = {}) 
   const rendered = new Set()
 
   let wrappers = container.querySelectorAll('.pdf-page-wrapper')
+
+  const wrapperShapeMatches = wrappers.length === numPages
+    && Array.from(wrappers).every((wrapper, index) => Number(wrapper.dataset.page) === index + 1)
+  if (!wrapperShapeMatches) {
+    container.querySelectorAll('.pdf-page-wrapper').forEach(wrapper => wrapper.remove())
+    wrappers = container.querySelectorAll('.pdf-page-wrapper')
+  }
 
   if (wrappers.length === 0) {
     // ─── placeholder 생성 (기존에 없는 경우만) ───────────────────────────


### PR DESCRIPTION
# Summary
## 1. 문서 전환 비동기 상태 충돌 수정
- 문서 열기 세대 검증을 추가해 이전 PDF와 채팅 기록이 최신 문서 상태를 덮어쓰는 문제 수정함
- PDF 로딩 세대 검증 및 이전 PDF 리소스 정리를 추가함
- 진행 중인 이전 페이지 렌더링을 문서 교체 시 무효화함

## 2. PDF 및 번역 상호작용 안정화
- PDF 페이지 수와 wrapper 구조가 불일치할 때 페이지 구조를 재생성함
- 이전 문서의 번역 폴링 결과가 현재 문서에 반영되지 않도록 세션 검증을 추가함
- 번역 DOM이 없는 페이지가 번역 중 상태에 고정되는 문제 수정함

## 3. 검증
- 프런트엔드 단위 테스트 62개 통과함
- PDF·메모·채팅 인용·수동 번역·주석 E2E 테스트 19개 통과함
- 프로덕션 빌드 및 다국어 리소스 검증 통과함