### PR TITLE
fix(viewer): stabilize outline over memos

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17790,12 +17790,10 @@ async function loadPDFOutline() {
 
     if (chapterData.status === 'available') {
       const fullButton = document.createElement('button')
-      fullButton.type = 'button'; fullButton.className = 'btn btn-secondary'
-      fullButton.style.cssText = 'margin:6px 10px 12px; width:calc(100% - 20px); font-size:11px;'
+      fullButton.type = 'button'; fullButton.className = 'btn btn-secondary outline-full-summary-btn'
       fullButton.textContent = t('viewer:chapter.full')
       const cancelFullButton = document.createElement('button')
-      cancelFullButton.type = 'button'; cancelFullButton.className = 'btn btn-secondary'; cancelFullButton.hidden = true
-      cancelFullButton.style.cssText = 'margin:0 10px 12px;width:calc(100% - 20px);font-size:11px;'
+      cancelFullButton.type = 'button'; cancelFullButton.className = 'btn btn-secondary outline-full-summary-cancel-btn'; cancelFullButton.hidden = true
       cancelFullButton.textContent = t('viewer:chapter.cancel')
       let activeFullTaskId = null
       let fullCancelRequested = false
@@ -17829,7 +17827,6 @@ async function loadPDFOutline() {
             status = await getFullSummaryStatusAPI(state.sessionId)
           }
           const panel = document.createElement('div'); panel.className = 'outline-summary-result'
-          panel.style.cssText = 'margin:0 10px 12px;padding:10px;font-size:12px;line-height:1.5;border:1px solid var(--border);border-radius:8px;'
           panel.innerHTML = renderFullSummaryHtml(status.summary, { title: t('viewer:chapter.fullTitle'), keyPoints: t('viewer:chapter.keyPoints'), connections: t('viewer:chapter.connections'), limitations: t('viewer:chapter.limitations') })
           fullButton.after(panel); fullButton.textContent = t('viewer:chapter.fullView')
         } catch (error) {
@@ -17842,14 +17839,13 @@ async function loadPDFOutline() {
       outlineContent.append(fullButton, cancelFullButton)
       chapterData.chapters.forEach(chapter => {
         const row = document.createElement('div'); row.className = 'outline-chapter-row'
-        row.style.cssText = 'border-bottom:1px solid var(--border);padding:4px 8px;'
         const nav = document.createElement('button'); nav.type = 'button'; nav.className = 'outline-item depth-0'
-        nav.innerHTML = `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">${escapeHtml(chapter.title)}</span><small>${chapter.start_page}–${chapter.end_page}</small>`
+        nav.innerHTML = `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">${escapeHtml(chapter.title)}</span><small class="outline-chapter-pages">${chapter.start_page}–${chapter.end_page}</small>`
         nav.addEventListener('click', () => scrollToPage(viewerScrollContainer, chapter.start_page))
         nav.title = t('viewer:goToPage', { page: chapter.start_page })
-        const summary = document.createElement('button'); summary.type = 'button'; summary.className = 'btn btn-secondary'
-        summary.style.cssText = 'font-size:10px;margin:2px 0 4px;'; summary.textContent = chapter.summary_status === 'completed' ? t('viewer:chapter.view') : t('viewer:chapter.summarize')
-        const result = document.createElement('div'); result.hidden = true; result.style.cssText = 'font-size:11px;line-height:1.45;padding:8px 2px;'
+        const summary = document.createElement('button'); summary.type = 'button'; summary.className = 'outline-summary-btn'
+        summary.textContent = chapter.summary_status === 'completed' ? t('viewer:chapter.view') : t('viewer:chapter.summarize')
+        const result = document.createElement('div'); result.className = 'outline-summary-result'; result.hidden = true
         summary.addEventListener('click', () => waitForSummary(chapter, summary, result))
         row.append(nav, summary, result); outlineContent.appendChild(row)
       })
@@ -17885,14 +17881,16 @@ function hideOutlineSidebar({ restoreFocus = false } = {}) {
   }
 }
 
-function showOutlineSidebar() {
+function showOutlineSidebar({ focusContent = false } = {}) {
   if (outlineSidebar) {
     outlineSidebar.classList.remove('hidden')
     if (outlineToggleBtn) {
       outlineToggleBtn.classList.add('active')
       outlineToggleBtn.setAttribute('aria-expanded', 'true')
     }
-    window.requestAnimationFrame(() => outlineContent?.querySelector('.outline-item:not(:disabled)')?.focus())
+    // 포인터로 열 때 메모 textarea를 강제로 blur시키면 메모 렌더링 전환과
+    // 패널 애니메이션이 겹쳐 깜빡인다. 키보드로 연 경우에만 탐색 위치를 옮긴다.
+    if (focusContent) window.requestAnimationFrame(() => outlineContent?.querySelector('.outline-item:not(:disabled)')?.focus())
   }
 }
 
@@ -17900,14 +17898,22 @@ function showOutlineSidebar() {
 if (outlineToggleBtn) {
   outlineToggleBtn.setAttribute('aria-controls', 'outline-sidebar')
   outlineToggleBtn.setAttribute('aria-expanded', 'false')
-  outlineToggleBtn.addEventListener('click', () => {
+  outlineToggleBtn.addEventListener('mousedown', (event) => {
+    // 편집 중인 메모 위로 목차를 여는 포인터 동작은 textarea의 포커스를
+    // 유지한다. 버튼의 click은 그대로 발생하므로 패널 토글에는 영향이 없다.
+    if (outlineSidebar?.classList.contains('hidden')
+        && document.activeElement?.classList.contains('floating-memo-textarea')) {
+      event.preventDefault()
+    }
+  })
+  outlineToggleBtn.addEventListener('click', (event) => {
     console.log("[Outline] Toggle button clicked. Sidebar:", outlineSidebar, "ToggleBtn:", outlineToggleBtn)
     if (!outlineSidebar) {
       showToast('목차 사이드바를 찾을 수 없습니다.', 'error')
       return
     }
     if (outlineSidebar.classList.contains('hidden')) {
-      showOutlineSidebar()
+      showOutlineSidebar({ focusContent: event.detail === 0 })
     } else {
       hideOutlineSidebar()
     }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4947,7 +4947,8 @@ body:not(.toolbar-pos-left):not(.toolbar-pos-right):has(.chat-sidebar:not(.hidde
   background: var(--bg-panel);
   border-right: 1px solid var(--border-strong);
   box-shadow: 4px 0 30px rgba(0, 0, 0, 0.2);
-  z-index: 120 !important;
+  /* 떠 있는 메모(10000)보다 위에서 하나의 불투명한 패널로 동작해야 한다. */
+  z-index: 10010 !important;
   display: flex;
   flex-direction: column;
   transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), top 0.25s ease, bottom 0.25s ease, left 0.25s ease;
@@ -4998,6 +4999,31 @@ body.toolbar-hidden .outline-sidebar {
   flex: 1;
   overflow-y: auto;
   padding: 12px;
+}
+.outline-full-summary-btn { width:calc(100% - 8px); margin:4px 4px 12px; min-height:34px; font-size:11px; }
+.outline-full-summary-cancel-btn { width:calc(100% - 8px); margin:0 4px 12px; min-height:32px; font-size:11px; }
+.outline-chapter-row { padding:7px 4px 9px; border-bottom:1px solid var(--border); }
+.outline-chapter-row .outline-item { width:100%; border:0; background:transparent; text-align:left; }
+.outline-chapter-pages { flex:0 0 auto; color:var(--text-muted); font-size:10px; font-weight:500; }
+.outline-summary-btn {
+  display:inline-flex; align-items:center; justify-content:center; gap:5px;
+  min-height:27px; margin:3px 6px 0 10px; padding:4px 10px;
+  border:1px solid color-mix(in srgb,var(--accent-mid) 38%,var(--border));
+  border-radius:999px; background:color-mix(in srgb,var(--accent-mid) 10%,var(--bg-panel));
+  color:var(--accent-mid); font-size:10px; font-weight:650; line-height:1; cursor:pointer;
+  transition:background .15s ease,border-color .15s ease,box-shadow .15s ease,transform .15s ease;
+}
+.outline-summary-btn::before { content:"✦"; font-size:10px; }
+.outline-summary-btn:hover:not(:disabled) {
+  border-color:var(--accent-mid);
+  background:color-mix(in srgb,var(--accent-mid) 17%,var(--bg-panel));
+  box-shadow:0 3px 10px color-mix(in srgb,var(--accent-mid) 16%,transparent);
+  transform:translateY(-1px);
+}
+.outline-summary-btn:disabled { cursor:wait; opacity:.65; }
+.outline-summary-result {
+  margin:8px 6px 2px; padding:10px; border:1px solid var(--border); border-radius:8px;
+  background:color-mix(in srgb,var(--bg-elevated) 82%,transparent); font-size:11px; line-height:1.5;
 }
 .outline-item {
   font-size: 12px;

--- a/frontend/tests/e2e/viewer-memo.spec.js
+++ b/frontend/tests/e2e/viewer-memo.spec.js
@@ -109,6 +109,28 @@ test('뷰어 메모 입력창에 포커스 테두리를 표시하지 않는다',
   await expect.poll(() => textarea.evaluate(element => getComputedStyle(element).outlineStyle)).toBe('none')
 })
 
+test('메모 편집 중 목차가 메모를 덮고 포커스를 빼앗지 않는다', async ({ page }) => {
+  await openViewerWithMemo(page)
+
+  const memo = page.locator('.floating-memo[data-id="memo-regression"]')
+  await memo.locator('.edit-btn').click()
+  const textarea = memo.locator('.floating-memo-textarea')
+  await expect(textarea).toBeFocused()
+
+  await page.locator('#outline-toggle-btn').click()
+  const outline = page.locator('#outline-sidebar')
+  await expect(outline).not.toHaveClass(/hidden/)
+  await page.waitForTimeout(200)
+  await expect(textarea).toBeFocused()
+  await expect(memo.locator('.floating-memo-render')).toHaveCount(0)
+
+  const layers = await page.evaluate(() => ({
+    outline: Number(getComputedStyle(document.querySelector('#outline-sidebar')).zIndex),
+    memo: Number(getComputedStyle(document.querySelector('.floating-memo')).zIndex),
+  }))
+  expect(layers.outline).toBeGreaterThan(layers.memo)
+})
+
 
 test('메모 편집 중 원격 snapshot은 입력 DOM 교체를 편집 종료까지 미룬다', async ({ page }) => {
   await openViewerWithMemo(page)


### PR DESCRIPTION
# Summary
## 1. 목차·메모 레이어 및 포커스 버그 수정
- 목차 패널이 떠 있는 메모를 완전히 덮도록 레이어 우선순위 조정
- 메모 편집 중 목차 버튼 클릭 시 textarea 포커스와 편집 DOM 유지
- 키보드 탐색 시 목차 포커스 이동은 유지
## 2. 목차 섹션 요약 버튼 스타일 개선
- 섹션 요약 버튼을 pill 형태와 hover/loading 상태로 개선
- 전체 요약·취소 버튼 및 결과 패널 스타일을 전용 클래스로 정리
## 3. 검증
- 프런트엔드 단위 테스트 85개 통과
- 프로덕션 빌드 성공
- 목차·메모 포커스/레이어 Chromium E2E 통과