### PR TITLE
fix: 문장 확대 및 슬라이더 끝점 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1044,7 +1044,7 @@
                 <div id="focus-mode-controls" class="focus-mode-controls" aria-hidden="true">
                   <label class="focus-range"><span data-i18n="settings:focusBlur">블러 강도</span><input id="setting-focus-blur" type="range" min="0" max="16" step="1" value="6" aria-label="블러 강도" /><output id="setting-focus-blur-value">6px</output></label>
                   <label class="focus-range"><span data-i18n="settings:focusDim">배경 디밍</span><input id="setting-focus-dim" type="range" min="0" max="60" step="5" value="20" aria-label="배경 디밍" /><output id="setting-focus-dim-value">20%</output></label>
-                  <label class="focus-range"><span data-i18n="settings:focusScale">문장 확대</span><input id="setting-focus-scale" type="range" min="100" max="110" step="1" value="104" aria-label="문장 확대" /><output id="setting-focus-scale-value">104%</output></label>
+                  <label class="focus-range"><span data-i18n="settings:focusScale">문장 확대</span><input id="setting-focus-scale" type="range" min="100" max="150" step="1" value="104" aria-label="문장 확대" /><output id="setting-focus-scale-value">104%</output></label>
                   <small class="focus-keyboard-help" data-i18n="settings:focusKeyboardHelp">문장을 클릭해 고정한 뒤 방향키로 이동하고 Esc로 해제</small>
                 </div>
               </div>

--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -10,7 +10,7 @@ export function normalizeFocusSettings(value = {}) {
     enabled: value.enabled === true,
     blurStrength: number(value.blurStrength, 6, 0, 16),
     dimOpacity: number(value.dimOpacity, 20, 0, 60, 5),
-    scale: number(value.scale, 104, 100, 110),
+    scale: number(value.scale, 104, 100, 150),
   }
 }
 
@@ -136,6 +136,86 @@ export function createSentenceFilter(id, rects, bounds, strength, zoom = 1) {
   return filter
 }
 
+function copyStyledTree(element) {
+  const clone = element.cloneNode(false)
+  if (element instanceof Element) {
+    const style = getComputedStyle(element)
+    for (const property of style) clone.style.setProperty(property, style.getPropertyValue(property))
+    clone.removeAttribute('id')
+    clone.removeAttribute('contenteditable')
+    clone.classList.remove('sentence-highlight', 'active-mapped-sentence', 'sentence-pulse')
+  }
+  for (const child of element.childNodes) clone.append(child instanceof Element ? copyStyledTree(child) : child.cloneNode(true))
+  return clone
+}
+
+function sentenceBackground(element) {
+  for (let current = element; current; current = current.parentElement) {
+    const color = getComputedStyle(current).backgroundColor
+    if (color !== 'transparent' && color !== 'rgba(0, 0, 0, 0)') return color
+  }
+  return 'var(--bg-primary, white)'
+}
+
+// Magnify visual copies only; native PDF/text layout and selection stay intact.
+export function createFocusMagnification(pair, viewportRects, scale) {
+  if (scale <= 1) return []
+  const groups = [], erasures = []
+  const build = (rects, draw, kind, background, filter = 'none') => {
+    const visible = mergeClientRects(rects).flatMap(rect => viewportRects.map(view => {
+      const left = Math.max(rect.left, view.left), top = Math.max(rect.top, view.top)
+      const right = Math.min(rect.right, view.left + view.width), bottom = Math.min(rect.bottom, view.top + view.height)
+      return { left, top, right, bottom, width: right - left, height: bottom - top }
+    })).filter(rect => rect.width > 0 && rect.height > 0)
+    if (!visible.length) return
+    const left = Math.min(...visible.map(r => r.left)), top = Math.min(...visible.map(r => r.top))
+    const width = Math.max(...visible.map(r => r.right)) - left, height = Math.max(...visible.map(r => r.bottom)) - top
+    const effectiveScale = Math.max(1, Math.min(scale, (window.innerWidth - 8) / width, (window.innerHeight - 8) / height))
+    const group = document.createElement('div')
+    group.className = 'focus-mode-magnification'; group.dataset.kind = kind; group.inert = true
+    const dx = Math.max(4 - (left - width * (effectiveScale - 1) / 2), Math.min(0, window.innerWidth - 4 - (left + width * (effectiveScale + 1) / 2)))
+    const dy = Math.max(4 - (top - height * (effectiveScale - 1) / 2), Math.min(0, window.innerHeight - 4 - (top + height * (effectiveScale + 1) / 2)))
+    Object.assign(group.style, { position: 'absolute', left: `${left}px`, top: `${top}px`, width: `${width}px`, height: `${height}px`, transform: `translate(${dx}px, ${dy}px) scale(${effectiveScale})`, transformOrigin: 'center' })
+    for (const rect of visible) {
+      const erasure = document.createElement('div')
+      erasure.className = 'focus-mode-erasure'
+      Object.assign(erasure.style, { position: 'absolute', left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px`, background, filter })
+      erasures.push(erasure)
+      const crop = document.createElement('div')
+      Object.assign(crop.style, { position: 'absolute', overflow: 'hidden', left: `${rect.left - left}px`, top: `${rect.top - top}px`, width: `${rect.width}px`, height: `${rect.height}px` })
+      draw(crop, rect); group.append(crop)
+    }
+    groups.push(group)
+  }
+  if (pair.sourceCanvas) {
+    const source = pair.sourceCanvas, bounds = source.getBoundingClientRect()
+    if (bounds.width && bounds.height) build(pair.sourceRects || [], (crop, rect) => {
+      const canvas = document.createElement('canvas')
+      const sx = source.width / bounds.width, sy = source.height / bounds.height
+      canvas.width = Math.ceil(rect.width * sx); canvas.height = Math.ceil(rect.height * sy)
+      const ctx = canvas.getContext('2d')
+      ctx.fillStyle = 'white'; ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(source, (rect.left - bounds.left) * sx, (rect.top - bounds.top) * sy, rect.width * sx, rect.height * sy, 0, 0, canvas.width, canvas.height)
+      Object.assign(canvas.style, { display: 'block', width: '100%', height: '100%', filter: getComputedStyle(source).filter })
+      crop.append(canvas)
+    }, 'source', 'white', getComputedStyle(source).filter)
+  }
+  for (const element of pair.elements || []) {
+    const host = element.closest('p, li, h1, h2, h3, h4, h5, h6') || element.parentElement
+    if (!host) continue
+    const bounds = host.getBoundingClientRect(), zoom = bounds.width / host.offsetWidth || 1
+    const clone = copyStyledTree(host)
+    Object.assign(clone.style, { position: 'absolute', right: 'auto', bottom: 'auto', margin: '0', width: `${bounds.width / zoom}px`, height: 'auto', boxSizing: 'border-box', transform: 'none', zoom: String(zoom) })
+    build(visibleFocusRects(element), (crop, rect) => {
+      crop.style.background = sentenceBackground(host)
+      const content = clone.cloneNode(true)
+      content.style.left = `${(bounds.left - rect.left) / zoom}px`; content.style.top = `${(bounds.top - rect.top) / zoom}px`
+      crop.append(content)
+    }, 'translation', sentenceBackground(host))
+  }
+  return [...erasures, ...groups]
+}
+
 export class FocusModeController {
   constructor({ root, resolvePair, listSentences, announce = () => {}, notifyFallback = () => {}, releaseDelay = 150 }) {
     Object.assign(this, { root, resolvePair, listSentences, announce, notifyFallback, releaseDelay })
@@ -242,7 +322,7 @@ export class FocusModeController {
     const targets = Array.from(document.body.children).filter(element => element instanceof HTMLElement && !['SCRIPT', 'STYLE', 'LINK'].includes(element.tagName) && element !== this.layer)
       .filter(element => { const bounds = element.getBoundingClientRect(); return bounds.width > 0 && bounds.height > 0 })
     const targetBounds = targets.map(element => element.getBoundingClientRect())
-    const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, targetBounds.map(b => [b.left, b.top, b.width, b.height])])
+    const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, targetBounds.map(b => [b.left, b.top, b.width, b.height]), pair.elements?.map(e => e.textContent), document.body.className])
     if (geometry === this.lastGeometry && targets.every(element => this.filteredElements.has(element))) { this.scheduleRender(); return }
     this.lastGeometry = geometry
     if (!this.filterSvg) {
@@ -288,6 +368,7 @@ export class FocusModeController {
       return backdrop
     }))
     this.root?.classList.add('focus-mode-active')
+    this.layer.append(...createFocusMagnification(pair, rects, this.settings.scale / 100))
     this.scheduleRender()
   }
   destroy() {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17258,7 +17258,7 @@ function focusPairRects(ref) {
   const idx = ref.sentenceIdx >= 10000 ? (sentenceRange?.originalSentenceIdx ?? ref.sentenceIdx) : ref.sentenceIdx
   const translationRects = []
   viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`).forEach(element => translationRects.push(...visibleFocusRects(element)))
-  return { sourceRects, translationRects, elements: Array.from(viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`)) }
+  return { sourceRects, translationRects, sourceCanvas: viewerScrollContainer.querySelector(`.pdf-page-wrapper[data-page="${ref.pageNum}"] canvas`), elements: Array.from(viewerScrollContainer.querySelectorAll(`.trans-sentence[data-page="${ref.pageNum}"][data-sentence-idx="${idx}"]`)) }
 }
 
 function listFocusSentences() {

--- a/frontend/src/modeSettings.js
+++ b/frontend/src/modeSettings.js
@@ -71,7 +71,7 @@ const BOOLEAN_SETTINGS = new Set([
 const NUMBER_SETTINGS = {
   focusBlurStrength: { min: 0, max: 16, step: 1 },
   focusDimOpacity: { min: 0, max: 60, step: 5 },
-  focusScale: { min: 100, max: 110, step: 1 },
+  focusScale: { min: 100, max: 150, step: 1 },
 }
 
 const LEGACY_LANGUAGE_VALUES = {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7961,6 +7961,8 @@ body.light-theme .chat-drawer {
 .focus-mode-controls { display: grid; gap: 9px; }
 .focus-range { display: grid; grid-template-columns: minmax(90px, 1fr) minmax(120px, 2fr) 46px; align-items: center; gap: 10px; font-size: 12px; color: var(--text-secondary); }
 .focus-range output { color: var(--text-primary); font-variant-numeric: tabular-nums; text-align: right; }
+.focus-range input[type="range"] { width: 100%; min-width: 0; padding: 0; margin: 0; border: 0; box-sizing: border-box; cursor: pointer; }
+.focus-mode-magnification, .focus-mode-magnification * { pointer-events: none !important; }
 .focus-range input:disabled { opacity: .45; }
 .focus-keyboard-help { color: var(--text-muted); }
 .focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; }

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -147,6 +147,48 @@ test('focus restores existing inline filters and cleans up when disabled', async
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
 
+for (const zoom of [0.8, 1, 1.25]) {
+  test(`150% magnifies canvas and multiline translation without reflow at UI scale ${zoom}`, async ({ page }) => {
+    await setup(page, zoom)
+    const original = await page.evaluate(async moduleSource => {
+      const { visibleFocusRects } = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+      window.controller.clear()
+      const root = document.querySelector('#root')
+      const canvas = document.createElement('canvas'); canvas.id = 'focus-canvas'; canvas.width = 400; canvas.height = 80
+      Object.assign(canvas.style, { position: 'absolute', left: '100px', top: '120px', width: '200px', height: '40px' })
+      const ctx = canvas.getContext('2d'); ctx.fillStyle = 'white'; ctx.fillRect(0, 0, 400, 80); ctx.fillStyle = 'black'; ctx.font = '28px sans-serif'; ctx.fillText('Focused source', 12, 48)
+      const paragraph = document.createElement('p'); paragraph.id = 'focus-paragraph'
+      Object.assign(paragraph.style, { position: 'absolute', left: '650px', top: '240px', width: '200px', margin: '0', fontSize: '18px', lineHeight: '28px' })
+      paragraph.innerHTML = '<span class="trans-sentence">A translated sentence that wraps across multiple lines.</span>'
+      root.append(canvas, paragraph)
+      const element = paragraph.firstElementChild
+      window.controller.resolvePair = () => ({ sourceCanvas: canvas, sourceRects: [canvas.getBoundingClientRect()], translationRects: visibleFocusRects(element), elements: [element] })
+      const original = { canvas: canvas.getBoundingClientRect().toJSON(), paragraph: paragraph.getBoundingClientRect().toJSON() }
+      window.controller.applySettings({ enabled: true, blurStrength: 1, dimOpacity: 20, scale: 150 })
+      window.controller.togglePin({ pageNum: 1, sentenceIdx: 0 })
+      return original
+    }, moduleSource)
+    const source = page.locator('.focus-mode-magnification[data-kind="source"]')
+    const translation = page.locator('.focus-mode-magnification[data-kind="translation"]')
+    await expect(source).toBeVisible()
+    await expect(translation).toBeVisible()
+    await expect.poll(() => page.evaluate(async () => {
+      const before = document.querySelector('.focus-mode-magnification')
+      await new Promise(requestAnimationFrame)
+      await new Promise(requestAnimationFrame)
+      return before === document.querySelector('.focus-mode-magnification')
+    })).toBe(true)
+    await expect.poll(() => source.evaluate(e => Math.round(e.getBoundingClientRect().width))).toBe(Math.round(original.canvas.width * 1.5))
+    await expect(translation.locator(':scope > div')).not.toHaveCount(1)
+    expect(await page.locator('#focus-paragraph').boundingBox()).toEqual({ x: original.paragraph.x, y: original.paragraph.y, width: original.paragraph.width, height: original.paragraph.height })
+    await expect(page.locator('.focus-mode-magnification [id]')).toHaveCount(0)
+    await page.evaluate(() => window.controller.applySettings({ enabled: true, blurStrength: 1, dimOpacity: 20, scale: 120 }))
+    await expect.poll(() => source.evaluate(e => Math.round(e.getBoundingClientRect().width))).toBe(Math.round(original.canvas.width * 1.2))
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.focus-mode-magnification, .focus-mode-erasure')).toHaveCount(0)
+  })
+}
+
 for (const scale of [0.8, 1, 1.25]) {
   test(`translation reveal scrolls only its pane and clips hidden fragments at scale ${scale}`, async ({ page }) => {
     await page.setContent('<div class="trans-page-content" style="position:absolute;left:400px;top:80px;width:200px;height:100px;overflow:auto;border:2px solid"><div style="height:500px"></div><span id="translation">Translated sentence</span><div style="height:500px"></div></div>')
@@ -170,6 +212,7 @@ for (const scale of [0.8, 1, 1.25]) {
 }
 
 test('real PDF hover reveals source and translation together and clears on viewer exit', async ({ page }) => {
+  test.setTimeout(60000)
   const doc = { id: 'focus-pdf', filename: 'focus.pdf', total_pages: 1, translated_pages: [1], metadata: { title: 'Focus' } }
   const pdf = fs.readFileSync(new URL('./fixtures/text-geometry.pdf', import.meta.url))
   await mockBaseRoutes(page, { documents: [doc] })
@@ -180,6 +223,7 @@ test('real PDF hover reveals source and translation together and clears on viewe
   await gotoApp(page)
   await page.evaluate(() => {
     localStorage.setItem('easypaper_focus_mode_enabled_research', 'true')
+    localStorage.setItem('easypaper_focus_scale_research', '100')
     localStorage.setItem('easypaper_disable_hover_tooltip', 'true')
     location.hash = '#viewer?id=focus-pdf'
   })
@@ -207,7 +251,7 @@ test('real PDF hover reveals source and translation together and clears on viewe
   })).toBe(true)
   expect((await source.boundingBox()).y).toBeCloseTo(sourceBefore.y, 0)
   await source.click()
-  const sourceMask = await page.locator('.focus-mode-layer').innerHTML()
+  const sourceMask = await page.locator('.focus-mode-backdrop').evaluateAll(elements => elements.map(e => ['left', 'top', 'width', 'height'].map(p => parseFloat(e.style[p]))))
   // Compare actual PDF canvas and translation glyph pixels, not just geometry
   // or CSS declarations. Keep native layout/scroll positions fixed for both.
   const focused = (await page.screenshot({ scale: 'css', path: test.info().outputPath('focused.png') })).toString('base64')
@@ -248,8 +292,44 @@ test('real PDF hover reveals source and translation together and clears on viewe
     expect(result.focused.edges).toBeGreaterThan(result.original.edges * 0.9)
     expect(result.focused.contrast).toBeGreaterThan(result.original.contrast * 0.95)
   }
+  await page.evaluate(() => {
+    document.querySelector('#setting-focus-mode').checked = true
+    const range = document.querySelector('#setting-focus-scale')
+    range.value = '150'; range.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  const enlargedSource = page.locator('.focus-mode-magnification[data-kind="source"]')
+  await expect(enlargedSource).toBeVisible()
+  await expect(page.locator('.focus-mode-magnification[data-kind="translation"]').first()).toBeVisible()
+  await expect(page.locator('.focus-mode-magnification .sentence-highlight, .focus-mode-magnification .active-mapped-sentence')).toHaveCount(0)
+  expect((await enlargedSource.boundingBox()).width).toBeGreaterThan(sourceBefore.width * 1.4)
+  expect((await source.boundingBox()).width).toBeCloseTo(sourceBefore.width, 0)
+  const magnified = (await page.screenshot({ scale: 'css', path: test.info().outputPath('magnified-150.png') })).toString('base64')
+  const enlargedBoxes = await page.locator('.focus-mode-magnification').evaluateAll(elements => elements.map(e => e.getBoundingClientRect().toJSON()))
+  const glyphs = await page.evaluate(async ({ magnified, enlargedBoxes }) => {
+    const image = new Image(); image.src = `data:image/png;base64,${magnified}`; await image.decode()
+    const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
+    const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
+    return enlargedBoxes.map(b => {
+      const width = Math.floor(b.width), data = ctx.getImageData(Math.ceil(b.x), Math.ceil(b.y), width, Math.floor(b.height)).data
+      const gray = Array.from({ length: data.length / 4 }, (_, i) => (data[i * 4] + data[i * 4 + 1] + data[i * 4 + 2]) / 3)
+      return { contrast: Math.max(...gray) - Math.min(...gray), edges: gray.reduce((sum, value, i) => sum + (i % width ? Math.abs(value - gray[i - 1]) : 0), 0) / gray.length }
+    })
+  }, { magnified, enlargedBoxes })
+  for (const glyph of glyphs) {
+    expect(glyph.contrast).toBeGreaterThan(100)
+    expect(glyph.edges).toBeGreaterThan(4)
+  }
+  await page.evaluate(() => {
+    const range = document.querySelector('#setting-focus-scale')
+    range.value = '100'; range.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await expect(page.locator('.focus-mode-magnification')).toHaveCount(0)
   await translation.hover()
-  await expect.poll(() => page.locator('.focus-mode-layer').innerHTML()).toBe(sourceMask)
+  // Native hover can scroll the pane by a fractional pixel in WebKit.
+  await expect.poll(() => page.locator('.focus-mode-backdrop').evaluateAll((elements, before) => {
+    if (elements.length !== before.length) return Infinity
+    return Math.max(...elements.flatMap((e, i) => ['left', 'top', 'width', 'height'].map((p, j) => Math.abs(parseFloat(e.style[p]) - before[i][j]))))
+  }, sourceMask)).toBeLessThanOrEqual(2)
   await expect(page.locator('.focus-mode-outline')).toHaveCount(0)
   await expect(translation).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
   await expect(translation).toHaveCSS('box-shadow', 'none')

--- a/frontend/tests/e2e/focus-mode-settings.spec.js
+++ b/frontend/tests/e2e/focus-mode-settings.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { mockBaseRoutes, gotoApp } from './helpers.js'
 
 test('Focus 설정을 모드별로 저장하고 슬라이더 활성 상태를 복원한다', async ({ page }) => {
+  test.setTimeout(60000)
   await mockBaseRoutes(page, { documents: [] })
   await gotoApp(page)
   await page.locator('#sidebar-settings-btn').click()
@@ -9,6 +10,29 @@ test('Focus 설정을 모드별로 저장하고 슬라이더 활성 상태를 �
   await expect(page.locator('#setting-focus-mode')).not.toBeChecked()
   await expect(page.locator('#setting-focus-blur')).toBeDisabled()
   await page.locator('#setting-focus-mode').locator('..').click()
+  for (const zoom of [0.8, 1, 1.25]) {
+  await page.evaluate(zoom => { document.documentElement.style.zoom = String(zoom) }, zoom)
+  for (const [id, min, max] of [['blur', '0', '16'], ['dim', '0', '60'], ['scale', '100', '150']]) {
+    const range = page.locator(`#setting-focus-${id}`)
+    await range.scrollIntoViewIfNeeded()
+    const bounds = await range.boundingBox()
+    await page.mouse.click(bounds.x + 1, bounds.y + bounds.height / 2)
+    await expect(range).toHaveValue(min)
+    await page.mouse.click(bounds.x + bounds.width - 1, bounds.y + bounds.height / 2)
+    await expect(range).toHaveValue(max)
+    await page.mouse.move(bounds.x + bounds.width - 4, bounds.y + bounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(bounds.x + 1, bounds.y + bounds.height / 2, { steps: 8 })
+    await page.mouse.up()
+    await expect(range).toHaveValue(min)
+    await page.mouse.move(bounds.x + 4, bounds.y + bounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(bounds.x + bounds.width - 1, bounds.y + bounds.height / 2, { steps: 8 })
+    await page.mouse.up()
+    await expect(range).toHaveValue(max)
+  }
+  }
+  await page.evaluate(() => { document.documentElement.style.zoom = '1' })
   await page.locator('#setting-focus-blur').focus()
   await page.keyboard.press('Home')
   await expect(page.locator('#setting-focus-blur-value')).toHaveText('0px')

--- a/frontend/tests/focusMode.test.js
+++ b/frontend/tests/focusMode.test.js
@@ -21,6 +21,8 @@ test('배경 영역은 겹치는 문장 구멍을 제외하고 한 번만 덮는
 })
 
 test('Focus 설정은 손상값과 범위를 정규화한다', () => {
+  assert.equal(normalizeFocusSettings({ scale: 180 }).scale, 150)
+  assert.equal(normalizeFocusSettings({ scale: 125 }).scale, 125)
   assert.deepEqual(normalizeFocusSettings({ enabled: true, blurStrength: 99, dimOpacity: 23, scale: 'bad' }), { enabled: true, blurStrength: 16, dimOpacity: 25, scale: 104 })
   assert.deepEqual(normalizeFocusSettings({ blurStrength: 0, dimOpacity: 0, scale: 100 }), { enabled: false, blurStrength: 0, dimOpacity: 0, scale: 100 })
 })


### PR DESCRIPTION
# Summary

## 1. 문장 확대 개선
- 최대 확대 범위를 110%에서 150%로 확장함
- PDF 캔버스와 번역문의 별도 시각 레이어에 실제 확대를 적용함
- 원래 줄바꿈과 선택 좌표를 유지하고 기존 글자 겹침 및 파란 강조 재출현을 방지함

## 2. 슬라이더 끝점 수정
- 일반 입력창에서 상속되던 padding과 border를 제거함
- UI 배율 80%, 100%, 125%에서 양끝 클릭 및 드래그를 검증함

## 3. 검증
- 단위 테스트 93개 통과함
- Chromium 및 WebKit 관련 브라우저 테스트 48개 통과함
- i18n 검증 및 프로덕션 빌드 통과함