### PR TITLE
fix(ui): show document source modal

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17723,13 +17723,15 @@ if (viewerScrollContainer) {
 
 function setModalVisible(modal, visible, focusTarget = null) {
   if (!modal) return
-  if (visible && !modal._returnFocus) modal._returnFocus = document.activeElement
-  modal.classList.toggle('hidden', !visible)
-  if (visible) requestAnimationFrame(() => focusTarget?.focus())
-  else if (modal._returnFocus) {
-    const returnFocus = modal._returnFocus
-    modal._returnFocus = null
-    requestAnimationFrame(() => returnFocus?.focus())
+  if (visible) {
+    openOverlayModal(modal)
+    if (focusTarget) {
+      requestAnimationFrame(() => {
+        if (modal.classList.contains('is-visible')) focusTarget.focus()
+      })
+    }
+  } else {
+    closeOverlayModal(modal)
   }
 }
 

--- a/frontend/tests/e2e/web-document-import.spec.js
+++ b/frontend/tests/e2e/web-document-import.spec.js
@@ -16,7 +16,7 @@ async function openArticle(page) {
 
 test('문서 추가 소스 모달은 키보드 포커스를 가두고 Escape로 닫힌다', async ({ page }) => {
   await mockBaseRoutes(page); await gotoApp(page); await page.locator('#lib-upload-btn').click(); await page.locator('#lib-add-paper-btn').click()
-  await expect(page.locator('#document-source-modal')).toBeVisible(); await expect(page.locator('#document-source-local')).toBeFocused()
+  await expect(page.locator('#document-source-modal')).toBeVisible(); await expect(page.locator('#document-source-modal')).toHaveClass(/is-visible/); await expect(page.locator('#document-source-local')).toBeFocused()
   await page.locator('#document-source-close').focus(); await page.keyboard.press('Tab'); await expect(page.locator('#document-source-local')).toBeFocused()
   await page.keyboard.press('Escape'); await expect(page.locator('#document-source-modal')).toBeHidden()
 })


### PR DESCRIPTION
Fix the document source chooser so it uses the shared overlay visibility lifecycle. Adds an E2E assertion for the visible modal state.