### PR TITLE
fix: Focus 블러 및 메모 가림 수정

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: npm run build
       - name: Verify PDF geometry on macOS WebKit
         working-directory: frontend
-        run: npm run test:e2e:webkit -- tests/e2e/pdf-text-geometry.spec.js tests/e2e/pdf-text-layer-alignment.spec.js tests/e2e/pdf-viewer-race.spec.js --workers=2
+        run: npm run test:e2e:webkit -- tests/e2e/pdf-text-geometry.spec.js tests/e2e/pdf-text-layer-alignment.spec.js tests/e2e/pdf-viewer-race.spec.js tests/e2e/focus-isolation.spec.js --workers=2
       - name: Upload PDF geometry failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -102,10 +102,41 @@ export function visibleFocusRects(element) {
   return rects
 }
 
+const SVG_NS = 'http://www.w3.org/2000/svg'
+let filterId = 0
+function svgElement(name, attributes = {}) {
+  const element = document.createElementNS(SVG_NS, name)
+  for (const [key, value] of Object.entries(attributes)) element.setAttribute(key, String(value))
+  return element
+}
+
+// Filter SourceGraphic itself, not the browser's optional backdrop compositor.
+// The original pixels inside each sentence are merged over the blurred pixels.
+export function createSentenceFilter(id, rects, bounds, strength) {
+  // Normalized coordinates avoid WebKit/Chromium differences under CSS zoom.
+  const width = bounds.width || 1, height = bounds.height || 1
+  const px = Math.max(4, strength * 3) / width, py = Math.max(4, strength * 3) / height
+  const filter = svgElement('filter', { id, filterUnits: 'objectBoundingBox', primitiveUnits: 'objectBoundingBox', x: -px, y: -py, width: 1 + px * 2, height: 1 + py * 2, 'color-interpolation-filters': 'sRGB' })
+  filter.append(svgElement('feGaussianBlur', { in: 'SourceGraphic', stdDeviation: `${strength / width} ${strength / height}`, result: 'blurred' }))
+  rects.forEach((rect, index) => filter.append(svgElement('feFlood', {
+    x: (rect.left - bounds.left - 4) / width, y: (rect.top - bounds.top - 4) / height,
+    width: (rect.width + 8) / width, height: (rect.height + 8) / height,
+    'flood-color': 'white', result: `hole${index}`,
+  })))
+  const holes = svgElement('feMerge', { result: 'holes' })
+  rects.forEach((_, index) => holes.append(svgElement('feMergeNode', { in: `hole${index}` })))
+  filter.append(holes, svgElement('feComposite', { in: 'blurred', in2: 'holes', operator: 'out', result: 'background' }), svgElement('feComposite', { in: 'SourceGraphic', in2: 'holes', operator: 'in', result: 'sentence' }))
+  const output = svgElement('feMerge')
+  output.append(svgElement('feMergeNode', { in: 'background' }), svgElement('feMergeNode', { in: 'sentence' }))
+  filter.append(output)
+  return filter
+}
+
 export class FocusModeController {
   constructor({ root, resolvePair, listSentences, announce = () => {}, notifyFallback = () => {}, releaseDelay = 150 }) {
     Object.assign(this, { root, resolvePair, listSentences, announce, notifyFallback, releaseDelay })
-    this.settings = normalizeFocusSettings(); this.current = null; this.pinned = false; this.slowFrames = 0; this.performanceFallback = false
+    this.settings = normalizeFocusSettings(); this.current = null; this.pinned = false
+    this.filteredElements = new Map(); this.hiddenMemos = new Map()
     this.onKeyDown = event => this.handleKeyDown(event); this.onViewportChange = () => this.scheduleRender()
     this.onLeave = () => this.leave()
     this.onInteraction = event => {
@@ -143,6 +174,13 @@ export class FocusModeController {
     this.current = null; this.pinned = false; this.lastGeometry = null
     this.layer?.remove()
     this.layer = null
+    for (const [element, original] of this.filteredElements) {
+      element.style.setProperty('filter', original.value, original.priority)
+    }
+    this.filteredElements.clear()
+    for (const [element, original] of this.hiddenMemos) element.style.setProperty('visibility', original.value, original.priority)
+    this.hiddenMemos.clear()
+    this.filterSvg?.remove(); this.filterSvg = null
     this.root?.classList.remove('focus-mode-active')
     this.root?.querySelectorAll('.trans-sentence[aria-pressed]').forEach(element => element.removeAttribute('aria-pressed'))
   }
@@ -167,7 +205,6 @@ export class FocusModeController {
   }
   render() {
     if (!this.current || !this.settings.enabled) return
-    const started = performance.now()
     let pair = this.resolvePair?.(this.current) || {}
     if (this.current.revealTranslation && !this.revealedTranslation && pair.elements?.length) {
       revealFocusTranslation(pair.elements)
@@ -186,16 +223,41 @@ export class FocusModeController {
     // Only sentence pixels are revealed. Panels, popups and toolbars remain covered.
     // Rendering can temporarily disappear during PDF zoom; retain the pinned reference.
     const zoom = Number.parseFloat(getComputedStyle(document.documentElement).zoom) || 1
-    const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, this.performanceFallback])
-    if (geometry === this.lastGeometry) { this.scheduleRender(); return }
+    const memoRects = Array.from(document.querySelectorAll('.floating-memo')).map(element => ({ element, bounds: element.getBoundingClientRect() }))
+    for (const { element, bounds: memo } of memoRects) {
+      const overlaps = rects.some(rect => rect.left < memo.right && rect.left + rect.width > memo.left && rect.top < memo.bottom && rect.top + rect.height > memo.top)
+      if (overlaps && !this.hiddenMemos.has(element)) {
+        this.hiddenMemos.set(element, { value: element.style.getPropertyValue('visibility'), priority: element.style.getPropertyPriority('visibility') })
+        element.style.setProperty('visibility', 'hidden', 'important')
+      } else if (!overlaps && this.hiddenMemos.has(element)) {
+        const original = this.hiddenMemos.get(element)
+        element.style.setProperty('visibility', original.value, original.priority); this.hiddenMemos.delete(element)
+      }
+    }
+    const targets = Array.from(document.body.children).filter(element => element instanceof HTMLElement && !['SCRIPT', 'STYLE', 'LINK'].includes(element.tagName) && element !== this.layer)
+    const targetBounds = targets.map(element => element.getBoundingClientRect())
+    const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, targetBounds.map(b => [b.left, b.top, b.width, b.height])])
+    if (geometry === this.lastGeometry && targets.every(element => this.filteredElements.has(element))) { this.scheduleRender(); return }
     this.lastGeometry = geometry
+    if (!this.filterSvg) {
+      this.filterSvg = svgElement('svg', { width: 0, height: 0, 'aria-hidden': 'true' })
+      this.filterSvg.style.position = 'absolute'; document.body.append(this.filterSvg)
+    }
+    this.filterSvg.replaceChildren()
+    targets.forEach((element, index) => {
+      if (!this.filteredElements.has(element)) this.filteredElements.set(element, { value: element.style.getPropertyValue('filter'), priority: element.style.getPropertyPriority('filter'), computed: getComputedStyle(element).filter })
+      const original = this.filteredElements.get(element)
+      const id = `focus-sentence-filter-${++filterId}`
+      this.filterSvg.append(createSentenceFilter(id, rects, targetBounds[index], this.settings.blurStrength))
+      const prefix = original.computed === 'none' ? '' : original.computed
+      element.style.setProperty('filter', `${prefix} url("#${id}")`, 'important')
+    })
     if (!this.layer) { this.layer = document.createElement('div'); this.layer.className = 'focus-mode-layer'; this.layer.setAttribute('aria-hidden', 'true'); document.body.append(this.layer) }
     for (const layer of [this.layer]) {
       // Client rects use viewport pixels; cancel the application's root CSS zoom.
       layer.style.zoom = String(1 / zoom)
       for (const [name, value] of Object.entries(focusCssVariables(this.settings))) layer.style.setProperty(name, value)
     }
-    this.layer.classList.toggle('focus-performance-fallback', this.performanceFallback)
     this.layer.replaceChildren(...createFocusBackdropRects(rects, window.innerWidth, window.innerHeight).map(rect => {
       const backdrop = document.createElement('div')
       backdrop.className = 'focus-mode-backdrop'
@@ -203,8 +265,6 @@ export class FocusModeController {
       return backdrop
     }))
     this.root?.classList.add('focus-mode-active')
-    this.slowFrames = performance.now() - started > 20 ? this.slowFrames + 1 : Math.max(0, this.slowFrames - 1)
-    if (!this.performanceFallback && this.slowFrames >= 8) { this.performanceFallback = true; this.notifyFallback(); this.scheduleRender() }
     this.scheduleRender()
   }
   destroy() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7961,8 +7961,7 @@ body.light-theme .chat-drawer {
 .focus-range input:disabled { opacity: .45; }
 .focus-keyboard-help { color: var(--text-muted); }
 .focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; }
-.focus-mode-backdrop { position: absolute; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); backdrop-filter: blur(var(--focus-blur)); -webkit-backdrop-filter: blur(var(--focus-blur)); }
-.focus-performance-fallback .focus-mode-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; }
+.focus-mode-backdrop { position: absolute; pointer-events: none; background: rgba(5, 7, 12, var(--focus-dim)); }
 @media (prefers-reduced-motion: reduce) { .focus-mode-layer { transition: none; } }
 /* Focus reveals unchanged sentence pixels, without the legacy blue hover/click decoration. */
 .focus-mode-active .sentence-hover-box,

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -60,34 +60,69 @@ test('pinned focus ignores hover, follows geometry changes and releases with Esc
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
 
-test('blur actually softens background pixels while preserving sentence pixels', async ({ page, browserName }) => {
-  test.skip(browserName === 'webkit' && process.platform === 'linux', 'Linux headless WebKit does not rasterize backdrop-filter, even on an unmasked standalone element')
-  await setup(page)
+for (const scale of [0.8, 1, 1.25]) {
+test(`blur actually softens background pixels while preserving sentence pixels at scale ${scale}`, async ({ page }) => {
+  await setup(page, scale)
   await page.addStyleTag({ content: '#panel, #root .sentence { background: repeating-linear-gradient(90deg, black 0 2px, white 2px 4px) }' })
   await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 12, dimOpacity: 0, scale: 100 }))
-  await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('backdrop-filter', 'blur(12px)')
+  await expect.poll(() => page.locator('.focus-mode-layer').evaluate(element => element.style.getPropertyValue('--focus-blur'))).toBe('12px')
   const screenshot = (await page.screenshot({ scale: 'css' })).toString('base64')
-  const contrasts = await page.evaluate(async screenshot => {
+  const contrasts = await page.evaluate(async ({ screenshot, scale }) => {
     const image = new Image(); image.src = `data:image/png;base64,${screenshot}`; await image.decode()
     const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
     const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
     const contrast = (x, y) => {
-      const data = ctx.getImageData(x, y, 32, 1).data
+      const data = ctx.getImageData(Math.round(x * scale), Math.round(y * scale), 32, 1).data
       const samples = Array.from({ length: 32 }, (_, i) => data[i * 4])
       return Math.max(...samples) - Math.min(...samples)
     }
     return { source: contrast(220, 150), background: contrast(450, 175) }
-  }, screenshot)
+  }, { screenshot, scale })
   expect(contrasts.source).toBeGreaterThan(200)
   expect(contrasts.background).toBeLessThan(30)
 })
+}
 
 test('blur and tint can be independently disabled; controls release the mask before interaction', async ({ page }) => {
   await setup(page)
   await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 10, dimOpacity: 0, scale: 100 }))
-  await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('backdrop-filter', 'blur(10px)')
+  await expect.poll(() => page.locator('.focus-mode-layer').evaluate(element => element.style.getPropertyValue('--focus-blur'))).toBe('10px')
   await expect(page.locator('.focus-mode-backdrop').first()).toHaveCSS('background-color', 'rgba(5, 7, 12, 0)')
   await page.locator('#panel').click()
+  await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+  await expect(page.locator('#root')).toHaveCSS('filter', 'none')
+})
+
+test('overlapping memos cannot obscure focus and are restored on release', async ({ page }) => {
+  await setup(page)
+  await page.evaluate(() => {
+    const memo = document.createElement('aside')
+    memo.className = 'floating-memo'
+    memo.textContent = 'Covering note'
+    Object.assign(memo.style, { position: 'fixed', left: '100px', top: '120px', width: '200px', height: '40px', background: 'red', zIndex: '999999' })
+    document.body.append(memo)
+  })
+  await expect(page.locator('.floating-memo')).toHaveCSS('visibility', 'hidden')
+  await page.locator('.floating-memo').evaluate(element => { element.style.left = '600px' })
+  await expect(page.locator('.floating-memo')).toHaveCSS('visibility', 'visible')
+  await page.locator('.floating-memo').evaluate(element => { element.style.left = '100px' })
+  await expect(page.locator('.floating-memo')).toHaveCSS('visibility', 'hidden')
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.floating-memo')).toHaveCSS('visibility', 'visible')
+  await expect(page.locator('.floating-memo')).toHaveCSS('filter', 'none')
+})
+
+test('focus restores existing inline filters and cleans up when disabled', async ({ page }) => {
+  await setup(page)
+  await page.evaluate(() => {
+    window.controller.clear()
+    document.querySelector('#root').style.setProperty('filter', 'brightness(0.8)', 'important')
+    window.controller.togglePin({ pageNum: 1, sentenceIdx: 0 })
+  })
+  await expect(page.locator('feGaussianBlur').first()).toBeAttached()
+  await page.evaluate(() => window.controller.applySettings({ enabled: false }))
+  await expect(page.locator('#root')).toHaveCSS('filter', 'brightness(0.8)')
+  await expect(page.locator('feGaussianBlur')).toHaveCount(0)
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
 
@@ -128,7 +163,7 @@ test('real PDF hover reveals source and translation together and clears on viewe
     location.hash = '#viewer?id=focus-pdf'
   })
   const source = page.locator('.textLayer span').filter({ hasText: 'The quick brown fox' }).first()
-  await expect(source).toBeVisible()
+  await expect(source).toBeVisible({ timeout: 15000 })
   const translation = page.locator('.trans-sentence').first()
   await expect(translation).toBeVisible()
   // Put the matching translation below its own scroll viewport, not below the page.


### PR DESCRIPTION
# Summary

## 1. 실제 배경 블러 적용
- backdrop-filter 의존을 제거하고 SVG 필터로 원본 화면 픽셀을 직접 블러 처리하도록 수정함
- 문장 영역의 원본 픽셀은 그대로 합성해 텍스트 좌표와 선명도를 유지함
- 비율 좌표로 Chromium과 WebKit의 CSS zoom 차이를 보정함
- DOM 처리 시간에 따라 블러가 영구 해제되던 자동 폴백을 제거함

## 2. 메모 가림 방지
- 포커스 문장과 겹치는 메모만 일시적으로 숨기도록 수정함
- 문장 이동 및 Focus 해제 시 메모의 기존 표시 상태를 복원함
- Focus 해제 시 기존 CSS 필터 및 임시 SVG 리소스를 복원·정리함

## 3. 검증
- Chromium·WebKit 관련 E2E 30개를 제외 없이 통과함
- 배율 80%, 100%, 125%에서 실제 블러 픽셀과 문장 선명도를 검증함
- 메모 겹침·이동·해제 및 기존 필터 복원 테스트를 추가함
- 단위 테스트 92개, validate:i18n 및 프로덕션 빌드를 통과함
- macOS WebKit CI에도 Focus 픽셀 회귀 검사를 추가함