### PR TITLE
fix: Focus 번역 자동 스크롤 및 파란 강조 제거

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -39,8 +39,67 @@ export function focusCssVariables(settings) {
   return { '--focus-blur': `${value.blurStrength}px`, '--focus-dim': String(value.dimOpacity / 100), '--focus-scale': String(value.scale / 100) }
 }
 
+// Keep the sentence openings independent of CSS image-mask support.
+export function createFocusBackdropRects(rects, width, height, padding = 4) {
+  const holes = mergeClientRects(rects).map(rect => ({
+    left: Math.max(0, rect.left - padding), right: Math.min(width, rect.right + padding),
+    top: Math.max(0, rect.top - padding), bottom: Math.min(height, rect.bottom + padding),
+  })).filter(rect => rect.left < rect.right && rect.top < rect.bottom)
+  const rows = [...new Set([0, height, ...holes.flatMap(rect => [rect.top, rect.bottom])])].sort((a, b) => a - b)
+  const regions = []
+  for (let i = 1; i < rows.length; i++) {
+    const top = rows[i - 1], bottom = rows[i]
+    let left = 0
+    const spans = holes.filter(rect => rect.top < bottom && rect.bottom > top).sort((a, b) => a.left - b.left)
+    const add = right => { if (right > left) regions.push({ left, top, width: right - left, height: bottom - top }) }
+    for (const span of spans) { add(span.left); left = Math.max(left, span.right) }
+    add(width)
+  }
+  return regions
+}
+
 export function isFocusKeyboardExcluded(target) {
   return !!target?.closest?.('input, textarea, select, [contenteditable="true"], [role="textbox"], [role="menu"], .chat-input-box')
+}
+
+export function revealFocusTranslation(elements) {
+  const first = elements?.[0]
+  const pane = first?.closest('.trans-page-content')
+  if (!pane || !pane.clientHeight) return
+  const bounds = pane.getBoundingClientRect()
+  const scale = bounds.height / pane.offsetHeight || 1
+  const top = bounds.top + pane.clientTop * scale
+  const bottom = top + pane.clientHeight * scale
+  const rects = elements.flatMap(element => Array.from(element.getClientRects()))
+  if (!rects.length) return
+  const start = Math.min(...rects.map(rect => rect.top))
+  const end = Math.max(...rects.map(rect => rect.bottom))
+  // Scroll only the translation pane, so the source stays under the pointer.
+  if (start < top || end > bottom) {
+    const offset = end - start > bottom - top ? start - top : (start + end - top - bottom) / 2
+    pane.scrollTop += offset / scale
+  }
+}
+
+export function visibleFocusRects(element) {
+  let rects = Array.from(element.getClientRects())
+  for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+    const style = getComputedStyle(parent)
+    const clipX = /auto|scroll|hidden|clip/.test(style.overflowX)
+    const clipY = /auto|scroll|hidden|clip/.test(style.overflowY)
+    if (!clipX && !clipY) continue
+    const bounds = parent.getBoundingClientRect()
+    const sx = bounds.width / parent.offsetWidth || 1, sy = bounds.height / parent.offsetHeight || 1
+    const x = bounds.left + parent.clientLeft * sx, y = bounds.top + parent.clientTop * sy
+    rects = rects.map(rect => {
+      const left = clipX ? Math.max(rect.left, x) : rect.left
+      const right = clipX ? Math.min(rect.right, x + parent.clientWidth * sx) : rect.right
+      const top = clipY ? Math.max(rect.top, y) : rect.top
+      const bottom = clipY ? Math.min(rect.bottom, y + parent.clientHeight * sy) : rect.bottom
+      return { left, top, right, bottom, width: right - left, height: bottom - top }
+    }).filter(rect => rect.width > 0 && rect.height > 0)
+  }
+  return rects
 }
 
 export class FocusModeController {
@@ -67,8 +126,13 @@ export class FocusModeController {
     this.cancelLeave()
     if (this.pinned && !pin) return true
     if (pin && this.pinned && this.sameRef(ref, this.current)) { this.clear(); return true }
-    if (!pin && this.sameRef(ref, this.current)) return true
-    this.current = ref; if (pin) this.pinned = true; this.scheduleRender(); this.announce(this.pinned ? 'focusPinned' : 'focusActive'); return true
+    if (!pin && this.sameRef(ref, this.current)) {
+      if (ref.revealTranslation && !this.current.revealTranslation) {
+        this.current = ref; this.revealedTranslation = false; this.scheduleRender()
+      }
+      return true
+    }
+    this.current = ref; this.revealedTranslation = false; if (pin) this.pinned = true; this.scheduleRender(); this.announce(this.pinned ? 'focusPinned' : 'focusActive'); return true
   }
   leave() { if (!this.pinned && !this.releaseTimer) this.releaseTimer = setTimeout(() => this.clear(), this.releaseDelay) }
   cancelLeave() { clearTimeout(this.releaseTimer); this.releaseTimer = null }
@@ -77,8 +141,8 @@ export class FocusModeController {
     if (this.raf) cancelAnimationFrame(this.raf)
     this.raf = null
     this.current = null; this.pinned = false; this.lastGeometry = null
-    this.layer?.remove(); this.outlineLayer?.remove()
-    this.layer = null; this.outlineLayer = null
+    this.layer?.remove()
+    this.layer = null
     this.root?.classList.remove('focus-mode-active')
     this.root?.querySelectorAll('.trans-sentence[aria-pressed]').forEach(element => element.removeAttribute('aria-pressed'))
   }
@@ -89,7 +153,7 @@ export class FocusModeController {
     if (index < 0) return false
     const next = sequence[Math.max(0, Math.min(sequence.length - 1, index + delta))]
     if (!next || this.sameRef(next, this.current)) return true
-    this.current = next; next.element?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }); this.scheduleRender(); this.announce('focusMoved'); return true
+    this.current = next; this.revealedTranslation = false; next.element?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }); this.scheduleRender(); this.announce('focusMoved'); return true
   }
   handleKeyDown(event) {
     if (!this.pinned || isFocusKeyboardExcluded(event.target)) return
@@ -104,7 +168,12 @@ export class FocusModeController {
   render() {
     if (!this.current || !this.settings.enabled) return
     const started = performance.now()
-    const pair = this.resolvePair?.(this.current) || {}
+    let pair = this.resolvePair?.(this.current) || {}
+    if (this.current.revealTranslation && !this.revealedTranslation && pair.elements?.length) {
+      revealFocusTranslation(pair.elements)
+      this.revealedTranslation = true
+      pair = this.resolvePair(this.current)
+    }
     const bounds = this.root.getBoundingClientRect()
     const rects = [...(pair.sourceRects || []), ...(pair.translationRects || [])].map(rect => {
       const left = Math.max(0, bounds.left, rect.left)
@@ -120,15 +189,19 @@ export class FocusModeController {
     const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, this.performanceFallback])
     if (geometry === this.lastGeometry) { this.scheduleRender(); return }
     this.lastGeometry = geometry
-    if (!this.layer) { this.layer = document.createElement('div'); this.layer.className = 'focus-mode-layer'; this.layer.setAttribute('aria-hidden', 'true'); this.outlineLayer = document.createElement('div'); this.outlineLayer.className = 'focus-mode-outline-layer'; this.outlineLayer.setAttribute('aria-hidden', 'true'); document.body.append(this.layer, this.outlineLayer) }
-    for (const layer of [this.layer, this.outlineLayer]) {
+    if (!this.layer) { this.layer = document.createElement('div'); this.layer.className = 'focus-mode-layer'; this.layer.setAttribute('aria-hidden', 'true'); document.body.append(this.layer) }
+    for (const layer of [this.layer]) {
       // Client rects use viewport pixels; cancel the application's root CSS zoom.
       layer.style.zoom = String(1 / zoom)
       for (const [name, value] of Object.entries(focusCssVariables(this.settings))) layer.style.setProperty(name, value)
     }
     this.layer.classList.toggle('focus-performance-fallback', this.performanceFallback)
-    this.layer.style.maskImage = createFocusMask(rects, window.innerWidth, window.innerHeight); this.layer.style.webkitMaskImage = this.layer.style.maskImage
-    this.outlineLayer.replaceChildren(...mergeClientRects(rects).map(rect => { const outline = document.createElement('i'); outline.className = 'focus-mode-outline'; Object.assign(outline.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` }); return outline }))
+    this.layer.replaceChildren(...createFocusBackdropRects(rects, window.innerWidth, window.innerHeight).map(rect => {
+      const backdrop = document.createElement('div')
+      backdrop.className = 'focus-mode-backdrop'
+      Object.assign(backdrop.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` })
+      return backdrop
+    }))
     this.root?.classList.add('focus-mode-active')
     this.slowFrames = performance.now() - started > 20 ? this.slowFrames + 1 : Math.max(0, this.slowFrames - 1)
     if (!this.performanceFallback && this.slowFrames >= 8) { this.performanceFallback = true; this.notifyFallback(); this.scheduleRender() }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,7 +7,7 @@ import "./styles/document-modes.css"
 import { marked } from 'marked'
 import { createWorkspaceModeController } from "./workspaceModeController.js"
 import { getModeSetting, normalizeSettingsMode, setModeSetting } from './modeSettings.js'
-import { FocusModeController } from './focusMode.js'
+import { FocusModeController, visibleFocusRects } from './focusMode.js'
 import { parseStructuredVocabulary, renderStructuredVocabulary } from "./vocabularyView.js"
 import { defaultDocumentType, loadDocumentTypeOptions, saveDocumentTypeOptions, CURRENT_ONBOARDING_VERSION, ONBOARDING_VERSION_KEY } from "./documentModes.js"
 import DOMPurify from 'dompurify'
@@ -17235,7 +17235,7 @@ function createDomRangeFromVtmRange(vtm, charStart, charEnd) {
 // hover는 시각적 overlay와 내부 범위만 갱신한다. native Selection은 사용자의
 // 실제 드래그에만 맡겨 hover 직후에도 caret이 끊기지 않게 한다.
 function focusRef(pageNum, sentenceRange) {
-  return { pageNum, sentenceIdx: sentenceRange.sentenceIdx, element: viewerScrollContainer.querySelector(`.trans-sentence[data-page="${pageNum}"][data-sentence-idx="${sentenceRange.sentenceIdx >= 10000 ? (sentenceRange.originalSentenceIdx ?? sentenceRange.sentenceIdx) : sentenceRange.sentenceIdx}"]`) || viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`) }
+  return { pageNum, sentenceIdx: sentenceRange.sentenceIdx, revealTranslation: true, element: viewerScrollContainer.querySelector(`.trans-sentence[data-page="${pageNum}"][data-sentence-idx="${sentenceRange.sentenceIdx >= 10000 ? (sentenceRange.originalSentenceIdx ?? sentenceRange.sentenceIdx) : sentenceRange.sentenceIdx}"]`) || viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${pageNum}"]`) }
 }
 
 function focusPairRects(ref) {
@@ -17252,7 +17252,7 @@ function focusPairRects(ref) {
   }
   const idx = ref.sentenceIdx >= 10000 ? (sentenceRange?.originalSentenceIdx ?? ref.sentenceIdx) : ref.sentenceIdx
   const translationRects = []
-  viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`).forEach(element => translationRects.push(...element.getClientRects()))
+  viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`).forEach(element => translationRects.push(...visibleFocusRects(element)))
   return { sourceRects, translationRects, elements: Array.from(viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`)) }
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7960,10 +7960,20 @@ body.light-theme .chat-drawer {
 .focus-range output { color: var(--text-primary); font-variant-numeric: tabular-nums; text-align: right; }
 .focus-range input:disabled { opacity: .45; }
 .focus-keyboard-help { color: var(--text-muted); }
-.focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); backdrop-filter: blur(var(--focus-blur)); -webkit-backdrop-filter: blur(var(--focus-blur)); mask-mode: alpha; mask-repeat: no-repeat; -webkit-mask-repeat: no-repeat; transition: opacity 120ms ease; }
-.focus-mode-outline { position: fixed; display: block; border-radius: 5px; outline: 2px solid var(--control-accent); box-shadow: 0 0 10px var(--control-accent-soft); transform: scale(var(--focus-scale)); transform-origin: center; transition: transform 120ms ease, opacity 120ms ease; }
-.focus-performance-fallback { backdrop-filter: none; -webkit-backdrop-filter: none; }
-@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) { .focus-mode-layer { backdrop-filter: none; -webkit-backdrop-filter: none; } }
-@supports not (mask-image: url("")) { .focus-mode-layer { mask-image: none !important; -webkit-mask-image: none !important; background: rgba(5, 7, 12, calc(var(--focus-dim) * .45)); } }
-@media (prefers-reduced-motion: reduce) { .focus-mode-layer, .focus-mode-outline { transition: none; } }
-.focus-mode-outline-layer { position: fixed; inset: 0; z-index: 2147483647; pointer-events: none; }
+.focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; }
+.focus-mode-backdrop { position: absolute; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); backdrop-filter: blur(var(--focus-blur)); -webkit-backdrop-filter: blur(var(--focus-blur)); }
+.focus-performance-fallback .focus-mode-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; }
+@media (prefers-reduced-motion: reduce) { .focus-mode-layer { transition: none; } }
+/* Focus reveals unchanged sentence pixels, without the legacy blue hover/click decoration. */
+.focus-mode-active .sentence-hover-box,
+.focus-mode-active .sentence-equation-box,
+.focus-mode-active .sentence-active-box,
+.focus-mode-active .sentence-pulse-box { visibility: hidden; }
+.focus-mode-active .trans-sentence.sentence-highlight,
+.focus-mode-active .trans-sentence.active-mapped-sentence,
+.focus-mode-active .trans-sentence.sentence-pulse {
+  background: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  animation: none !important;
+}

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -53,21 +53,65 @@ test('pinned focus ignores hover, follows geometry changes and releases with Esc
     document.querySelector('.sentence').style.left = '250px'
   })
   expect(await page.evaluate(() => window.controller.current.sentenceIdx)).toBe(0)
-  await expect(page.locator('.focus-mode-outline')).toHaveCSS('left', '250px')
+  await expect.poll(() => page.locator('.focus-mode-layer').innerHTML()).toContain('246px')
   await page.keyboard.press('ArrowRight')
   expect(await page.evaluate(() => window.controller.current.sentenceIdx)).toBe(1)
   await page.keyboard.press('Escape')
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
 
+test('blur actually softens background pixels while preserving sentence pixels', async ({ page, browserName }) => {
+  test.skip(browserName === 'webkit' && process.platform === 'linux', 'Linux headless WebKit does not rasterize backdrop-filter, even on an unmasked standalone element')
+  await setup(page)
+  await page.addStyleTag({ content: '#panel, #root .sentence { background: repeating-linear-gradient(90deg, black 0 2px, white 2px 4px) }' })
+  await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 12, dimOpacity: 0, scale: 100 }))
+  await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('backdrop-filter', 'blur(12px)')
+  const screenshot = (await page.screenshot({ scale: 'css' })).toString('base64')
+  const contrasts = await page.evaluate(async screenshot => {
+    const image = new Image(); image.src = `data:image/png;base64,${screenshot}`; await image.decode()
+    const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
+    const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
+    const contrast = (x, y) => {
+      const data = ctx.getImageData(x, y, 32, 1).data
+      const samples = Array.from({ length: 32 }, (_, i) => data[i * 4])
+      return Math.max(...samples) - Math.min(...samples)
+    }
+    return { source: contrast(220, 150), background: contrast(450, 175) }
+  }, screenshot)
+  expect(contrasts.source).toBeGreaterThan(200)
+  expect(contrasts.background).toBeLessThan(30)
+})
+
 test('blur and tint can be independently disabled; controls release the mask before interaction', async ({ page }) => {
   await setup(page)
   await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 10, dimOpacity: 0, scale: 100 }))
-  await expect(page.locator('.focus-mode-layer')).toHaveCSS('backdrop-filter', 'blur(10px)')
-  await expect(page.locator('.focus-mode-layer')).toHaveCSS('background-color', 'rgba(5, 7, 12, 0)')
+  await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('backdrop-filter', 'blur(10px)')
+  await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('background-color', 'rgba(5, 7, 12, 0)')
   await page.locator('#panel').click()
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
+
+for (const scale of [0.8, 1, 1.25]) {
+  test(`translation reveal scrolls only its pane and clips hidden fragments at scale ${scale}`, async ({ page }) => {
+    await page.setContent('<div class="trans-page-content" style="position:absolute;left:400px;top:80px;width:200px;height:100px;overflow:auto;border:2px solid"><div style="height:500px"></div><span id="translation">Translated sentence</span><div style="height:500px"></div></div>')
+    const result = await page.evaluate(async ({ moduleSource, scale }) => {
+      const { visibleFocusRects, revealFocusTranslation } = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+      document.documentElement.style.zoom = String(scale)
+      const element = document.querySelector('#translation'), pane = element.closest('.trans-page-content')
+      const hidden = visibleFocusRects(element)
+      revealFocusTranslation([element])
+      const visible = visibleFocusRects(element)
+      const scroll = pane.scrollTop
+      revealFocusTranslation([element])
+      return { hidden, visible, scroll, secondScroll: pane.scrollTop, pageScroll: window.scrollY }
+    }, { moduleSource, scale })
+    expect(result.hidden).toEqual([])
+    expect(result.visible.length).toBeGreaterThan(0)
+    expect(result.scroll).toBeGreaterThan(0)
+    expect(result.secondScroll).toBe(result.scroll)
+    expect(result.pageScroll).toBe(0)
+  })
+}
 
 test('real PDF hover reveals source and translation together and clears on viewer exit', async ({ page }) => {
   const doc = { id: 'focus-pdf', filename: 'focus.pdf', total_pages: 1, translated_pages: [1], metadata: { title: 'Focus' } }
@@ -87,12 +131,31 @@ test('real PDF hover reveals source and translation together and clears on viewe
   await expect(source).toBeVisible()
   const translation = page.locator('.trans-sentence').first()
   await expect(translation).toBeVisible()
+  // Put the matching translation below its own scroll viewport, not below the page.
+  await translation.evaluate(element => {
+    const pane = element.closest('.trans-page-content')
+    pane.style.height = '180px'
+    pane.style.maxHeight = '180px'
+    const spacer = document.createElement('div')
+    spacer.style.height = '700px'
+    pane.insertBefore(spacer, pane.firstChild)
+    pane.scrollTop = 0
+  })
+  const sourceBefore = await source.boundingBox()
   await source.hover()
   await expect(page.locator('.focus-mode-layer')).toBeVisible()
-  const sourceMask = await page.locator('.focus-mode-layer').evaluate(el => el.style.maskImage)
+  await expect.poll(() => translation.evaluate(element => {
+    const pane = element.closest('.trans-page-content')
+    const bounds = pane.getBoundingClientRect(), rect = element.getBoundingClientRect()
+    return pane.scrollTop > 0 && rect.top >= bounds.top && rect.bottom <= bounds.bottom
+  })).toBe(true)
+  expect((await source.boundingBox()).y).toBeCloseTo(sourceBefore.y, 0)
+  const sourceMask = await page.locator('.focus-mode-layer').innerHTML()
   await translation.hover()
-  await expect.poll(() => page.locator('.focus-mode-layer').evaluate(el => el.style.maskImage)).toBe(sourceMask)
-  await expect(page.locator('.focus-mode-outline')).toHaveCount(2)
+  await expect.poll(() => page.locator('.focus-mode-layer').innerHTML()).toBe(sourceMask)
+  await expect(page.locator('.focus-mode-outline')).toHaveCount(0)
+  await expect(translation).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(translation).toHaveCSS('box-shadow', 'none')
   await translation.click()
   await page.keyboard.press('Escape')
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)

--- a/frontend/tests/focusMode.test.js
+++ b/frontend/tests/focusMode.test.js
@@ -1,6 +1,17 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { createFocusMask, focusCssVariables, isFocusKeyboardExcluded, mergeClientRects, normalizeFocusSettings } from '../src/focusMode.js'
+import { createFocusBackdropRects, createFocusMask, focusCssVariables, isFocusKeyboardExcluded, mergeClientRects, normalizeFocusSettings } from '../src/focusMode.js'
+
+test('배경 영역은 겹치는 문장 구멍을 제외하고 한 번만 덮는다', () => {
+  const regions = createFocusBackdropRects([
+    { left: 10, top: 10, width: 20, height: 20 },
+    { left: 20, top: 20, width: 20, height: 20 },
+  ], 50, 50, 0)
+  for (let y = 0; y < 50; y++) for (let x = 0; x < 50; x++) {
+    const hole = (x >= 10 && x < 30 && y >= 10 && y < 30) || (x >= 20 && x < 40 && y >= 20 && y < 40)
+    assert.equal(regions.filter(r => x >= r.left && x < r.left + r.width && y >= r.top && y < r.top + r.height).length, hole ? 0 : 1)
+  }
+})
 
 test('Focus 설정은 손상값과 범위를 정규화한다', () => {
   assert.deepEqual(normalizeFocusSettings({ enabled: true, blurStrength: 99, dimOpacity: 23, scale: 'bad' }), { enabled: true, blurStrength: 16, dimOpacity: 25, scale: 104 })


### PR DESCRIPTION
# Summary

## 1. 가려진 번역문 Focus 수정
- 원문 호버 시 대응 번역문의 내부 패널만 스크롤하도록 수정함
- 스크롤 후 좌표를 재계산하고 overflow 영역 밖의 번역문 조각을 제외함
- UI 배율 80%, 100%, 125%와 실제 PDF 연동 회귀 테스트를 추가함

## 2. 문장 강조와 배경 처리 수정
- Focus 테두리와 기존 파란 문장 강조 표시를 제거함
- SVG 마스크 대신 문장 영역을 제외한 배경 사각형에 블러와 디밍을 적용함
- Chromium에서 배경 픽셀 흐림과 원문 선명도 검증을 추가함
- Linux headless WebKit은 최소 독립 화면에서도 backdrop blur를 렌더링하지 않아 해당 픽셀 검사만 명시적으로 제외함. 사용자 브라우저의 블러 문제 해결은 아직 확정하지 않음

## 3. 검증
- 단위 테스트 92개 통과함
- Focus 브라우저 테스트 19개 통과, Linux WebKit 블러 픽셀 검사 1개 제외함
- validate:i18n 및 프로덕션 빌드 통과함