### PR TITLE
fix(settings): hide inactive focus controls

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1041,10 +1041,12 @@
                   <span class="toggle-switch-track"><span class="toggle-switch-thumb"></span></span>
                   <span class="toggle-switch-label"><span data-i18n="settings:focusMode">Focus 모드</span><small id="focus-mode-help" data-i18n="settings:focusModeDescription">문장 위에 마우스를 올리면 대응 원문과 번역만 선명하게 표시</small></span>
                 </label>
-                <label class="focus-range"><span data-i18n="settings:focusBlur">블러 강도</span><input id="setting-focus-blur" type="range" min="0" max="16" step="1" value="6" aria-label="블러 강도" /><output id="setting-focus-blur-value">6px</output></label>
-                <label class="focus-range"><span data-i18n="settings:focusDim">배경 디밍</span><input id="setting-focus-dim" type="range" min="0" max="60" step="5" value="20" aria-label="배경 디밍" /><output id="setting-focus-dim-value">20%</output></label>
-                <label class="focus-range"><span data-i18n="settings:focusScale">문장 확대</span><input id="setting-focus-scale" type="range" min="100" max="110" step="1" value="104" aria-label="문장 확대" /><output id="setting-focus-scale-value">104%</output></label>
-                <small class="focus-keyboard-help" data-i18n="settings:focusKeyboardHelp">문장을 클릭해 고정한 뒤 방향키로 이동하고 Esc로 해제</small>
+                <div id="focus-mode-controls" class="focus-mode-controls" aria-hidden="true">
+                  <label class="focus-range"><span data-i18n="settings:focusBlur">블러 강도</span><input id="setting-focus-blur" type="range" min="0" max="16" step="1" value="6" aria-label="블러 강도" /><output id="setting-focus-blur-value">6px</output></label>
+                  <label class="focus-range"><span data-i18n="settings:focusDim">배경 디밍</span><input id="setting-focus-dim" type="range" min="0" max="60" step="5" value="20" aria-label="배경 디밍" /><output id="setting-focus-dim-value">20%</output></label>
+                  <label class="focus-range"><span data-i18n="settings:focusScale">문장 확대</span><input id="setting-focus-scale" type="range" min="100" max="110" step="1" value="104" aria-label="문장 확대" /><output id="setting-focus-scale-value">104%</output></label>
+                  <small class="focus-keyboard-help" data-i18n="settings:focusKeyboardHelp">문장을 클릭해 고정한 뒤 방향키로 이동하고 Esc로 해제</small>
+                </div>
               </div>
               <label class="toggle-switch">
                 <input type="checkbox" id="setting-disable-hover-tooltip" />

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -647,6 +647,7 @@ const settingFocusScale = $('setting-focus-scale')
 const settingFocusBlurValue = $('setting-focus-blur-value')
 const settingFocusDimValue = $('setting-focus-dim-value')
 const settingFocusScaleValue = $('setting-focus-scale-value')
+const focusModeControls = $('focus-mode-controls')
 const settingDisableBookmark = $('setting-disable-bookmark')
 const settingDisableInsights = $('setting-disable-insights')
 const settingDisableCitationOverlay = $('setting-disable-citation-overlay')
@@ -4397,6 +4398,8 @@ function readFocusModeSettings(mode = settingsTranslationModeContext) {
 }
 function syncFocusSettingsControls() {
   const enabled = settingFocusMode.checked
+  focusModeControls?.classList.toggle('hidden', !enabled)
+  focusModeControls?.setAttribute('aria-hidden', String(!enabled))
   for (const control of [settingFocusBlur, settingFocusDim, settingFocusScale]) control.disabled = !enabled
   settingFocusBlurValue.value = `${settingFocusBlur.value}px`
   settingFocusDimValue.value = `${settingFocusDim.value}%`

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7958,6 +7958,7 @@ body.light-theme .chat-drawer {
 
 /* Focus mode keeps layout and selection coordinates untouched; only this fixed visual layer changes. */
 .focus-settings { display: grid; gap: 9px; padding: 8px 0; }
+.focus-mode-controls { display: grid; gap: 9px; }
 .focus-range { display: grid; grid-template-columns: minmax(90px, 1fr) minmax(120px, 2fr) 46px; align-items: center; gap: 10px; font-size: 12px; color: var(--text-secondary); }
 .focus-range output { color: var(--text-primary); font-variant-numeric: tabular-nums; text-align: right; }
 .focus-range input:disabled { opacity: .45; }


### PR DESCRIPTION
## Summary
- Focus 모드가 꺼진 경우 블러·디밍·확대 슬라이더와 키보드 안내 숨김
- Focus 모드 활성화 시에만 관련 설정 표시

## Verification
- npm run validate:i18n
- node --test tests/modeSettings.test.js tests/settingsScaleDefaults.test.js
- node --test tests/focusMode.test.js