### PR TITLE
fix: 같은 높이의 원문·번역 포커스 연결 오류 수정

### DIFF
--- a/frontend/src/focusMode.js
+++ b/frontend/src/focusMode.js
@@ -20,7 +20,9 @@ export function mergeClientRects(rects, gap = 3) {
   const rows = []
   for (const rect of values) {
     const last = rows.at(-1)
-    if (last && Math.abs(last.top - rect.top) <= gap && rect.left <= last.right + gap) {
+    // Sorting by top can put the right-hand pane first when baselines differ
+    // by a fraction of a pixel. Check both horizontal edges before merging.
+    if (last && Math.abs(last.top - rect.top) <= gap && rect.left <= last.right + gap && rect.right >= last.left - gap) {
       last.left = Math.min(last.left, rect.left); last.top = Math.min(last.top, rect.top)
       last.right = Math.max(last.right, rect.right); last.bottom = Math.max(last.bottom, rect.bottom)
     } else rows.push({ ...rect })

--- a/frontend/tests/e2e/focus-isolation.spec.js
+++ b/frontend/tests/e2e/focus-isolation.spec.js
@@ -32,6 +32,35 @@ async function setup(page, scale = 1) {
 }
 
 for (const zoom of [0.8, 1, 1.25]) {
+  test(`aligned source and translation leave their gutter dimmed at zoom ${zoom}`, async ({ page }) => {
+    await page.setContent('<style>body{margin:0;background:white}#layer{position:fixed;inset:0;--focus-dim:.6}.focus-mode-backdrop{position:absolute;inset:0}</style><div id="layer"></div>')
+    for (const magnification of [1, 1.5]) for (const offset of [-0.25, 0.25]) {
+      await page.evaluate(async ({ moduleSource, zoom, magnification, offset }) => {
+        const { createFocusTint } = await import(URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' })))
+        document.documentElement.style.zoom = String(zoom)
+        const layer = document.querySelector('#layer'); layer.style.zoom = String(1 / zoom)
+        layer.replaceChildren(createFocusTint([
+          { left: 100 * zoom, top: (200 + offset) * zoom, width: 200 * magnification * zoom, height: 20 * magnification * zoom },
+          { left: 600 * zoom, top: 200 * zoom, width: 200 * magnification * zoom, height: 20 * magnification * zoom },
+        ], innerWidth, innerHeight, 0))
+      }, { moduleSource, zoom, magnification, offset })
+      await expect(page.locator('.focus-tint-hole')).toHaveCount(2)
+      const screenshot = (await page.screenshot({ scale: 'css', path: test.info().outputPath(`gutter-${magnification}-${offset}.png`) })).toString('base64')
+      const pixels = await page.evaluate(async ({ screenshot, zoom }) => {
+        const image = new Image(); image.src = `data:image/png;base64,${screenshot}`; await image.decode()
+        const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height
+        const ctx = canvas.getContext('2d'); ctx.drawImage(image, 0, 0)
+        const red = x => ctx.getImageData(Math.round(x * zoom), Math.round(210 * zoom), 1, 1).data[0]
+        return { source: red(200), translation: red(700), gutter: red(500) }
+      }, { screenshot, zoom })
+      expect(pixels.source).toBe(255)
+      expect(pixels.translation).toBe(255)
+      expect(pixels.gutter).toBeLessThan(130)
+    }
+  })
+}
+
+for (const zoom of [0.8, 1, 1.25]) {
   test(`keyboard navigation scrolls once without recentering or bounce at zoom ${zoom}`, async ({ page }) => {
     await page.setContent('<div id="root"><div class="page-pair"><div class="trans-page-content"><p><span id="s0" class="trans-sentence">First sentence.</span><span id="s1" class="trans-sentence">Second sentence.</span><span id="s2" class="trans-sentence">Offscreen sentence.</span></p></div></div><div style="height:400px"></div><div class="page-pair"><div class="trans-page-content"><p><span id="s3" class="trans-sentence">Next page sentence.</span></p></div></div></div>')
     await page.addStyleTag({ content: css })

--- a/frontend/tests/focusMode.test.js
+++ b/frontend/tests/focusMode.test.js
@@ -34,6 +34,23 @@ test('여러 DOM 조각을 같은 행 단위로 병합한다', () => {
   ])
 })
 
+test('높이가 비슷해도 떨어진 원문과 번역 패널 사이를 병합하지 않는다', () => {
+  for (const offset of [-2, -0.25, 0, 0.25, 2]) {
+    const rects = [{ left: 100, top: 100 + offset, width: 200, height: 20 }, { left: 600, top: 100, width: 200, height: 20 }]
+    for (const input of [rects, [...rects].reverse()]) {
+      assert.equal(mergeClientRects(input).length, 2)
+      const regions = createFocusBackdropRects(input, 1000, 300, 0)
+      assert.equal(regions.filter(r => 450 >= r.left && 450 < r.left + r.width && 110 >= r.top && 110 < r.top + r.height).length, 1)
+    }
+  }
+})
+
+test('오른쪽 조각이 먼저 정렬되어도 실제로 인접한 조각은 병합한다', () => {
+  assert.deepEqual(mergeClientRects([{ left: 130, top: 100, width: 20, height: 20 }, { left: 100, top: 101, width: 28, height: 20 }]), [
+    { left: 100, top: 100, right: 150, bottom: 121, width: 50, height: 21 },
+  ])
+})
+
 test('마스크와 CSS 값은 0 값도 그대로 보존한다', () => {
   const mask = createFocusMask([{ left: 10, top: 20, width: 30, height: 40 }], 800, 600)
   assert.match(mask, /data:image\/svg\+xml/)


### PR DESCRIPTION
# Summary

## 1. 포커스 영역 병합 조건 수정
- ask/image.png의 원문·번역 사이가 밝게 연결되는 현상을 수정함
- 높이 기준 정렬로 오른쪽 영역이 먼저 나오는 경우에도 양쪽 가로 경계를 확인하도록 수정함
- 실제로 떨어진 영역은 분리하고 인접한 문장 조각은 기존처럼 병합함
- 기존 코드에서 두 200px 영역이 하나의 700px 영역으로 합쳐지는 조건을 재현함

## 2. 검증
- 높이 오차 및 입력 순서 변화, 실제 인접 조각 병합 단위 테스트 추가함
- UI 배율 80/100/125%, 확대 100/150%에서 패널 간 틴트 유지 픽셀 테스트 추가함
- Chromium·WebKit 관련 E2E 86개 및 단위 테스트 95개 통과함
- i18n 검증 및 프로덕션 빌드 통과함