### PR TITLE
fix: 메모 단축키 토글 해제 지원

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11322,22 +11322,56 @@ function renderPageMemos(pageNum) {
       const start = textarea.selectionStart
       const end = textarea.selectionEnd
       const selected = textarea.value.slice(start, end)
-      const outside = start >= prefix.length
+      const lastFormat = textarea._memoLastInlineFormat
+      if (lastFormat?.prefix === prefix
+          && lastFormat.suffix === suffix
+          && textarea.value.slice(lastFormat.start, lastFormat.end) === lastFormat.wrapped) {
+        textarea.setRangeText(lastFormat.content, lastFormat.start, lastFormat.end, 'select')
+        textarea.setSelectionRange(lastFormat.start, lastFormat.start + lastFormat.content.length)
+        textarea._memoLastInlineFormat = null
+        dispatchMemoTextareaInput(textarea)
+        return
+      }
+      const directlyWrapped = start >= prefix.length
         && textarea.value.slice(start - prefix.length, start) === prefix
         && textarea.value.slice(end, end + suffix.length) === suffix
-        && textarea.value.slice(start - prefix.length - 1, start - prefix.length) !== prefix[0]
-        && textarea.value.slice(end + suffix.length, end + suffix.length + 1) !== suffix[suffix.length - 1]
       if (selected.startsWith(prefix) && selected.endsWith(suffix)) {
         const content = selected.slice(prefix.length, -suffix.length)
         textarea.setRangeText(content, start, end, 'select')
         textarea.setSelectionRange(start, start + content.length)
-      } else if (outside) {
+        textarea._memoLastInlineFormat = null
+      } else if (directlyWrapped) {
         textarea.setRangeText(selected, start - prefix.length, end + suffix.length, 'select')
         textarea.setSelectionRange(start - prefix.length, end - prefix.length)
+        textarea._memoLastInlineFormat = null
       } else {
+        // Safari/macOS에서는 Command 단축키 처리 뒤 선택 영역이 커서로 접힐 수
+        // 있다. 이 경우에도 커서를 감싼 가장 가까운 Markdown 마커를 찾아
+        // 중첩 마커를 추가하지 않고 기존 서식을 해제한다.
+        const prefixStart = textarea.value.lastIndexOf(prefix, Math.max(0, start - prefix.length))
+        const suffixStart = textarea.value.indexOf(suffix, end)
+        const wrapsSelection = prefixStart !== -1
+          && suffixStart !== -1
+          && prefixStart + prefix.length <= start
+          && suffixStart >= end
+        if (wrapsSelection) {
+          const contentStart = prefixStart + prefix.length
+          const content = textarea.value.slice(contentStart, suffixStart)
+          const selectionStart = Math.max(prefixStart, start - prefix.length)
+          const selectionEnd = Math.max(selectionStart, end - prefix.length)
+          textarea.setRangeText(content, prefixStart, suffixStart + suffix.length, 'select')
+          textarea.setSelectionRange(selectionStart, Math.min(prefixStart + content.length, selectionEnd))
+          textarea._memoLastInlineFormat = null
+          dispatchMemoTextareaInput(textarea)
+          return
+        }
         const content = selected || placeholder
-        textarea.setRangeText(prefix + content + suffix, start, end, 'select')
+        const wrapped = prefix + content + suffix
+        textarea.setRangeText(wrapped, start, end, 'select')
         textarea.setSelectionRange(start + prefix.length, start + prefix.length + content.length)
+        textarea._memoLastInlineFormat = {
+          prefix, suffix, start, end: start + wrapped.length, wrapped, content,
+        }
       }
       dispatchMemoTextareaInput(textarea)
     }

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -96,8 +96,16 @@ test('뷰어 메모 입력창에 포커스 테두리를 표시하지 않는다',
   await textarea.selectText()
   await textarea.press('ControlOrMeta+b')
   await expect(textarea).toHaveValue('**굵게**')
+  await textarea.evaluate(element => element.setSelectionRange(4, 4))
+  await textarea.press('ControlOrMeta+b')
+  await expect(textarea).toHaveValue('굵게')
+
+  await textarea.selectText()
   await textarea.press('ControlOrMeta+i')
-  await expect(textarea).toHaveValue('***굵게***')
+  await expect(textarea).toHaveValue('*굵게*')
+  await textarea.evaluate(element => element.setSelectionRange(3, 3))
+  await textarea.press('ControlOrMeta+i')
+  await expect(textarea).toHaveValue('굵게')
   await expect.poll(() => textarea.evaluate(element => getComputedStyle(element).outlineStyle)).toBe('none')
 })
 
@@ -204,25 +212,62 @@ test('메모 Markdown 서식과 줄 단축키를 토글한다', async ({ page })
   await textarea.selectText()
   await textarea.press('ControlOrMeta+Shift+7')
   await expect(textarea).toHaveValue('1. 첫째\n2. 둘째')
+  await textarea.press('ControlOrMeta+Shift+7')
+  await expect(textarea).toHaveValue('첫째\n둘째')
 
   await textarea.fill('할 일')
   await textarea.selectText()
   await textarea.press('ControlOrMeta+Shift+l')
   await expect(textarea).toHaveValue('- [ ] 할 일')
+  await textarea.press('ControlOrMeta+Shift+l')
+  await expect(textarea).toHaveValue('할 일')
 
   await textarea.fill('인용')
   await textarea.selectText()
   await textarea.press('ControlOrMeta+Shift+.')
   await expect(textarea).toHaveValue('> 인용')
+  await textarea.press('ControlOrMeta+Shift+.')
+  await expect(textarea).toHaveValue('인용')
 
   await textarea.fill('코드')
   await textarea.selectText()
   await textarea.press('ControlOrMeta+Shift+c')
   await expect(textarea).toHaveValue('```\n코드\n```')
+  await textarea.evaluate(element => element.setSelectionRange(6, 6))
+  await textarea.press('ControlOrMeta+Shift+c')
+  await expect(textarea).toHaveValue('코드')
+
+  for (const [shortcut, formatted] of [
+    ['ControlOrMeta+k', '[링크](url)'],
+    ['ControlOrMeta+e', '`링크`'],
+  ]) {
+    await textarea.fill('링크')
+    await textarea.selectText()
+    await textarea.press(shortcut)
+    await expect(textarea).toHaveValue(formatted)
+    const caret = formatted.indexOf('링크') + '링크'.length
+    await textarea.evaluate((element, position) => element.setSelectionRange(position, position), caret)
+    await textarea.press(shortcut)
+    await expect(textarea).toHaveValue('링크')
+  }
 
   await textarea.fill('[')
   await textarea.press('[')
   await expect(textarea).toHaveValue('[[]]')
+})
+
+test('메모 편집 중 Control/Cmd+Z는 브라우저 기본 실행 취소를 유지한다', async ({ page }) => {
+  await openViewerWithMemo(page)
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+
+  await textarea.fill('실행 취소 전')
+  await textarea.press('End')
+  await textarea.type(' 추가')
+  await expect(textarea).toHaveValue('실행 취소 전 추가')
+  await textarea.press('ControlOrMeta+z')
+  await expect(textarea).toHaveValue('실행 취소 전 추')
 })
 
 test('메모 목록 자동 편집과 완료 및 취소를 지원한다', async ({ page }) => {


### PR DESCRIPTION
# Summary
## 1. 메모 서식 단축키 토글 수정
- Safari에서 반복 입력한 메모 서식 단축키가 중첩 마커를 추가하지 않고 기존 Markdown 서식을 해제하도록 수정함
- 굵게, 기울임, 링크, 인라인 코드, 취소선, 코드 블록 단축키의 직전 적용 범위를 추적하도록 보완함
## 2. 메모 편집 단축키 회귀 테스트 추가
- 목록·체크리스트·인용 단축키의 적용 및 해제 동작을 검증함
- 메모 입력창에서 Cmd/Ctrl+Z 브라우저 기본 실행 취소 동작을 검증함