### PR TITLE
feat: add interface scale setting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -929,6 +929,17 @@
             <label for="setting-ui-locale" data-i18n="settings:uiLanguage">화면 언어</label>
             <select id="setting-ui-locale" class="form-select"><option value="ko">한국어</option><option value="en">English</option></select>
           </div>
+          <div id="setting-ui-scale-group" class="form-group">
+            <label for="setting-ui-scale" data-i18n="settings:uiScale">UI 배율</label>
+            <select id="setting-ui-scale" class="form-select">
+              <option value="0.8">80%</option>
+              <option value="0.9">90%</option>
+              <option value="1">100%</option>
+              <option value="1.1">110%</option>
+              <option value="1.25">125%</option>
+            </select>
+            <small data-i18n="settings:uiScaleDescription">전체 인터페이스 크기를 조절합니다.</small>
+          </div>
           <div class="form-group">
             <label for="setting-source-lang" data-i18n="settings:sourceLanguage">기본 원문 언어</label>
             <select id="setting-source-lang" class="form-select"></select>

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -266,6 +266,15 @@
   "settings:uiLanguage": {
     "description": "Interface language"
   },
+  "settings:uiScale": {
+    "description": "Label for the interface scale selector shared by browser and desktop builds"
+  },
+  "settings:uiScaleDescription": {
+    "description": "Helper text explaining that interface scale changes the entire UI"
+  },
+  "settings:uiScaleSaved": {
+    "description": "Toast shown after an interface scale is saved and applied"
+  },
   "settings:sourceLanguage": {
     "description": "Default source language"
   },

--- a/frontend/src/locales/en/settings.json
+++ b/frontend/src/locales/en/settings.json
@@ -1,5 +1,8 @@
 {
   "uiLanguage": "Interface language",
+  "uiScale": "UI scale",
+  "uiScaleDescription": "Adjust the size of the entire interface.",
+  "uiScaleSaved": "UI scale saved.",
   "sourceLanguage": "Default source language",
   "targetLanguage": "Translation target language",
   "saved": "Language settings saved.",

--- a/frontend/src/locales/ko/settings.json
+++ b/frontend/src/locales/ko/settings.json
@@ -1,5 +1,8 @@
 {
   "uiLanguage": "화면 언어",
+  "uiScale": "UI 배율",
+  "uiScaleDescription": "전체 인터페이스 크기를 조절합니다.",
+  "uiScaleSaved": "UI 배율이 저장되었습니다.",
   "sourceLanguage": "기본 원문 언어",
   "targetLanguage": "번역 대상 언어",
   "saved": "언어 설정이 저장되었습니다.",

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -795,6 +795,8 @@
   "현재 폴더로 이동했습니다.": "common:legacy.ui.0791",
   "현재 Ollama API 주소가 이 서버(localhost)가 아닌 원격 호스트를 가리키고 있어, 여기서 직접 설치할 수 없습니다. 해당 원격 서버에서 직접 설치해 주세요.": "common:legacy.ui.0792",
   "형식의 중괄호 태그들은 시스템 치환용 매개변수이므로 형태를 그대로 유지해 주세요.": "common:legacy.ui.0793",
+  "UI 배율": "settings:uiScale",
+  "전체 인터페이스 크기를 조절합니다.": "settings:uiScaleDescription",
   "화면 언어": "common:legacy.ui.0794",
   "화면에 맞추기": "common:legacy.ui.0795",
   "화이트/다크 모드 전환": "common:legacy.ui.0796",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -25,8 +25,10 @@ import { buildScholarSearchUrl, extractCitationTitle } from './citationSearch.js
 import { changeLocale, getLocale, initI18n, loadFeatureNamespaces, loadNamespaces, t } from './i18n.js'
 import { saveUserLanguagePreferences, saveDocumentLanguageOverride } from './languagePreferences.js'
 import { canRetryTranslationTask, isTranslationTaskRunning, shouldRetryFailedTranslationTask } from './translationTaskState.js'
+import { applyUiScale, loadUiScale, saveUiScale } from './uiScale.js'
 
 const i18nReady = initI18n()
+applyUiScale(loadUiScale())
 
 
 // ── 글로벌 API 인터셉터 (인증 만료/실패 대응) ─────────
@@ -534,7 +536,7 @@ function initializeSettingsInformationArchitecture() {
   }
 
   const rowControlIds = [
-    'setting-ui-locale', 'setting-source-lang', 'setting-accent-swatches',
+    'setting-ui-locale', 'setting-ui-scale', 'setting-source-lang', 'setting-accent-swatches',
     'setting-target-lang', 'setting-trans-style', 'setting-translation-mode',
     'setting-ignore-math', 'setting-default-zoom', 'setting-toolbar-position',
     'setting-disable-hover-tooltip', 'setting-auto-generate-keywords',
@@ -618,6 +620,7 @@ const settingsKeywordsLabel = $('settings-keywords-label')
 const settingsKeywordsDescription = $('settings-keywords-description')
 const settingsReadingToolsLabel = $('settings-reading-tools-label')
 const settingUiLocale = $('setting-ui-locale')
+const settingUiScale = $('setting-ui-scale')
 const settingSourceLang = $('setting-source-lang')
 const settingTargetLang   = $('setting-target-lang')
 const settingTransStyle   = $('setting-trans-style')
@@ -641,6 +644,15 @@ const settingAutoGenerateSummaries = $('setting-auto-generate-summaries')
 for (const id of ['login-ui-locale', 'onboarding-ui-locale', 'setting-ui-locale']) {
   const selector = $(id)
   if (selector) selector.addEventListener('change', (event) => handleLocaleSelector(event).catch(console.error))
+}
+if (settingUiScale) {
+  settingUiScale.value = String(loadUiScale())
+  settingUiScale.addEventListener('change', () => {
+    const scale = saveUiScale(settingUiScale.value)
+    settingUiScale.value = String(scale)
+    applyUiScale(scale)
+    showToast(t('settings:uiScaleSaved'), 'success')
+  })
 }
 document.addEventListener('easypaper:locale-changed', () => { if (languageCatalog.length) populateLanguageControls(); renderDocumentLanguageStatus() })
 i18nReady.then(() => populateLanguageControls()).catch(console.error)

--- a/frontend/src/uiScale.js
+++ b/frontend/src/uiScale.js
@@ -1,0 +1,24 @@
+export const UI_SCALE_STORAGE_KEY = 'easypaper_ui_scale'
+export const DEFAULT_UI_SCALE = 1
+export const UI_SCALE_OPTIONS = Object.freeze([0.8, 0.9, 1, 1.1, 1.25])
+
+export function normalizeUiScale(value) {
+  const parsed = Number.parseFloat(value)
+  return UI_SCALE_OPTIONS.includes(parsed) ? parsed : DEFAULT_UI_SCALE
+}
+
+export function loadUiScale(storage = localStorage) {
+  return normalizeUiScale(storage.getItem(UI_SCALE_STORAGE_KEY))
+}
+
+export function saveUiScale(value, storage = localStorage) {
+  const scale = normalizeUiScale(value)
+  storage.setItem(UI_SCALE_STORAGE_KEY, String(scale))
+  return scale
+}
+
+export function applyUiScale(value, root = document.documentElement) {
+  const scale = normalizeUiScale(value)
+  root.style.zoom = String(scale)
+  return scale
+}

--- a/frontend/tests/uiScale.test.js
+++ b/frontend/tests/uiScale.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { DEFAULT_UI_SCALE, UI_SCALE_STORAGE_KEY, applyUiScale, loadUiScale, normalizeUiScale, saveUiScale } from '../src/uiScale.js'
+
+function memoryStorage(entries = {}) {
+  const values = new Map(Object.entries(entries))
+  return {
+    getItem: key => values.has(key) ? values.get(key) : null,
+    setItem: (key, value) => values.set(key, String(value)),
+  }
+}
+
+test('지원하는 UI 배율만 허용한다', () => {
+  assert.equal(normalizeUiScale('0.8'), 0.8)
+  assert.equal(normalizeUiScale('1.25'), 1.25)
+  assert.equal(normalizeUiScale('1.5'), DEFAULT_UI_SCALE)
+  assert.equal(normalizeUiScale('invalid'), DEFAULT_UI_SCALE)
+})
+
+test('저장된 UI 배율을 불러오고 정규화해 저장한다', () => {
+  const storage = memoryStorage({ [UI_SCALE_STORAGE_KEY]: '1.1' })
+  assert.equal(loadUiScale(storage), 1.1)
+  assert.equal(saveUiScale('0.9', storage), 0.9)
+  assert.equal(storage.getItem(UI_SCALE_STORAGE_KEY), '0.9')
+})
+
+test('전체 문서 루트에 UI 배율을 적용한다', () => {
+  const root = { style: {} }
+  assert.equal(applyUiScale('1.25', root), 1.25)
+  assert.equal(root.style.zoom, '1.25')
+})


### PR DESCRIPTION
# Summary
## 1. UI 배율 설정 기능을 추가
- 설정 일반 탭에 80%~125% 전체 UI 배율 선택 항목을 추가
- 브라우저와 Tauri 앱에서 CSS zoom으로 즉시 전체 인터페이스에 적용
- 선택한 배율을 localStorage에 저장하여 재실행 및 재방문 시 복원
- 한국어·영어 번역과 UI 배율 로직 단위 테스트를 추가