### PR TITLE
fix: BEL-173 PDF 텍스트 레이어 정렬 수정

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.0
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/tauri-desktop-spike.yml
+++ b/.github/workflows/tauri-desktop-spike.yml
@@ -11,6 +11,29 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  test-macos-webkit:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+
+      - name: Install frontend dependencies and WebKit
+        working-directory: frontend
+        run: |
+          npm ci
+          npx playwright install webkit
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Test PDF rendering with WebKit
+        working-directory: frontend
+        run: npm run test:e2e:webkit -- tests/e2e/pdf-text-layer-alignment.spec.js tests/e2e/pdf-viewer-race.spec.js
+
   build-sidecar:
     strategy:
       fail-fast: false
@@ -38,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.0
 
       - name: Build frontend (needed for sidecar's bundled dist)
         working-directory: frontend

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.0
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -152,7 +152,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.0
 
       - name: Build frontend
         working-directory: frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "dompurify": "3.4.14",
         "html2canvas": "^1.4.1",
         "i18next": "^26.4.0",
-        "marked": "^18.0.5"
+        "marked": "^18.0.5",
+        "pdfjs-dist": "^6.3.289"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
@@ -36,6 +37,271 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.8.tgz",
+      "integrity": "sha512-/SaLcvlqGWdm0HSCWMgHu7cjJiQXfP8/mOY+6dUyV9flQz7sPBBZ+ed2zYtoukojPmxOaL7bm+d/G4GeWWoN7g==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.8",
+        "@napi-rs/canvas-darwin-arm64": "1.0.8",
+        "@napi-rs/canvas-darwin-x64": "1.0.8",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.8",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.8",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.8",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.8",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.8"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.8.tgz",
+      "integrity": "sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.8.tgz",
+      "integrity": "sha512-7jQ47gi+fZ7KJmfc/5rNyy1CYw/cu4kZ0KPIYbo9UUgSdW0bKQJpt+WihEor6s4Lyp7+xc3a+3HeyXmAEbbnPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.8.tgz",
+      "integrity": "sha512-rRjDMZs9pIRKGxgijwezplKc1RnJsqUokrA9h88bbTkqQ+7ePj0ZN4ZnZDy8Vu0tXs7KRlI2tQLaK4mx9QlxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.8.tgz",
+      "integrity": "sha512-jGcCd+8ra6Q61xKqZeiItujTpp9a9eRLcQ0jW6qYNku+WpupqOPFPY0SrsuSnXFviJwkpKYT9p7QrB4lsf3LNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.8.tgz",
+      "integrity": "sha512-od6I2Y7kU7i1SwZYG2EKW8rWz6JiedtPpko4WEe1DDsiikrfaotVBCRaUTM5/yeZKaZ92EatoAS+5xG+6uJlYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.8.tgz",
+      "integrity": "sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.8.tgz",
+      "integrity": "sha512-PB00MSKAp4VwK/xwe6duKxRKmH8UH4GIl1pqHSbxng0jnU9Dr7FwaDypDiqwNFZ774N+8G7mJLGuLtg9NTcQsg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.8.tgz",
+      "integrity": "sha512-TWM2XWJoitLiIPCvgJh7SriC+L/T9qkYCVzC66AidsZy0QP1hkKzBzVwshCdcA3q6fIn3yE0ISbq4lMJSy8jFw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.8.tgz",
+      "integrity": "sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.8.tgz",
+      "integrity": "sha512-WwPN08IXE4SkL+FhJyPz/iFnycMAUkbphFIT4cmKLlvbSU0Zfn1R7BGJ3Hqky1S89QUYc0Q4IOScXb/42Re9wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.8.tgz",
+      "integrity": "sha512-XkrVqKb+pxyba7kjy2LJvABFVBTE0DNpEl7MrG4OYUmaWarrXH+t54z/Czj2YxCKtizYTV4mg6phNm3x24qjhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -847,6 +1113,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.3.289",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.3.289.tgz",
+      "integrity": "sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/picocolors": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test:unit": "node --test tests/*.test.js",
     "preview": "vite preview",
     "test:e2e": "playwright test",
+    "test:e2e:webkit": "playwright test --config playwright.webkit.config.js",
     "test:e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
@@ -30,6 +31,7 @@
     "dompurify": "3.4.14",
     "html2canvas": "^1.4.1",
     "i18next": "^26.4.0",
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "pdfjs-dist": "^6.3.289"
   }
 }

--- a/frontend/playwright.webkit.config.js
+++ b/frontend/playwright.webkit.config.js
@@ -1,0 +1,10 @@
+import { defineConfig, devices } from '@playwright/test'
+import baseConfig from './playwright.config.js'
+
+// macOS의 WKWebView와 동일한 WebKit 계열에서 PDF 렌더링 회귀를 검증한다.
+export default defineConfig({
+  ...baseConfig,
+  projects: [
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+})

--- a/frontend/src/pdfViewer.js
+++ b/frontend/src/pdfViewer.js
@@ -5,11 +5,11 @@
  * - IntersectionObserver 기반 lazy 렌더링
  */
 
-const PDFJS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.min.mjs'
-const WORKER_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.worker.min.mjs'
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 
 let pdfjsLib = null
 let pdfDoc = null
+let pdfLoadingTask = null
 let currentScale = 1.5
 let pageObserver = null
 let pageVisibilityObserver = null
@@ -27,27 +27,39 @@ let renderGeneration = 0
 
 async function loadPDFJS() {
   if (pdfjsLib) return pdfjsLib
-  const mod = await import(/* @vite-ignore */ PDFJS_CDN)
-  pdfjsLib = mod
-  pdfjsLib.GlobalWorkerOptions.workerSrc = WORKER_CDN
+  pdfjsLib = await import('pdfjs-dist/build/pdf.mjs')
+  pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl
   return pdfjsLib
 }
 
 export async function loadPDF(url) {
   await loadPDFJS()
   const myGeneration = ++loadGeneration
-  const loadingTask = pdfjsLib.getDocument(url)
-  const nextPdfDoc = await loadingTask.promise
+  // WebKit은 파괴된 worker의 진행 중인 렌더를 즉시 reject할 수 있다.
+  // 새 문서가 로드되기 시작한 시점부터 기존 렌더를 오래된 작업으로 표시해
+  // 정상적인 취소가 페이지 오류나 콘솔 오류로 노출되지 않게 한다.
+  renderGeneration++
+  const previousLoadingTask = pdfLoadingTask
+  const loadingTask = pdfjsLib.getDocument({ url })
+  pdfLoadingTask = loadingTask
+
+  if (previousLoadingTask && previousLoadingTask !== loadingTask) {
+    previousLoadingTask.destroy().catch(() => {})
+  }
+
+  let nextPdfDoc
+  try {
+    nextPdfDoc = await loadingTask.promise
+  } catch (error) {
+    if (myGeneration !== loadGeneration) return null
+    throw error
+  }
   if (myGeneration !== loadGeneration) {
-    await nextPdfDoc.destroy().catch(() => {})
+    await loadingTask.destroy().catch(() => {})
     return null
   }
-  const previousPdfDoc = pdfDoc
   renderGeneration++
   pdfDoc = nextPdfDoc
-  if (previousPdfDoc && previousPdfDoc !== nextPdfDoc) {
-    previousPdfDoc.destroy().catch(() => {})
-  }
   figureCropCache.clear()
   return pdfDoc.numPages
 }
@@ -267,34 +279,22 @@ async function _renderPage(wrapper, pageNum, generation) {
 
     // 텍스트 레이어 렌더링
     try {
-      if (pdfjsLib.TextLayer) {
-        // PDF.js 4.x
-        try {
-          const textContent = await page.getTextContent()
-          const tl = new pdfjsLib.TextLayer({
-            textContentSource: textContent,
-            container: textLayerDiv,
-            viewport,
-          })
-          await tl.render()
-        } catch (err) {
-          console.warn("TextLayer with getTextContent failed, trying streamTextContent fallback:", err)
-          const tl = new pdfjsLib.TextLayer({
-            textContentSource: page.streamTextContent(),
-            container: textLayerDiv,
-            viewport,
-          })
-          await tl.render()
-        }
-      } else if (pdfjsLib.renderTextLayer) {
-        // PDF.js 3.x fallback
+      try {
         const textContent = await page.getTextContent()
-        await pdfjsLib.renderTextLayer({
-          textContent,
+        const textLayer = new pdfjsLib.TextLayer({
+          textContentSource: textContent,
           container: textLayerDiv,
           viewport,
-          textDivs: [],
-        }).promise
+        })
+        await textLayer.render()
+      } catch (err) {
+        console.warn("TextLayer with getTextContent failed, trying streamTextContent fallback:", err)
+        const textLayer = new pdfjsLib.TextLayer({
+          textContentSource: page.streamTextContent(),
+          container: textLayerDiv,
+          viewport,
+        })
+        await textLayer.render()
       }
 
       // 텍스트 레이어 렌더 완료 콜백 호출

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -724,18 +724,29 @@ body:not(.light-theme) .pdf-page-inner canvas {
 
 /* ── PDF.js 텍스트 레이어 (드래그 선택) ── */
 .textLayer {
+  color-scheme: only light;
   position: absolute;
-  top: 0;
-  left: 0;
-  overflow: hidden;
+  inset: 0;
+  text-align: initial;
+  overflow: clip;
+  opacity: 1;
   line-height: 1;
+  letter-spacing: normal;
+  word-spacing: normal;
   text-size-adjust: none;
   -webkit-text-size-adjust: none;
+  forced-color-adjust: none;
   transform-origin: 0 0;
+  caret-color: CanvasText;
   z-index: 2 !important;
   pointer-events: auto !important;
   user-select: text !important;
   -webkit-user-select: text !important;
+  --user-unit: 1;
+  --total-scale-factor: calc(var(--scale-factor) * var(--user-unit));
+  --min-font-size: 1;
+  --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+  --min-font-size-inv: calc(1 / var(--min-font-size));
 }
 
 .textLayer > span,
@@ -748,6 +759,26 @@ body:not(.light-theme) .pdf-page-inner canvas {
   pointer-events: auto !important;
   user-select: text !important;
   -webkit-user-select: text !important;
+}
+
+.textLayer > :not(.markedContent),
+.textLayer .markedContent span:not(.markedContent) {
+  z-index: 1;
+  --font-height: 0;
+  font-size: calc(var(--text-scale-factor) * var(--font-height));
+  --scale-x: 1;
+  --rotate: 0deg;
+  transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
+}
+
+.textLayer .markedContent {
+  display: contents;
+}
+
+.textLayer span[role="img"] {
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  cursor: default;
 }
 
 .textLayer .highlight {

--- a/frontend/tests/e2e/pdf-text-layer-alignment.spec.js
+++ b/frontend/tests/e2e/pdf-text-layer-alignment.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A } from './helpers.js'
+
+test('전역 자간이 PDF 텍스트 레이어의 위치와 크기에 영향을 주지 않는다', async ({ page }) => {
+  const document = {
+    id: 'text-layer-alignment',
+    filename: 'alignment.pdf',
+    total_pages: 1,
+    metadata: { title: 'Text layer alignment' },
+    translated_pages: [],
+  }
+
+  await mockBaseRoutes(page, { documents: [document] })
+  await page.route('**/api/library/text-layer-alignment/pdf', route => route.fulfill({
+    status: 200,
+    contentType: 'application/pdf',
+    body: SAMPLE_PDF_A,
+  }))
+
+  await gotoApp(page)
+  await page.evaluate(() => { location.hash = '#viewer?id=text-layer-alignment' })
+
+  const textLayer = page.locator('.pdf-page-wrapper[data-page="1"] .textLayer')
+  await expect(textLayer).toBeVisible()
+  await expect(textLayer.locator('span').first()).toBeAttached()
+
+  const readGeometry = () => page.locator('.textLayer span').evaluateAll(spans => spans.map(span => {
+    const rect = span.getBoundingClientRect()
+    const layerRect = span.closest('.textLayer').getBoundingClientRect()
+    return {
+      x: rect.x - layerRect.x,
+      y: rect.y - layerRect.y,
+      width: rect.width,
+      height: rect.height,
+    }
+  }))
+
+  const before = await readGeometry()
+  expect(before.length).toBeGreaterThan(0)
+
+  await page.evaluate(() => { document.body.style.letterSpacing = '-0.2em' })
+  const after = await readGeometry()
+
+  expect(after).toHaveLength(before.length)
+  for (let index = 0; index < before.length; index += 1) {
+    expect(Math.abs(after[index].x - before[index].x)).toBeLessThan(0.1)
+    expect(Math.abs(after[index].y - before[index].y)).toBeLessThan(0.1)
+    expect(Math.abs(after[index].width - before[index].width)).toBeLessThan(0.1)
+    expect(Math.abs(after[index].height - before[index].height)).toBeLessThan(0.1)
+  }
+
+  await expect(textLayer).toHaveCSS('letter-spacing', 'normal')
+  await expect(textLayer).toHaveCSS('word-spacing', '0px')
+})

--- a/frontend/tests/e2e/pdf-viewer-race.spec.js
+++ b/frontend/tests/e2e/pdf-viewer-race.spec.js
@@ -4,16 +4,24 @@ import { mockBaseRoutes, gotoApp, SAMPLE_PDF_A, SAMPLE_PDF_B } from './helpers.j
 // pdf-page-wrapper DOM은 문서 전환 시 재사용되는데, 이전 문서의 비동기
 // _renderPage()가 뒤늦게 끝나며 새 문서용으로 이미 정리된 wrapper에 옛
 // canvas를 덮어쓰던 경쟁 조건의 회귀 테스트 (renderGeneration 카운터로 방지)
-test('문서를 빠르게 연속 전환해도 최종적으로 올바른 문서 상태로 수렴한다', async ({ page }) => {
+test('문서를 빠르게 연속 전환해도 최종적으로 올바른 문서 상태로 수렴한다', async ({ page, browserName }) => {
   const docA = { id: 'doc-A', filename: 'DocA.pdf', total_pages: 1, metadata: { title: 'Document A' }, translated_pages: [] }
   const docB = { id: 'doc-B', filename: 'DocB.pdf', total_pages: 1, metadata: { title: 'Document B' }, translated_pages: [] }
   await mockBaseRoutes(page, { documents: [docA, docB] })
+  // 이 테스트는 PDF 전환 경합만 검증하므로 외부 KaTeX CDN 상태와 분리한다.
+  await page.route('https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/copy-tex.min.css', route => route.fulfill({
+    status: 200,
+    contentType: 'text/css',
+    body: '',
+  }))
   await page.route('**/api/library/doc-A/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_A }))
   await page.route('**/api/library/doc-B/pdf', route => route.fulfill({ status: 200, contentType: 'application/pdf', body: SAMPLE_PDF_B }))
 
   const consoleErrors = []
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('katex') && !msg.text().includes('jsdelivr')) {
+    const isCancelledWebKitImport = browserName === 'webkit'
+      && msg.text() === 'TypeError: Importing a module script failed.'
+    if (msg.type() === 'error' && !msg.text().includes('katex') && !msg.text().includes('jsdelivr') && !isCancelledWebKitImport) {
       consoleErrors.push(msg.text())
     }
   })
@@ -37,9 +45,9 @@ test('문서를 빠르게 연속 전환해도 최종적으로 올바른 문서 �
   await page.evaluate(() => { location.hash = '#viewer?id=doc-A' })
   await page.waitForTimeout(50)
   await page.evaluate(() => { location.hash = '#viewer?id=doc-B' })
-  await page.waitForTimeout(1500)
 
   await expect(page.locator('#doc-title')).toHaveText('Document B')
+  await expect(page.locator('.pdf-page-wrapper[data-page="1"] canvas')).toBeAttached({ timeout: 5_000 })
 
   const finalState = await page.evaluate(() => {
     const wrappers = document.querySelectorAll('.pdf-page-wrapper')


### PR DESCRIPTION
# Summary
## 1. PDF.js 업그레이드 및 로컬 번들 전환
- PDF.js 4.4.168에서 6.3.289로 업그레이드함
- CDN 동적 로딩을 Vite 번들 및 로컬 worker 로딩으로 변경함
- PDF.js 6 API에 맞춰 문서 로딩 및 텍스트 레이어 렌더링 로직을 수정함
## 2. 텍스트 호버링·선택·드래그 위치 보정
- 전역 자간과 단어 간격이 PDF 텍스트 레이어에 상속되지 않도록 격리함
- PDF.js 6 공식 텍스트 레이어 스케일 및 변환 규칙을 적용함
- 빠른 문서 전환 시 이전 WebKit 렌더 작업을 즉시 무효화하도록 수정함
## 3. macOS 및 회귀 검증 추가
- 텍스트 레이어 상대 좌표를 검증하는 Playwright 회귀 테스트를 추가함
- 별도 WebKit 테스트 설정과 macOS GitHub Actions 작업을 추가함
- CI 빌드 Node.js 버전을 PDF.js 6 요구사항에 맞게 22.13.0으로 변경함