### PR TITLE
fix(ui): prevent mode switch compression

### DIFF
--- a/frontend/src/styles/document-modes.css
+++ b/frontend/src/styles/document-modes.css
@@ -111,9 +111,14 @@ button.document-type-chip:hover { background: color-mix(in srgb, var(--document-
 .onboarding-purpose-cards strong, .onboarding-purpose-cards span { display: block; }
 .onboarding-purpose-cards span { margin-top: 5px; color: var(--text-muted); font-size: 11px; line-height: 1.4; }
 
-@media (max-width: 760px) {
+/* shell.css가 사이드바를 축소 폭으로 전환하는 시점부터 사이드바 스위치 대신
+   상단 compact 스위치를 노출해 버튼이 좁은 사이드바 안에서 눌리지 않게 한다. */
+@media (max-width: 1100px) {
   .workspace-mode-switch:not(.workspace-mode-switch-compact) { display: none; }
   .workspace-mode-switch-compact { display: grid; width: 118px; }
+}
+
+@media (max-width: 760px) {
   .document-type-options { grid-template-columns: 1fr; }
 }
 


### PR DESCRIPTION
# Summary
## 1. 좁은 화면의 모드 전환 버튼 레이아웃 수정
- 사이드바 축소 기준인 1100px 이하에서 사이드바 내부 연구/일반 문서 모드 전환 버튼을 숨김
- 좁은 사이드바에서 버튼이 찌부되는 대신 상단 compact 모드 전환 버튼을 노출하도록 수정함