### PR TITLE
fix(import): show site challenge errors

### DIFF
--- a/backend/services/web_import.py
+++ b/backend/services/web_import.py
@@ -100,6 +100,8 @@ def fetch_url(url: str, client: httpx.Client | None = None) -> FetchResult:
             try:
                 with client.stream("GET", current, headers={"User-Agent": "EasyPaper/1 URL Importer", "Accept": "application/pdf,text/html;q=0.9"}) as response:
                     _validate_peer(response)
+                    if response.headers.get("x-amzn-waf-action", "").lower() == "challenge":
+                        raise WebImportError("challenge_page", "사이트의 봇 확인 페이지는 가져올 수 없습니다.")
                     if response.status_code in {301, 302, 303, 307, 308}:
                         if redirect_count >= MAX_REDIRECTS:
                             raise WebImportError("too_many_redirects", "리디렉션 횟수가 너무 많습니다.")

--- a/backend/tests/test_web_import.py
+++ b/backend/tests/test_web_import.py
@@ -25,6 +25,19 @@ def test_magic_bytes_override_content_type(monkeypatch):
     assert result.kind == "remote_pdf"
 
 
+def test_rejects_amazon_waf_challenge_response(monkeypatch):
+    monkeypatch.setattr(web_import, "_validate_url", lambda url: None)
+    transport = httpx.MockTransport(lambda request: httpx.Response(
+        202,
+        headers={"content-type": "text/html", "x-amzn-waf-action": "challenge"},
+        request=request,
+    ))
+    with httpx.Client(transport=transport) as client:
+        with pytest.raises(WebImportError) as exc:
+            web_import.fetch_url("https://example.test/challenge", client)
+    assert exc.value.code == "challenge_page"
+
+
 def test_extracts_sanitized_stable_article_units(tmp_path):
     html = b"""<!doctype html><html><head><title>Useful article</title><link rel='canonical' href='/canonical'></head><body><article><h1>Useful article</h1><p onclick='bad()'>""" + (b"A useful paragraph. " * 20) + b"""</p><script>alert(1)</script><h2>Details</h2><p>Second section with enough meaningful content for extraction and translation.</p><a href='javascript:alert(1)'>bad</a></article></body></html>"""
     result = FetchResult("web_article", "https://example.test/post", "text/html", {"x-frame-options": "DENY"}, html)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -663,7 +663,7 @@
   <div id="url-import-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="url-import-title">
     <div class="modal-content document-source-modal-content">
       <div class="modal-header"><h2 id="url-import-title">웹에서 가져오기</h2><button type="button" id="url-import-close" class="close-btn" aria-label="닫기">&times;</button></div>
-      <form id="url-import-form" class="url-import-form"><label for="url-import-input" data-i18n="library:source.urlLabel">문서 URL</label><input id="url-import-input" type="url" required inputmode="url" autocomplete="url" placeholder="https://example.com/article"><p id="url-import-error" class="url-import-error hidden" role="alert"></p><div class="document-type-modal-actions"><button type="button" id="url-import-cancel" class="btn btn-secondary">취소</button><button type="submit" class="btn btn-primary">다음</button></div></form>
+      <form id="url-import-form" class="url-import-form"><label for="url-import-input" data-i18n="library:source.urlLabel">문서 URL</label><input id="url-import-input" type="url" required inputmode="url" autocomplete="url" placeholder="https://example.com/article" aria-describedby="url-import-error"><p id="url-import-error" class="url-import-error hidden" role="alert" aria-live="assertive" tabindex="-1"></p><div class="document-type-modal-actions"><button type="button" id="url-import-cancel" class="btn btn-secondary">취소</button><button type="submit" class="btn btn-primary">다음</button></div></form>
     </div>
   </div>
 

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -176,6 +176,9 @@
   "errors:network": {
     "description": "Could not connect to the server."
   },
+  "errors:challenge_page": {
+    "description": "The remote site requires browser verification and cannot be imported."
+  },
   "library:document.count_one": {
     "description": "{{count}} document"
   },

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -7,6 +7,7 @@
   "source_language_not_translatable": "{{language}} cannot be translated automatically. Choose a supported source language.",
   "generation_failed": "Generation failed. Please try again.",
   "network": "Could not connect to the server.",
+  "challenge_page": "This site requires a browser verification that EasyPaper cannot complete. Open the page in your browser instead.",
   "external_processing_blocked": "This document allows local processing only. Select a loopback Ollama provider for {{operation}}.",
   "invalid_processing_policy": "Unsupported document processing policy.",
   "selected_text_requires_viewer_page": "Selected text can only be used from the current document viewer page.",

--- a/frontend/src/locales/ko/errors.json
+++ b/frontend/src/locales/ko/errors.json
@@ -7,6 +7,7 @@
   "source_language_not_translatable": "{{language}} 언어는 자동 번역할 수 없습니다. 지원하는 원문 언어를 선택하세요.",
   "generation_failed": "생성하지 못했습니다. 다시 시도해 주세요.",
   "network": "서버에 연결할 수 없습니다.",
+  "challenge_page": "이 사이트는 EasyPaper에서 처리할 수 없는 브라우저 확인을 요구합니다. 브라우저에서 원본 페이지를 열어주세요.",
   "external_processing_blocked": "이 문서는 로컬 처리만 허용합니다. {{operation}} 작업에는 loopback 주소의 Ollama를 선택하세요.",
   "invalid_processing_policy": "지원하지 않는 문서 처리 정책입니다.",
   "selected_text_requires_viewer_page": "선택한 본문은 문서 뷰어의 현재 페이지에서만 사용할 수 있습니다.",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17770,6 +17770,7 @@ $('url-import-form')?.addEventListener('submit', async event => {
   const url = input.value.trim()
   if (!input.checkValidity()) { input.reportValidity(); return }
   error.classList.add('hidden')
+  input.removeAttribute('aria-invalid')
   const selected = await workspaceModeController.chooseUploadClassifications([{ name: new URL(url).hostname }])
   if (!selected?.length) return
   closeUrlImportModal()
@@ -17798,7 +17799,8 @@ $('url-import-form')?.addEventListener('submit', async event => {
     row.spinner.classList.add('hidden'); row.error.classList.remove('hidden')
     row.status.textContent = err.message; uploadPopupTitle.textContent = t('library:import.failed')
     error.textContent = err.message; error.classList.remove('hidden')
-    setModalVisible($('url-import-modal'), true, input)
+    input.setAttribute('aria-invalid', 'true')
+    setModalVisible($('url-import-modal'), true, error)
   }
 })
 

--- a/frontend/tests/e2e/web-document-import.spec.js
+++ b/frontend/tests/e2e/web-document-import.spec.js
@@ -40,3 +40,25 @@ test('HTML 선택 하이라이트를 section anchor로 저장하고 다시 열 �
   expect(stored.section_1[0].anchor).toMatchObject({ unit_id: 'section-1', block_id: 'block-1', exact: 'Unique searchable source text' })
   await page.reload(); await page.evaluate(() => { location.hash = '#viewer?id=web-1' }); await expect(page.locator('.article-highlight')).toContainText('Unique searchable source text')
 })
+
+test('봇 확인으로 차단된 URL 오류를 가져오기 모달에 표시한다', async ({ page }) => {
+  await mockBaseRoutes(page)
+  await page.route('**/api/import-url', route => route.fulfill({
+    status: 422, contentType: 'application/json',
+    body: JSON.stringify({ detail: { code: 'challenge_page' } }),
+  }))
+  await gotoApp(page)
+  await page.locator('#lib-upload-btn').click()
+  await page.locator('#lib-add-paper-btn').click()
+  await page.locator('#document-source-web').click()
+  await page.locator('#url-import-input').fill('https://computer.howstuffworks.com/computer-memory.htm#pt1')
+  await page.locator('#url-import-form').press('Enter')
+  await expect(page.locator('#document-type-modal')).toBeVisible()
+  await page.locator('#document-type-options button').first().click()
+  await page.locator('#document-type-confirm-btn').click()
+  const error = page.locator('#url-import-error')
+  await expect(page.locator('#url-import-modal')).toBeVisible()
+  await expect(error).toContainText('브라우저 확인을 요구합니다')
+  await expect(page.locator('#url-import-input')).toHaveAttribute('aria-invalid', 'true')
+  await expect(error).toBeFocused()
+})


### PR DESCRIPTION
Detects AWS WAF browser challenges before article extraction and returns a localized, actionable error in the URL import modal. The modal marks the URL invalid, announces the error, and focuses it for keyboard and screen-reader users.\n\nValidation:\n- backend web import tests: 10 passed\n- frontend unit tests: 67 passed\n- frontend build/i18n: passed\n- web document import E2E: 4 passed\n- live HowStuffWorks URL: challenge_page detected