### PR TITLE
docs: restore README shield styling

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -8,11 +8,13 @@
 
 [English README](./README.md)
 
-[![Release](https://img.shields.io/github/v/release/orion-gz/EasyPaper?display_name=tag&label=release&color=4f7cff)](https://github.com/orion-gz/EasyPaper/releases/latest)
-[![Last commit](https://img.shields.io/github/last-commit/orion-gz/EasyPaper?label=last%20commit)](https://github.com/orion-gz/EasyPaper/commits/main)
-[![Stars](https://img.shields.io/github/stars/orion-gz/EasyPaper?label=stars)](https://github.com/orion-gz/EasyPaper/stargazers)
-[![Issues](https://img.shields.io/github/issues/orion-gz/EasyPaper?label=issues)](https://github.com/orion-gz/EasyPaper/issues)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-4f7cff)](https://github.com/orion-gz/EasyPaper/pulls)
+[![Last Commit](https://shieldcn.dev/github/last-commit/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/commits/main)
+[![Open Issues](https://shieldcn.dev/github/issues/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/issues)
+[![Stars](https://shieldcn.dev/github/stars/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/stargazers)
+[![Changelog](https://shieldcn.dev/badge/changelog-keep_a_changelog-4f7cff.svg)](./CHANGELOG.md)
+[![PRs Welcome](https://shieldcn.dev/badge/PRs-welcome-4f7cff.svg)](https://github.com/orion-gz/EasyPaper/pulls)
+
+[![Download Desktop App](https://shieldcn.dev/github/v/release/orion-gz/EasyPaper.svg?label=Download%20Desktop%20App)](https://github.com/orion-gz/EasyPaper/releases/latest)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ AI-assisted reading and translation for research papers and general documents.
 
 [한국어 README](./README.ko.md)
 
-[![Release](https://img.shields.io/github/v/release/orion-gz/EasyPaper?display_name=tag&label=release&color=4f7cff)](https://github.com/orion-gz/EasyPaper/releases/latest)
-[![Last commit](https://img.shields.io/github/last-commit/orion-gz/EasyPaper?label=last%20commit)](https://github.com/orion-gz/EasyPaper/commits/main)
-[![Stars](https://img.shields.io/github/stars/orion-gz/EasyPaper?label=stars)](https://github.com/orion-gz/EasyPaper/stargazers)
-[![Issues](https://img.shields.io/github/issues/orion-gz/EasyPaper?label=issues)](https://github.com/orion-gz/EasyPaper/issues)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-4f7cff)](https://github.com/orion-gz/EasyPaper/pulls)
+[![Last Commit](https://shieldcn.dev/github/last-commit/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/commits/main)
+[![Open Issues](https://shieldcn.dev/github/issues/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/issues)
+[![Stars](https://shieldcn.dev/github/stars/orion-gz/EasyPaper.svg)](https://github.com/orion-gz/EasyPaper/stargazers)
+[![Changelog](https://shieldcn.dev/badge/changelog-keep_a_changelog-4f7cff.svg)](./CHANGELOG.md)
+[![PRs Welcome](https://shieldcn.dev/badge/PRs-welcome-4f7cff.svg)](https://github.com/orion-gz/EasyPaper/pulls)
 
-[![Python](https://img.shields.io/badge/Python-3.8%2B-3776AB?logo=python&logoColor=white)](backend/requirements.txt)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688?logo=fastapi&logoColor=white)](backend/requirements.txt)
-[![Vite](https://img.shields.io/badge/Vite-5-646CFF?logo=vite&logoColor=white)](frontend/package.json)
-[![SQLite](https://img.shields.io/badge/SQLite-DB-003B57?logo=sqlite&logoColor=white)](backend/services/db.py)
-[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](Dockerfile)
-[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](#quick-start)
+[![Python](https://shieldcn.dev/badge/Python-3.8%2B-3776AB.svg?logo=python&logoColor=white)](backend/requirements.txt)
+[![FastAPI](https://shieldcn.dev/badge/FastAPI-0.115-009688.svg?logo=fastapi&logoColor=white)](backend/requirements.txt)
+[![Vite](https://shieldcn.dev/badge/Vite-5-646CFF.svg?logo=vite&logoColor=white)](frontend/package.json)
+[![SQLite](https://shieldcn.dev/badge/SQLite-DB-003B57.svg?logo=sqlite&logoColor=white)](backend/services/db.py)
+[![Docker Ready](https://shieldcn.dev/badge/Docker-Ready-2496ED.svg?logo=docker&logoColor=white)](./Dockerfile)
+[![Platform](https://shieldcn.dev/badge/platform-Windows_%7C_macOS_%7C_Linux-lightgrey.svg)](#quick-start)
+
+[![Download Desktop App](https://shieldcn.dev/github/v/release/orion-gz/EasyPaper.svg?label=Download%20Desktop%20App)](https://github.com/orion-gz/EasyPaper/releases/latest)
 
 </div>
 


### PR DESCRIPTION
Restores the previous shieldcn.dev badge styling in both README variants while keeping emoji-free labels.