### PR TITLE
feat: replace native selects with custom dropdowns

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -121,14 +121,19 @@ const $ = (id) => document.getElementById(id)
 
 let languageCatalog = []
 
-// Native select values and change events remain the source of truth while the viewer
-// menu presents the same button-and-popover pattern as the model picker.
-class LanguageSelectPicker {
+// Native select values and change events remain the source of truth while every
+// dropdown presents the same button-and-popover pattern as the model picker.
+class CustomSelectPicker {
   constructor(select) {
-    if (!select) return
+    if (!select || select.dataset.customSelectReady === 'true') return
     this.select = select
+    select.dataset.customSelectReady = 'true'
+    select._customSelectPicker = this
     this.container = document.createElement('div')
-    this.container.className = 'provider-picker language-picker'
+    this.container.className = 'provider-picker custom-select-picker'
+    if (select.classList.contains('form-select') || select.classList.contains('folder-dialog-input')) {
+      this.container.classList.add('picker-full-wrap')
+    }
     select.parentNode.insertBefore(this.container, select)
     this.container.appendChild(select)
     select.classList.add('sr-only')
@@ -136,13 +141,17 @@ class LanguageSelectPicker {
     select.tabIndex = -1
     this.button = document.createElement('button')
     this.button.type = 'button'
-    this.button.className = 'provider-picker-btn'
+    this.button.className = 'provider-picker-btn' + (this.container.classList.contains('picker-full-wrap') ? ' picker-full' : '')
     this.button.setAttribute('aria-haspopup', 'listbox')
     this.button.setAttribute('aria-expanded', 'false')
-    this.button.setAttribute('aria-labelledby', select.id + '-label ' + select.id + '-picker-value')
-    this.button.innerHTML = '<span id="' + select.id + '-picker-value" class="picker-label"></span><span class="picker-arrow" aria-hidden="true">▾</span>'
+    const pickerId = select.id || 'custom-select-' + CustomSelectPicker.nextId++
+    const label = select.id ? document.querySelector(`label[for="${CSS.escape(select.id)}"]`) : null
+    if (label && !label.id) label.id = pickerId + '-label'
+    const labelledBy = select.getAttribute('aria-labelledby') || label?.id || ''
+    this.button.setAttribute('aria-labelledby', [labelledBy, pickerId + '-picker-value'].filter(Boolean).join(' '))
+    this.button.innerHTML = '<span id="' + pickerId + '-picker-value" class="picker-label"></span><span class="picker-arrow" aria-hidden="true">▾</span>'
     this.panel = document.createElement('div')
-    this.panel.id = select.id + '-picker-panel'
+    this.panel.id = pickerId + '-picker-panel'
     this.panel.className = 'provider-picker-panel'
     this.panel.setAttribute('role', 'listbox')
     this.button.setAttribute('aria-controls', this.panel.id)
@@ -160,13 +169,15 @@ class LanguageSelectPicker {
       items[event.key === 'ArrowUp' ? Math.max(0, items.length - 1) : selectedIndex]?.focus()
     })
     select.addEventListener('change', () => this.refresh())
+    this.observer = new MutationObserver(() => this.refresh())
+    this.observer.observe(select, { attributes: true, childList: true, subtree: true })
     document.addEventListener('click', (event) => {
       if (!this.container.contains(event.target)) this.close()
     })
     this.refresh()
   }
   open() {
-    document.querySelectorAll('.language-picker.open .provider-picker-btn').forEach(button => {
+    document.querySelectorAll('.custom-select-picker.open .provider-picker-btn').forEach(button => {
       button.setAttribute('aria-expanded', 'false')
     })
     document.querySelectorAll('.provider-picker.open').forEach(picker => picker.classList.remove('open'))
@@ -183,6 +194,7 @@ class LanguageSelectPicker {
     const selected = this.select.selectedOptions[0]
     this.button.querySelector('.picker-label').textContent = selected?.textContent || ''
     this.button.title = this.select.getAttribute('aria-label') || selected?.textContent || ''
+    this.button.disabled = this.select.disabled
     if (this.container.classList.contains('open')) this.rebuildPanel()
   }
   rebuildPanel() {
@@ -190,9 +202,10 @@ class LanguageSelectPicker {
     ;[...this.select.options].forEach(option => {
       const item = document.createElement('button')
       item.type = 'button'
-      item.className = 'picker-model-item language-picker-item' + (option.selected ? ' selected' : '')
+      item.className = 'picker-model-item custom-select-item' + (option.selected ? ' selected' : '')
       item.textContent = option.textContent
       item.dataset.value = option.value
+      item.disabled = option.disabled
       item.setAttribute('role', 'option')
       item.setAttribute('aria-selected', String(option.selected))
       item.addEventListener('click', (event) => {
@@ -225,8 +238,22 @@ class LanguageSelectPicker {
     })
   }
 }
+CustomSelectPicker.nextId = 1
+
+function enhanceSelects(root = document) {
+  if (root.matches?.('select')) new CustomSelectPicker(root)
+  root.querySelectorAll?.('select:not([data-custom-select-ready="true"])').forEach(select => new CustomSelectPicker(select))
+}
+
+enhanceSelects()
+new MutationObserver(mutations => {
+  mutations.forEach(mutation => mutation.addedNodes.forEach(node => {
+    if (node.nodeType === Node.ELEMENT_NODE) enhanceSelects(node)
+  }))
+}).observe(document.body, { childList: true, subtree: true })
+
 const documentLanguagePickers = ['document-source-lang', 'document-target-lang']
-  .map(id => new LanguageSelectPicker($(id)))
+  .map(id => $(id)?._customSelectPicker)
 
 function populateLanguageControls(settings = {}) {
   const sourceSelect = $('setting-source-lang')

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3645,6 +3645,47 @@ body.light-theme .provider-picker-panel {
   left: 0;
 }
 
+/* Native selects enhanced with the model-picker interaction and visual language. */
+.custom-select-picker {
+  max-width: 100%;
+}
+.custom-select-picker.picker-full-wrap {
+  min-width: 0;
+}
+.custom-select-picker .provider-picker-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.custom-select-picker .provider-picker-panel {
+  min-width: max(100%, 180px);
+}
+.custom-select-item {
+  position: relative;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  font-family: var(--font-sans);
+  text-align: left;
+}
+.custom-select-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.custom-select-item:focus-visible {
+  outline: 2px solid var(--accent-mid);
+  outline-offset: -2px;
+}
+.settings-row .custom-select-picker,
+.login-language-selector .custom-select-picker {
+  width: 100%;
+}
+.lib-sort-dropdown .custom-select-picker .provider-picker-btn,
+.notes-sort-wrap .custom-select-picker .provider-picker-btn,
+.notes-annotation-toolbar .custom-select-picker .provider-picker-btn {
+  min-width: 0;
+  height: 32px;
+}
+
 /* ── Category Filters for Library ── */
 .category-filter-btn {
   padding: 6px 14px;
@@ -4813,20 +4854,6 @@ body:not(.toolbar-pos-left):not(.toolbar-pos-right):has(.chat-sidebar:not(.hidde
 .kebab-translation-grid .provider-picker-btn {
   width: 100%;
   min-width: 0;
-}
-.language-picker-item {
-  width: 100%;
-  border: 0;
-  position: relative;
-  background: transparent;
-  font-family: var(--font-sans);
-  text-align: left;
-}
-.language-picker-item:hover {
-  background: var(--bg-hover);
-}
-.language-picker-item.selected {
-  background: rgba(126, 196, 232, 0.15);
 }
 .kebab-menu-divider {
   height: 1px;


### PR DESCRIPTION
# Summary
## 1. 프로젝트 전체 드롭다운 디자인 통일
- 정적 및 동적으로 생성되는 네이티브 select를 모델 선택기와 동일한 버튼·팝오버 형태의 커스텀 드롭다운으로 변환함
- 로그인, 온보딩, 설정, 뷰어, 라이브러리, 노트 및 모달의 드롭다운에 공통 적용함
## 2. 기존 동작 및 접근성 유지
- 네이티브 select의 값과 change 이벤트를 원본 상태로 유지해 기존 저장 및 정렬 로직과 호환함
- 키보드 탐색, ARIA listbox 속성, label 연결, 비활성 옵션 및 동적 옵션 갱신을 지원함
## 3. 반응형 스타일 보완
- 설정의 전체 너비 선택기와 툴바의 컴팩트 선택기에 맞는 크기 및 포커스 스타일을 추가함