### PR TITLE
fix(release): sync Cargo package version

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "ctrlc",
  "log",


### PR DESCRIPTION
# Summary
## 1. Cargo 패키지 버전 동기화
- Cargo.lock의 app 패키지 버전을 Cargo.toml 및 tauri.conf.json과 동일한 0.1.30으로 수정함
## 2. 검증
- cargo check --locked --offline 통과
