### PR TITLE
fix(auth): harden release security

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -66,10 +66,11 @@ async def localized_http_exception_handler(request: Request, exc: HTTPException)
     return await http_exception_handler(request, exc)
 
 
-# CORS 설정 (모든 오리진 허용 — NPM/리버스 프록시 환경)
+# CORS 설정. 브라우저에서 접근 가능한 배포에서 임의 웹사이트가 API 응답을
+# 읽거나 로그인 생략 모드의 관리자 권한을 사용하는 일을 막는다.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=CORS_ORIGINS,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.115.0
+fastapi==0.116.2
+starlette==0.47.2
 uvicorn[standard]==0.30.6
 python-multipart>=0.0.18
 pymupdf==1.24.10

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -202,6 +202,13 @@ async def change_credentials(
             detail="이미 존재하는 아이디입니다."
         )
     update_credentials_in_env(new_username, new_hash)
+
+    # DB 소유권과 함께 현재 프로세스의 열린 문서 세션도 새 계정명으로 이동한다.
+    if new_username != current_user:
+        from routers.upload import sessions
+        for session in sessions.values():
+            if session.get("username") == current_user:
+                session["username"] = new_username
     
     # 세션 갱신
     new_token = create_session_token(new_username)

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -3,7 +3,10 @@ import hmac
 import os
 import time
 from fastapi import Depends, Request, HTTPException, status
-from config import get_app_password, get_app_username, get_skip_login, SECRET_KEY
+from config import (
+    get_app_password, get_app_password_hash, get_app_username, get_skip_login,
+    SECRET_KEY,
+)
 
 def verify_password(stored_password_hash: str, provided_password: str) -> bool:
     # 1. 만약 평문 비밀번호(APP_PASSWORD)가 설정되어 있다면 즉시 비교
@@ -92,8 +95,18 @@ SESSION_TTL_REMEMBER_SECONDS = 90 * 24 * 3600
 def create_session_token(username: str, ttl_seconds: int = SESSION_TTL_DEFAULT_SECONDS) -> str:
     expires = int(time.time()) + ttl_seconds
     payload = f"{username}:{expires}"
-    signature = hmac.new(SECRET_KEY.encode('utf-8'), payload.encode('utf-8'), hashlib.sha256).hexdigest()
+    signature = _session_signature(payload)
     return f"{payload}:{signature}"
+
+def _session_signature(payload: str) -> str:
+    """Bind sessions to the current credential hash as well as the install key."""
+    credential_key = hmac.new(
+        SECRET_KEY.encode("utf-8"),
+        get_app_password_hash().encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return hmac.new(credential_key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
 
 def verify_session_token(token: str) -> bool:
     try:
@@ -105,7 +118,7 @@ def verify_session_token(token: str) -> bool:
         if time.time() > expires:
             return False
         payload = f"{username}:{expires_str}"
-        expected_signature = hmac.new(SECRET_KEY.encode('utf-8'), payload.encode('utf-8'), hashlib.sha256).hexdigest()
+        expected_signature = _session_signature(payload)
         return hmac.compare_digest(expected_signature, signature)
     except Exception:
         return False

--- a/backend/tests/test_release_auth_hardening.py
+++ b/backend/tests/test_release_auth_hardening.py
@@ -1,0 +1,36 @@
+import asyncio
+
+from main import app
+from routers import upload
+from routers.auth import ChangeCredentialsRequest, change_credentials
+from services import auth
+
+
+def test_password_hash_change_invalidates_existing_session(monkeypatch):
+    password_hash = "old-hash"
+    monkeypatch.setattr(auth, "get_app_password_hash", lambda: password_hash)
+    token = auth.create_session_token("admin")
+    assert auth.verify_session_token(token) is True
+
+    password_hash = "new-hash"
+    assert auth.verify_session_token(token) is False
+
+
+def test_cors_uses_configured_origins_only():
+    middleware = next(item for item in app.user_middleware if item.cls.__name__ == "CORSMiddleware")
+    assert middleware.kwargs["allow_origins"] != ["*"]
+    assert "http://localhost:5173" in middleware.kwargs["allow_origins"]
+
+
+def test_credential_rename_updates_open_sessions(monkeypatch):
+    upload.sessions["doc"] = {"username": "admin"}
+    monkeypatch.setattr("services.db.get_user", lambda _username: {"password_hash": auth.hash_password("old")})
+    monkeypatch.setattr("services.db.update_user_credentials", lambda *_args: True)
+    monkeypatch.setattr("routers.auth.update_credentials_in_env", lambda *_args: None)
+
+    response = type("Response", (), {"set_cookie": lambda *args, **kwargs: None})()
+    body = ChangeCredentialsRequest(current_password="old", new_username="renamed", new_password="new")
+    asyncio.run(change_credentials(response, body, "admin"))
+
+    assert upload.sessions["doc"]["username"] == "renamed"
+    upload.sessions.pop("doc", None)


### PR DESCRIPTION
# Summary
## 1. 인증 세션 보안 강화
- 세션 서명을 현재 비밀번호 해시에 결합해 비밀번호 변경 시 기존 토큰을 폐기함
- 아이디 변경 시 메모리 내 열린 문서 세션의 소유자 정보도 함께 갱신함
## 2. 네트워크 및 의존성 보안 강화
- CORS 허용 대상을 CORS_ORIGINS 설정값으로 제한함
- FastAPI 0.116.2 및 Starlette 0.47.2로 갱신해 multipart DoS 취약 버전을 제거함
## 3. 검증
- 신규 의존성 가상환경에서 백엔드 테스트 660개 통과
- pip check 통과
