### PR TITLE
fix(import): recover remote PDF processing

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -26,6 +26,7 @@ class UploadResponse(BaseModel):
 
 class UrlImportRequest(BaseModel):
     url: str
+    upload_id: Optional[str] = None
     target_lang: str = "ko"
     source_lang: str = "auto"
     style: str = "academic"

--- a/backend/routers/web_import.py
+++ b/backend/routers/web_import.py
@@ -41,12 +41,22 @@ def _validate_options(body: UrlImportRequest) -> tuple[str, str]:
 async def import_url(body: UrlImportRequest, current_user: str = Depends(get_current_user)):
     enforce_rate_limit("upload", current_user)
     target_lang, source_lang = _validate_options(body)
+    if body.upload_id:
+        try:
+            doc_id = str(uuid.UUID(body.upload_id))
+        except (ValueError, AttributeError):
+            raise HTTPException(status_code=400, detail={"code": "invalid_upload_id"})
+        from routers.upload import sessions
+        from services.db import db_get_document
+        if doc_id in sessions or db_get_document(doc_id):
+            raise HTTPException(status_code=409, detail={"code": "upload_id_conflict"})
+    else:
+        doc_id = str(uuid.uuid4())
     try:
         fetched = await asyncio.to_thread(fetch_url, body.url)
     except WebImportError as exc:
         raise HTTPException(status_code=422, detail={"code": exc.code, "message": str(exc)}) from exc
 
-    doc_id = str(uuid.uuid4())
     if fetched.kind == "remote_pdf":
         session_dir = Path(UPLOAD_DIR) / doc_id
         try:
@@ -54,7 +64,7 @@ async def import_url(body: UrlImportRequest, current_user: str = Depends(get_cur
             pdf_path = session_dir / "document.pdf"
             partial_path = session_dir / "document.pdf.part"
             shutil.copyfile(fetched.temp_path, partial_path)
-            with partial_path.open("rb") as source:
+            with partial_path.open("rb+") as source:
                 os.fsync(source.fileno())
             os.replace(partial_path, pdf_path)
             downloaded_size = pdf_path.stat().st_size
@@ -68,7 +78,7 @@ async def import_url(body: UrlImportRequest, current_user: str = Depends(get_cur
             filename = Path(fetched.final_url.split("?", 1)[0]).name or "remote-document.pdf"
             if not filename.lower().endswith(".pdf"):
                 filename += ".pdf"
-            options = body.model_dump(exclude={"url"}) | {"filename": filename, "username": current_user, "source_lang": source_lang, "target_lang": target_lang, "file_size_mb": downloaded_size / 1048576}
+            options = body.model_dump(exclude={"url", "upload_id"}) | {"filename": filename, "username": current_user, "source_lang": source_lang, "target_lang": target_lang, "file_size_mb": downloaded_size / 1048576}
             task = create_task(doc_id, "parse", options, status="queued")
             parsed = await execute_parse_task(task["id"], sessions, page_extractor=extract_pages, metadata_reader=get_pdf_metadata, translation_starter=start_job, keyword_starter=start_keyword_job, summary_starter=start_summary_job, upload_root=UPLOAD_DIR)
             from services.db import get_db

--- a/backend/tests/test_web_import_api.py
+++ b/backend/tests/test_web_import_api.py
@@ -1,6 +1,16 @@
 from pathlib import Path
 
+import pytest
+
 from services.web_import import FetchResult
+
+
+@pytest.fixture(autouse=True)
+def reset_upload_rate_limit():
+    from services.rate_limiter import request_rate_limiter
+    request_rate_limiter.reset()
+    yield
+    request_rate_limiter.reset()
 
 
 ARTICLE = ("<!doctype html><html><head><title>Imported article</title>"
@@ -16,9 +26,11 @@ def test_import_html_endpoint_is_atomic_and_serves_manifest(test_client, isolate
     monkeypatch.setattr(router, "LIBRARY_DIR", str(isolated_dirs["library_dir"]))
     monkeypatch.setattr(router, "UPLOAD_DIR", str(isolated_dirs["upload_dir"]))
     monkeypatch.setattr(router, "fetch_url", lambda url: FetchResult("web_article", url, "text/html", {}, content=ARTICLE))
-    response = test_client.post("/api/import-url", json={"url": "https://example.test/article", "translation_mode": "manual"})
+    upload_id = "123e4567-e89b-42d3-a456-426614174010"
+    response = test_client.post("/api/import-url", json={"url": "https://example.test/article", "upload_id": upload_id, "translation_mode": "manual"})
     assert response.status_code == 200, response.text
     body = response.json(); doc_id = body["session_id"]
+    assert doc_id == upload_id
     assert body["content_kind"] == "html_article"
     assert body["source_origin"] == "web"
     assert body["total_units"] >= 1
@@ -41,3 +53,44 @@ def test_import_failure_leaves_no_document_or_directory(test_client, isolated_di
     assert response.status_code == 422
     assert set(isolated_dirs["library_dir"].iterdir()) == before
     assert isolated_dirs["db"].db_list_documents("testuser") == []
+
+
+def test_import_rejects_invalid_client_upload_id(test_client):
+    response = test_client.post(
+        "/api/import-url",
+        json={"url": "https://example.test/article", "upload_id": "not-a-uuid"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_upload_id"
+
+
+def test_import_remote_pdf_uses_client_id_and_finishes_parse(test_client, isolated_dirs, monkeypatch, tmp_path):
+    import fitz
+    from routers import primer
+    from routers import upload
+    from routers import web_import as router
+
+    source = tmp_path / "remote.pdf"
+    document = fitz.open()
+    page = document.new_page()
+    page.insert_text((72, 72), "Remote PDF body text for import recovery testing.")
+    document.save(source)
+    document.close()
+
+    monkeypatch.setattr(router, "LIBRARY_DIR", str(isolated_dirs["library_dir"]))
+    monkeypatch.setattr(router, "UPLOAD_DIR", str(isolated_dirs["upload_dir"]))
+    monkeypatch.setattr(router, "fetch_url", lambda url: FetchResult(
+        "remote_pdf", url, "application/pdf", {}, temp_path=str(source),
+    ))
+    monkeypatch.setattr(primer, "_ensure_generation_started", lambda *args, **kwargs: None)
+    upload_id = "123e4567-e89b-42d3-a456-426614174011"
+    response = test_client.post("/api/import-url", json={
+        "url": "https://example.test/remote.pdf",
+        "upload_id": upload_id,
+        "translation_mode": "manual",
+    })
+    assert response.status_code == 200, response.text
+    assert response.json()["session_id"] == upload_id
+    assert response.json()["content_kind"] == "pdf"
+    assert isolated_dirs["db"].db_get_document(upload_id)["source_origin"] == "web"
+    upload.sessions.pop(upload_id, None)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -94,9 +94,9 @@ export async function cancelInsightJobAPI(sessionId, kind) {
 
 const uploadRecoveryDelays = [400, 800, 1600, 3200, 5000]
 
-async function recoverCompletedUpload(uploadId, onProgress) {
-  onProgress?.(100, 'verifying')
-  for (const delay of uploadRecoveryDelays) {
+async function recoverCompletedUpload(uploadId, onProgress, verifyingPercent = 100, delays = uploadRecoveryDelays) {
+  onProgress?.(verifyingPercent, 'verifying')
+  for (const delay of delays) {
     await new Promise(resolve => setTimeout(resolve, delay))
     try {
       const session = await getSession(uploadId)
@@ -1058,9 +1058,11 @@ export async function uninstallPdfParserAPI(parserId) {
 
 
 export async function importURL(url, options, onProgress) {
+  const uploadId = crypto.randomUUID()
   onProgress?.(10, 'checking')
   const payload = {
     url,
+    upload_id: uploadId,
     target_lang: options.targetLang,
     source_lang: options.sourceLang || 'auto',
     style: options.style,
@@ -1074,10 +1076,29 @@ export async function importURL(url, options, onProgress) {
     document_type: options.documentType || 'research_paper',
   }
   onProgress?.(30, 'downloading')
-  const res = await fetch(`${API_BASE}/import-url`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
-  if (!res.ok) throw await apiError(res)
-  onProgress?.(100, 'complete')
-  return res.json()
+  let progress = 30
+  const progressTimer = setInterval(() => {
+    progress = Math.min(85, progress + 5)
+    onProgress?.(progress, 'processing')
+  }, 800)
+  try {
+    let res
+    try {
+      res = await fetch(`${API_BASE}/import-url`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+    } catch (networkError) {
+      clearInterval(progressTimer)
+      const remoteRecoveryDelays = [1000, 2000, 3000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000]
+      const recovered = await recoverCompletedUpload(uploadId, onProgress, 90, remoteRecoveryDelays)
+      if (recovered) return recovered
+      throw networkError
+    }
+    if (!res.ok) throw await apiError(res)
+    const result = await res.json()
+    onProgress?.(100, 'complete')
+    return result
+  } finally {
+    clearInterval(progressTimer)
+  }
 }
 
 export async function getArticleAPI(docId) {

--- a/frontend/tests/api-upload.test.js
+++ b/frontend/tests/api-upload.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { uploadPDF } from '../src/api.js'
+import { importURL, uploadPDF } from '../src/api.js'
 
 const options = {
   targetLang: 'ko', sourceLang: 'auto', style: 'academic',
@@ -94,5 +94,41 @@ test('malformed success response rejects instead of leaving upload pending', asy
     await assert.rejects(promise)
   } finally {
     globalThis.XMLHttpRequest = originalXHR
+  }
+})
+
+test('URL import sends a recoverable id and restores a completed session after disconnect', async () => {
+  const originalCrypto = globalThis.crypto
+  const originalFetch = globalThis.fetch
+  const originalSetInterval = globalThis.setInterval
+  const originalClearInterval = globalThis.clearInterval
+  const originalSetTimeout = globalThis.setTimeout
+  const uploadId = "123e4567-e89b-42d3-a456-426614174002"
+  Object.defineProperty(globalThis, "crypto", { configurable: true, value: { randomUUID: () => uploadId } })
+  globalThis.setInterval = () => 1
+  globalThis.clearInterval = () => {}
+  globalThis.setTimeout = handler => { handler(); return 0 }
+  let requestCount = 0
+  globalThis.fetch = async (url, init) => {
+    requestCount++
+    if (requestCount === 1) {
+      assert.equal(url, "/api/import-url")
+      assert.equal(JSON.parse(init.body).upload_id, uploadId)
+      throw new TypeError("connection closed")
+    }
+    assert.equal(url, `/api/session/${uploadId}`)
+    return new Response(JSON.stringify({ session_id: uploadId, filename: "remote.pdf", total_pages: 30, metadata: {} }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
+  try {
+    const phases = []
+    const result = await importURL("https://arxiv.org/pdf/1611.08024", options, (percent, phase) => phases.push([percent, phase]))
+    assert.equal(result.session_id, uploadId)
+    assert.deepEqual(phases, [[10, "checking"], [30, "downloading"], [90, "verifying"]])
+  } finally {
+    globalThis.fetch = originalFetch
+    globalThis.setInterval = originalSetInterval
+    globalThis.clearInterval = originalClearInterval
+    globalThis.setTimeout = originalSetTimeout
+    Object.defineProperty(globalThis, "crypto", { configurable: true, value: originalCrypto })
   }
 })


### PR DESCRIPTION
Keep URL-import progress moving while the server parses a remote PDF. Use a client-known document ID to recover completed imports after a dropped response, and cover the full remote PDF parse path and disconnect recovery.