### PR TITLE
fix(settings): reflect saved scale selection

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -934,7 +934,7 @@
             <select id="setting-ui-scale" class="form-select">
               <option value="0.8">80%</option>
               <option value="0.9">90%</option>
-              <option value="1" selected>100%</option>
+              <option value="1">100%</option>
               <option value="1.1">110%</option>
               <option value="1.25">125%</option>
             </select>
@@ -1016,7 +1016,7 @@
             <label for="setting-default-zoom">기본 PDF 확대 비율</label>
             <select id="setting-default-zoom" class="form-select">
               <option value="1.0">70%</option>
-              <option value="1.5" selected>100% (기본)</option>
+              <option value="1.5">100% (기본)</option>
               <option value="2.0">130%</option>
               <option value="2.5">170%</option>
             </select>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -25,7 +25,7 @@ import { buildScholarSearchUrl, extractCitationTitle } from './citationSearch.js
 import { changeLocale, getLocale, initI18n, loadFeatureNamespaces, loadNamespaces, t } from './i18n.js'
 import { saveUserLanguagePreferences, saveDocumentLanguageOverride } from './languagePreferences.js'
 import { canRetryTranslationTask, isTranslationTaskRunning, shouldRetryFailedTranslationTask } from './translationTaskState.js'
-import { applyUiScale, loadUiScale, saveUiScale } from './uiScale.js'
+import { applyUiScale, loadUiScale, saveUiScale, syncUiScaleControl } from './uiScale.js'
 import { adaptiveBriefingSummary, hasAdaptiveBriefing, renderAdaptiveBriefingHtml } from './adaptiveBriefing.js'
 import { classificationModalMarkup, recommendedClassification } from './classificationConfirmationView.js'
 import { renderChapterSummaryHtml, renderFullSummaryHtml } from './chapterSummaryView.js'
@@ -648,7 +648,7 @@ for (const id of ['login-ui-locale', 'onboarding-ui-locale', 'setting-ui-locale'
   if (selector) selector.addEventListener('change', (event) => handleLocaleSelector(event).catch(console.error))
 }
 if (settingUiScale) {
-  settingUiScale.value = String(loadUiScale())
+  syncUiScaleControl(settingUiScale)
   settingUiScale.addEventListener('change', () => {
     const scale = saveUiScale(settingUiScale.value)
     settingUiScale.value = String(scale)
@@ -4029,6 +4029,8 @@ async function changeProviderAndModel(type, newProvider, newModel) {
 // ── EasyPaper 설정 모달 이벤트 ──────────────────────────
 globalSettingsBtn.addEventListener('click', async () => {
   await loadFeatureNamespaces('settings')
+  syncUiScaleControl(settingUiScale)
+  settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
   openOverlayModal(settingsModal)
 
   // 1. 기본 진입 카테고리는 일반
@@ -4036,8 +4038,6 @@ globalSettingsBtn.addEventListener('click', async () => {
 
   // 2. 일반 설정값 로드
   syncModeSettings(workspaceModeController.getMode())
-  settingUiScale.value = String(loadUiScale())
-  settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
   settingToolbarPosition.value = getToolbarPosition()
   // 아래 항목은 모드와 관계없는 공통 뷰어 설정이다.
   settingDisableHoverTooltip.checked = !state.disableHoverTooltip

--- a/frontend/src/uiScale.js
+++ b/frontend/src/uiScale.js
@@ -17,6 +17,12 @@ export function saveUiScale(value, storage = localStorage) {
   return scale
 }
 
+export function syncUiScaleControl(control, storage = localStorage) {
+  const scale = loadUiScale(storage)
+  if (control) control.value = String(scale)
+  return scale
+}
+
 export function applyUiScale(value, root = document.documentElement) {
   const scale = normalizeUiScale(value)
   root.style.zoom = String(scale)

--- a/frontend/tests/settingsScaleDefaults.test.js
+++ b/frontend/tests/settingsScaleDefaults.test.js
@@ -4,16 +4,13 @@ import test from 'node:test'
 
 const indexHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8')
 
-function selectedValue(selectId) {
+function selectMarkup(selectId) {
   const select = indexHtml.match(new RegExp(`<select id="${selectId}"[^>]*>([\\s\\S]*?)</select>`))
   assert.ok(select, `${selectId} select가 있어야 한다`)
-
-  const selected = select[1].match(/<option value="([^"]+)" selected>/)
-  assert.ok(selected, `${selectId}에 명시적인 기본 선택값이 있어야 한다`)
-  return selected[1]
+  return select[1]
 }
 
-test('배율 드롭다운의 초기 표시값은 실제 애플리케이션 기본값과 일치한다', () => {
-  assert.equal(selectedValue('setting-ui-scale'), '1')
-  assert.equal(selectedValue('setting-default-zoom'), '1.5')
+test('배율 드롭다운은 HTML 선택값으로 고정하지 않는다', () => {
+  assert.doesNotMatch(selectMarkup('setting-ui-scale'), /<option[^>]+selected>/)
+  assert.doesNotMatch(selectMarkup('setting-default-zoom'), /<option[^>]+selected>/)
 })

--- a/frontend/tests/uiScale.test.js
+++ b/frontend/tests/uiScale.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { DEFAULT_UI_SCALE, UI_SCALE_STORAGE_KEY, applyUiScale, loadUiScale, normalizeUiScale, saveUiScale } from '../src/uiScale.js'
+import { DEFAULT_UI_SCALE, UI_SCALE_STORAGE_KEY, applyUiScale, loadUiScale, normalizeUiScale, saveUiScale, syncUiScaleControl } from '../src/uiScale.js'
 
 function memoryStorage(entries = {}) {
   const values = new Map(Object.entries(entries))
@@ -28,4 +28,12 @@ test('전체 문서 루트에 UI 배율을 적용한다', () => {
   const root = { style: {} }
   assert.equal(applyUiScale('1.25', root), 1.25)
   assert.equal(root.style.zoom, '1.25')
+})
+
+test('저장된 UI 배율을 설정 드롭다운의 현재 값으로 동기화한다', () => {
+  const control = { value: '1' }
+  const storage = memoryStorage({ [UI_SCALE_STORAGE_KEY]: '0.8' })
+
+  assert.equal(syncUiScaleControl(control, storage), 0.8)
+  assert.equal(control.value, '0.8')
 })


### PR DESCRIPTION
# Summary
## 1. UI 배율 선택값 고정 수정
- 배율 option의 하드코딩된 selected 속성을 제거함
- 설정 창 표시 전에 localStorage의 UI 배율과 PDF 확대 비율을 드롭다운에 동기화함
- 저장된 UI 배율 80%가 드롭다운 값으로 반영되는 회귀 테스트 추가함
- HTML 선택값 고정 방지 테스트 추가함