### PR TITLE
test(e2e): wait for initial routing

### DIFF
--- a/frontend/tests/e2e/helpers.js
+++ b/frontend/tests/e2e/helpers.js
@@ -130,6 +130,7 @@ export async function gotoApp(page, { navigateToLibrary = true } = {}) {
   })
   await page.reload()
   if (navigateToLibrary) {
+    await page.locator('#page-dashboard.active').waitFor({ state: 'visible' })
     const libraryNav = page.locator('.sidebar-nav-item[data-page="library"]')
     await libraryNav.waitFor({ state: 'visible' })
     await libraryNav.click()


### PR DESCRIPTION
# Summary
## 1. E2E 초기 라우팅 경합 수정
- 인증 후 Dashboard 초기 라우팅이 완료된 다음 Library 이동을 실행하도록 테스트 헬퍼를 수정함
- 비동기 초기화가 Library 이동을 덮어써 간헐적으로 테스트가 실패하는 문제를 제거함
## 2. 검증
- auth-and-library E2E 병렬 반복 10회 통과
