### PR TITLE
fix: prevent desktop backend startup hangs

### DIFF
--- a/backend/tests/test_venv_manager.py
+++ b/backend/tests/test_venv_manager.py
@@ -161,13 +161,49 @@ def test_packaged_parser_activation_and_restart_decision(tmp_path, monkeypatch):
     original_path = list(sys.path)
     try:
         venv_manager.relaunch_into_required_venv("mineru")
-        assert sys.path[0] == str(package_dir)
+        assert sys.path == original_path + [str(package_dir)]
         assert venv_manager.restart_required_for_engine("mineru") is False
         assert venv_manager.restart_required_for_engine("pymupdf") is True
     finally:
         sys.path[:] = original_path
         venv_manager._active_engine = "pymupdf"
 
+
+
+@pytest.mark.parametrize("engine", ["pdfplumber", "marker", "mineru"])
+def test_packaged_restart_preserves_bundled_dependencies(tmp_path, engine):
+    """Fresh startup must not load incompatible pip --target dependencies."""
+    import subprocess
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "startup_dependency.py").write_text("SOURCE = 'bundle'\n")
+    packages = tmp_path / "pdf-parser-packages" / engine
+    module = venv_manager.PARSER_PACKAGES[engine][1]
+    (packages / module).mkdir(parents=True)
+    (packages / module / "__init__.py").write_text("AVAILABLE = True\n")
+    (packages / "startup_dependency.py").write_text(
+        "raise RuntimeError('incompatible parser dependency at startup')\n"
+    )
+    script = """
+import sys
+import venv_manager
+sys.frozen = True
+sys.path[:] = [p for p in sys.path if 'site-packages' not in p]
+sys.path.insert(0, sys.argv[1])
+venv_manager.relaunch_into_required_venv(sys.argv[2])
+import startup_dependency
+assert startup_dependency.SOURCE == 'bundle'
+assert __import__(sys.argv[3]).AVAILABLE
+assert not venv_manager.restart_required_for_engine(sys.argv[2])
+"""
+    env = dict(os.environ, EASYPAPER_DESKTOP="1", EASYPAPER_CONFIG_DIR=str(tmp_path))
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(bundle), engine, module],
+        cwd=os.path.dirname(venv_manager.__file__), env=env,
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_packaged_installer_configures_windows_streams_as_utf8(monkeypatch):

--- a/backend/venv_manager.py
+++ b/backend/venv_manager.py
@@ -155,10 +155,11 @@ def _activate_packaged_parser(engine: str) -> None:
         return
 
     package_dir = parser_packages_dir(engine)
+    # pip --target installs transitive dependencies too. Keep bundled server
+    # packages first so their Python code and native extensions stay compatible
+    # after restarting with a different parser. Parser-only packages remain
+    # available through the appended site-packages directory.
     site.addsitedir(package_dir)
-    while package_dir in sys.path:
-        sys.path.remove(package_dir)
-    sys.path.insert(0, package_dir)
     _active_engine = engine
 
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -7,7 +7,10 @@ fn main() {
   // 자동 생성되도록 명시해야 capabilities/default.json에서 참조할 수 있다.
   tauri_build::try_build(
     tauri_build::Attributes::new()
-      .app_manifest(tauri_build::AppManifest::new().commands(&["kill_backend_sidecar"])),
+      .app_manifest(tauri_build::AppManifest::new().commands(&[
+        "kill_backend_sidecar",
+        "backend_startup_error",
+      ])),
   )
   .expect("failed to run tauri-build");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-set-theme",
     "core:window:allow-set-background-color",
     "opener:default",
-    "allow-kill-backend-sidecar"
+    "allow-kill-backend-sidecar",
+    "allow-backend-startup-error"
   ]
 }

--- a/src-tauri/loading-page/index.html
+++ b/src-tauri/loading-page/index.html
@@ -17,6 +17,31 @@
 </style>
 </head>
 <body>
-  <p>EasyPaper 백엔드를 시작하는 중입니다...</p>
+  <div style="max-width: 560px; padding: 24px; text-align: center">
+    <p id="status" role="status">EasyPaper 백엔드를 시작하는 중입니다...</p>
+    <p id="help" hidden>앱을 종료한 뒤 다시 실행해 주세요. 문제가 반복되면 EasyPaper 로그와 함께 오류 메시지를 전달해 주세요.</p>
+  </div>
+  <script>
+    function showError(error) {
+      clearInterval(timer);
+      clearTimeout(deadline);
+      document.getElementById('status').textContent = error;
+      document.getElementById('help').hidden = false;
+    }
+    const deadline = setTimeout(() => showError(
+      '앱 시작을 완료하지 못했습니다. 백엔드 연결 또는 화면 로딩에 실패했습니다.'
+    ), 130000);
+    const timer = setInterval(async () => {
+      let error;
+      try {
+        error = await window.__TAURI_INTERNALS__.invoke('backend_startup_error');
+      } catch (_) {
+        // A local deadline also covers a failed IPC connection or navigation.
+      }
+      if (error) {
+        showError(error);
+      }
+    }, 500);
+  </script>
 </body>
 </html>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,14 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 /// kill하기 위해 앱 상태로 보관한다(고아 프로세스 방지, 계획 Phase 3).
 struct SidecarState(Mutex<Option<Child>>);
 
+#[derive(Default)]
+struct StartupState(Mutex<Option<String>>);
+
+#[tauri::command]
+fn backend_startup_error(state: tauri::State<StartupState>) -> Option<String> {
+    state.0.lock().unwrap().clone()
+}
+
 /// 선호 포트(8000)를 우선 시도하고, 이미 사용 중이면(기존 웹 배포판이 로컬에
 /// 동시 실행 중인 경우 등) OS가 골라주는 임시 포트로 폴백한다(계획 Phase 2).
 fn find_available_port(preferred: u16) -> u16 {
@@ -90,28 +98,36 @@ fn resolve_user_shell_path() -> Option<String> {
 /// 백엔드의 루트(`/`)에 재시도 GET을 보내 준비 상태를 확인한다. `/api/*`는
 /// 전역 인증이 걸려 있어 로그인 전 판별에 쓸 수 없지만, 루트는 인증 없이
 /// 200을 반환하며 기존 Dockerfile의 HEALTHCHECK도 동일하게 `/`를 쓴다.
-fn wait_for_backend(port: u16, timeout: Duration) -> bool {
+fn wait_for_backend(port: u16, timeout: Duration, app: &tauri::AppHandle) -> Result<(), String> {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) {
+        {
+            let state = app.state::<SidecarState>();
+            let mut guard = state.0.lock().unwrap();
+            let child = guard.as_mut().ok_or("백엔드 프로세스가 없습니다.")?;
+            if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
+                return Err(format!("백엔드가 시작 중 종료되었습니다 ({status})."));
+            }
+        }
+        let address = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+        if let Ok(mut stream) = TcpStream::connect_timeout(&address, Duration::from_millis(500)) {
             let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+            let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
             let request =
                 format!("GET / HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n");
             if stream.write_all(request.as_bytes()).is_ok() {
-                let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n > 0 {
-                        let text = String::from_utf8_lossy(&buf[..n]);
-                        if text.starts_with("HTTP/1.1 200") || text.starts_with("HTTP/1.0 200") {
-                            return true;
-                        }
+                let mut buf = [0u8; 12];
+                if stream.read_exact(&mut buf).is_ok() {
+                    let text = String::from_utf8_lossy(&buf);
+                    if text.starts_with("HTTP/1.1 200") || text.starts_with("HTTP/1.0 200") {
+                        return Ok(());
                     }
                 }
             }
         }
         std::thread::sleep(Duration::from_millis(200));
     }
-    false
+    Err("백엔드 시작 대기 시간(120초)을 초과했습니다.".to_string())
 }
 
 /// 백엔드 sidecar 실행파일 경로를 계산한다.
@@ -187,15 +203,17 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .manage(SidecarState(Mutex::new(None)))
-        .invoke_handler(tauri::generate_handler![kill_backend_sidecar])
+        .manage(StartupState::default())
+        .invoke_handler(tauri::generate_handler![
+            kill_backend_sidecar,
+            backend_startup_error
+        ])
         .setup(|app| {
-            if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
-            }
+            app.handle().plugin(
+                tauri_plugin_log::Builder::default()
+                    .level(log::LevelFilter::Info)
+                    .build(),
+            )?;
 
             let app_handle = app.handle().clone();
 
@@ -215,9 +233,18 @@ pub fn run() {
             let cache_dir = app_data_dir.join("cache");
             let library_dir = app_data_dir.join("library");
             let logs_dir = app_data_dir.join("logs");
-            for dir in [&app_data_dir, &uploads_dir, &cache_dir, &library_dir, &logs_dir] {
+            for dir in [
+                &app_data_dir,
+                &uploads_dir,
+                &cache_dir,
+                &library_dir,
+                &logs_dir,
+            ] {
                 if let Err(e) = std::fs::create_dir_all(dir) {
-                    die(&format!("앱 데이터 하위 디렉토리를 만들 수 없습니다 ({dir:?})"), e);
+                    die(
+                        &format!("앱 데이터 하위 디렉토리를 만들 수 없습니다 ({dir:?})"),
+                        e,
+                    );
                 }
             }
             let db_path = app_data_dir.join("easypaper.db");
@@ -279,10 +306,8 @@ pub fn run() {
                 .spawn()
                 .unwrap_or_else(|e| die("백엔드 sidecar 프로세스를 실행할 수 없습니다", e));
 
-            // 디버깅 편의를 위해 sidecar의 stdout/stderr을 그대로 로그로 흘려보낸다.
-            // tauri_plugin_log는 디버그 빌드에서만 설치되므로(위 참고), 릴리스
-            // 빌드에서는 별도 로거가 없어 이 log:: 호출들이 실제로는 아무 데도
-            // 쓰이지 않는다 - 별도 볼륨 조정이 필요 없다.
+            // 릴리스에서도 import 단계의 실패를 진단할 수 있도록 sidecar의
+            // stdout/stderr을 Tauri 로그 파일에 남긴다.
             if let Some(stdout) = child.stdout.take() {
                 std::thread::spawn(move || {
                     use std::io::BufRead;
@@ -318,14 +343,18 @@ pub fn run() {
                 .get_webview_window("main")
                 .unwrap_or_else(|| die_msg("main 윈도우를 찾을 수 없습니다"));
             std::thread::spawn(move || {
-                if wait_for_backend(port, Duration::from_secs(15)) {
+                let result = wait_for_backend(port, Duration::from_secs(120), &app_handle);
+                let result = result.and_then(|()| {
                     let url = format!("http://127.0.0.1:{port}/");
                     log::info!("backend ready, navigating window to {}", url);
-                    if let Err(e) = window.navigate(url.parse().expect("invalid url")) {
-                        log::error!("failed to navigate window: {}", e);
-                    }
-                } else {
-                    log::error!("backend healthcheck did not succeed within timeout");
+                    window
+                        .navigate(url.parse().expect("invalid url"))
+                        .map_err(|e| format!("앱 화면을 열 수 없습니다: {e}"))
+                });
+                if let Err(error) = result {
+                    log::error!("backend startup failed: {}", error);
+                    *app_handle.state::<StartupState>().0.lock().unwrap() = Some(error);
+                    kill_sidecar(&app_handle.state::<SidecarState>());
                 }
             });
 

--- a/src-tauri/tests/startup.test.cjs
+++ b/src-tauri/tests/startup.test.cjs
@@ -1,0 +1,41 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const script = fs.readFileSync(`${__dirname}/../loading-page/index.html`, 'utf8').match(/<script>([\s\S]*?)<\/script>/)[1];
+function setup(invoke) {
+  const elements = { status: { textContent: 'starting' }, help: { hidden: true } };
+  let poll, deadline;
+  vm.runInNewContext(script, {
+    window: { __TAURI_INTERNALS__: { invoke } },
+    document: { getElementById: id => elements[id] },
+    setInterval: fn => { poll = fn; return 1; },
+    setTimeout: fn => { deadline = fn; return 2; },
+    clearInterval() {}, clearTimeout() {},
+  });
+  return { elements, poll, deadline };
+}
+test('startup failure is shown even when it predates page initialization', async () => {
+  const page = setup(async () => 'backend exited');
+  await page.poll();
+  assert.equal(page.elements.status.textContent, 'backend exited');
+  assert.equal(page.elements.help.hidden, false);
+});
+test('pending startup keeps the loading message', async () => {
+  const page = setup(async () => null);
+  await page.poll();
+  assert.equal(page.elements.status.textContent, 'starting');
+});
+test('deadline ends loading when IPC never responds', () => {
+  const page = setup(() => new Promise(() => {}));
+  page.poll();
+  page.deadline();
+  assert.equal(page.elements.help.hidden, false);
+});
+test('deadline ends loading when IPC rejects', async () => {
+  const page = setup(async () => { throw new Error('IPC unavailable'); });
+  await page.poll();
+  page.deadline();
+  assert.equal(page.elements.help.hidden, false);
+});


### PR DESCRIPTION
## Summary
- 파서 변경 후 재시작 시 번들 백엔드 의존성이 파서 패키지에 덮어써지는 문제 수정
- sidecar 조기 종료, 헬스체크 타임아웃, IPC 실패 시 시작 화면에 오류 표시
- 파서 재시작 및 Tauri 로딩 화면 회귀 테스트 추가

## Validation
- Python tests: 21 passed
- Loading page tests: 4 passed
- `cargo check --offline` passed with Tauri resources disabled for local validation
