### PR TITLE
fix(summary): preserve chapter coverage

### DIFF
--- a/backend/services/chapter_summaries.py
+++ b/backend/services/chapter_summaries.py
@@ -72,7 +72,7 @@ def _html_outline(manifest_path: str, total_pages: int) -> list[dict]:
     entries = []
     for item in data.get("toc") or []:
         index = int(item.get("index") or 0)
-        entries.append({"title": item.get("title"), "start_page": index + 1})
+        entries.append({"title": item.get("title"), "start_page": index})
     return _ranges(entries, total_pages, "toc")
 
 
@@ -176,12 +176,37 @@ def _term_list(value: object, limit: int = 12) -> list[dict | str]:
 
 
 def _chapter_text(pages: list[dict], chapter: dict) -> str:
-    chunks = []
+    selected = []
     for index, page in enumerate(pages):
         number = int(page.get("page_num") or index + 1)
-        if chapter["start_page"] <= number <= chapter["end_page"] and (page.get("text") or "").strip():
-            chunks.append(f"--- Page {number} ---\n{(page.get('text') or '').strip()}")
-    return "\n\n".join(chunks)[:MAX_CHAPTER_INPUT_CHARS]
+        text = (page.get("text") or "").strip()
+        if chapter["start_page"] <= number <= chapter["end_page"] and text:
+            selected.append((number, text))
+    chunks = [f"--- Page {number} ---\n{text}" for number, text in selected]
+    complete = "\n\n".join(chunks)
+    if len(complete) <= MAX_CHAPTER_INPUT_CHARS:
+        return complete
+
+    headers = [f"--- Page {number} ---\n" for number, _ in selected]
+    overhead = sum(map(len, headers)) + 2 * (len(headers) - 1)
+    available = max(0, MAX_CHAPTER_INPUT_CHARS - overhead)
+    per_page, remainder = divmod(available, len(selected))
+    omission = "\n… omitted …\n"
+
+    def excerpt(text: str, budget: int) -> str:
+        if len(text) <= budget:
+            return text
+        if budget <= len(omission):
+            return text[:budget]
+        kept = budget - len(omission)
+        head = kept // 2
+        return text[:head] + omission + text[-(kept - head):]
+
+    bounded = [
+        header + excerpt(text, per_page + (index < remainder))
+        for index, (header, (_, text)) in enumerate(zip(headers, selected))
+    ]
+    return "\n\n".join(bounded)[:MAX_CHAPTER_INPUT_CHARS]
 
 
 async def _generate_chapter(document: dict, pages: list[dict], chapter: dict, target_lang: str, session_id: str) -> dict:

--- a/backend/tests/test_chapter_summaries.py
+++ b/backend/tests/test_chapter_summaries.py
@@ -179,3 +179,35 @@ def test_chapter_router_reports_unconfirmed_structure(test_client, monkeypatch):
     response = test_client.get("/api/library/route-doc/full-summary/estimate")
     assert response.status_code == 409
     assert response.json()["code"] == "chapter_structure_unconfirmed"
+
+
+def test_html_outline_uses_manifest_one_based_unit_indexes(tmp_path):
+    manifest = {
+        "toc": [
+            {"index": 1, "title": "First"},
+            {"index": 2, "title": "Second"},
+            {"index": 3, "title": "Third"},
+        ]
+    }
+    path = tmp_path / "article.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    chapters = summaries._html_outline(str(path), 3)
+
+    assert [(item["start_page"], item["end_page"]) for item in chapters] == [
+        (1, 1), (2, 2), (3, 3),
+    ]
+
+
+def test_capped_chapter_input_preserves_each_page_and_tail_content():
+    pages = [
+        {"page_num": 1, "text": "FIRST_START " + "a" * 20_000 + " FIRST_END"},
+        {"page_num": 2, "text": "SECOND_START " + "b" * 20_000 + " SECOND_END"},
+    ]
+
+    text = summaries._chapter_text(pages, {"start_page": 1, "end_page": 2})
+
+    assert len(text) == summaries.MAX_CHAPTER_INPUT_CHARS
+    assert all(marker in text for marker in (
+        "FIRST_START", "FIRST_END", "SECOND_START", "SECOND_END",
+    ))


### PR DESCRIPTION
# Summary
## 1. 웹 문서 목차 범위 수정
- 1부터 시작하는 웹 문서 unit index를 그대로 페이지 번호로 사용하도록 수정함
- 첫 장 이동과 마지막 장 누락 문제를 검증하는 회귀 테스트를 추가함
## 2. 긴 장 요약 범위 개선
- 16,000자 제한 안에서 각 페이지의 앞뒤 본문을 균등하게 포함하도록 수정함
- 장 후반부 결론이 전체 요약 입력에서 누락되는 문제를 방지함
## 3. 검증
- 백엔드 전체 테스트 659개 통과
