### PR TITLE
feat(upload): add optional AI classification

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -46,6 +46,7 @@ class UrlImportRequest(BaseModel):
     summary_mode: str = "manual"
     document_mode: str = "research"
     document_type: str = "research_paper"
+    classification_method: str = "manual"
 
 
 class PageInfo(BaseModel):

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -164,6 +164,7 @@ async def upload_pdf(
     summary_mode: str = "manual",
     document_mode: str = "research",
     document_type: str = "research_paper",
+    classification_method: str = "manual",
     current_user: str = Depends(get_current_user)
 ):
     """PDF 파일을 업로드하고 텍스트를 추출합니다."""
@@ -180,6 +181,8 @@ async def upload_pdf(
         raise HTTPException(status_code=400, detail=api_language_error(source_lang, source=True))
 
     from services.document_policy import feature_enabled, validate_classification
+    if classification_method not in {"manual", "ai"}:
+        raise HTTPException(status_code=400, detail="유효하지 않은 문서 분류 방식입니다.")
     try:
         validate_classification(document_mode, document_type, allow_deprecated=False)
         if document_mode == "general" and not feature_enabled("general_document_mode"):
@@ -259,6 +262,7 @@ async def upload_pdf(
         "summary_mode": summary_mode,
         "document_mode": document_mode,
         "document_type": document_type,
+        "classification_method": classification_method,
     }
     parse_task = create_task(session_id, "parse", parse_options, status="queued")
     from services.parse_job import resume_parse_task

--- a/backend/routers/web_import.py
+++ b/backend/routers/web_import.py
@@ -28,6 +28,8 @@ def _validate_options(body: UrlImportRequest) -> tuple[str, str]:
     from services.languages import normalize_document_language
     try:
         validate_classification(body.document_mode, body.document_type, allow_deprecated=False)
+        if body.classification_method not in {"manual", "ai"}:
+            raise ValueError("유효하지 않은 문서 분류 방식입니다.")
         if body.document_mode == "general" and not feature_enabled("general_document_mode"):
             raise ValueError("일반 문서 모드가 아직 활성화되지 않았습니다.")
         target = normalize_document_language(body.target_lang, allow_legacy=True)
@@ -117,17 +119,21 @@ async def import_url(body: UrlImportRequest, current_user: str = Depends(get_cur
         detection = detect_document_language(pages)
         from services.db import db_save_document
         metadata = {"title": manifest["title"], "source_url": body.url, "canonical_url": manifest["canonical_url"]}
-        db_save_document(doc_id, current_user, f"{manifest['title']}.html", str(manifest_path), len(pages), metadata, document_mode=body.document_mode, document_type=body.document_type, source_language=source_lang, detected_source_language=str(detection["language"]), source_language_confidence=float(detection["confidence"]), preferred_target_language=target_lang, parser_engine="readability", parser_version="1", source_origin="web", content_kind="html_article", source_url=body.url, canonical_url=manifest["canonical_url"], fetched_at=manifest["fetched_at"], content_schema_version=1, content_unit_count=len(pages))
+        classification_status = "pending" if body.classification_method == "ai" else "confirmed"
+        db_save_document(doc_id, current_user, f"{manifest['title']}.html", str(manifest_path), len(pages), metadata, document_mode=body.document_mode, document_type=body.document_type, classification_status=classification_status, source_language=source_lang, detected_source_language=str(detection["language"]), source_language_confidence=float(detection["confidence"]), preferred_target_language=target_lang, parser_engine="readability", parser_version="1", source_origin="web", content_kind="html_article", source_url=body.url, canonical_url=manifest["canonical_url"], fetched_at=manifest["fetched_at"], content_schema_version=1, content_unit_count=len(pages))
         from services.cache import save_pages_cache
         save_pages_cache(doc_id, str(manifest_path), pages, "readability", "1", strict=True)
         from services.context_retrieval import index_document_chunks
         index_document_chunks(doc_id, pages)
         from routers.upload import sessions
-        sessions[doc_id] = {"pdf_path": str(manifest_path), "filename": f"{manifest['title']}.html", "pages": pages, "total_pages": len(pages), "metadata": metadata, "from_library": True, "username": current_user, "document_mode": body.document_mode, "document_type": body.document_type, "source_language": source_lang, "detected_source_language": detection["language"], "source_language_confidence": detection["confidence"], "preferred_target_language": target_lang, "processing_policy": "inherit", "content_revision": 1, "parser_engine": "readability", "parser_version": "1", "content_kind": "html_article", "source_origin": "web"}
-        if body.translation_mode == "auto" and len(pages) < 50 and (source_lang if source_lang != "auto" else detection["language"]) != target_lang:
+        sessions[doc_id] = {"pdf_path": str(manifest_path), "filename": f"{manifest['title']}.html", "pages": pages, "total_pages": len(pages), "metadata": metadata, "from_library": True, "username": current_user, "document_mode": body.document_mode, "document_type": body.document_type, "classification_status": classification_status, "processing_options": body.model_dump(exclude={"url", "upload_id"}), "source_language": source_lang, "detected_source_language": detection["language"], "source_language_confidence": detection["confidence"], "preferred_target_language": target_lang, "processing_policy": "inherit", "content_revision": 1, "parser_engine": "readability", "parser_version": "1", "content_kind": "html_article", "source_origin": "web"}
+        if body.classification_method == "ai":
+            from services.document_classification import start_classification_task
+            start_classification_task(doc_id, manifest["title"], pages)
+        elif body.translation_mode == "auto" and len(pages) < 50 and (source_lang if source_lang != "auto" else detection["language"]) != target_lang:
             from services.translation_job import start_job
             start_job(doc_id, pages, target_lang=target_lang, source_lang=source_lang if source_lang != "auto" else detection["language"], style=body.style, ignore_math=body.ignore_math, ignore_table=body.ignore_table, ignore_refs=body.ignore_refs)
-        return UploadResponse(session_id=doc_id, filename=f"{manifest['title']}.html", total_pages=len(pages), file_size_mb=round(downloaded_size / 1048576, 2), metadata=metadata, document_mode=body.document_mode, document_type=body.document_type, source_language=source_lang, detected_source_language=str(detection["language"]), source_language_confidence=float(detection["confidence"]), preferred_target_language=target_lang, source_origin="web", content_kind="html_article", source_url=body.url, canonical_url=manifest["canonical_url"], fetched_at=manifest["fetched_at"], total_units=len(pages), capabilities=_capabilities("html_article"))
+        return UploadResponse(session_id=doc_id, filename=f"{manifest['title']}.html", total_pages=len(pages), file_size_mb=round(downloaded_size / 1048576, 2), metadata=metadata, document_mode=body.document_mode, document_type=body.document_type, classification_status=classification_status, source_language=source_lang, detected_source_language=str(detection["language"]), source_language_confidence=float(detection["confidence"]), preferred_target_language=target_lang, source_origin="web", content_kind="html_article", source_url=body.url, canonical_url=manifest["canonical_url"], fetched_at=manifest["fetched_at"], total_units=len(pages), capabilities=_capabilities("html_article"))
     except WebImportError as exc:
         shutil.rmtree(staging, ignore_errors=True); shutil.rmtree(final_dir, ignore_errors=True)
         raise HTTPException(status_code=422, detail={"code": exc.code, "message": str(exc)}) from exc

--- a/backend/services/parse_job.py
+++ b/backend/services/parse_job.py
@@ -91,6 +91,7 @@ async def execute_parse_task(
     active_parser_engine = (pages[0].get("parser_engine") or "pymupdf") if pages else "pymupdf"
     from services.pdf_diagnostics import diagnose_pages, parser_version
     active_parser_version = parser_version(active_parser_engine)
+    classification_status = "pending" if options.get("classification_method", "ai") == "ai" else "confirmed"
 
     try:
         from services.library import get_document, get_pdf_path, save_document
@@ -116,7 +117,7 @@ async def execute_parse_task(
                 preferred_target_language=target_lang,
                 content_revision=1, parser_engine=active_parser_engine,
                 parser_version=active_parser_version,
-                classification_status="pending",
+                classification_status=classification_status,
             )
             persistent_pdf_path = get_pdf_path(doc_id)
 
@@ -182,7 +183,7 @@ async def execute_parse_task(
         "username": options.get("username", "admin"),
         "document_mode": options.get("document_mode", "research"),
         "document_type": options.get("document_type", "research_paper"),
-        "classification_status": "pending",
+        "classification_status": classification_status,
         "source_language": source_lang,
         "detected_source_language": detected_source_language,
         "source_language_confidence": detection["confidence"],
@@ -263,13 +264,16 @@ async def execute_parse_task(
                 resolved_source_language,
             )
 
-    # Classification is durable; all other AI work waits for explicit confirmation.
-    from services.document_classification import start_classification_task
-    start_classification_task(
-        doc_id, metadata.get("title") or options.get("filename", "document.pdf"), pages,
-    )
+    # Only an explicit AI choice starts classification. Manual selections are final.
+    if options.get("classification_method", "ai") == "ai":
+        from services.document_classification import start_classification_task
+        start_classification_task(
+            doc_id, metadata.get("title") or options.get("filename", "document.pdf"), pages,
+        )
     await asyncio.sleep(0)
     update_task(task_id, status="succeeded", last_error_code=None)
+    if classification_status == "confirmed":
+        start_processing_after_classification(doc_id, sessions)
     return {
         "session_id": doc_id,
         "filename": options.get("filename") or "document.pdf",
@@ -278,7 +282,7 @@ async def execute_parse_task(
         "metadata": metadata,
         "document_mode": options.get("document_mode", "research"),
         "document_type": options.get("document_type", "research_paper"),
-        "classification_status": "pending",
+        "classification_status": classification_status,
         "source_language": source_lang,
         "detected_source_language": detected_source_language,
         "source_language_confidence": float(detection["confidence"]),
@@ -319,7 +323,7 @@ def start_processing_after_classification(doc_id: str, sessions: dict) -> None:
     doc = db_get_document(doc_id)
     if not session or not doc:
         return
-    options = (latest_task(doc_id, "parse") or {}).get("options") or {}
+    options = (latest_task(doc_id, "parse") or {}).get("options") or session.get("processing_options") or {}
     source = session.get("source_language", "auto")
     resolved = session.get("detected_source_language", source) if source == "auto" else source
     target = session.get("preferred_target_language") or options.get("target_lang", "ko")

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -130,13 +130,31 @@ def test_auto_ai_jobs_wait_for_classification_confirmation(test_client, isolated
     monkeypatch.setattr(primer_router, "_ensure_generation_started", fake_generate_primer)
 
     res = test_client.post(
-        "/api/upload?translation_mode=auto&source_lang=en",
+        "/api/upload?translation_mode=auto&source_lang=en&classification_method=ai",
         files={"file": ("paper.pdf", _minimal_pdf_bytes(), "application/pdf")},
     )
 
     body = _await_upload(test_client, res)
     assert events == []
     assert upload_module.sessions[body["session_id"]]["classification_status"] == "pending"
+
+
+def test_manual_upload_skips_ai_classification(test_client, isolated_dirs, monkeypatch):
+    upload_dir = isolated_dirs["upload_dir"]
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(upload_module, "MAX_FILE_SIZE_MB", 50)
+    monkeypatch.setattr(upload_module, "start_job", lambda *_args, **_kwargs: {"status": "running"})
+    monkeypatch.setattr(primer_router, "_ensure_generation_started", lambda *_args, **_kwargs: {})
+
+    response = test_client.post(
+        "/api/upload?translation_mode=auto&source_lang=en&classification_method=manual",
+        files={"file": ("manual.pdf", _minimal_pdf_bytes(), "application/pdf")},
+    )
+
+    body = _await_upload(test_client, response)
+    from services.document_tasks import latest_task
+    assert upload_module.sessions[body["session_id"]]["classification_status"] == "confirmed"
+    assert latest_task(body["session_id"], "classification") is None
 
 
 def test_auto_translation_skips_full_job_at_fifty_pages(test_client, isolated_dirs, monkeypatch):

--- a/backend/tests/test_web_import_api.py
+++ b/backend/tests/test_web_import_api.py
@@ -36,6 +36,9 @@ def test_import_html_endpoint_is_atomic_and_serves_manifest(test_client, isolate
     assert body["total_units"] >= 1
     doc = isolated_dirs["db"].db_get_document(doc_id)
     assert doc["content_kind"] == "html_article"
+    assert doc["classification_status"] == "confirmed"
+    from services.document_tasks import latest_task
+    assert latest_task(doc_id, "classification") is None
     assert Path(doc["pdf_path"]).is_file()
     manifest = test_client.get(f"/api/library/{doc_id}/article")
     assert manifest.status_code == 200

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -711,7 +711,7 @@
         <p>문서 종류를 선택하면 번역과 AI 어시스턴트가 해당 목적에 맞게 동작합니다.</p>
         <div id="document-type-options" class="document-type-options" role="radiogroup" aria-label="문서 종류"></div>
         <div id="document-upload-summary" class="document-upload-summary"></div>
-        <div class="document-type-modal-actions"><button id="document-type-cancel-btn" class="btn btn-secondary">취소</button><button id="document-type-confirm-btn" class="btn btn-primary" disabled>업로드</button></div>
+        <div class="document-type-modal-actions"><button type="button" id="document-type-ai-btn" class="btn btn-secondary document-type-ai-btn" data-i18n="common:classification.classifyWithAi">AI로 분류하기</button><button id="document-type-cancel-btn" class="btn btn-secondary">취소</button><button id="document-type-confirm-btn" class="btn btn-primary" disabled>업로드</button></div>
       </div>
     </div>
   </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -153,9 +153,9 @@ export async function uploadPDF(file, options, onProgress) {
   const formData = new FormData()
   formData.append('file', file)
 
-  const { targetLang, sourceLang = "auto", style, ignoreMath, ignoreTable, ignoreRefs, translationMode, keywordMode, summaryMode, documentMode, documentType } = options
+  const { targetLang, sourceLang = "auto", style, ignoreMath, ignoreTable, ignoreRefs, translationMode, keywordMode, summaryMode, documentMode, documentType, classificationMethod = 'manual' } = options
   const query = `?target_lang=${encodeURIComponent(targetLang)}&source_lang=${encodeURIComponent(sourceLang)}&style=${style}&ignore_math=${ignoreMath}&ignore_table=${ignoreTable}&ignore_refs=${ignoreRefs}&translation_mode=${encodeURIComponent(translationMode || 'auto')}&keyword_mode=${encodeURIComponent(keywordMode || 'manual')}&summary_mode=${encodeURIComponent(summaryMode || 'manual')}`
-  const classificationQuery = "&document_mode=" + encodeURIComponent(documentMode || "research") + "&document_type=" + encodeURIComponent(documentType || "research_paper")
+  const classificationQuery = "&document_mode=" + encodeURIComponent(documentMode || "research") + "&document_type=" + encodeURIComponent(documentType || "research_paper") + "&classification_method=" + encodeURIComponent(classificationMethod)
   const uploadId = crypto.randomUUID()
 
   return new Promise((resolve, reject) => {
@@ -1118,6 +1118,7 @@ export async function importURL(url, options, onProgress) {
     summary_mode: options.summaryMode || 'manual',
     document_mode: options.documentMode || 'research',
     document_type: options.documentType || 'research_paper',
+    classification_method: options.classificationMethod || 'manual',
   }
   onProgress?.(30, 'downloading')
   let progress = 30

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -4292,6 +4292,9 @@
   "common:classification.manual": {
     "description": "Document classification confirmation UI: classification.manual"
   },
+  "common:classification.classifyWithAi": {
+    "description": "Upload classification action that requests an AI recommendation."
+  },
   "chat:chapterSummaryPreparing": {
     "description": "Shown while a requested chapter summary is generated before automatically retrying chat."
   },

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -1181,5 +1181,6 @@
   "classification.pending": "AI is analyzing the document type…",
   "classification.failed": "Automatic classification failed. Select the document type manually.",
   "classification.recommended": "Review the recommended document type.",
-  "classification.manual": "The evidence was insufficient, so your selection is required."
+  "classification.manual": "The evidence was insufficient, so your selection is required.",
+  "classification.classifyWithAi": "Classify with AI"
 }

--- a/frontend/src/locales/ko/common.json
+++ b/frontend/src/locales/ko/common.json
@@ -1181,5 +1181,6 @@
   "classification.pending": "AI가 문서 유형을 분석하고 있습니다…",
   "classification.failed": "자동 분류에 실패했습니다. 문서 유형을 직접 선택해 주세요.",
   "classification.recommended": "추천된 문서 유형을 확인해 주세요.",
-  "classification.manual": "분류 근거가 부족해 사용자 선택이 필요합니다."
+  "classification.manual": "분류 근거가 부족해 사용자 선택이 필요합니다.",
+  "classification.classifyWithAi": "AI로 분류하기"
 }

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -1137,4 +1137,5 @@
   ,"제목": "viewer:documentInfo.name"
   ,"파일명": "viewer:documentInfo.filename"
   ,"데이터 처리": "viewer:documentInfo.processing"
+  ,"AI로 분류하기": "common:classification.classifyWithAi"
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1316,6 +1316,7 @@ async function handleFiles(uploadItems, targetFolderId = null) {
         summaryMode: getSummaryMode(classification.documentMode),
         documentMode: classification.documentMode,
         documentType: classification.documentType,
+        classificationMethod: classification.classificationMethod,
       }, (pct, phase) => {
         row.bar.style.width = `${pct}%`
         row.status.textContent = phase === 'verifying'
@@ -1351,7 +1352,9 @@ async function handleFiles(uploadItems, targetFolderId = null) {
 
   for (const uploaded of successes) {
     const { classification, result, rememberedTypeOptions } = uploaded
-    const confirmedClassification = await requireClassificationConfirmation(result.session_id)
+    const confirmedClassification = classification.classificationMethod === 'ai'
+      ? await requireClassificationConfirmation(result.session_id)
+      : { document_mode: classification.documentMode, document_type: classification.documentType }
     result.document_mode = confirmedClassification.document_mode
     result.document_type = confirmedClassification.document_type
     result.classification_status = "confirmed"
@@ -18001,11 +18004,17 @@ $('url-import-form')?.addEventListener('submit', async event => {
   uploadPopupTitle.textContent = t('library:import.running')
   try {
     const remembered = loadDocumentTypeOptions()[classification.documentType] || {}
-    const result = await importURL(url, { ...getTranslationOptions(classification.documentMode), ...remembered, translationMode: getTranslationMode(classification.documentMode), keywordMode: getKeywordMode(classification.documentMode), summaryMode: getSummaryMode(classification.documentMode), documentMode: classification.documentMode, documentType: classification.documentType }, (_pct, phase) => {
+    const result = await importURL(url, { ...getTranslationOptions(classification.documentMode), ...remembered, translationMode: getTranslationMode(classification.documentMode), keywordMode: getKeywordMode(classification.documentMode), summaryMode: getSummaryMode(classification.documentMode), documentMode: classification.documentMode, documentType: classification.documentType, classificationMethod: classification.classificationMethod }, (_pct, phase) => {
       const labels = { checking: t('library:import.checking'), downloading: t('library:import.downloading'), complete: t('library:import.analyzed') }
       row.status.textContent = labels[phase] || t('library:import.processing')
       row.bar.style.width = `${_pct}%`
     })
+    if (classification.classificationMethod === 'ai') {
+      const confirmed = await requireClassificationConfirmation(result.session_id)
+      result.document_mode = confirmed.document_mode
+      result.document_type = confirmed.document_type
+      result.classification_status = 'confirmed'
+    }
     if (targetFolderId) await moveLibraryDocuments([result.session_id], targetFolderId)
     row.spinner.classList.add('hidden'); row.success.classList.remove('hidden')
     row.status.textContent = t('library:import.complete'); row.bar.style.width = '100%'

--- a/frontend/src/styles/document-modes.css
+++ b/frontend/src/styles/document-modes.css
@@ -103,6 +103,7 @@ button.document-type-chip:hover { background: color-mix(in srgb, var(--document-
 .document-type-option span { margin-top: 4px; color: var(--text-muted); font-size: 11px; }
 .document-upload-summary { margin-top: 14px; min-height: 18px; color: var(--text-secondary); font-size: 12px; }
 .document-type-modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
+.document-type-modal-actions .document-type-ai-btn { margin-right: auto; color: var(--control-accent); }
 
 .classification-confirmation-dialog {
   width: min(620px, calc(100vw - 40px));

--- a/frontend/src/workspaceModeController.js
+++ b/frontend/src/workspaceModeController.js
@@ -52,6 +52,7 @@ export function createWorkspaceModeController({
   const modal = document.getElementById('document-type-modal')
   const optionRoot = document.getElementById('document-type-options')
   const confirmBtn = document.getElementById('document-type-confirm-btn')
+  const aiBtn = document.getElementById('document-type-ai-btn')
   const summary = document.getElementById('document-upload-summary')
   const modeChip = document.getElementById('upload-mode-chip')
   const uploadModeSwitch = document.getElementById('document-upload-switch-mode-btn')
@@ -196,12 +197,13 @@ export function createWorkspaceModeController({
     classificationMode = initialMode === 'general' ? 'general' : 'research'
     classificationContext = context
     if (!modal || !optionRoot) {
-      return Promise.resolve({ documentMode: classificationMode, documentType: defaultDocumentType(classificationMode) })
+      return Promise.resolve({ documentMode: classificationMode, documentType: defaultDocumentType(classificationMode), classificationMethod: 'manual' })
     }
     if (pendingUpload) closeUploadModal(null)
     const title = modal.querySelector('.modal-header h2')
     if (title) title.textContent = purpose === 'upload' ? 'PDF 업로드' : '문서 분류 변경'
     if (confirmBtn) confirmBtn.textContent = purpose === 'upload' ? '업로드' : '변경'
+    if (aiBtn) aiBtn.classList.toggle('hidden', purpose !== 'upload')
     renderUploadTypes()
     modal.classList.remove('hidden')
     requestAnimationFrame(() => modal.classList.add('is-visible'))
@@ -230,7 +232,14 @@ export function createWorkspaceModeController({
 
   confirmBtn?.addEventListener('click', () => {
     if (!selectedType) return
-    closeUploadModal({ documentMode: classificationMode, documentType: selectedType })
+    closeUploadModal({ documentMode: classificationMode, documentType: selectedType, classificationMethod: 'manual' })
+  })
+  aiBtn?.addEventListener('click', () => {
+    closeUploadModal({
+      documentMode: classificationMode,
+      documentType: defaultDocumentType(classificationMode),
+      classificationMethod: 'ai',
+    })
   })
   document.getElementById('document-type-close-btn')?.addEventListener('click', () => closeUploadModal(null))
   document.getElementById('document-type-cancel-btn')?.addEventListener('click', () => closeUploadModal(null))

--- a/frontend/tests/api-upload.test.js
+++ b/frontend/tests/api-upload.test.js
@@ -43,6 +43,7 @@ test('upload sends a client-known id and reports progress phases', async () => {
     const xhr = MockXHR.instances[0]
     assert.equal(xhr.method, 'POST')
     assert.match(xhr.url, new RegExp(`upload_id=${uploadId}`))
+    assert.match(xhr.url, /classification_method=manual/)
     xhr.uploadHandler[1]({ lengthComputable: true, loaded: 1, total: 2 })
     xhr.status = 202
     xhr.responseText = JSON.stringify({ session_id: uploadId, task_id: "parse-task", status: "queued" })
@@ -123,6 +124,7 @@ test('URL import sends a recoverable id and restores a completed session after d
     if (requestCount === 1) {
       assert.equal(url, "/api/import-url")
       assert.equal(JSON.parse(init.body).upload_id, uploadId)
+      assert.equal(JSON.parse(init.body).classification_method, "manual")
       throw new TypeError("connection closed")
     }
     assert.equal(url, `/api/session/${uploadId}`)

--- a/frontend/tests/e2e/web-document-import.spec.js
+++ b/frontend/tests/e2e/web-document-import.spec.js
@@ -54,6 +54,7 @@ test('봇 확인으로 차단된 URL 오류를 가져오기 모달에 표시한�
   await page.locator('#url-import-input').fill('https://computer.howstuffworks.com/computer-memory.htm#pt1')
   await page.locator('#url-import-form').press('Enter')
   await expect(page.locator('#document-type-modal')).toBeVisible()
+  await expect(page.locator('#document-type-ai-btn')).toBeVisible()
   await page.locator('#document-type-options button').first().click()
   await page.locator('#document-type-confirm-btn').click()
   const error = page.locator('#url-import-error')


### PR DESCRIPTION
## Summary
- Add an AI classification option to the upload classification dialog
- Skip AI classification when users manually choose a document type
- Apply the choice to PDF uploads and web imports
- Add regression coverage for manual classification

## Tests
- npm run test:unit
- npm run build
- npx playwright test tests/e2e/web-document-import.spec.js
- pytest -q backend/tests/test_upload_size_limit.py backend/tests/test_document_tasks.py backend/tests/test_web_import_api.py backend/tests/test_document_classification.py