### PR TITLE
perf: 포커스 반응 지연 완화

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -156,11 +156,17 @@ export function createSentenceFilter(id, rects, bounds, strength, zoom = 1) {
   return filter
 }
 
+// Snapshot paint/layout properties, not interaction, scrolling, animation,
+// counters or hundreds of unrelated browser defaults on every inline span.
+const COPY_STYLE = /^(?:display$|position$|box-sizing$|(?:min-|max-)?(?:width|height)$|inset|top$|right$|bottom$|left$|margin|padding|border|background|color$|opacity$|font|line-height$|letter-spacing$|word-spacing$|white-space|word-break$|overflow-wrap$|text-|vertical-align$|direction$|unicode-bidi$|writing-mode$|transform|translate$|rotate$|scale$|zoom$|visibility$|overflow$|overflow-x$|overflow-y$|list-style|float$|clear$|flex|grid|align-|justify-|gap$|row-gap$|column-gap$|object-|fill|stroke|box-shadow$|filter$|clip-path$)/
+
 function copyStyledTree(element) {
   const clone = element.cloneNode(false)
   if (element instanceof Element) {
     const style = getComputedStyle(element)
-    for (const property of style) clone.style.setProperty(property, style.getPropertyValue(property))
+    // Set the declaration once instead of reparsing a growing declaration for
+    // every computed property (hundreds per element).
+    clone.style.cssText = Array.from(style).filter(property => COPY_STYLE.test(property)).map(property => `${property}:${style.getPropertyValue(property)}`).join(';')
     clone.removeAttribute('id')
     clone.removeAttribute('contenteditable')
     clone.classList.remove('sentence-highlight', 'active-mapped-sentence', 'sentence-pulse')
@@ -202,7 +208,7 @@ export function createFocusMagnification(pair, viewportRects, scale) {
     }
     return bounds
   }
-  const build = (rects, draw, kind, background, filter = 'none', element) => {
+  const build = (rects, draw, kind, background, filter = 'none', element, finish) => {
     const limits = containment(element)
     const visible = mergeClientRects(rects).flatMap(rect => viewportRects.map(view => {
       const left = Math.max(rect.left, view.left, limits.left), top = Math.max(rect.top, view.top, limits.top)
@@ -237,6 +243,7 @@ export function createFocusMagnification(pair, viewportRects, scale) {
       Object.assign(crop.style, { position: 'absolute', overflow: 'hidden', left: `${rect.left - left}px`, top: `${rect.top - top}px`, width: `${rect.width}px`, height: `${rect.height}px` })
       draw(crop, rect); group.append(crop)
     }
+    finish?.(group, visible, left, top, width, height)
     groups.push(group)
   }
   if (pair.sourceCanvas) {
@@ -260,10 +267,19 @@ export function createFocusMagnification(pair, viewportRects, scale) {
     Object.assign(clone.style, { position: 'absolute', right: 'auto', bottom: 'auto', margin: '0', width: `${bounds.width / zoom}px`, height: 'auto', boxSizing: 'border-box', transform: 'none', zoom: String(zoom) })
     build(visibleFocusRects(element), (crop, rect) => {
       crop.style.background = sentenceBackground(host)
-      const content = clone.cloneNode(true)
-      content.style.left = `${(bounds.left - rect.left) / zoom}px`; content.style.top = `${(bounds.top - rect.top) / zoom}px`
-      crop.append(content)
-    }, 'translation', sentenceBackground(host), 'none', element)
+    }, 'translation', sentenceBackground(host), 'none', element, (group, visible, left, top, width, height) => {
+      // One styled paragraph per sentence, not one complete paragraph per
+      // visible line. A single union clip preserves the same line openings.
+      const content = document.createElement('div')
+      content.className = 'focus-mode-text-copy'
+      const path = visible.map(rect => {
+        const x = rect.left - left, y = rect.top - top
+        return `M${x} ${y}h${rect.width}v${rect.height}h${-rect.width}Z`
+      }).join(' ')
+      Object.assign(content.style, { position: 'absolute', inset: '0', width: `${width}px`, height: `${height}px`, overflow: 'hidden', clipPath: `path("${path}")` })
+      clone.style.left = `${(bounds.left - left) / zoom}px`; clone.style.top = `${(bounds.top - top) / zoom}px`
+      content.append(clone); group.append(content)
+    })
   }
   return [...erasures, ...groups]
 }
@@ -305,6 +321,7 @@ export class FocusModeController {
   cancelLeave() { clearTimeout(this.releaseTimer); this.releaseTimer = null }
   clear() {
     this.cancelLeave()
+    clearTimeout(this.idleTimer); this.idleTimer = null
     if (this.raf) cancelAnimationFrame(this.raf)
     this.raf = null
     this.current = null; this.pinned = false; this.lastGeometry = null
@@ -337,6 +354,9 @@ export class FocusModeController {
     if (delta) { event.preventDefault(); this.navigate(delta) }
   }
   scheduleRender() {
+    // Explicit input (hover, scroll, resize, settings) never waits for the idle
+    // geometry check. Only unchanged frames are polled at a lower frequency.
+    clearTimeout(this.idleTimer); this.idleTimer = null
     if (!this.current || !this.settings.enabled || this.raf) return
     this.raf = requestAnimationFrame(() => { this.raf = null; this.render() })
   }
@@ -380,7 +400,10 @@ export class FocusModeController {
       return [b.left, b.top, b.width, b.height, element.clientWidth, element.clientHeight]
     })
     const geometry = JSON.stringify([rects, window.innerWidth, window.innerHeight, zoom, this.settings, targetBounds.map(b => [b.left, b.top, b.width, b.height]), paneGeometry, pair.elements?.map(e => e.textContent), document.body.className])
-    if (geometry === this.lastGeometry && targets.every(element => this.filteredElements.has(element))) { this.scheduleRender(); return }
+    if (geometry === this.lastGeometry && targets.every(element => this.filteredElements.has(element))) {
+      this.idleTimer = setTimeout(() => { this.idleTimer = null; this.scheduleRender() }, 120)
+      return
+    }
     this.lastGeometry = geometry
     if (!this.filterSvg) {
       this.filterSvg = svgElement('svg', { width: 0, height: 0, 'aria-hidden': 'true' })

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -110,6 +110,34 @@ test('pinned focus ignores hover, follows geometry changes and releases with Esc
   await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
 })
 
+test('idle focus avoids per-frame resolution without delaying explicit input', async ({ page }) => {
+  await setup(page)
+  const counts = await page.evaluate(async () => {
+    let calls = 0
+    const resolve = window.controller.resolvePair
+    window.controller.resolvePair = ref => { calls++; return resolve(ref) }
+    const frames = async count => { for (let i = 0; i < count; i++) await new Promise(requestAnimationFrame) }
+    await frames(4)
+    calls = 0
+    await frames(12)
+    const idle = calls
+    // Queueing a new hover cancels the idle check and resolves on the next RAF.
+    window.controller.pinned = false
+    calls = 0
+    window.controller.focus({ pageNum: 1, sentenceIdx: 1 })
+    await frames(1)
+    const hover = calls
+    window.controller.clear()
+    calls = 0
+    await new Promise(resolve => setTimeout(resolve, 160))
+    return { idle, hover, cleared: calls, timer: window.controller.idleTimer }
+  })
+  expect(counts.idle).toBeLessThan(8)
+  expect(counts.hover).toBeGreaterThan(0)
+  expect(counts.cleared).toBe(0)
+  expect(counts.timer).toBeNull()
+})
+
 for (const scale of [0.8, 1, 1.25]) {
 for (const strength of [1, 6, 16]) {
 test(`blur ${strength}px preserves sentence pixels with offscreen overflow at scale ${scale}`, async ({ page }) => {
@@ -278,7 +306,7 @@ for (const zoom of [0.8, 1, 1.25]) {
       const ctx = canvas.getContext('2d'); ctx.fillStyle = 'white'; ctx.fillRect(0, 0, 400, 80); ctx.fillStyle = 'black'; ctx.font = '28px sans-serif'; ctx.fillText('Focused source', 12, 48)
       const paragraph = document.createElement('p'); paragraph.id = 'focus-paragraph'
       Object.assign(paragraph.style, { position: 'absolute', left: '650px', top: '240px', width: '200px', margin: '0', fontSize: '18px', lineHeight: '28px' })
-      paragraph.innerHTML = '<span class="trans-sentence">A translated sentence that wraps across multiple lines.</span>'
+      paragraph.innerHTML = '<span class="trans-sentence">A <strong>translated</strong> sentence that <em>wraps</em> across multiple lines.</span>'
       root.append(canvas, paragraph)
       const element = paragraph.firstElementChild
       window.controller.resolvePair = () => ({ sourceCanvas: canvas, sourceRects: [canvas.getBoundingClientRect()], translationRects: visibleFocusRects(element), elements: [element] })
@@ -291,6 +319,12 @@ for (const zoom of [0.8, 1, 1.25]) {
     const translation = page.locator('.focus-mode-magnification[data-kind="translation"]')
     await expect(source).toBeVisible()
     await expect(translation).toBeVisible()
+    await expect(translation.locator('.focus-mode-text-copy')).toHaveCount(1)
+    await expect(translation.locator('p')).toHaveCount(1)
+    for (const [selector, property] of [['strong', 'font-weight'], ['em', 'font-style']]) {
+      const originalStyle = await page.locator(`#focus-paragraph ${selector}`).evaluate((e, property) => getComputedStyle(e).getPropertyValue(property), property)
+      await expect(translation.locator(selector)).toHaveCSS(property, originalStyle)
+    }
     await expect.poll(() => page.evaluate(async () => {
       const before = document.querySelector('.focus-mode-magnification')
       await new Promise(requestAnimationFrame)

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -308,6 +308,10 @@ for (const zoom of [0.8, 1, 1.25]) {
       Object.assign(paragraph.style, { position: 'absolute', left: '650px', top: '240px', width: '200px', margin: '0', fontSize: '18px', lineHeight: '28px' })
       paragraph.innerHTML = '<span class="trans-sentence">A <strong>translated</strong> sentence that <em>wraps</em> across multiple lines.</span>'
       root.append(canvas, paragraph)
+      // The fixture inherits web fonts; newly used bold/italic faces may still
+      // load after insertion. Compare layout only after font metrics settle.
+      paragraph.getBoundingClientRect()
+      await document.fonts.ready
       const element = paragraph.firstElementChild
       window.controller.resolvePair = () => ({ sourceCanvas: canvas, sourceRects: [canvas.getBoundingClientRect()], translationRects: visibleFocusRects(element), elements: [element] })
       const original = { canvas: canvas.getBoundingClientRect().toJSON(), paragraph: paragraph.getBoundingClientRect().toJSON() }


### PR DESCRIPTION
# Summary

## 1. 확대 문장 복제 비용 개선
- 행마다 문단 전체를 복제하던 방식을 문장당 한 번 복제하는 방식으로 변경함
- 행별 클리핑과 배경을 유지하며 하나의 텍스트 복제 레이어를 사용함
- 시각 복제에 필요한 CSS 속성만 읽고 스타일 선언을 한 번에 적용함
- 6줄·80개 후속 span 재현 문단에서 DOM 505개→96개로 감소함
- 로컬 비교 실행에서 복제·레이아웃 중앙값 280ms→135ms를 측정함(전체 사용자 입력 지연 수치가 아닌 재현 벤치마크임)

## 2. 정지 상태 반복 계산 개선
- 좌표가 동일할 때 매 프레임 전체 문장 매핑을 재조회하지 않도록 120ms 유휴 확인을 적용함
- 새 호버·스크롤·크기 및 설정 변경은 유휴 타이머를 취소하고 다음 프레임에 처리함
- 포커스 해제 시 유휴 타이머를 정리함

## 3. 검증
- Chromium·WebKit 관련 E2E 74개 및 단위 테스트 93개 통과함
- 기존 가로줄·흰 박스·문장 확대·서식 유지 회귀 검사 통과함
- i18n 검증과 프로덕션 빌드 통과함