### PR TITLE
fix: avoid upload processing timeouts

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -23,6 +23,13 @@ class UploadResponse(BaseModel):
     total_units: Optional[int] = None
     capabilities: dict = {}
 
+class UploadAcceptedResponse(BaseModel):
+    session_id: str
+    task_id: str
+    status: str = "queued"
+    filename: str
+    file_size_mb: float
+
 
 class UrlImportRequest(BaseModel):
     url: str

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -12,7 +12,7 @@ from services.library import get_document, get_pdf_path as lib_pdf_path, list_do
 from services.translation_job import start_job, resume_incomplete_jobs, get_job_status
 from services.insight_job import start_keyword_job, start_summary_job
 from services.rate_limiter import enforce_rate_limit
-from models.schemas import UploadResponse
+from models.schemas import UploadAcceptedResponse
 
 router = APIRouter()
 
@@ -148,7 +148,7 @@ def restore_sessions_from_library():
     recover_reparse_previews()
 
 
-@router.post("/upload", response_model=UploadResponse)
+@router.post("/upload", response_model=UploadAcceptedResponse, status_code=202)
 async def upload_pdf(
     file: UploadFile = File(...),
     upload_id: str | None = None,
@@ -260,23 +260,51 @@ async def upload_pdf(
         "document_type": document_type,
     }
     parse_task = create_task(session_id, "parse", parse_options, status="queued")
-    from services.parse_job import execute_parse_task
-    try:
-        parsed = await execute_parse_task(
-            parse_task["id"], sessions,
-            page_extractor=extract_pages,
-            metadata_reader=get_pdf_metadata,
-            translation_starter=start_job,
-            keyword_starter=start_keyword_job,
-            summary_starter=start_summary_job,
-            upload_root=UPLOAD_DIR,
-        )
-    except Exception as exc:
-        shutil.rmtree(session_dir, ignore_errors=True)
-        raise HTTPException(status_code=422, detail=f"PDF 파싱 실패: {exc}") from exc
+    from services.parse_job import resume_parse_task
+    resume_parse_task(
+        parse_task["id"], sessions,
+        page_extractor=extract_pages,
+        metadata_reader=get_pdf_metadata,
+        translation_starter=start_job,
+        keyword_starter=start_keyword_job,
+        summary_starter=start_summary_job,
+        upload_root=UPLOAD_DIR,
+    )
+    return UploadAcceptedResponse(
+        session_id=session_id, task_id=parse_task["id"], status="queued",
+        filename=file.filename, file_size_mb=round(file_size_mb, 2),
+    )
 
-    parsed["file_size_mb"] = round(file_size_mb, 2)
-    return UploadResponse(**parsed)
+
+@router.get("/upload/{session_id}/status")
+async def get_upload_status(session_id: str, current_user: str = Depends(get_current_user)):
+    """Return durable parse state even before the document row exists."""
+    from services.document_tasks import latest_task
+
+    task = latest_task(session_id, "parse")
+    if not task or task.get("options", {}).get("username") != current_user:
+        raise HTTPException(status_code=404, detail="업로드 작업을 찾을 수 없습니다.")
+
+    response = {
+        "session_id": session_id, "task_id": task["id"],
+        "status": task["status"], "error_code": task.get("last_error_code"),
+    }
+    if task["status"] == "succeeded":
+        session = require_session_owner(session_id, current_user)
+        response["result"] = {
+            "session_id": session_id, "filename": session["filename"],
+            "total_pages": session["total_pages"],
+            "file_size_mb": round(float(task["options"].get("file_size_mb") or 0), 2),
+            "metadata": session["metadata"],
+            "document_mode": session.get("document_mode", "research"),
+            "document_type": session.get("document_type", "research_paper"),
+            "source_language": session.get("source_language", "auto"),
+            "detected_source_language": session.get("detected_source_language", "und"),
+            "source_language_confidence": session.get("source_language_confidence"),
+            "preferred_target_language": session.get("preferred_target_language"),
+            "translation_skipped_reason": session.get("translation_skipped_reason"),
+        }
+    return response
 
 
 @router.get("/session/{session_id}")
@@ -294,6 +322,7 @@ async def get_session(session_id: str, current_user: str = Depends(get_current_u
         "detected_source_language": session.get("detected_source_language", "und"),
         "source_language_confidence": session.get("source_language_confidence"),
         "preferred_target_language": session.get("preferred_target_language"),
+        "translation_skipped_reason": session.get("translation_skipped_reason"),
         "source_origin": session.get("source_origin", "local"),
         "content_kind": session.get("content_kind", "pdf"),
         "source_url": session.get("source_url"),

--- a/backend/services/parse_job.py
+++ b/backend/services/parse_job.py
@@ -196,6 +196,7 @@ async def execute_parse_task(
         translation_skipped_reason = "unsupported_source_language"
     elif resolved_source_language == target_lang:
         translation_skipped_reason = "same_source_and_target_language"
+    sessions[doc_id]["translation_skipped_reason"] = translation_skipped_reason
 
     from services.document_tasks import latest_task
     if translation_starter is None:
@@ -279,7 +280,7 @@ async def execute_parse_task(
     }
 
 
-def resume_parse_task(task_id: str, sessions: dict) -> asyncio.Task | None:
+def resume_parse_task(task_id: str, sessions: dict, **execute_kwargs) -> asyncio.Task | None:
     """Resume an orphaned upload directly from its server-owned source file."""
     existing = _running_parse_tasks.get(task_id)
     if existing is not None and not existing.done():
@@ -287,7 +288,7 @@ def resume_parse_task(task_id: str, sessions: dict) -> asyncio.Task | None:
     task = get_task(task_id)
     if not task or task["status"] not in {"queued", "running", "retry_wait"}:
         return None
-    worker = asyncio.create_task(execute_parse_task(task_id, sessions))
+    worker = asyncio.create_task(execute_parse_task(task_id, sessions, **execute_kwargs))
     _running_parse_tasks[task_id] = worker
 
     def _finished(done: asyncio.Task) -> None:

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -6,6 +6,22 @@ MAX_FILE_SIZE_MB를 검사해서, 한도를 아무리 작게 잡아도 큰 업�
 전부 소비한 뒤에야 거부되는 DoS 벡터였다.
 """
 
+import time
+
+
+def _await_upload(test_client, response):
+    assert response.status_code == 202
+    session_id = response.json()["session_id"]
+    for _ in range(200):
+        status = test_client.get(f"/api/upload/{session_id}/status")
+        assert status.status_code == 200
+        body = status.json()
+        if body["status"] == "succeeded":
+            return body["result"]
+        assert body["status"] not in {"failed", "partial_failed", "cancelled"}, body
+        time.sleep(0.01)
+    raise AssertionError("upload parsing did not finish")
+
 import fitz
 import uuid
 import routers.upload as upload_module
@@ -46,8 +62,7 @@ def test_upload_accepts_file_within_size_limit(test_client, isolated_dirs, monke
         files={"file": ("small.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
-    assert res.status_code == 200
-    body = res.json()
+    body = _await_upload(test_client, res)
     assert body["filename"] == "small.pdf"
     assert body["session_id"] in upload_module.sessions
 
@@ -63,8 +78,8 @@ def test_upload_uses_valid_client_upload_id(test_client, isolated_dirs, monkeypa
         files={"file": ("identified.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
-    assert response.status_code == 200
-    assert response.json()["session_id"] == upload_id
+    body = _await_upload(test_client, response)
+    assert body["session_id"] == upload_id
 
 
 def test_upload_rejects_invalid_client_upload_id(test_client):
@@ -119,7 +134,7 @@ def test_auto_translation_job_starts_before_primer(test_client, isolated_dirs, m
         files={"file": ("paper.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
-    assert res.status_code == 200
+    body = _await_upload(test_client, res)
     assert events
     assert events[0] == "translation"
 
@@ -150,10 +165,10 @@ def test_auto_translation_skips_full_job_at_fifty_pages(test_client, isolated_di
         files={"file": ("long.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
-    assert response.status_code == 200
-    assert response.json()["total_pages"] == 50
+    body = _await_upload(test_client, response)
+    assert body["total_pages"] == 50
     assert starts == []
-    upload_module.sessions.pop(response.json()["session_id"], None)
+    upload_module.sessions.pop(body["session_id"], None)
 
 
 def test_auto_translation_does_not_start_for_undetermined_source(test_client, isolated_dirs, monkeypatch):
@@ -171,8 +186,8 @@ def test_auto_translation_does_not_start_for_undetermined_source(test_client, is
         "/api/upload?translation_mode=auto",
         files={"file": ("empty.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
-    assert response.status_code == 200
-    assert response.json()["detected_source_language"] == "und"
-    assert response.json()["translation_skipped_reason"] == "unsupported_source_language"
+    body = _await_upload(test_client, response)
+    assert body["detected_source_language"] == "und"
+    assert body["translation_skipped_reason"] == "unsupported_source_language"
     assert starts == []
-    upload_module.sessions.pop(response.json()["session_id"], None)
+    upload_module.sessions.pop(body["session_id"], None)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -93,6 +93,33 @@ export async function cancelInsightJobAPI(sessionId, kind) {
 }
 
 const uploadRecoveryDelays = [400, 800, 1600, 3200, 5000]
+const uploadPollInterval = 1000
+
+async function waitForUpload(uploadId, onProgress) {
+  onProgress?.(100, "processing")
+  let consecutiveNetworkErrors = 0
+  while (true) {
+    try {
+      const res = await fetch(`${API_BASE}/upload/${encodeURIComponent(uploadId)}/status`, { cache: "no-store" })
+      if (!res.ok) throw await apiError(res)
+      const task = await res.json()
+      consecutiveNetworkErrors = 0
+      if (task.status === "succeeded" && task.result) return task.result
+      if (["failed", "partial_failed", "cancelled"].includes(task.status)) {
+        const terminalError = new Error(errorMessage({ code: task.error_code || "unknown" }))
+        terminalError.uploadTerminal = true
+        throw terminalError
+      }
+    } catch (error) {
+      if (error.uploadTerminal) throw error
+      consecutiveNetworkErrors += 1
+      if (consecutiveNetworkErrors >= 5) throw error
+      onProgress?.(100, "verifying")
+    }
+    await new Promise(resolve => setTimeout(resolve, uploadPollInterval))
+  }
+}
+
 
 async function recoverCompletedUpload(uploadId, onProgress, verifyingPercent = 100, delays = uploadRecoveryDelays) {
   onProgress?.(verifyingPercent, 'verifying')
@@ -125,29 +152,32 @@ export async function uploadPDF(file, options, onProgress) {
       if (event.lengthComputable) onProgress?.(Math.round((event.loaded / event.total) * 100), 'uploading')
     })
 
-    xhr.addEventListener('load', () => {
-      if (xhr.status === 200) {
+    xhr.addEventListener("load", async () => {
+      if (xhr.status === 202) {
         try {
-          const result = JSON.parse(xhr.responseText)
-          onProgress?.(100, 'processing')
-          resolve(result)
-        } catch {
-          reject(new Error(errorMessage({ code: 'unknown' })))
+          const accepted = JSON.parse(xhr.responseText)
+          resolve(await waitForUpload(accepted.session_id || uploadId, onProgress))
+        } catch (error) {
+          reject(error)
         }
       } else {
         try {
           const err = JSON.parse(xhr.responseText)
           reject(new Error(errorMessage(err)))
         } catch {
-          reject(new Error(errorMessage({ code: 'unknown' })))
+          reject(new Error(errorMessage({ code: "unknown" })))
         }
       }
     })
 
     const recoverOrReject = async () => {
-      const recovered = await recoverCompletedUpload(uploadId, onProgress)
-      if (recovered) resolve(recovered)
-      else reject(new Error(errorMessage({ code: 'network' })))
+      try {
+        resolve(await waitForUpload(uploadId, onProgress))
+      } catch {
+        const recovered = await recoverCompletedUpload(uploadId, onProgress)
+        if (recovered) resolve(recovered)
+        else reject(new Error(errorMessage({ code: "network" })))
+      }
     }
     xhr.addEventListener('error', recoverOrReject)
     xhr.addEventListener('timeout', recoverOrReject)

--- a/frontend/tests/api-upload.test.js
+++ b/frontend/tests/api-upload.test.js
@@ -25,9 +25,16 @@ class MockXHR {
 
 test('upload sends a client-known id and reports progress phases', async () => {
   const originalXHR = globalThis.XMLHttpRequest
+  const originalFetch = globalThis.fetch
+  const originalSetTimeout = globalThis.setTimeout
   const originalCrypto = globalThis.crypto
   const uploadId = '123e4567-e89b-42d3-a456-426614174000'
   Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { randomUUID: () => uploadId } })
+  globalThis.setTimeout = handler => { handler(); return 0 }
+  globalThis.fetch = async url => {
+    assert.equal(url, `/api/upload/${uploadId}/status`)
+    return new Response(JSON.stringify({ status: "succeeded", result: { session_id: uploadId, filename: "one.pdf", total_pages: 1, metadata: {} } }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
   globalThis.XMLHttpRequest = MockXHR
   MockXHR.instances = []
   try {
@@ -37,13 +44,15 @@ test('upload sends a client-known id and reports progress phases', async () => {
     assert.equal(xhr.method, 'POST')
     assert.match(xhr.url, new RegExp(`upload_id=${uploadId}`))
     xhr.uploadHandler[1]({ lengthComputable: true, loaded: 1, total: 2 })
-    xhr.status = 200
-    xhr.responseText = JSON.stringify({ session_id: uploadId, filename: 'one.pdf', total_pages: 1, metadata: {} })
+    xhr.status = 202
+    xhr.responseText = JSON.stringify({ session_id: uploadId, task_id: "parse-task", status: "queued" })
     xhr.emit('load')
     assert.equal((await promise).session_id, uploadId)
     assert.deepEqual(phases, [[50, 'uploading'], [100, 'processing']])
   } finally {
     globalThis.XMLHttpRequest = originalXHR
+    globalThis.fetch = originalFetch
+    globalThis.setTimeout = originalSetTimeout
     Object.defineProperty(globalThis, 'crypto', { configurable: true, value: originalCrypto })
   }
 })
@@ -58,11 +67,11 @@ test('connection loss recovers a completed server upload by id', async () => {
   globalThis.XMLHttpRequest = MockXHR
   globalThis.setTimeout = handler => { handler(); return 0 }
   globalThis.fetch = async url => {
-    assert.equal(url, `/api/session/${uploadId}`)
-    return new Response(JSON.stringify({
-      session_id: uploadId, filename: 'recovered.pdf', total_pages: 3, metadata: {},
-      document_mode: 'research', document_type: 'research_paper',
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    assert.equal(url, `/api/upload/${uploadId}/status`)
+    return new Response(JSON.stringify({ status: "succeeded", result: {
+      session_id: uploadId, filename: "recovered.pdf", total_pages: 3, metadata: {},
+      document_mode: "research", document_type: "research_paper",
+    } }), { status: 200, headers: { "Content-Type": "application/json" } })
   }
   MockXHR.instances = []
   try {
@@ -72,7 +81,7 @@ test('connection loss recovers a completed server upload by id', async () => {
     const result = await promise
     assert.equal(result.session_id, uploadId)
     assert.equal(result.filename, 'recovered.pdf')
-    assert.deepEqual(phases, [[100, 'verifying']])
+    assert.deepEqual(phases, [[100, "processing"]])
   } finally {
     globalThis.XMLHttpRequest = originalXHR
     globalThis.fetch = originalFetch
@@ -88,7 +97,7 @@ test('malformed success response rejects instead of leaving upload pending', asy
   try {
     const promise = uploadPDF(new Blob(['pdf']), options)
     const xhr = MockXHR.instances[0]
-    xhr.status = 200
+    xhr.status = 202
     xhr.responseText = '{invalid json'
     xhr.emit('load')
     await assert.rejects(promise)


### PR DESCRIPTION
# Summary
## 1. 대용량 PDF 비동기 처리 전환
- 업로드 파일 저장 후 `202 Accepted`와 파싱 작업 ID를 반환하도록 수정함
- 영속 parse 작업을 백그라운드에서 수행하고 서버 재시작 후에도 복구되도록 연결함

## 2. 업로드 완료 상태 확인 개선
- 업로드 상태 조회 API를 추가하고 웹 클라이언트가 완료·실패까지 폴링하도록 수정함
- 네트워크 연결 종료 시에도 서버 작업 상태를 재확인하도록 수정함

## 3. 회귀 테스트 갱신
- 비동기 업로드 응답 및 상태 폴링 계약을 검증하도록 테스트를 수정함