### PR TITLE
fix: isolate focused sentences across the screen

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -30,7 +30,7 @@ export function mergeClientRects(rects, gap = 3) {
 
 export function createFocusMask(rects, width, height, padding = 4) {
   const holes = mergeClientRects(rects).map(rect => `<rect x="${Math.max(0, rect.left - padding)}" y="${Math.max(0, rect.top - padding)}" width="${rect.width + padding * 2}" height="${rect.height + padding * 2}" rx="5" fill="black"/>`).join('')
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect width="100%" height="100%" fill="white"/>${holes}</svg>`
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs><mask id="holes" maskUnits="userSpaceOnUse"><rect width="100%" height="100%" fill="white"/>${holes}</mask></defs><rect width="100%" height="100%" fill="white" mask="url(#holes)"/></svg>`
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`
 }
 
@@ -46,21 +46,42 @@ export function isFocusKeyboardExcluded(target) {
 export class FocusModeController {
   constructor({ root, resolvePair, listSentences, announce = () => {}, notifyFallback = () => {}, releaseDelay = 150 }) {
     Object.assign(this, { root, resolvePair, listSentences, announce, notifyFallback, releaseDelay })
-    this.settings = normalizeFocusSettings(); this.current = null; this.pinned = false; this.exclusions = new Set(); this.slowFrames = 0; this.performanceFallback = false
+    this.settings = normalizeFocusSettings(); this.current = null; this.pinned = false; this.slowFrames = 0; this.performanceFallback = false
     this.onKeyDown = event => this.handleKeyDown(event); this.onViewportChange = () => this.scheduleRender()
-    document.addEventListener('keydown', this.onKeyDown); window.addEventListener('resize', this.onViewportChange); root?.addEventListener('scroll', this.onViewportChange, { passive: true })
+    this.onLeave = () => this.leave()
+    this.onInteraction = event => {
+      if (!event.target.closest?.('.textLayer, .trans-sentence')) this.clear()
+    }
+    this.onVisibility = () => { if (document.hidden) this.clear() }
+    document.addEventListener('keydown', this.onKeyDown)
+    document.addEventListener('pointerdown', this.onInteraction, true)
+    document.addEventListener('visibilitychange', this.onVisibility)
+    window.addEventListener('resize', this.onViewportChange)
+    root?.addEventListener('mouseleave', this.onLeave)
+    root?.addEventListener('scroll', this.onViewportChange, { passive: true, capture: true })
   }
   applySettings(settings) { this.settings = normalizeFocusSettings(settings); if (!this.settings.enabled) this.clear(); else if (this.current) this.scheduleRender() }
   sameRef(a, b) { return !!a && !!b && a.pageNum === b.pageNum && a.sentenceIdx === b.sentenceIdx }
   focus(ref, { pin = false } = {}) {
     if (!this.settings.enabled || !ref) return false
     this.cancelLeave()
+    if (this.pinned && !pin) return true
     if (pin && this.pinned && this.sameRef(ref, this.current)) { this.clear(); return true }
+    if (!pin && this.sameRef(ref, this.current)) return true
     this.current = ref; if (pin) this.pinned = true; this.scheduleRender(); this.announce(this.pinned ? 'focusPinned' : 'focusActive'); return true
   }
-  leave() { this.cancelLeave(); if (!this.pinned) this.releaseTimer = setTimeout(() => this.clear(), this.releaseDelay) }
+  leave() { if (!this.pinned && !this.releaseTimer) this.releaseTimer = setTimeout(() => this.clear(), this.releaseDelay) }
   cancelLeave() { clearTimeout(this.releaseTimer); this.releaseTimer = null }
-  clear() { this.cancelLeave(); this.current = null; this.pinned = false; this.layer?.remove(); this.outlineLayer?.remove(); this.layer = null; this.outlineLayer = null; document.querySelectorAll('.focus-mode-target').forEach(element => element.classList.remove('focus-mode-target')); this.root?.classList.remove('focus-mode-active') }
+  clear() {
+    this.cancelLeave()
+    if (this.raf) cancelAnimationFrame(this.raf)
+    this.raf = null
+    this.current = null; this.pinned = false; this.lastGeometry = null
+    this.layer?.remove(); this.outlineLayer?.remove()
+    this.layer = null; this.outlineLayer = null
+    this.root?.classList.remove('focus-mode-active')
+    this.root?.querySelectorAll('.trans-sentence[aria-pressed]').forEach(element => element.removeAttribute('aria-pressed'))
+  }
   togglePin(ref) { return this.focus(ref, { pin: true }) }
   navigate(delta) {
     if (!this.pinned || !this.current) return false
@@ -76,21 +97,50 @@ export class FocusModeController {
     const delta = ['ArrowDown', 'ArrowRight'].includes(event.key) ? 1 : ['ArrowUp', 'ArrowLeft'].includes(event.key) ? -1 : 0
     if (delta) { event.preventDefault(); this.navigate(delta) }
   }
-  registerExclusion(element) { if (element) this.exclusions.add(element); this.scheduleRender(); return () => { this.exclusions.delete(element); this.scheduleRender() } }
-  scheduleRender() { if (this.raf) cancelAnimationFrame(this.raf); this.raf = requestAnimationFrame(() => { this.raf = null; this.render() }) }
+  scheduleRender() {
+    if (!this.current || !this.settings.enabled || this.raf) return
+    this.raf = requestAnimationFrame(() => { this.raf = null; this.render() })
+  }
   render() {
     if (!this.current || !this.settings.enabled) return
-    const started = performance.now(); const pair = this.resolvePair?.(this.current) || {}; const rects = [...(pair.sourceRects || []), ...(pair.translationRects || [])]
-    for (const element of this.exclusions) if (element?.isConnected) rects.push(...element.getClientRects())
-    if (!rects.length) { this.clear(); return }
+    const started = performance.now()
+    const pair = this.resolvePair?.(this.current) || {}
+    const bounds = this.root.getBoundingClientRect()
+    const rects = [...(pair.sourceRects || []), ...(pair.translationRects || [])].map(rect => {
+      const left = Math.max(0, bounds.left, rect.left)
+      const top = Math.max(0, bounds.top, rect.top)
+      const right = Math.min(window.innerWidth, bounds.right, rect.right ?? rect.left + rect.width)
+      const bottom = Math.min(window.innerHeight, bounds.bottom, rect.bottom ?? rect.top + rect.height)
+      return { left, top, width: right - left, height: bottom - top }
+    }).filter(rect => rect.width > 0 && rect.height > 0)
+    if (this.root?.closest('#viewer-screen')?.classList.contains('active') === false) { this.clear(); return }
+    // Only sentence pixels are revealed. Panels, popups and toolbars remain covered.
+    // Rendering can temporarily disappear during PDF zoom; retain the pinned reference.
+    const zoom = Number.parseFloat(getComputedStyle(document.documentElement).zoom) || 1
+    const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, this.performanceFallback])
+    if (geometry === this.lastGeometry) { this.scheduleRender(); return }
+    this.lastGeometry = geometry
     if (!this.layer) { this.layer = document.createElement('div'); this.layer.className = 'focus-mode-layer'; this.layer.setAttribute('aria-hidden', 'true'); this.outlineLayer = document.createElement('div'); this.outlineLayer.className = 'focus-mode-outline-layer'; this.outlineLayer.setAttribute('aria-hidden', 'true'); document.body.append(this.layer, this.outlineLayer) }
-    for (const [name, value] of Object.entries(focusCssVariables(this.settings))) { this.layer.style.setProperty(name, value); this.outlineLayer.style.setProperty(name, value); this.root?.style.setProperty(name, value) }
+    for (const layer of [this.layer, this.outlineLayer]) {
+      // Client rects use viewport pixels; cancel the application's root CSS zoom.
+      layer.style.zoom = String(1 / zoom)
+      for (const [name, value] of Object.entries(focusCssVariables(this.settings))) layer.style.setProperty(name, value)
+    }
     this.layer.classList.toggle('focus-performance-fallback', this.performanceFallback)
     this.layer.style.maskImage = createFocusMask(rects, window.innerWidth, window.innerHeight); this.layer.style.webkitMaskImage = this.layer.style.maskImage
-    document.querySelectorAll('.focus-mode-target').forEach(element => element.classList.remove('focus-mode-target')); if (!this.performanceFallback) for (const element of pair.elements || []) element.classList.add('focus-mode-target'); this.outlineLayer.replaceChildren(...mergeClientRects(rects).map(rect => { const outline = document.createElement('i'); outline.className = 'focus-mode-outline'; Object.assign(outline.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` }); return outline }))
+    this.outlineLayer.replaceChildren(...mergeClientRects(rects).map(rect => { const outline = document.createElement('i'); outline.className = 'focus-mode-outline'; Object.assign(outline.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` }); return outline }))
     this.root?.classList.add('focus-mode-active')
     this.slowFrames = performance.now() - started > 20 ? this.slowFrames + 1 : Math.max(0, this.slowFrames - 1)
     if (!this.performanceFallback && this.slowFrames >= 8) { this.performanceFallback = true; this.notifyFallback(); this.scheduleRender() }
+    this.scheduleRender()
   }
-  destroy() { this.clear(); if (this.raf) cancelAnimationFrame(this.raf); document.removeEventListener('keydown', this.onKeyDown); window.removeEventListener('resize', this.onViewportChange); this.root?.removeEventListener('scroll', this.onViewportChange); this.exclusions.clear() }
+  destroy() {
+    this.clear()
+    document.removeEventListener('keydown', this.onKeyDown)
+    document.removeEventListener('pointerdown', this.onInteraction, true)
+    document.removeEventListener('visibilitychange', this.onVisibility)
+    window.removeEventListener('resize', this.onViewportChange)
+    this.root?.removeEventListener('mouseleave', this.onLeave)
+    this.root?.removeEventListener('scroll', this.onViewportChange, true)
+  }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10364,6 +10364,8 @@ async function hydrateAnnotationsAndMemosFromServer(docId) {
 async function openFromLibrary(doc, shouldPushState = true) {
   await loadFeatureNamespaces('viewer')
   if (docOpeningId === doc.id) return
+  focusModeController?.clear()
+  if (focusModeController) focusModeController.performanceFallback = false
   const myOpenGeneration = ++documentOpenGeneration
   const isCurrentOpen = () => myOpenGeneration === documentOpenGeneration
   docOpeningId = doc.id
@@ -17263,7 +17265,6 @@ function listFocusSentences() {
 }
 
 focusModeController = new FocusModeController({ root: viewerScrollContainer, resolvePair: focusPairRects, listSentences: listFocusSentences, announce: key => announceA11y({ focusActive: t('viewer:a11y.focusActive'), focusPinned: t('viewer:a11y.focusPinned'), focusMoved: t('viewer:a11y.focusMoved') }[key]), notifyFallback: () => showToast(t('viewer:focus.performanceFallback'), 'info') })
-for (const selector of ['.selection-menu', '#ann-hover-tooltip', '.chat-sidebar', '.floating-memo', '.citation-popup', '.figure-ref-popup', '.modal-overlay']) document.querySelectorAll(selector).forEach(element => focusModeController.registerExclusion(element))
 
 function startDwellSelection(pageNum, sentenceRange) {
   if (sentenceHoverTimer) { clearTimeout(sentenceHoverTimer); sentenceHoverTimer = null }
@@ -17349,7 +17350,7 @@ if (viewerScrollContainer) {
       }
     }
 
-    if (isSame) return;
+    if (isSame) { focusModeController.focus(focusRef(pageNum, sentenceRange)); return; }
 
     // 이전 페이지 호버 클리어
     if (currentHoverPage !== null && currentHoverPage !== pageNum) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7960,11 +7960,10 @@ body.light-theme .chat-drawer {
 .focus-range output { color: var(--text-primary); font-variant-numeric: tabular-nums; text-align: right; }
 .focus-range input:disabled { opacity: .45; }
 .focus-keyboard-help { color: var(--text-muted); }
-.focus-mode-layer { position: fixed; inset: 0; z-index: 900; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); backdrop-filter: blur(var(--focus-blur)); -webkit-backdrop-filter: blur(var(--focus-blur)); mask-repeat: no-repeat; -webkit-mask-repeat: no-repeat; transition: opacity 120ms ease; }
+.focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); backdrop-filter: blur(var(--focus-blur)); -webkit-backdrop-filter: blur(var(--focus-blur)); mask-mode: alpha; mask-repeat: no-repeat; -webkit-mask-repeat: no-repeat; transition: opacity 120ms ease; }
 .focus-mode-outline { position: fixed; display: block; border-radius: 5px; outline: 2px solid var(--control-accent); box-shadow: 0 0 10px var(--control-accent-soft); transform: scale(var(--focus-scale)); transform-origin: center; transition: transform 120ms ease, opacity 120ms ease; }
 .focus-performance-fallback { backdrop-filter: none; -webkit-backdrop-filter: none; }
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) { .focus-mode-layer { backdrop-filter: none; -webkit-backdrop-filter: none; } }
 @supports not (mask-image: url("")) { .focus-mode-layer { mask-image: none !important; -webkit-mask-image: none !important; background: rgba(5, 7, 12, calc(var(--focus-dim) * .45)); } }
 @media (prefers-reduced-motion: reduce) { .focus-mode-layer, .focus-mode-outline { transition: none; } }
-.focus-mode-outline-layer { position: fixed; inset: 0; z-index: 901; pointer-events: none; }
-.focus-mode-target { z-index: 902; transform: scale(var(--focus-scale, 1.04)); transform-origin: center; }
+.focus-mode-outline-layer { position: fixed; inset: 0; z-index: 2147483647; pointer-events: none; }

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+import fs from 'node:fs'
+import { mockBaseRoutes, gotoApp } from './helpers.js'
+
+const moduleSource = fs.readFileSync(new URL('../../src/focusMode.js', import.meta.url), 'utf8')
+const css = fs.readFileSync(new URL('../../src/style.css', import.meta.url), 'utf8')
+
+async function setup(page, scale = 1) {
+  await page.setContent(`<style>body{margin:0;background:white} #root{position:absolute;inset:0} .sentence{position:absolute;left:100px;top:120px;width:200px;height:40px;background:white} #panel{position:fixed;left:400px;top:120px;width:150px;height:80px;z-index:10000;background:white}</style><div id="root"><div class="sentence trans-sentence">Source sentence</div></div><aside id="panel">AI panel</aside>`)
+  await page.addStyleTag({ content: css })
+  await page.addStyleTag({ content: '#root .sentence { position:absolute; display:block; left:100px; top:120px; width:200px; height:40px; background:white }' })
+  await page.evaluate(async ({ moduleSource, scale }) => {
+    const module = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+    document.documentElement.style.zoom = String(scale)
+    document.body.style.background = 'white'
+    window.controller = new module.FocusModeController({
+      root: document.querySelector('#root'),
+      resolvePair: () => ({ sourceRects: [document.querySelector('.sentence').getBoundingClientRect()] }),
+      listSentences: () => [{ pageNum: 1, sentenceIdx: 0 }, { pageNum: 1, sentenceIdx: 1 }],
+    })
+    window.controller.applySettings({ enabled: true, blurStrength: 0, dimOpacity: 60, scale: 100 })
+    window.controller.togglePin({ pageNum: 1, sentenceIdx: 0 })
+  }, { moduleSource, scale })
+  await expect(page.locator('.focus-mode-layer')).toBeVisible()
+}
+
+for (const scale of [0.8, 1, 1.25]) {
+  test(`only the sentence stays clear, including above high-z-index panels at scale ${scale}`, async ({ page }) => {
+    await setup(page, scale)
+    const bounds = await page.locator('.focus-mode-layer').boundingBox()
+    expect(bounds.x).toBeCloseTo(0, 0)
+    expect(bounds.y).toBeCloseTo(0, 0)
+    expect(bounds.width).toBeCloseTo(page.viewportSize().width, 0)
+    expect(bounds.height).toBeCloseTo(page.viewportSize().height, 0)
+    const screenshot = (await page.screenshot({ scale: 'css' })).toString('base64')
+    const pixels = await page.evaluate(async ({ screenshot, scale }) => {
+      const image = new Image(); image.src = `data:image/png;base64,${screenshot}`; await image.decode()
+      const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
+      const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
+      const pixel = (x, y) => [...ctx.getImageData(Math.round(x * scale), Math.round(y * scale), 1, 1).data]
+      return { sentence: pixel(220, 150), panel: pixel(500, 175), background: pixel(50, 50) }
+    }, { screenshot, scale })
+    expect(pixels.sentence.slice(0, 3)).toEqual([255, 255, 255])
+    expect(pixels.panel[0]).toBeLessThan(130)
+    expect(pixels.background[0]).toBeLessThan(130)
+  })
+}
+
+test('pinned focus ignores hover, follows geometry changes and releases with Escape', async ({ page }) => {
+  await setup(page)
+  await page.evaluate(() => {
+    window.controller.focus({ pageNum: 1, sentenceIdx: 1 })
+    document.querySelector('.sentence').style.left = '250px'
+  })
+  expect(await page.evaluate(() => window.controller.current.sentenceIdx)).toBe(0)
+  await expect(page.locator('.focus-mode-outline')).toHaveCSS('left', '250px')
+  await page.keyboard.press('ArrowRight')
+  expect(await page.evaluate(() => window.controller.current.sentenceIdx)).toBe(1)
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+})
+
+test('blur and tint can be independently disabled; controls release the mask before interaction', async ({ page }) => {
+  await setup(page)
+  await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 10, dimOpacity: 0, scale: 100 }))
+  await expect(page.locator('.focus-mode-layer')).toHaveCSS('backdrop-filter', 'blur(10px)')
+  await expect(page.locator('.focus-mode-layer')).toHaveCSS('background-color', 'rgba(5, 7, 12, 0)')
+  await page.locator('#panel').click()
+  await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+})
+
+test('real PDF hover reveals source and translation together and clears on viewer exit', async ({ page }) => {
+  const doc = { id: 'focus-pdf', filename: 'focus.pdf', total_pages: 1, translated_pages: [1], metadata: { title: 'Focus' } }
+  const pdf = fs.readFileSync(new URL('./fixtures/text-geometry.pdf', import.meta.url))
+  await mockBaseRoutes(page, { documents: [doc] })
+  await page.route('**/api/library/focus-pdf/pdf', route => route.fulfill({ contentType: 'application/pdf', body: pdf }))
+  await page.route('**/api/library/focus-pdf/translation/1**', route => route.fulfill({ json: {
+    translation: 'The translated first sentence. The translated second sentence. The translated third sentence.', sentences: [],
+  } }))
+  await gotoApp(page)
+  await page.evaluate(() => {
+    localStorage.setItem('easypaper_focus_mode_enabled_research', 'true')
+    localStorage.setItem('easypaper_disable_hover_tooltip', 'true')
+    location.hash = '#viewer?id=focus-pdf'
+  })
+  const source = page.locator('.textLayer span').filter({ hasText: 'The quick brown fox' }).first()
+  await expect(source).toBeVisible()
+  const translation = page.locator('.trans-sentence').first()
+  await expect(translation).toBeVisible()
+  await source.hover()
+  await expect(page.locator('.focus-mode-layer')).toBeVisible()
+  const sourceMask = await page.locator('.focus-mode-layer').evaluate(el => el.style.maskImage)
+  await translation.hover()
+  await expect.poll(() => page.locator('.focus-mode-layer').evaluate(el => el.style.maskImage)).toBe(sourceMask)
+  await expect(page.locator('.focus-mode-outline')).toHaveCount(2)
+  await translation.click()
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+  await source.hover()
+  await expect(page.locator('.focus-mode-layer')).toBeVisible()
+  await page.evaluate(() => { location.hash = '#library' })
+  await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+})


### PR DESCRIPTION
# Summary

## 1. 문장 외 전체 화면 Focus 효과 수정

- Monocle의 활성 대상 외 화면 억제 동작을 원문·번역 문장 쌍에 적용함
- 불투명 검은 SVG 영역을 실제 alpha 투명 구멍으로 변환하여 Focus 문장은 효과에서 제외하도록 수정함
- 툴바, 메모, AI 패널, 팝업의 상시 예외를 제거하고 화면 전체에 블러·tint 적용함
- UI 배율 보정과 스크롤 영역 밖 문장 좌표 잘림 처리 추가
- 문장 원본 DOM의 transform을 제거하여 원문과 번역의 좌표 유지

## 2. Focus 상태와 검증 보완

- 고정 중 다른 문장 호버에 따른 변경 방지, 같은 문장 재진입과 지연 해제 수정
- 좌표 변화 추적, 화면 이탈·문서 전환 정리, 다른 UI 클릭 시 Focus 해제 처리 추가
- Chromium·WebKit의 실제 스크린샷 픽셀로 문장 투명 영역과 패널 차폐 검증
- UI 배율 80%·100%·125%, 실제 PDF 양방향 호버, 고정·방향키·Esc, 설정 저장 검증
- 단위 테스트 91개, 브라우저 테스트 14개, 로케일 검증 및 프로덕션 빌드 통과

참고: https://www.heyiam.dk/monocle
