### PR TITLE
fix(settings): sync rendered scale selection

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -25,7 +25,7 @@ import { buildScholarSearchUrl, extractCitationTitle } from './citationSearch.js
 import { changeLocale, getLocale, initI18n, loadFeatureNamespaces, loadNamespaces, t } from './i18n.js'
 import { saveUserLanguagePreferences, saveDocumentLanguageOverride } from './languagePreferences.js'
 import { canRetryTranslationTask, isTranslationTaskRunning, shouldRetryFailedTranslationTask } from './translationTaskState.js'
-import { applyUiScale, loadUiScale, saveUiScale, syncUiScaleControl } from './uiScale.js'
+import { applyUiScale, loadUiScale, saveUiScale, syncSelectValue, syncUiScaleControl } from './uiScale.js'
 import { adaptiveBriefingSummary, hasAdaptiveBriefing, renderAdaptiveBriefingHtml } from './adaptiveBriefing.js'
 import { classificationModalMarkup, recommendedClassification } from './classificationConfirmationView.js'
 import { renderChapterSummaryHtml, renderFullSummaryHtml } from './chapterSummaryView.js'
@@ -651,7 +651,7 @@ if (settingUiScale) {
   syncUiScaleControl(settingUiScale)
   settingUiScale.addEventListener('change', () => {
     const scale = saveUiScale(settingUiScale.value)
-    settingUiScale.value = String(scale)
+    syncSelectValue(settingUiScale, scale)
     applyUiScale(scale)
     showToast(t('settings:uiScaleSaved'), 'success')
   })
@@ -4085,7 +4085,7 @@ async function changeProviderAndModel(type, newProvider, newModel) {
 globalSettingsBtn.addEventListener('click', async () => {
   await loadFeatureNamespaces('settings')
   syncUiScaleControl(settingUiScale)
-  settingDefaultZoom.value = localStorage.getItem('easypaper_default_zoom') || '1.5'
+  syncSelectValue(settingDefaultZoom, localStorage.getItem('easypaper_default_zoom') || '1.5')
   openOverlayModal(settingsModal)
 
   // 1. 기본 진입 카테고리는 일반
@@ -4337,6 +4337,7 @@ async function handleTranslationAffectingSettingChange() {
 })
 
 settingDefaultZoom.addEventListener('change', () => {
+  syncSelectValue(settingDefaultZoom, settingDefaultZoom.value)
   persistGeneralSettingsToStorage()
   showToast('일반 설정이 저장되었습니다.', 'success')
   const newZoom = parseFloat(settingDefaultZoom.value) || 1.5

--- a/frontend/src/uiScale.js
+++ b/frontend/src/uiScale.js
@@ -17,9 +17,23 @@ export function saveUiScale(value, storage = localStorage) {
   return scale
 }
 
+export function syncSelectValue(control, value) {
+  if (!control) return ''
+
+  const nextValue = String(value)
+  for (const option of control.options) {
+    const isSelected = option.value === nextValue
+    option.selected = isSelected
+    option.defaultSelected = isSelected
+    option.toggleAttribute('selected', isSelected)
+  }
+  control.value = nextValue
+  return control.value
+}
+
 export function syncUiScaleControl(control, storage = localStorage) {
   const scale = loadUiScale(storage)
-  if (control) control.value = String(scale)
+  syncSelectValue(control, scale)
   return scale
 }
 

--- a/frontend/tests/e2e/settings-scale.spec.js
+++ b/frontend/tests/e2e/settings-scale.spec.js
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { gotoApp, mockBaseRoutes } from './helpers.js'
+
+test('배율 드롭다운의 표시값과 펼친 목록 선택값을 동일하게 유지한다', async ({ page }) => {
+  await mockBaseRoutes(page, { documents: [] })
+  await page.addInitScript(() => {
+    localStorage.setItem('easypaper_ui_scale', '0.8')
+    localStorage.setItem('easypaper_default_zoom', '1.0')
+  })
+  await gotoApp(page)
+
+  await page.locator('#sidebar-settings-btn').click()
+  await expect(page.locator('#settings-modal')).toBeVisible()
+
+  const uiScale = page.locator('#setting-ui-scale')
+  await expect(uiScale).toHaveValue('0.8')
+  await expect(uiScale.locator('option[selected]')).toHaveAttribute('value', '0.8')
+  await expect(uiScale.locator('option[selected]')).toHaveCount(1)
+
+  await uiScale.selectOption('0.9')
+  await expect(uiScale).toHaveValue('0.9')
+  await expect(uiScale.locator('option[selected]')).toHaveAttribute('value', '0.9')
+  expect(await page.evaluate(() => localStorage.getItem('easypaper_ui_scale'))).toBe('0.9')
+
+  await page.locator('#settings-nav-viewer').click()
+  const pdfZoom = page.locator('#setting-default-zoom')
+  await expect(pdfZoom).toHaveValue('1.0')
+  await expect(pdfZoom.locator('option[selected]')).toHaveAttribute('value', '1.0')
+  await expect(pdfZoom.locator('option[selected]')).toHaveCount(1)
+
+  await pdfZoom.selectOption('2.0')
+  await expect(pdfZoom).toHaveValue('2.0')
+  await expect(pdfZoom.locator('option[selected]')).toHaveAttribute('value', '2.0')
+  expect(await page.evaluate(() => localStorage.getItem('easypaper_default_zoom'))).toBe('2.0')
+})

--- a/frontend/tests/uiScale.test.js
+++ b/frontend/tests/uiScale.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { DEFAULT_UI_SCALE, UI_SCALE_STORAGE_KEY, applyUiScale, loadUiScale, normalizeUiScale, saveUiScale, syncUiScaleControl } from '../src/uiScale.js'
+import { DEFAULT_UI_SCALE, UI_SCALE_STORAGE_KEY, applyUiScale, loadUiScale, normalizeUiScale, saveUiScale, syncSelectValue, syncUiScaleControl } from '../src/uiScale.js'
 
 function memoryStorage(entries = {}) {
   const values = new Map(Object.entries(entries))
@@ -8,6 +8,20 @@ function memoryStorage(entries = {}) {
     getItem: key => values.has(key) ? values.get(key) : null,
     setItem: (key, value) => values.set(key, String(value)),
   }
+}
+
+function selectControl(values, currentValue) {
+  const options = values.map(value => ({
+    value,
+    selected: false,
+    defaultSelected: false,
+    attributes: new Set(),
+    toggleAttribute(name, enabled) {
+      if (enabled) this.attributes.add(name)
+      else this.attributes.delete(name)
+    },
+  }))
+  return { value: currentValue, options }
 }
 
 test('지원하는 UI 배율만 허용한다', () => {
@@ -31,9 +45,21 @@ test('전체 문서 루트에 UI 배율을 적용한다', () => {
 })
 
 test('저장된 UI 배율을 설정 드롭다운의 현재 값으로 동기화한다', () => {
-  const control = { value: '1' }
+  const control = selectControl(['0.8', '0.9', '1'], '1')
   const storage = memoryStorage({ [UI_SCALE_STORAGE_KEY]: '0.8' })
 
   assert.equal(syncUiScaleControl(control, storage), 0.8)
   assert.equal(control.value, '0.8')
+  assert.deepEqual(control.options.map(option => option.selected), [true, false, false])
+  assert.deepEqual(control.options.map(option => option.defaultSelected), [true, false, false])
+  assert.deepEqual(control.options.map(option => option.attributes.has('selected')), [true, false, false])
+})
+
+test('변경된 선택값의 프로퍼티와 DOM 속성을 함께 갱신한다', () => {
+  const control = selectControl(['1.0', '1.5', '2.0'], '1.0')
+
+  assert.equal(syncSelectValue(control, '2.0'), '2.0')
+  assert.deepEqual(control.options.map(option => option.selected), [false, false, true])
+  assert.deepEqual(control.options.map(option => option.defaultSelected), [false, false, true])
+  assert.deepEqual(control.options.map(option => option.attributes.has('selected')), [false, false, true])
 })


### PR DESCRIPTION
# Summary
## 1. 배율 드롭다운 표시값 동기화 수정
- select value와 option의 selected 프로퍼티 및 DOM 속성을 함께 갱신하는 공통 로직 추가함
- UI 배율 초기화·변경 시 닫힌 표시값과 펼친 목록 선택값을 동기화함
- PDF 확대 비율 초기화·변경 시 동일한 동기화 로직 적용함
## 2. 회귀 테스트 추가
- 선택 프로퍼티와 DOM 속성 동기화 단위 테스트 추가함
- 실제 Chromium에서 UI/PDF 배율의 저장값·변경값 일치를 검증하는 E2E 테스트 추가함