### PR TITLE
feat: add viewer document info menu

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -412,14 +412,6 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15,18 9,12 15,6"/></svg>
         </button>
         <button id="logo-btn" class="logo-small-btn" title="라이브러리로 돌아가기"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:4px"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 9 Q12 13 16 13 Q12 13 12 17 Q12 13 8 13 Q12 13 12 9 Z" fill="currentColor"/></svg>EasyPaper</button>
-        <!-- 독서 완료 토글 버튼 -->
-        <button id="viewer-read-toggle-btn" class="viewer-read-btn" title="독서 완료 상태 토글">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path d="m9 12 2 2 4-4"></path>
-          </svg>
-          <span class="read-btn-text">독서 완료</span>
-        </button>
         <button id="outline-toggle-btn" class="icon-btn" title="논문 목차 보기">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
         </button>
@@ -427,8 +419,6 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
         </button>
         <span id="doc-title" class="doc-title" style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"></span>
-        <span id="viewer-document-type-chip" class="document-type-chip research"></span>
-        <span id="viewer-processing-badge" class="processing-badge hidden"></span>
         <button id="doc-title-edit-btn" class="doc-title-edit-btn" title="제목 수정" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; transition: opacity 0.2s;">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4z"></path></svg>
         </button>
@@ -505,6 +495,20 @@
 
             <div class="kebab-menu-divider"></div>
 
+            <button id="viewer-read-toggle-btn" class="kebab-menu-item viewer-read-btn" title="독서 완료 상태 토글">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"></circle>
+                <path d="m9 12 2 2 4-4"></path>
+              </svg>
+              <span class="read-btn-text">독서 완료</span>
+            </button>
+            <button id="viewer-document-info-btn" class="kebab-menu-item" title="문서 정보 보기" data-i18n-title="viewer:documentInfo.open">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+              <span data-i18n="viewer:documentInfo.menu">정보</span>
+            </button>
+
+            <div class="kebab-menu-divider"></div>
+
             <button id="translation-scope-btn" class="kebab-menu-item" title="번역할 페이지 범위 선택">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 6h13"/><path d="M8 12h13"/><path d="M8 18h13"/><path d="M3 6h.01"/><path d="M3 12h.01"/><path d="M3 18h.01"/></svg>
               <span>번역 범위 선택</span>
@@ -546,6 +550,35 @@
         </div>
       </div>
     </header>
+
+    <div id="viewer-document-info-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="viewer-document-info-title">
+      <div class="modal-content viewer-document-info-dialog">
+        <div class="modal-header">
+          <h2 id="viewer-document-info-title" data-i18n="viewer:documentInfo.title">문서 정보</h2>
+          <button type="button" id="viewer-document-info-close-btn" class="close-btn" aria-label="닫기">&times;</button>
+        </div>
+        <div class="viewer-document-info-body">
+          <dl class="viewer-document-info-list">
+            <div class="viewer-document-info-row">
+              <dt data-i18n="viewer:documentInfo.name">제목</dt>
+              <dd id="viewer-document-info-name"></dd>
+            </div>
+            <div class="viewer-document-info-row">
+              <dt data-i18n="viewer:documentInfo.filename">파일명</dt>
+              <dd id="viewer-document-info-filename"></dd>
+            </div>
+            <div class="viewer-document-info-row">
+              <dt data-i18n="viewer:documentInfo.type">문서 종류</dt>
+              <dd><span id="viewer-document-type-chip" class="document-type-chip research"></span></dd>
+            </div>
+            <div class="viewer-document-info-row">
+              <dt data-i18n="viewer:documentInfo.processing">데이터 처리</dt>
+              <dd><span id="viewer-processing-badge" class="processing-badge hidden"></span></dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
 
     <!-- 좌측 목차 사이드바 -->
     <aside class="outline-sidebar hidden" id="outline-sidebar" aria-label="Document outline" data-i18n-aria-label="viewer:a11y.outlinePanel">

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -4192,5 +4192,26 @@
   },
   "library:article.capture": {
     "description": "Button capturing the current saved article section for AI chat."
+  },
+  "viewer:documentInfo.open": {
+    "description": "Tooltip for opening the viewer document information dialog."
+  },
+  "viewer:documentInfo.menu": {
+    "description": "Kebab menu item that opens document information."
+  },
+  "viewer:documentInfo.title": {
+    "description": "Title of the viewer document information dialog."
+  },
+  "viewer:documentInfo.name": {
+    "description": "Label for the displayed document title."
+  },
+  "viewer:documentInfo.filename": {
+    "description": "Label for the original document filename."
+  },
+  "viewer:documentInfo.type": {
+    "description": "Label for the document type badge."
+  },
+  "viewer:documentInfo.processing": {
+    "description": "Label for the local or external data processing badge."
   }
 }

--- a/frontend/src/locales/en/viewer.json
+++ b/frontend/src/locales/en/viewer.json
@@ -44,5 +44,12 @@
   "a11y.red": "Red",
   "a11y.previewSize": "Preview size {{width}} by {{height}} pixels",
   "sync.conflict": "A sync conflict occurred, so both versions were preserved.",
-  "sync.delayed": "Annotation sync is delayed due to a network problem."
+  "sync.delayed": "Annotation sync is delayed due to a network problem.",
+  "documentInfo.open": "View document information",
+  "documentInfo.menu": "Information",
+  "documentInfo.title": "Document information",
+  "documentInfo.name": "Title",
+  "documentInfo.filename": "Filename",
+  "documentInfo.type": "Document type",
+  "documentInfo.processing": "Data processing"
 }

--- a/frontend/src/locales/ko/viewer.json
+++ b/frontend/src/locales/ko/viewer.json
@@ -44,5 +44,12 @@
   "a11y.red": "빨강",
   "a11y.previewSize": "미리보기 크기 너비 {{width}}픽셀, 높이 {{height}}픽셀",
   "sync.conflict": "동기화 충돌이 있어 두 버전을 모두 보존했습니다.",
-  "sync.delayed": "네트워크 문제로 주석 동기화가 지연되고 있습니다."
+  "sync.delayed": "네트워크 문제로 주석 동기화가 지연되고 있습니다.",
+  "documentInfo.open": "문서 정보 보기",
+  "documentInfo.menu": "정보",
+  "documentInfo.title": "문서 정보",
+  "documentInfo.name": "제목",
+  "documentInfo.filename": "파일명",
+  "documentInfo.type": "문서 종류",
+  "documentInfo.processing": "데이터 처리"
 }

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -1130,4 +1130,9 @@
   ,"웹에서 가져오기": "library:source.web"
   ,"PDF 또는 아티클 URL": "library:source.webHelp"
   ,"문서 URL": "library:source.urlLabel"
+  ,"문서 정보 보기": "viewer:documentInfo.open"
+  ,"문서 정보": "viewer:documentInfo.title"
+  ,"제목": "viewer:documentInfo.name"
+  ,"파일명": "viewer:documentInfo.filename"
+  ,"데이터 처리": "viewer:documentInfo.processing"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -835,6 +835,11 @@ const toast                 = $('toast')
 const a11yLiveRegion        = $('a11y-live-region')
 const toolbarKebabBtn       = $('toolbar-kebab-btn')
 const toolbarKebabMenu      = $('toolbar-kebab-menu')
+const viewerDocumentInfoBtn = $('viewer-document-info-btn')
+const viewerDocumentInfoModal = $('viewer-document-info-modal')
+const viewerDocumentInfoCloseBtn = $('viewer-document-info-close-btn')
+const viewerDocumentInfoName = $('viewer-document-info-name')
+const viewerDocumentInfoFilename = $('viewer-document-info-filename')
 
 // AI Chat Sidebar DOM references
 const chatToggleBtn      = $('chat-toggle-btn')
@@ -2268,6 +2273,24 @@ if (toolbarKebabBtn && toolbarKebabMenu) {
   })
 }
 
+if (viewerDocumentInfoBtn && viewerDocumentInfoModal) {
+  const closeViewerDocumentInfo = () => closeOverlayModal(viewerDocumentInfoModal)
+  viewerDocumentInfoBtn.addEventListener('click', () => {
+    if (viewerDocumentInfoName) viewerDocumentInfoName.textContent = state.title || state.filename || '-'
+    if (viewerDocumentInfoFilename) viewerDocumentInfoFilename.textContent = state.filename || '-'
+    toolbarKebabMenu?.classList.add('hidden')
+    toolbarKebabBtn?.focus()
+    openOverlayModal(viewerDocumentInfoModal)
+  })
+  viewerDocumentInfoCloseBtn?.addEventListener('click', closeViewerDocumentInfo)
+  viewerDocumentInfoModal.addEventListener('click', event => {
+    if (event.target === viewerDocumentInfoModal) closeViewerDocumentInfo()
+  })
+  viewerDocumentInfoModal.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closeViewerDocumentInfo()
+  })
+}
+
 const viewerClearCacheBtn = $('viewer-clear-cache-btn')
 if (viewerClearCacheBtn) {
   viewerClearCacheBtn.addEventListener('click', async () => {
@@ -2514,6 +2537,7 @@ if (viewerReadToggleBtn) {
       state.currentDocMetadata.read = nextReadState
       state.currentDocMetadata.read_at = payload.read_at
       viewerReadToggleBtn.classList.toggle('active', nextReadState)
+      toolbarKebabMenu?.classList.add('hidden')
       showToast(nextReadState ? '읽은 논문으로 표시되었습니다.' : '보관함으로 이동되었습니다.', 'success')
       await loadLibraryCount()
     } catch (err) {
@@ -10208,6 +10232,12 @@ async function openFromLibrary(doc, shouldPushState = true) {
     state.pageInsightCache = {}
     // 번역이 완료된 페이지 번호만 기록하고 번역본 로드는 lazy-load에 위임
     state.translatedPages  = new Set(doc.translated_pages || [])
+    if (viewerDocumentTypeChip) {
+      const docMode = doc.document_mode || "research"
+      viewerDocumentTypeChip.className = `document-type-chip ${docMode}`
+      viewerDocumentTypeChip.textContent = workspaceModeController.getTypeLabel(docMode, doc.document_type || "research_paper")
+    }
+    renderViewerProcessingBadge(doc.processing)
 
     // 채팅 내역 초기화
     state.chatHistory = []
@@ -10238,12 +10268,6 @@ async function openFromLibrary(doc, shouldPushState = true) {
     if (!isCurrentOpen() || loadedPages === null) return
     docTitle.textContent  = displayTitle
     docTitle.title        = doc.filename
-    if (viewerDocumentTypeChip) {
-      const docMode = doc.document_mode || "research"
-      viewerDocumentTypeChip.className = `document-type-chip ${docMode}`
-      viewerDocumentTypeChip.textContent = workspaceModeController.getTypeLabel(docMode, doc.document_type || "research_paper")
-    }
-    renderViewerProcessingBadge(doc.processing)
     pageTotal.textContent = `/ ${doc.total_pages}`
     pageInput.max   = doc.total_pages
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -6149,6 +6149,70 @@ body.light-theme .viewer-read-btn.active svg {
   color: #059669;
 }
 
+/* 케밥 메뉴로 이동한 읽기 완료 항목은 다른 메뉴 액션과 같은 행 레이아웃을
+   유지하면서 완료 상태만 초록색으로 강조한다. */
+.kebab-menu-item.viewer-read-btn {
+  width: 100%;
+  height: auto;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.kebab-menu-item.viewer-read-btn:hover {
+  border-color: transparent;
+  background: var(--bg-hover);
+}
+.kebab-menu-item.viewer-read-btn.active {
+  border-color: transparent;
+  background: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+}
+
+.viewer-document-info-dialog {
+  max-width: 520px;
+}
+.viewer-document-info-body {
+  padding: 20px 28px 28px;
+}
+.viewer-document-info-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+.viewer-document-info-row {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+  min-height: 44px;
+  border-bottom: 1px solid var(--border);
+}
+.viewer-document-info-row:last-child {
+  border-bottom: 0;
+}
+.viewer-document-info-row dt {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.viewer-document-info-row dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 520px) {
+  .viewer-document-info-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    padding: 12px 0;
+  }
+}
+
 /* ── Integrated Quoted Box Styling inside Chat Input ── */
 .chat-input-box .chat-quote-area {
   border-top-left-radius: 19px;

--- a/frontend/tests/e2e/accessibility.spec.js
+++ b/frontend/tests/e2e/accessibility.spec.js
@@ -8,6 +8,12 @@ const documentFixture = {
   total_pages: 1,
   metadata: { title: "Accessible document" },
   translated_pages: [],
+  document_mode: "research",
+  document_type: "research_paper",
+  processing: {
+    badge: "external_transfer",
+    transfer_items: ["document_text"],
+  },
 }
 
 async function openViewer(page) {
@@ -41,7 +47,6 @@ test("뷰어 툴바를 Tab만으로 논리적인 순서로 이동하고 포커�
   const tabOrder = [
     "#back-btn",
     "#logo-btn",
-    "#viewer-read-toggle-btn",
     "#outline-toggle-btn",
     "#doc-title-edit-btn",
     "#page-input",
@@ -92,7 +97,7 @@ test("메뉴와 개요를 키보드로 열고 Escape로 원래 트리거에 복�
   await menuButton.focus()
   await menuButton.press("Enter")
   await expect(menuButton).toHaveAttribute("aria-expanded", "true")
-  await expect(page.locator("#translation-scope-btn")).toBeFocused()
+  await expect(page.locator("#viewer-read-toggle-btn")).toBeFocused()
   await page.keyboard.press("Escape")
   await expect(menuButton).toBeFocused()
   await expect(menuButton).toHaveAttribute("aria-expanded", "false")
@@ -104,6 +109,27 @@ test("메뉴와 개요를 키보드로 열고 Escape로 원래 트리거에 복�
   await page.keyboard.press("Escape")
   await expect(outlineButton).toBeFocused()
   await expect(outlineButton).toHaveAttribute("aria-expanded", "false")
+})
+
+test("케밥 메뉴의 정보 항목이 문서 정보 다이얼로그를 연다", async ({ page }) => {
+  await openViewer(page)
+
+  const menuButton = page.locator("#toolbar-kebab-btn")
+  await menuButton.click()
+  await page.locator("#viewer-document-info-btn").click()
+
+  const modal = page.locator("#viewer-document-info-modal")
+  await expect(modal).toBeVisible()
+  await expect(modal).toHaveAttribute("role", "dialog")
+  await expect(page.locator("#viewer-document-info-name")).toHaveText("Accessible document")
+  await expect(page.locator("#viewer-document-info-filename")).toHaveText("Accessible.pdf")
+  await expect(page.locator("#viewer-document-type-chip")).not.toBeEmpty()
+  await expect(page.locator("#viewer-processing-badge")).toHaveText("외부 전송")
+  await expect(page.locator("#toolbar-kebab-menu")).toBeHidden()
+
+  await page.keyboard.press("Escape")
+  await expect(modal).toBeHidden()
+  await expect(menuButton).toBeFocused()
 })
 
 test("채팅 패널과 리사이저를 키보드로 조작하고 닫을 때 포커스를 복귀한다", async ({ page }) => {


### PR DESCRIPTION
# Summary
## 1. Viewer 케밥 메뉴 개선
- 읽기 완료 동작을 케밥 메뉴 항목으로 이동
- 문서 정보 항목 및 커스텀 다이얼로그 추가
- 제목, 파일명, 문서 종류, 데이터 처리 상태 표시
## 2. 접근성 및 다국어 지원
- Escape 및 바깥 클릭 닫기와 포커스 복귀 지원
- 한국어/영어 번역 및 E2E 검증 추가