### PR TITLE
fix: 설정 정보 자동 갱신

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1175,23 +1175,32 @@ async def post_update_notice_endpoint(current_user: str = Depends(get_current_us
 
 @router.get("/settings/changelog")
 async def get_full_changelog(current_user: str = Depends(get_current_user)):
-    """저장소 루트의 CHANGELOG.md 전체 내용을 반환합니다.
+    """현재 버전과 저장소 커밋에서 자동 생성한 변경 이력을 반환합니다.
 
-    설정 화면에서 버전 텍스트를 클릭하면 지금까지의 전체 변경 이력을 보여주는
-    용도 - 업데이트 확인 시 뜨는 changelog(현재~최신 사이의 diff)와 달리
-    이건 프로젝트 전체 누적 이력이라 git 조회가 아니라 이 파일 자체를
-    그대로 서빙한다.
+    Git 메타데이터가 없는 PyInstaller 배포본에서는 빌드에 포함된
+    CHANGELOG.md를 대신 사용한다.
     """
     import os
     import sys
+    from services.update_checker import (
+        get_current_version,
+        get_current_version_date,
+        get_repository_changelog_markdown,
+    )
+
+    version, version_date, generated_content = await asyncio.gather(
+        get_current_version(), get_current_version_date(), get_repository_changelog_markdown(),
+    )
+    if generated_content:
+        return {"version": version, "version_date": version_date, "content": generated_content}
 
     candidates = [os.path.join(get_project_root(), "CHANGELOG.md")]
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         candidates.append(os.path.join(sys._MEIPASS, "CHANGELOG.md"))
     changelog_path = next((path for path in candidates if os.path.isfile(path)), None)
     if changelog_path is None:
-        return {"content": ""}
+        return {"version": version, "version_date": version_date, "content": ""}
     with open(changelog_path, "r", encoding="utf-8") as f:
-        return {"content": f.read()}
+        return {"version": version, "version_date": version_date, "content": f.read()}
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, Response, HTTPException, status, Depends
 from fastapi.responses import StreamingResponse
+import asyncio
 import json
 import os
 import sys

--- a/backend/services/update_checker.py
+++ b/backend/services/update_checker.py
@@ -161,6 +161,42 @@ async def _get_changelog(from_ref: str, to_ref: str) -> list[dict]:
     return entries
 
 
+async def get_repository_changelog_markdown() -> Optional[str]:
+    """현재 체크아웃의 커밋 이력을 날짜별 Markdown으로 생성합니다.
+
+    CHANGELOG.md를 사람이 매번 갱신하지 않아도 설정 > 정보에 현재 실행 중인
+    코드까지 반영하기 위한 값이다. Git 메타데이터가 없는 패키지 실행 환경에서는
+    호출자가 번들된 CHANGELOG.md를 사용할 수 있도록 None을 반환한다.
+    """
+    code, out, _ = await _run_git(
+        "log", "--no-merges", "--date=short",
+        "--pretty=format:%cd%x1f%h%x1f%s", "HEAD",
+    )
+    if code != 0 or not out:
+        return None
+
+    lines = [
+        "# Changelog", "",
+        "EasyPaper의 Git 커밋 이력에서 자동 생성된 변경 이력입니다.", "",
+    ]
+    current_date = None
+    for line in out.splitlines():
+        parts = line.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        date, sha, subject = (part.strip() for part in parts)
+        if not subject:
+            continue
+        if date != current_date:
+            if current_date is not None:
+                lines.append("")
+            lines.extend([f"## {date}", ""])
+            current_date = date
+        lines.append(f"- {subject} (`{sha}`)")
+
+    return "\n".join(lines).rstrip() + "\n" if current_date else None
+
+
 def get_update_check_config() -> dict:
     interval = db_get_meta("update_check_interval") or DEFAULT_INTERVAL
     if interval not in VALID_INTERVALS:

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -1,7 +1,7 @@
-"""GET /settings/changelog 테스트 - 저장소 루트 CHANGELOG.md를 그대로 서빙하는지 확인."""
+"""GET /settings/changelog 테스트 - 자동 Git 이력과 패키지 fallback을 확인."""
 
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 
 def test_get_changelog_returns_actual_file_content(test_client):
@@ -13,7 +13,10 @@ def test_get_changelog_returns_actual_file_content(test_client):
 
 
 def test_get_changelog_returns_empty_string_when_file_missing(test_client, tmp_path):
-    with patch("routers.auth.get_project_root", return_value=str(tmp_path)):
+    with (
+        patch("routers.auth.get_project_root", return_value=str(tmp_path)),
+        patch("services.update_checker.get_repository_changelog_markdown", new=AsyncMock(return_value=None)),
+    ):
         res = test_client.get("/api/settings/changelog")
     assert res.status_code == 200
     assert res.json()["content"] == ""
@@ -27,6 +30,7 @@ def test_get_changelog_uses_pyinstaller_bundle_path(test_client, tmp_path):
         patch("routers.auth.get_project_root", return_value=str(tmp_path / "missing")),
         patch.object(sys, "frozen", True, create=True),
         patch.object(sys, "_MEIPASS", str(tmp_path), create=True),
+        patch("services.update_checker.get_repository_changelog_markdown", new=AsyncMock(return_value=None)),
     ):
         res = test_client.get("/api/settings/changelog")
 

--- a/backend/tests/test_update_checker.py
+++ b/backend/tests/test_update_checker.py
@@ -15,6 +15,7 @@ from services.update_checker import (
     set_update_check_interval,
     get_post_update_notice,
     _get_changelog,
+    get_repository_changelog_markdown,
     VALID_INTERVALS,
 )
 
@@ -107,6 +108,37 @@ async def test_check_for_update_handles_fetch_failure_gracefully(monkeypatch):
     assert result["ok"] is False
     assert result["update_available"] is False
     assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_repository_changelog_markdown_groups_commits_by_date(monkeypatch):
+    import services.update_checker as uc
+
+    async def fake_run_git(*args, timeout=30.0):
+        assert args[-1] == "HEAD"
+        return 0, (
+            "2026-09-02\x1fbbb2222\x1ffix: latest change\n"
+            "2026-09-01\x1faaa1111\x1ffeat: earlier change"
+        ), ""
+
+    monkeypatch.setattr(uc, "_run_git", fake_run_git)
+    content = await get_repository_changelog_markdown()
+
+    assert "## 2026-09-02" in content
+    assert "- fix: latest change (`bbb2222`)" in content
+    assert "## 2026-09-01" in content
+    assert content.index("2026-09-02") < content.index("2026-09-01")
+
+
+@pytest.mark.asyncio
+async def test_repository_changelog_markdown_returns_none_without_git(monkeypatch):
+    import services.update_checker as uc
+
+    async def fake_run_git(*args, timeout=30.0):
+        return 1, "", "not a git repository"
+
+    monkeypatch.setattr(uc, "_run_git", fake_run_git)
+    assert await get_repository_changelog_markdown() is None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -906,7 +906,7 @@ export async function getPostUpdateNoticeAPI() {
 }
 
 /**
- * 저장소 루트 CHANGELOG.md 전체 내용을 조회합니다.
+ * 현재 실행 버전과 Git 이력에서 자동 생성된 전체 변경 이력을 조회합니다.
  */
 export async function getFullChangelogAPI() {
   const res = await fetch(`${API_BASE}/settings/changelog`, { cache: 'no-store' })

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -4079,6 +4079,9 @@
   "settings:versionHistoryDescription": {
     "description": "Settings information architecture label or description for versionHistoryDescription."
   },
+  "settings:versionHistoryLoadFailed": {
+    "description": "Console warning shown when the settings information version and changelog request fails."
+  },
   "common:documentTypes.academicBook": {
     "description": "General-document classification for textbooks, monographs, and scholarly learning material."
   },

--- a/frontend/src/locales/en/settings.json
+++ b/frontend/src/locales/en/settings.json
@@ -29,5 +29,6 @@
   "categoryDataSystemDescription": "Clear caches and update the server or desktop app.",
   "categoryInfoDescription": "View EasyPaper project and version information.",
   "versionHistoryTitle": "Version and changelog",
-  "versionHistoryDescription": "View the current version and open the complete changelog."
+  "versionHistoryDescription": "View the current version and open the complete changelog.",
+  "versionHistoryLoadFailed": "Failed to load version and changelog"
 }

--- a/frontend/src/locales/ko/settings.json
+++ b/frontend/src/locales/ko/settings.json
@@ -29,5 +29,6 @@
   "categoryDataSystemDescription": "캐시를 정리하고 서버 또는 데스크톱 앱을 업데이트합니다.",
   "categoryInfoDescription": "EasyPaper 프로젝트와 버전 정보를 확인합니다.",
   "versionHistoryTitle": "버전 및 변경 이력",
-  "versionHistoryDescription": "현재 버전을 확인하고 전체 변경 이력을 열 수 있습니다."
+  "versionHistoryDescription": "현재 버전을 확인하고 전체 변경 이력을 열 수 있습니다.",
+  "versionHistoryLoadFailed": "버전 및 변경 이력 조회 실패"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -605,6 +605,7 @@ function activateSettingsCategory(paneId, { focus = false } = {}) {
   })
   if (focus) activeButton.focus()
   $('settings-modal')?.querySelector('.settings-content')?.scrollTo({ top: 0 })
+  if (activeButton.dataset.tab === 'tab-info') refreshSettingsAppInfo()
 }
 
 initializeSettingsInformationArchitecture()
@@ -4725,6 +4726,19 @@ const fullChangelogModal   = $('full-changelog-modal')
 const fullChangelogCloseBtn = $('full-changelog-close-btn')
 const fullChangelogLoading = $('full-changelog-loading')
 const fullChangelogContent = $('full-changelog-content')
+let fullChangelogMarkdown = ''
+
+async function refreshSettingsAppInfo() {
+  try {
+    const info = await getFullChangelogAPI()
+    fullChangelogMarkdown = info.content || ''
+    if (!isTauriDesktop && currentVersionLabel && info.version) {
+      currentVersionLabel.textContent = `현재 버전: ${formatVersionLabel(info.version, info.version_date)}`
+    }
+  } catch (err) {
+    console.warn('버전 및 변경 이력 조회 실패:', err)
+  }
+}
 
 function closeFullChangelogModal() {
   if (fullChangelogModal) closeOverlayModal(fullChangelogModal)
@@ -4747,9 +4761,9 @@ if (fullChangelogTrigger) {
     fullChangelogContent.innerHTML = ''
 
     try {
-      const res = await getFullChangelogAPI()
-      fullChangelogContent.innerHTML = res.content
-        ? sanitizeMarkedHtml(marked.parse(res.content))
+      await refreshSettingsAppInfo()
+      fullChangelogContent.innerHTML = fullChangelogMarkdown
+        ? sanitizeMarkedHtml(marked.parse(fullChangelogMarkdown))
         : '<p>변경 이력을 찾을 수 없습니다.</p>'
     } catch (err) {
       fullChangelogContent.innerHTML = `<p>변경 이력을 불러오지 못했습니다: ${escapeHtml(err.message || '')}</p>`

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4736,7 +4736,7 @@ async function refreshSettingsAppInfo() {
       currentVersionLabel.textContent = `현재 버전: ${formatVersionLabel(info.version, info.version_date)}`
     }
   } catch (err) {
-    console.warn('버전 및 변경 이력 조회 실패:', err)
+    console.warn(t('settings:versionHistoryLoadFailed'), err)
   }
 }
 

--- a/frontend/tests/e2e/update-notifications.spec.js
+++ b/frontend/tests/e2e/update-notifications.spec.js
@@ -172,7 +172,7 @@ test('현재 버전 텍스트를 클릭하면 CHANGELOG.md 전체 내용을 보�
   await mockUpdateEndpoints(page, { postUpdateShow: false, updateAvailable: false })
   await page.route('**/api/settings/changelog', route => route.fulfill({
     status: 200, contentType: 'application/json',
-    body: JSON.stringify({ content: '# Changelog\n\n## 2026-07-22\n\n- feat: 새 기능 추가 (#110)\n- fix: 버그 수정 (#111)\n' }),
+    body: JSON.stringify({ version: 'abc1234', version_date: '2026-07-22', content: '# Changelog\n\n## 2026-07-22\n\n- feat: 새 기능 추가 (#110)\n- fix: 버그 수정 (#111)\n' }),
   }))
 
   await gotoApp(page)
@@ -181,6 +181,7 @@ test('현재 버전 텍스트를 클릭하면 CHANGELOG.md 전체 내용을 보�
   await page.click('.tab-btn[data-tab="tab-info"]')
   await page.waitForTimeout(400)
 
+  await expect(page.locator('#current-version-label')).toHaveText('현재 버전: 2026-07-22 · abc1234')
   await expect(page.locator('#full-changelog-modal')).toHaveClass(/hidden/)
   await page.click('#current-version-label')
   await expect(page.locator('#full-changelog-modal')).not.toHaveClass(/hidden/)


### PR DESCRIPTION
## Summary
- 설정 > 정보 진입 시 현재 실행 버전을 자동으로 갱신함
- Git 커밋 이력에서 변경 이력을 자동 생성하고 패키지 fallback을 유지함
- 관련 백엔드 및 E2E 검증을 추가함

## Verification
- `python3 -m py_compile backend/services/update_checker.py backend/routers/auth.py backend/tests/test_update_checker.py backend/tests/test_changelog_endpoint.py`
- `node --check frontend/src/main.js`
- `node --check frontend/src/api.js`
- `git diff --check`
- `pytest`는 환경에 설치되어 있지 않아 실행하지 못함