### PR TITLE
fix(onboarding): move language picker into header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -673,12 +673,14 @@
   <!-- 첫 실행 시 AI 엔진 자동 감지 / 설치 안내 모달 -->
   <div id="onboarding-modal" class="modal-overlay hidden">
     <div class="modal-content" style="max-width: 460px;">
-      <label style="display:block;padding:12px 18px 0;text-align:right;font-size:12px"><span data-i18n="onboarding:uiLanguage">화면 언어</span>
-        <select id="onboarding-ui-locale" class="form-select" style="display:inline-block;width:auto;margin-left:8px"><option value="ko">한국어</option><option value="en">English</option></select>
-      </label>
       <div class="modal-header">
         <h2><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:6px"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>AI 엔진 설정</h2>
-        <button id="onboarding-close-btn" class="close-btn">&times;</button>
+        <div class="onboarding-header-actions">
+          <label class="onboarding-locale-label"><span data-i18n="onboarding:uiLanguage">화면 언어</span>
+            <select id="onboarding-ui-locale" class="form-select"><option value="ko">한국어</option><option value="en">English</option></select>
+          </label>
+          <button id="onboarding-close-btn" class="close-btn">&times;</button>
+        </div>
       </div>
 
       <div style="padding: 24px; max-height: 70vh; overflow-y: auto;">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2402,6 +2402,26 @@ body.light-theme .pdf-annotation-underline {
   -webkit-text-fill-color: transparent;
 }
 
+.onboarding-header-actions,
+.onboarding-locale-label {
+  display: flex;
+  align-items: center;
+}
+
+.onboarding-header-actions {
+  gap: 12px;
+}
+
+.onboarding-locale-label {
+  gap: 8px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.onboarding-locale-label .form-select {
+  width: auto;
+}
+
 .close-btn {
   background: none;
   border: none;

--- a/frontend/tests/e2e/i18n.spec.js
+++ b/frontend/tests/e2e/i18n.spec.js
@@ -32,6 +32,7 @@ test('locale selector updates onboarding immediately without reload', async ({ p
   await mockBaseRoutes(page, { workspaceSettings: { onboarding_version: 0 }, languageSettings: { ui_locale: 'ko', default_source_language: 'auto', target_language: 'ko' } })
   await page.goto('/index.html')
   await expect(page.locator('#onboarding-modal')).not.toHaveClass(/hidden/)
+  await expect(page.locator('.onboarding-header-actions > .onboarding-locale-label + #onboarding-close-btn')).toBeVisible()
   await expect(page.locator('#onboarding-purpose h3')).toHaveText('EasyPaper를 어떤 용도로 사용하시나요?')
   await page.selectOption('#onboarding-ui-locale', 'en')
   await expect(page.locator('#onboarding-purpose h3')).toHaveText('How will you use EasyPaper?')


### PR DESCRIPTION
# Summary
## 1. 온보딩 언어 선택기 위치 수정
- 온보딩 팝업의 언어 선택 드롭다운을 헤더 내부의 닫기 버튼 왼쪽으로 이동함
- 언어 선택기와 닫기 버튼을 정렬하는 헤더 액션 스타일을 추가함
## 2. 회귀 검증 추가
- 언어 선택기와 닫기 버튼의 DOM 배치 순서를 확인하는 E2E 검증을 추가함