### PR TITLE
feat: add suggested questions toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1071,6 +1071,11 @@
                 <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
                 <span class="toggle-switch-label">논문을 열 때 "읽기 전 브리핑" 팝업<small>꺼도 툴바 버튼으로 언제든 다시 볼 수 있음</small></span>
               </label>
+              <label class="toggle-switch">
+                <input type="checkbox" id="setting-disable-suggested-questions" />
+                <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
+                <span class="toggle-switch-label"><span data-i18n="settings:suggestedQuestions">AI 답변의 추천·관련 질문</span><small data-i18n="settings:suggestedQuestionsDescription">끄면 답변 아래에 후속 질문을 생성하지 않음</small></span>
+              </label>
             </div>
           </div>
 

--- a/frontend/src/locales/developer-context.json
+++ b/frontend/src/locales/developer-context.json
@@ -3803,6 +3803,12 @@
   "settings:viewerReadingTools": {
     "description": "Label for reading tools shown for the active mode"
   },
+  "settings:suggestedQuestions": {
+    "description": "Toggle label for suggested and related questions below AI answers."
+  },
+  "settings:suggestedQuestionsDescription": {
+    "description": "Description of the AI answer follow-up question toggle."
+  },
   "settings:accentColor": {
     "description": "Accent color setting label"
   },

--- a/frontend/src/locales/en/settings.json
+++ b/frontend/src/locales/en/settings.json
@@ -9,6 +9,8 @@
   "themeHeading": "Display theme",
   "viewerReadingBehavior": "Reading behavior",
   "viewerReadingTools": "Reading tools",
+  "suggestedQuestions": "Suggested and related questions for AI answers",
+  "suggestedQuestionsDescription": "Turn off to stop generating follow-up questions below answers.",
   "accentColor": "Accent color",
   "themeLightEnabled": "Switched to light mode ✓",
   "themeDarkEnabled": "Switched to dark mode ✓",

--- a/frontend/src/locales/ko/settings.json
+++ b/frontend/src/locales/ko/settings.json
@@ -9,6 +9,8 @@
   "themeHeading": "화면 테마",
   "viewerReadingBehavior": "읽기 동작",
   "viewerReadingTools": "읽기 도구",
+  "suggestedQuestions": "AI 답변의 추천·관련 질문",
+  "suggestedQuestionsDescription": "끄면 답변 아래에 후속 질문을 생성하지 않음",
   "accentColor": "테마 색상",
   "themeLightEnabled": "라이트 모드로 전환 ✓",
   "themeDarkEnabled": "다크 모드로 전환 ✓",

--- a/frontend/src/locales/ui-source-map.json
+++ b/frontend/src/locales/ui-source-map.json
@@ -55,6 +55,8 @@
   "공통 읽기 동작": "common:legacy.ui.0054",
   "읽기 동작": "settings:viewerReadingBehavior",
   "읽기 도구": "settings:viewerReadingTools",
+  "AI 답변의 추천·관련 질문": "settings:suggestedQuestions",
+  "끄면 답변 아래에 후속 질문을 생성하지 않음": "settings:suggestedQuestionsDescription",
   "과": "common:legacy.ui.0055",
   "관련 노드가 없습니다.": "common:legacy.ui.0056",
   "관련 논문": "common:legacy.ui.0057",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -116,6 +116,8 @@ const state = {
   // 논문을 처음 열 때 뜨는 "읽기 전 브리핑" 게이팅 모달을 끌지 여부. 꺼도
   // 뷰어 툴바 버튼으로는 언제든 다시 열어볼 수 있다.
   disablePrimer: getModeSetting('disablePrimer', 'research'),
+  // AI 답변 아래의 추천·관련 질문 생성을 끌지 여부.
+  disableSuggestedQuestions: getModeSetting('disableSuggestedQuestions', 'research'),
   // 아래로 스크롤하면 상단 툴바를 자동으로 숨기고 위로 스크롤하면 다시 보여줄지
   // 여부. 다른 편의 설정과 달리 새로 추가하는 화면 동작이라 기본값은 꺼짐(false).
   toolbarAutoHide: localStorage.getItem('easypaper_toolbar_autohide') === 'true',
@@ -640,6 +642,7 @@ const settingDisableInsights = $('setting-disable-insights')
 const settingDisableCitationOverlay = $('setting-disable-citation-overlay')
 const settingDisableFigureOverlay = $('setting-disable-figure-overlay')
 const settingDisablePrimer = $('setting-disable-primer')
+const settingDisableSuggestedQuestions = $('setting-disable-suggested-questions')
 const settingToolbarAutoHide = $('setting-toolbar-autohide')
 const settingAutoGenerateKeywords = $('setting-auto-generate-keywords')
 const settingAutoGenerateSummaries = $('setting-auto-generate-summaries')
@@ -941,6 +944,7 @@ function applyModeViewerSettings(documentMode) {
   state.disableCitationOverlay = getModeSetting('disableCitationOverlay', mode)
   state.disableFigureOverlay = getModeSetting('disableFigureOverlay', mode)
   state.disablePrimer = getModeSetting('disablePrimer', mode)
+  state.disableSuggestedQuestions = getModeSetting('disableSuggestedQuestions', mode)
 }
 
 function showInsightJobProgress(sessionId, kind, title) {
@@ -1072,6 +1076,7 @@ function syncModeSettings(documentMode) {
   settingDisableCitationOverlay.checked = !getModeSetting('disableCitationOverlay', settingsTranslationModeContext)
   settingDisableFigureOverlay.checked = !getModeSetting('disableFigureOverlay', settingsTranslationModeContext)
   settingDisablePrimer.checked = !getModeSetting('disablePrimer', settingsTranslationModeContext)
+  settingDisableSuggestedQuestions.checked = !getModeSetting('disableSuggestedQuestions', settingsTranslationModeContext)
   updateAccentSettingsUI(getModeSetting('accentColor', settingsTranslationModeContext))
 
   settingsModeBadge.textContent = isGeneral ? '일반 문서 모드' : '연구 모드'
@@ -4411,6 +4416,15 @@ settingDisablePrimer.addEventListener('change', () => {
   setModeSetting('disablePrimer', settingsTranslationModeContext, disabled)
   if (state.sessionId && normalizeSettingsMode(state.currentDocumentMode) === settingsTranslationModeContext) {
     state.disablePrimer = disabled
+  }
+})
+
+settingDisableSuggestedQuestions.addEventListener('change', () => {
+  const disabled = !settingDisableSuggestedQuestions.checked
+  setModeSetting('disableSuggestedQuestions', settingsTranslationModeContext, disabled)
+  if (state.sessionId && normalizeSettingsMode(state.currentDocumentMode) === settingsTranslationModeContext) {
+    state.disableSuggestedQuestions = disabled
+    if (disabled) clearSuggestedQuestions()
   }
 })
 
@@ -10505,7 +10519,7 @@ async function openFromLibrary(doc, shouldPushState = true) {
       const lastMsg = chatHistoryList[chatHistoryList.length - 1]
       if (lastMsg.role === 'assistant') {
         const cachedQuestions = loadSuggestedQuestionsCache(doc.id)
-        if (cachedQuestions?.length) {
+        if (!state.disableSuggestedQuestions && cachedQuestions?.length) {
           renderSuggestedQuestionChips(chatMessages.lastElementChild, cachedQuestions)
         }
       }
@@ -14904,7 +14918,7 @@ function renderSuggestedQuestionChips(msgEl, questions) {
 // bubble 아래에 클릭 가능한 칩으로 붙인다. 클릭하면 바로 그 질문으로 다음
 // 메시지를 보낸다.
 async function renderSuggestedQuestions(msgEl) {
-  if (!state.sessionId) return
+  if (state.disableSuggestedQuestions || !state.sessionId) return
   try {
     const questions = await getSuggestedQuestionsAPI(state.sessionId, state.chatHistory)
     if (!questions.length) return
@@ -18110,7 +18124,7 @@ async function restoreArticleChatHistory(chatRes, doc) {
     if (assistant && msg.verification) renderVerificationBadge(element, msg.verification)
   }
   const last = messages[messages.length - 1]
-  if (last?.role === 'assistant') { const questions = loadSuggestedQuestionsCache(doc.id); if (questions?.length) renderSuggestedQuestionChips(chatMessages.lastElementChild, questions) }
+  if (last?.role === 'assistant') { const questions = loadSuggestedQuestionsCache(doc.id); if (!state.disableSuggestedQuestions && questions?.length) renderSuggestedQuestionChips(chatMessages.lastElementChild, questions) }
 }
 
 async function renderArticleDocument(doc) {

--- a/frontend/src/modeSettings.js
+++ b/frontend/src/modeSettings.js
@@ -14,6 +14,7 @@ const MODE_DEFAULTS = {
     disableCitationOverlay: false,
     disableFigureOverlay: false,
     disablePrimer: false,
+    disableSuggestedQuestions: false,
   },
   general: {
     theme: 'dark',
@@ -30,6 +31,7 @@ const MODE_DEFAULTS = {
     disableCitationOverlay: true,
     disableFigureOverlay: false,
     disablePrimer: true,
+    disableSuggestedQuestions: false,
   },
 }
 
@@ -48,13 +50,14 @@ const LEGACY_KEYS = {
   disableCitationOverlay: 'easypaper_disable_citation_overlay',
   disableFigureOverlay: 'easypaper_disable_figure_overlay',
   disablePrimer: 'easypaper_disable_primer',
+  disableSuggestedQuestions: 'easypaper_disable_suggested_questions',
 }
 
 const SHARED_LEGACY_PREFERENCES = new Set(['theme', 'accentColor', 'targetLang'])
 
 const BOOLEAN_SETTINGS = new Set([
   'ignoreMath', 'ignoreTable', 'ignoreRefs', 'disableInsights',
-  'disableCitationOverlay', 'disableFigureOverlay', 'disablePrimer',
+  'disableCitationOverlay', 'disableFigureOverlay', 'disablePrimer', 'disableSuggestedQuestions',
 ])
 const LEGACY_LANGUAGE_VALUES = {
   '한국어': 'ko', '영어': 'en', '일본어': 'ja', '중국어': 'zh-Hans',

--- a/frontend/tests/modeSettings.test.js
+++ b/frontend/tests/modeSettings.test.js
@@ -27,6 +27,14 @@ test('기존 일반 설정을 연구 모드에 승계한다', () => {
   assert.equal(getModeSetting('disablePrimer', 'research', storage), true)
 })
 
+test('추천 질문 설정은 모드별 불리언 값으로 저장한다', () => {
+  const storage = memoryStorage()
+  setModeSetting('disableSuggestedQuestions', 'research', true, storage)
+
+  assert.equal(getModeSetting('disableSuggestedQuestions', 'research', storage), true)
+  assert.equal(getModeSetting('disableSuggestedQuestions', 'general', storage), false)
+})
+
 test('기존 테마 설정은 두 모드의 최초 값으로 승계한다', () => {
   const storage = memoryStorage({
     theme: 'light',
@@ -45,6 +53,7 @@ test('일반 문서는 자연스러운 문체와 필요 시 번역을 기본으�
   assert.equal(defaults.style, 'natural')
   assert.equal(defaults.translationMode, 'scroll')
   assert.equal(defaults.ignoreTable, false)
+  assert.equal(defaults.disableSuggestedQuestions, false)
 })
 
 test('모드별 저장 값이 서로 덮어쓰지 않는다', () => {


### PR DESCRIPTION
설정에 AI 답변의 추천·관련 질문 생성 스위치를 추가합니다. 설정을 끄면 새 후속 질문 생성과 캐시 복원을 중단하며 모드별로 값을 저장합니다.