### PR TITLE
fix: 방향키 포커스 스크롤 및 바운스 수정

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -77,7 +77,7 @@ export function revealFocusTranslation(elements) {
   // Scroll only the translation pane, so the source stays under the pointer.
   if (start < top || end > bottom) {
     const offset = end - start > bottom - top ? start - top : (start + end - top - bottom) / 2
-    pane.scrollTop += offset / scale
+    pane.scrollTo({ top: pane.scrollTop + offset / scale, behavior: 'instant' })
   }
 }
 
@@ -302,7 +302,13 @@ export class FocusModeController {
     root?.addEventListener('mouseleave', this.onLeave)
     root?.addEventListener('scroll', this.onViewportChange, { passive: true, capture: true })
   }
-  applySettings(settings) { this.settings = normalizeFocusSettings(settings); if (!this.settings.enabled) this.clear(); else if (this.current) this.scheduleRender() }
+  applySettings(settings) {
+    this.settings = normalizeFocusSettings(settings)
+    // Suppress the card lift before the pointer enters, not when the focus
+    // overlay appears: changing it on activation shifts the source by 2px.
+    this.root?.classList.toggle('focus-mode-enabled', this.settings.enabled)
+    if (!this.settings.enabled) this.clear(); else if (this.current) this.scheduleRender()
+  }
   sameRef(a, b) { return !!a && !!b && a.pageNum === b.pageNum && a.sentenceIdx === b.sentenceIdx }
   focus(ref, { pin = false } = {}) {
     if (!this.settings.enabled || !ref) return false
@@ -345,7 +351,15 @@ export class FocusModeController {
     if (index < 0) return false
     const next = sequence[Math.max(0, Math.min(sequence.length - 1, index + delta))]
     if (!next || this.sameRef(next, this.current)) return true
-    this.current = next; this.revealedTranslation = false; next.element?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }); this.scheduleRender(); this.announce('focusMoved'); return true
+    this.current = next
+    // Commit one nearest-position scroll before measuring the new pair. A
+    // smooth center scroll was being retargeted by translation reveal and by
+    // repeated keys, rebuilding magnification on every intermediate position.
+    next.element?.scrollIntoView?.({ block: 'nearest', inline: 'nearest', behavior: 'instant' })
+    // scrollIntoView already reveals the translation through all ancestors;
+    // do not follow it with a second, centered translation-pane scroll.
+    this.revealedTranslation = !!next.element
+    this.scheduleRender(); this.announce('focusMoved'); return true
   }
   handleKeyDown(event) {
     if (!this.pinned || isFocusKeyboardExcluded(event.target)) return
@@ -459,6 +473,7 @@ export class FocusModeController {
   }
   destroy() {
     this.clear()
+    this.root?.classList.remove('focus-mode-enabled')
     document.removeEventListener('keydown', this.onKeyDown)
     document.removeEventListener('pointerdown', this.onInteraction, true)
     document.removeEventListener('visibilitychange', this.onVisibility)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7963,6 +7963,7 @@ body.light-theme .chat-drawer {
 .focus-range output { color: var(--text-primary); font-variant-numeric: tabular-nums; text-align: right; }
 .focus-range input[type="range"] { width: 100%; min-width: 0; padding: 0; margin: 0; border: 0; box-sizing: border-box; cursor: pointer; }
 .focus-mode-magnification, .focus-mode-magnification * { pointer-events: none !important; }
+.focus-mode-enabled .page-pair { transform: none; transition: none; }
 .focus-range input:disabled { opacity: .45; }
 .focus-keyboard-help { color: var(--text-muted); }
 .focus-mode-layer { position: fixed; inset: 0; z-index: 2147483646; pointer-events: none; }

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -31,6 +31,59 @@ async function setup(page, scale = 1) {
   await expect(page.locator('.focus-mode-layer')).toBeVisible()
 }
 
+for (const zoom of [0.8, 1, 1.25]) {
+  test(`keyboard navigation scrolls once without recentering or bounce at zoom ${zoom}`, async ({ page }) => {
+    await page.setContent('<div id="root"><div class="page-pair"><div class="trans-page-content"><p><span id="s0" class="trans-sentence">First sentence.</span><span id="s1" class="trans-sentence">Second sentence.</span><span id="s2" class="trans-sentence">Offscreen sentence.</span></p></div></div><div style="height:400px"></div><div class="page-pair"><div class="trans-page-content"><p><span id="s3" class="trans-sentence">Next page sentence.</span></p></div></div></div>')
+    await page.addStyleTag({ content: css })
+    await page.addStyleTag({ content: 'body{margin:0} #root{position:absolute;left:40px;top:40px;width:560px;height:240px;overflow:auto;scroll-behavior:smooth} .page-pair{display:block;width:500px;max-width:none;margin:0;padding:0;border:0} .trans-page-content{height:140px;min-height:0;padding:10px;overflow:auto;scroll-behavior:smooth} p{margin:0;font:18px/30px sans-serif} .trans-sentence{display:block} #s2{margin-top:300px}' })
+    await page.evaluate(async ({ moduleSource, zoom }) => {
+      document.documentElement.style.zoom = String(zoom)
+      const { FocusModeController, visibleFocusRects } = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+      const refs = Array.from({ length: 4 }, (_, i) => ({ pageNum: i === 3 ? 2 : 1, sentenceIdx: i, revealTranslation: true, element: document.querySelector(`#s${i}`) }))
+      window.controller = new FocusModeController({ root: document.querySelector('#root'), listSentences: () => refs, resolvePair: ref => ({ elements: [ref.element], translationRects: visibleFocusRects(ref.element) }) })
+      window.controller.applySettings({ enabled: true, blurStrength: 1, dimOpacity: 20, scale: 125 })
+      window.controller.togglePin(refs[0])
+    }, { moduleSource, zoom })
+    await expect(page.locator('.focus-mode-magnification')).toBeVisible()
+    await page.locator('#s0').hover()
+    await expect(page.locator('.page-pair').first()).toHaveCSS('transform', 'none')
+    const scrolls = () => page.evaluate(() => [document.querySelector('#root').scrollTop, ...Array.from(document.querySelectorAll('.trans-page-content'), e => e.scrollTop)])
+    const initial = await scrolls()
+    await page.keyboard.press('ArrowDown')
+    expect(await scrolls()).toEqual(initial)
+    const stable = async () => {
+      await expect(page.locator('.focus-mode-magnification')).toBeVisible()
+      const samples = await page.evaluate(async () => {
+        const samples = []
+        for (let i = 0; i < 15; i++) {
+          await new Promise(requestAnimationFrame)
+          const r = document.querySelector('.focus-mode-magnification')?.getBoundingClientRect()
+          samples.push([document.querySelector('#root').scrollTop, ...Array.from(document.querySelectorAll('.trans-page-content'), e => e.scrollTop), r?.left, r?.top, r?.width, r?.height])
+        }
+        return samples
+      })
+      expect(samples.every(sample => sample.every(Number.isFinite))).toBe(true)
+      for (const sample of samples) expect(sample).toEqual(samples[0])
+    }
+    await page.keyboard.press('ArrowDown')
+    expect((await scrolls())[1]).toBeGreaterThan(0)
+    await stable()
+    await page.keyboard.press('ArrowDown')
+    expect((await scrolls())[0]).toBeGreaterThan(0)
+    await stable()
+    await page.keyboard.press('ArrowUp')
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('ArrowUp')
+    await stable()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.focus-mode-layer')).toHaveCount(0)
+    await page.evaluate(() => window.controller.applySettings({ enabled: false }))
+    await expect(page.locator('#root')).not.toHaveClass(/focus-mode-enabled/)
+    await page.evaluate(() => { window.controller.applySettings({ enabled: true }); window.controller.destroy() })
+    await expect(page.locator('#root')).not.toHaveClass(/focus-mode-enabled/)
+  })
+}
+
 for (const density of [1, 2]) {
   test.describe(`single tint surface at DPR ${density}`, () => {
     test.use({ deviceScaleFactor: density })


### PR DESCRIPTION
# Summary

## 1. 방향키 스크롤 안정화
- 매 문장을 중앙으로 부드럽게 이동시키던 동작을 필요한 최소 거리의 즉시 이동으로 변경함
- 화면 안의 다음 문장은 스크롤하지 않도록 수정함
- 방향키 스크롤 직후 번역 패널이 다시 중앙 정렬하는 중복 보정을 방지함
- 번역 자동 노출도 CSS smooth 설정과 충돌하지 않도록 명시적으로 즉시 처리함

## 2. 페이지 바운스 제거
- Focus 모드 설정이 켜진 동안 페이지 카드의 호버 이동·전환 효과를 억제함
- 포커스 표시 순간 2px 이동하지 않도록 모드 활성화 상태부터 적용함
- 모드 비활성화 및 컨트롤러 종료 시 기존 스타일을 복원함

## 3. 검증
- 중첩 스크롤, 페이지 경계, 빠른 방향키 입력 이후 15프레임의 스크롤·확대 좌표 안정성 검증함
- UI 배율 80/100/125%의 Chromium·WebKit 관련 E2E 80개 통과함
- 단위 테스트 93개, i18n 검증 및 프로덕션 빌드 통과함