### PR TITLE
fix: show Tauri version and changelog

### DIFF
--- a/backend/packaging/easypaper-backend.spec
+++ b/backend/packaging/easypaper-backend.spec
@@ -29,6 +29,8 @@ a = Analysis(
         # 사용자가 커스터마이징하기 전 기본 템플릿 파일을 그대로 들고 있으면
         # 첫 실행 UX가 서버/Docker 배포와 동일해진다.
         (os.path.join(BACKEND_DIR, "translation_prompt.txt"), "."),
+        # 패키징된 데스크탑 앱에서도 설정 화면의 전체 변경 이력을 제공한다.
+        (os.path.join(BACKEND_DIR, "..", "CHANGELOG.md"), "."),
         # frontend/dist를 _internal/frontend/dist에 둔다(PyInstaller는 datas
         # 목적지가 onedir 최상위 밖을 가리키는 것을 허용하지 않는다). main.py는
         # EASYPAPER_FRONTEND_DIST 환경변수가 있으면 그 경로를 그대로 쓰도록

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1183,8 +1183,13 @@ async def get_full_changelog(current_user: str = Depends(get_current_user)):
     그대로 서빙한다.
     """
     import os
-    changelog_path = os.path.join(get_project_root(), "CHANGELOG.md")
-    if not os.path.exists(changelog_path):
+    import sys
+
+    candidates = [os.path.join(get_project_root(), "CHANGELOG.md")]
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        candidates.append(os.path.join(sys._MEIPASS, "CHANGELOG.md"))
+    changelog_path = next((path for path in candidates if os.path.isfile(path)), None)
+    if changelog_path is None:
         return {"content": ""}
     with open(changelog_path, "r", encoding="utf-8") as f:
         return {"content": f.read()}

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -1,5 +1,6 @@
 """GET /settings/changelog 테스트 - 저장소 루트 CHANGELOG.md를 그대로 서빙하는지 확인."""
 
+import sys
 from unittest.mock import patch
 
 
@@ -16,3 +17,18 @@ def test_get_changelog_returns_empty_string_when_file_missing(test_client, tmp_p
         res = test_client.get("/api/settings/changelog")
     assert res.status_code == 200
     assert res.json()["content"] == ""
+
+
+def test_get_changelog_uses_pyinstaller_bundle_path(test_client, tmp_path):
+    bundled_changelog = tmp_path / "CHANGELOG.md"
+    bundled_changelog.write_text("# Changelog\n\n## Desktop release", encoding="utf-8")
+
+    with (
+        patch("routers.auth.get_project_root", return_value=str(tmp_path / "missing")),
+        patch.object(sys, "frozen", True, create=True),
+        patch.object(sys, "_MEIPASS", str(tmp_path), create=True),
+    ):
+        res = test_client.get("/api/settings/changelog")
+
+    assert res.status_code == 200
+    assert res.json()["content"] == "# Changelog\n\n## Desktop release"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -544,13 +544,18 @@ function initializeSettingsInformationArchitecture() {
     pane.prepend(header)
   }
 
-  const versionLabel = $('current-version-label')
+  // Tauri에서는 git 커밋 해시 대신 앱 패키지 버전을 사용한다. 데스크탑 전용
+  // 라벨을 공통 버전/변경 이력 카드로 옮겨 두 화면에서 같은 진입점을 제공한다.
+  const versionLabel = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+    ? $('tauri-current-version-label')
+    : $('current-version-label')
   const infoBody = $('tab-info')?.querySelector('.modal-form')
   if (versionLabel && infoBody) {
     const versionCard = document.createElement('section')
     versionCard.className = 'settings-action-card settings-version-card'
     versionCard.innerHTML = `<div><strong data-i18n="settings:versionHistoryTitle">${t('settings:versionHistoryTitle')}</strong><p data-i18n="settings:versionHistoryDescription">${t('settings:versionHistoryDescription')}</p></div>`
     versionLabel.classList.add('settings-version-link')
+    versionLabel.title = t('settings:versionHistoryTitle')
     versionCard.appendChild(versionLabel)
     infoBody.appendChild(versionCard)
   }
@@ -4703,8 +4708,9 @@ if (fullChangelogModal) {
   })
 }
 
-if (currentVersionLabel) {
-  currentVersionLabel.addEventListener('click', async () => {
+const fullChangelogTrigger = isTauriDesktop ? tauriCurrentVersionLabel : currentVersionLabel
+if (fullChangelogTrigger) {
+  fullChangelogTrigger.addEventListener('click', async () => {
     if (!fullChangelogModal) return
     openOverlayModal(fullChangelogModal)
     fullChangelogLoading.classList.remove('hidden')


### PR DESCRIPTION
# Summary
## 1. Tauri 앱 버전 표시 수정
- 데스크탑 앱 버전 라벨을 설정의 버전 및 변경 이력 카드에 연결
- Tauri 앱 버전 클릭 시 전체 변경 이력 팝업을 표시하는 기능을 추가
## 2. 패키징 환경 변경 이력 제공 수정
- PyInstaller sidecar 패키지에 CHANGELOG.md 포함
- 패키징 환경에서 PyInstaller 리소스 경로의 변경 이력을 조회하도록 수정
- PyInstaller 번들 경로에 대한 변경 이력 API 회귀 테스트 추가