### PR TITLE
fix(settings): sync scale dropdown values

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -934,7 +934,7 @@
             <select id="setting-ui-scale" class="form-select">
               <option value="0.8">80%</option>
               <option value="0.9">90%</option>
-              <option value="1">100%</option>
+              <option value="1" selected>100%</option>
               <option value="1.1">110%</option>
               <option value="1.25">125%</option>
             </select>
@@ -1016,7 +1016,7 @@
             <label for="setting-default-zoom">기본 PDF 확대 비율</label>
             <select id="setting-default-zoom" class="form-select">
               <option value="1.0">70%</option>
-              <option value="1.5">100% (기본)</option>
+              <option value="1.5" selected>100% (기본)</option>
               <option value="2.0">130%</option>
               <option value="2.5">170%</option>
             </select>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3952,6 +3952,7 @@ globalSettingsBtn.addEventListener('click', async () => {
 
   // 2. 일반 설정값 로드
   syncModeSettings(workspaceModeController.getMode())
+  settingUiScale.value = String(loadUiScale())
   settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
   settingToolbarPosition.value = getToolbarPosition()
   // 아래 항목은 모드와 관계없는 공통 뷰어 설정이다.

--- a/frontend/tests/settingsScaleDefaults.test.js
+++ b/frontend/tests/settingsScaleDefaults.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const indexHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8')
+
+function selectedValue(selectId) {
+  const select = indexHtml.match(new RegExp(`<select id="${selectId}"[^>]*>([\\s\\S]*?)</select>`))
+  assert.ok(select, `${selectId} select가 있어야 한다`)
+
+  const selected = select[1].match(/<option value="([^"]+)" selected>/)
+  assert.ok(selected, `${selectId}에 명시적인 기본 선택값이 있어야 한다`)
+  return selected[1]
+}
+
+test('배율 드롭다운의 초기 표시값은 실제 애플리케이션 기본값과 일치한다', () => {
+  assert.equal(selectedValue('setting-ui-scale'), '1')
+  assert.equal(selectedValue('setting-default-zoom'), '1.5')
+})


### PR DESCRIPTION
# Summary
## 1. 배율 드롭다운 기본값 수정
- UI 배율 드롭다운의 초기 선택값을 실제 기본값 100%로 수정함
- PDF 확대 비율 드롭다운의 초기 선택값을 실제 기본값 100%로 수정함
- 설정 창 진입 시 저장된 UI 배율을 동기화함
- 드롭다운 기본값 회귀 테스트 추가함