### PR TITLE
fix: improve UI scale viewport compatibility

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2400,6 +2400,7 @@ body.light-theme .pdf-annotation-underline {
 .modal-overlay {
   position: fixed;
   inset: 0;
+  padding: 16px;
   background: rgba(10, 11, 15, 0.75);
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
@@ -2423,6 +2424,7 @@ body.light-theme .pdf-annotation-underline {
   border-radius: var(--radius-lg);
   width: 90%;
   max-width: 440px;
+  max-height: 100%;
   box-shadow: var(--shadow-md);
   overflow: hidden;
   transform: scale(0.95);
@@ -5499,10 +5501,8 @@ body.light-theme .floating-memo-render code {
 /* ── Custom Confirm Modal ── */
 .custom-confirm-modal-wrapper {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  inset: 0;
+  padding: 16px;
   z-index: 11000;
   background: rgba(0, 0, 0, 0.65);
   backdrop-filter: blur(4px);
@@ -5519,7 +5519,8 @@ body.light-theme .floating-memo-render code {
   pointer-events: auto;
 }
 .custom-confirm-modal {
-  width: 320px;
+  width: min(320px, 100%);
+  max-height: 100%;
   background: var(--bg-panel);
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: var(--radius-lg);
@@ -5529,6 +5530,7 @@ body.light-theme .floating-memo-render code {
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   display: flex;
   flex-direction: column;
+  overflow: auto;
   gap: 14px;
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);

--- a/frontend/tests/e2e/ui-scale-viewport.spec.js
+++ b/frontend/tests/e2e/ui-scale-viewport.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { gotoApp, mockBaseRoutes } from './helpers.js'
+
+for (const uiScale of [0.8, 0.9, 1, 1.25]) {
+  test(`fixed UI fills the viewport at ${uiScale * 100}% UI scale`, async ({ page }) => {
+    await mockBaseRoutes(page, { documents: [] })
+    await page.addInitScript(scale => {
+      localStorage.setItem('easypaper_ui_scale', String(scale))
+    }, uiScale)
+    await gotoApp(page)
+
+    const viewport = page.viewportSize()
+    const activeScreen = await page.locator('.screen.active').boundingBox()
+    expect(activeScreen).toEqual({ x: 0, y: 0, width: viewport.width, height: viewport.height })
+
+    await page.locator('#sidebar-settings-btn').click()
+    await expect(page.locator('#settings-modal')).toBeVisible()
+    const modalOverlay = await page.locator('#settings-modal').boundingBox()
+    expect(modalOverlay).toEqual({ x: 0, y: 0, width: viewport.width, height: viewport.height })
+    await page.locator('#close-settings-btn').click()
+
+    await page.locator('#sidebar-logout-btn').click()
+    const confirmOverlay = page.locator('.custom-confirm-modal-wrapper')
+    await expect(confirmOverlay).toBeVisible()
+    expect(await confirmOverlay.boundingBox()).toEqual({
+      x: 0, y: 0, width: viewport.width, height: viewport.height,
+    })
+    const confirmDialog = await confirmOverlay.locator('.custom-confirm-modal').boundingBox()
+    expect(confirmDialog.x).toBeGreaterThanOrEqual(0)
+    expect(confirmDialog.y).toBeGreaterThanOrEqual(0)
+    expect(confirmDialog.x + confirmDialog.width).toBeLessThanOrEqual(viewport.width)
+    expect(confirmDialog.y + confirmDialog.height).toBeLessThanOrEqual(viewport.height)
+  })
+}

--- a/frontend/tests/e2e/viewer-chat-scale.spec.js
+++ b/frontend/tests/e2e/viewer-chat-scale.spec.js
@@ -23,6 +23,20 @@ for (const uiScale of [0.8, 0.9]) {
     await page.evaluate(id => { location.hash = `#viewer?id=${id}` }, doc.id)
     await expect(page.locator('#viewer-screen')).toHaveClass(/active/)
 
+    await page.evaluate(() => Promise.all(document.getAnimations()
+      .filter(animation => animation.effect.getComputedTiming().iterations !== Infinity)
+      .map(animation => animation.finished.catch(() => {}))))
+
+    const viewport = page.viewportSize()
+    expect(await page.locator('#viewer-screen').boundingBox()).toEqual({
+      x: 0, y: 0, width: viewport.width, height: viewport.height,
+    })
+    const viewerContainer = await page.locator('#viewer-scroll-container').boundingBox()
+    expect(viewerContainer.x).toBeGreaterThanOrEqual(0)
+    expect(viewerContainer.y).toBeGreaterThan(0)
+    expect(viewerContainer.x + viewerContainer.width).toBeLessThanOrEqual(viewport.width)
+    expect(Math.abs(viewerContainer.y + viewerContainer.height - viewport.height)).toBeLessThanOrEqual(1)
+
     await page.locator('#chat-toggle-btn').click()
     const chatSidebar = page.locator('#chat-sidebar')
     await expect(chatSidebar).toBeVisible()
@@ -30,5 +44,8 @@ for (const uiScale of [0.8, 0.9]) {
     const bottomGap = await chatSidebar.evaluate(element =>
       window.innerHeight - element.getBoundingClientRect().bottom)
     expect(Math.abs(bottomGap)).toBeLessThanOrEqual(1)
+    const rightGap = await chatSidebar.evaluate(element =>
+      window.innerWidth - element.getBoundingClientRect().right)
+    expect(Math.abs(rightGap)).toBeLessThanOrEqual(1)
   })
 }


### PR DESCRIPTION
## Summary
- Fix modal and custom confirmation viewport coverage at reduced UI scales
- Keep viewer and AI assistant panel aligned across UI scale changes
- Add Chromium/WebKit regression coverage for overlays and viewer bounds

## Tests
- npm run test:unit
- npm run build
- Playwright UI scale/viewer E2E (Chromium, WebKit)