### PR TITLE
fix(test): align automation tab label

### DIFF
--- a/frontend/tests/e2e/translation-policy.spec.js
+++ b/frontend/tests/e2e/translation-policy.spec.js
@@ -74,7 +74,7 @@ test('설정 화면이 현재 워크스페이스 모드의 값과 항목 구성�
   await page.locator('[data-tab="tab-automation"]').click()
   await expect(page.locator('#settings-keywords-label')).toHaveText('고급 어휘 자동 생성')
   await expect(page.locator('#setting-disable-suggested-questions').locator('..')).toBeVisible()
-  await expect(page.locator('#settings-nav-automation')).toHaveText('생성 및 자동화')
+  await expect(page.locator('#settings-nav-automation')).toHaveText('AI 자동 생성')
 
   await page.locator('[data-tab="tab-translation"]').click()
   await page.locator('#setting-trans-style').selectOption('summary')


### PR DESCRIPTION
v1.0.0 릴리스 CI를 막는 translation-policy E2E의 오래된 탭 라벨 기대값을 현재 번역 값에 맞춥니다.