### PR TITLE
fix(viewer): retain note jump target

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10897,6 +10897,7 @@ function applyAnnotationsFromOffsets(textLayerDiv, annotations, pageNum) {
       overlay.appendChild(box)
     })
   })
+  if (activeViewerAnnotationTarget?.page === pageNum) markViewerAnnotationTarget()
 }
 
 // PDF와 번역본의 문장 수 차이를 고려한 오프셋 기반 매핑 함수
@@ -17580,6 +17581,21 @@ function viewerAnnotationTargetFromParams(params) {
   }
 }
 
+let activeViewerAnnotationTarget = null
+
+function markViewerAnnotationTarget() {
+  if (!activeViewerAnnotationTarget) return null
+  const targetEl = findViewerAnnotationElement(activeViewerAnnotationTarget)
+  if (!targetEl) return null
+  viewerScrollContainer.querySelectorAll('[data-viewer-note-jump-target="true"]').forEach(el => {
+    delete el.dataset.viewerNoteJumpTarget
+  })
+  targetEl.dataset.viewerNoteJumpTarget = 'true'
+  targetEl.classList.add('viewer-note-jump-target')
+  setTimeout(() => targetEl.classList.remove('viewer-note-jump-target'), 1800)
+  return targetEl
+}
+
 function findViewerAnnotationElement(target) {
   const pageWrapper = viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${target.page}"]`)
   if (!pageWrapper) return null
@@ -17601,6 +17617,7 @@ function findViewerAnnotationElement(target) {
 
 async function navigateToViewerAnnotation(target) {
   if (!target || target.page > state.totalPages) return
+  activeViewerAnnotationTarget = target
   scrollToPage(viewerScrollContainer, target.page, { instant: true })
   if (target.quote) {
     await locateTermInPdf(target.page, target.quote, target.occurrence)
@@ -17617,9 +17634,8 @@ async function navigateToViewerAnnotation(target) {
   }
   if (!targetEl) return
 
+  targetEl = markViewerAnnotationTarget() || targetEl
   targetEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
-  targetEl.classList.add('viewer-note-jump-target')
-  setTimeout(() => targetEl.classList.remove('viewer-note-jump-target'), 1800)
 }
 
 async function handleRouting() {
@@ -17632,6 +17648,7 @@ async function handleRouting() {
       const docId = params.get('id')
       const wantChatOpen = params.get('chat') === '1'
       const annotationTarget = viewerAnnotationTargetFromParams(params)
+      activeViewerAnnotationTarget = annotationTarget
       if (docId) {
         if (state.sessionId === docId && viewerScreen.classList.contains('active')) {
           console.log("[Router] Viewer already active for document:", docId)

--- a/frontend/tests/e2e/notes-annotations.spec.js
+++ b/frontend/tests/e2e/notes-annotations.spec.js
@@ -89,6 +89,6 @@ test('Notes 하이라이트 클릭 시 뷰어의 저장 오프셋 위치를 강�
   await page.locator('.notes-annotation-card').click()
 
   await expect(page.locator('#viewer-screen')).toHaveClass(/active/)
-  await expect(page.locator('.pdf-annotation-highlight[data-start-offset="0"][data-end-offset="6"]')).toHaveClass(/viewer-note-jump-target/, { timeout: 10_000 })
+  await expect(page.locator('.pdf-annotation-highlight[data-start-offset="0"][data-end-offset="6"]')).toHaveAttribute('data-viewer-note-jump-target', 'true', { timeout: 10_000 })
   await expect(page.locator('#page-input')).toHaveValue('1')
 })


### PR DESCRIPTION
# Summary
## 1. Notes 이동 대상 유지
- PDF 오버레이 재렌더링 시 현재 Notes 이동 대상을 새 annotation DOM에 다시 적용함
- 이전 이동 대상 표시를 제거하고 현재 대상에 안정적인 data 속성을 기록함
## 2. 회귀 테스트 안정화
- 일시적인 애니메이션 클래스 대신 현재 이동 대상 상태를 검증하도록 수정함
## 3. 검증
- Notes annotation E2E 병렬 반복 24회 통과
