### PR TITLE
fix: 확대 글자와 포커스 배경 크기 불일치 수정

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -144,6 +144,11 @@ function copyStyledTree(element) {
     clone.removeAttribute('id')
     clone.removeAttribute('contenteditable')
     clone.classList.remove('sentence-highlight', 'active-mapped-sentence', 'sentence-pulse')
+    // Computed styles can capture an in-flight hover transition even after the
+    // class is removed. Copies must never retain that transient decoration.
+    if (element.matches('.trans-sentence')) {
+      Object.assign(clone.style, { background: 'transparent', boxShadow: 'none', outline: 'none', animation: 'none', transition: 'none' })
+    }
   }
   for (const child of element.childNodes) clone.append(child instanceof Element ? copyStyledTree(child) : child.cloneNode(true))
   return clone
@@ -197,9 +202,15 @@ export function createFocusMagnification(pair, viewportRects, scale) {
     const dx = Math.max(limits.left + insetX - (left - width * (effectiveScale - 1) / 2), Math.min(0, limits.right - insetX - (left + width * (effectiveScale + 1) / 2)))
     const dy = Math.max(limits.top + insetY - (top - height * (effectiveScale - 1) / 2), Math.min(0, limits.bottom - insetY - (top + height * (effectiveScale + 1) / 2)))
     Object.assign(group.style, { position: 'absolute', left: `${left}px`, top: `${top}px`, width: `${width}px`, height: `${height}px`, transform: `translate(${dx}px, ${dy}px) scale(${effectiveScale})`, transformOrigin: 'center' })
+    group.focusRects = visible.map(rect => ({
+      left: left + dx + (rect.left - left - width / 2) * effectiveScale + width / 2,
+      top: top + dy + (rect.top - top - height / 2) * effectiveScale + height / 2,
+      width: rect.width * effectiveScale, height: rect.height * effectiveScale,
+    }))
     for (const rect of visible) {
       const erasure = document.createElement('div')
       erasure.className = 'focus-mode-erasure'
+      erasure.focusRect = rect
       Object.assign(erasure.style, { position: 'absolute', left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px`, background, filter })
       erasures.push(erasure)
       const crop = document.createElement('div')
@@ -387,14 +398,25 @@ export class FocusModeController {
       layer.style.zoom = String(1 / zoom)
       for (const [name, value] of Object.entries(focusCssVariables(this.settings))) layer.style.setProperty(name, value)
     }
-    this.layer.replaceChildren(...createFocusBackdropRects(rects, window.innerWidth, window.innerHeight).map(rect => {
+    this.root?.classList.add('focus-mode-active')
+    const copies = createFocusMagnification(pair, rects, this.settings.scale / 100)
+    const erasures = copies.filter(element => element.classList.contains('focus-mode-erasure'))
+    const groups = copies.filter(element => element.classList.contains('focus-mode-magnification'))
+    // Erase native glyphs BELOW the tint. Only the transformed sentence gets
+    // an opening; otherwise the old white holes remain behind enlarged text.
+    const displayedRects = [
+      ...rects.filter(rect => !erasures.some(element => {
+        const original = element.focusRect
+        return original.left < rect.left + rect.width && original.right > rect.left && original.top < rect.top + rect.height && original.bottom > rect.top
+      })),
+      ...groups.flatMap(element => element.focusRects),
+    ]
+    this.layer.replaceChildren(...erasures, ...createFocusBackdropRects(displayedRects, window.innerWidth, window.innerHeight, groups.length ? 0 : 4).map(rect => {
       const backdrop = document.createElement('div')
       backdrop.className = 'focus-mode-backdrop'
       Object.assign(backdrop.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` })
       return backdrop
-    }))
-    this.root?.classList.add('focus-mode-active')
-    this.layer.append(...createFocusMagnification(pair, rects, this.settings.scale / 100))
+    }), ...groups)
     this.scheduleRender()
   }
   destroy() {

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -148,6 +148,47 @@ test('focus restores existing inline filters and cleans up when disabled', async
 })
 
 for (const zoom of [0.8, 1, 1.25]) {
+  test(`expanded Korean sentence openings match text, not old white boxes at scale ${zoom}`, async ({ page }) => {
+    await setup(page, zoom)
+    await page.evaluate(async moduleSource => {
+      const { visibleFocusRects } = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+      window.controller.clear()
+      document.body.classList.add('light-theme')
+      document.querySelector('#root').innerHTML = `<div class="trans-page-content" style="position:absolute;left:50px;top:60px;width:850px;height:300px;background:white"><p style="margin:35px;width:680px;font:20px/60px sans-serif;color:black"><span class="trans-sentence sentence-highlight" style="background:rgba(74,135,181,.2);box-shadow:0 0 0 2px blue;transition:background-color 1s">2. 합성곱 커널 가중치 시각화: 이 접근법은 모델의 합성곱 커널 가중치를 직접 시각화하고 해석하는 데 중점을 둡니다.</span> 일반적으로 임의의 두 층 간의 교차 필터 맵 연결성으로 인해</p></div>`
+      const element = document.querySelector('#root .trans-sentence')
+      window.controller.resolvePair = () => ({ translationRects: visibleFocusRects(element), elements: [element] })
+      window.controller.applySettings({ enabled: true, blurStrength: 1, dimOpacity: 60, scale: 125 })
+      window.controller.togglePin({ pageNum: 1, sentenceIdx: 0 })
+    }, moduleSource)
+    const group = page.locator('.focus-mode-magnification')
+    await expect(group).toBeVisible()
+    for (const clone of await group.locator('.trans-sentence').all()) {
+      await expect(clone).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+      await expect(clone).toHaveCSS('box-shadow', 'none')
+    }
+    const points = await page.evaluate(() => {
+      const inside = (x, y, r) => x >= r.left - 1 && x <= r.left + r.width + 1 && y >= r.top - 1 && y <= r.top + r.height + 1
+      const enlarged = [...document.querySelectorAll('.focus-mode-magnification')].flatMap(e => e.focusRects)
+      const points = []
+      for (const e of document.querySelectorAll('.focus-mode-erasure')) {
+        const r = e.focusRect
+        for (let y = Math.ceil(r.top + 1); y < r.bottom - 1; y += 2) for (let x = Math.ceil(r.left + 1); x < r.right - 1; x += 4) {
+          if (!enlarged.some(r => inside(x, y, r))) points.push([x, y])
+        }
+      }
+      return points
+    })
+    expect(points.length).toBeGreaterThan(10)
+    const screenshot = (await page.screenshot({ scale: 'css', path: test.info().outputPath('korean-focus-box.png') })).toString('base64')
+    const brightest = await page.evaluate(async ({ screenshot, points }) => {
+      const image = new Image(); image.src = `data:image/png;base64,${screenshot}`; await image.decode()
+      const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
+      const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
+      return Math.max(...points.map(([x, y]) => ctx.getImageData(x, y, 1, 1).data[0]))
+    }, { screenshot, points })
+    expect(brightest).toBeLessThan(150)
+  })
+
   test(`magnified sentences stay inside bordered panes at UI scale ${zoom}`, async ({ page }) => {
     await page.setContent(`<style>
       .pane { position:absolute; top:80px; width:240px; height:180px; border:5px solid; overflow:auto; }


### PR DESCRIPTION
# Summary

## 1. 이미지에서 확인된 배경 불일치 수정
- ask/image.png의 확대 글자 뒤에 원래 크기 흰 박스가 남는 현상을 수정함
- 확대·이동된 행별 좌표로 틴트 제외 영역을 계산함
- 원래 글자 제거 레이어를 틴트 아래로 이동하여 기존 흰 영역 잔존을 방지함
- 복제 문장에서 호버 전환 중의 파란 배경·그림자까지 제거함

## 2. 검증
- 참고 이미지의 한국어 여러 줄 문장을 재현한 픽셀 회귀 테스트 추가함
- Chromium·WebKit 및 UI 배율 80%, 100%, 125%에서 기존 흰 박스 잔존 여부 검증함
- 단위 테스트 93개, i18n 검증 및 프로덕션 빌드 통과함
- 관련 E2E 59개 통과, WebKit 설정 테스트 초기 로딩 시간 초과 1개는 단독 재검증 중임