### PR TITLE
fix: recover backend across desktop restarts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,8 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 import os
 from contextlib import asynccontextmanager
+import asyncio
+from contextlib import suppress
 import logging
 
 from logging_config import setup_logging
@@ -41,14 +43,27 @@ from services.auth import get_current_user
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    """Initialize persistent state and restore library sessions at startup."""
+    """Initialize storage, then recover library work without blocking startup."""
     from services.db import init_db
     from services.usage_tracker import init_usage_table
 
     init_db()
     init_usage_table()
-    upload.restore_sessions_from_library()
-    yield
+    async def recover_library():
+        try:
+            await upload.restore_sessions_from_library()
+        except Exception:
+            logger.exception("Library task recovery failed; the API remains available")
+
+    # Uncached documents can require PDF parsing or OCR model initialization.
+    # Keep the API available while restoring them in the background.
+    recovery = asyncio.create_task(recover_library())
+    try:
+        yield
+    finally:
+        recovery.cancel()
+        with suppress(asyncio.CancelledError):
+            await recovery
 
 
 app = FastAPI(

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -1,6 +1,8 @@
 import uuid
 import os
 import shutil
+import asyncio
+import logging
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from fastapi.responses import JSONResponse
 import aiofiles
@@ -73,7 +75,9 @@ def ensure_session(session_id: str) -> bool:
         # 기존 문서는 처음 열릴 때 원문 FTS 인덱스를 지연 백필한다.
         from services.context_retrieval import index_document_chunks
         index_document_chunks(session_id, pages)
-        sessions[session_id] = {
+        # Recovery may finish after an interactive request has opened this
+        # document. Preserve that live session and any edits made to it.
+        sessions.setdefault(session_id, {
             "pdf_path": pdf_path,
             "filename": doc["filename"],
             "pages": pages,
@@ -95,7 +99,7 @@ def ensure_session(session_id: str) -> bool:
             "content_kind": doc.get("content_kind", "pdf"),
             "source_origin": doc.get("source_origin", "local"),
             "source_url": doc.get("source_url"),
-        }
+        })
         return True
     except Exception:
         return False
@@ -117,8 +121,11 @@ def require_session_owner(session_id: str, current_user: str) -> dict:
     return session
 
 
-def restore_sessions_from_library():
-    """서버 시작 시 미완료 번역 잡이 있는 문서만 세션으로 복원하고 잡을 재개합니다.
+async def restore_sessions_from_library():
+    """API 시작 후 미완료 작업의 문서를 백그라운드 복원하고 잡을 재개합니다.
+
+    PDF/OCR 복원은 worker thread에서 수행하고, asyncio 작업 재개는
+    서버 이벤트 루프에서 수행한다. 복원이 느려도 시작 응답을 막지 않는다.
 
     예전에는 라이브러리의 모든 문서를 매번 세션으로 복원했다(각 PDF를
     처음부터 다시 extract_pages()로 텍스트 추출). 이러면 서버 기동 시간이
@@ -134,12 +141,15 @@ def restore_sessions_from_library():
     열지 않는 가벼운 파일 I/O라 문서 수가 많아도 부담이 없다.
     """
     from services.document_tasks import recoverable_tasks
-    recoverable_doc_ids = {task["doc_id"] for task in recoverable_tasks()}
-    for doc in list_documents():
+    recoverable_doc_ids = {task["doc_id"] for task in await asyncio.to_thread(recoverable_tasks)}
+    for doc in await asyncio.to_thread(list_documents):
         doc_id = doc["id"]
-        job = get_job_status(doc_id)
+        job = await asyncio.to_thread(get_job_status, doc_id)
         if doc_id in recoverable_doc_ids or (job and job.get("status") == "running"):
-            ensure_session(doc_id)
+            try:
+                await asyncio.to_thread(ensure_session, doc_id)
+            except Exception:
+                logging.getLogger(__name__).exception("Failed to restore document %s", doc_id)
 
     # 미완료 번역 잡과 나머지 영속 작업 재개
     resume_incomplete_jobs(sessions)

--- a/backend/tests/test_session_restore_lazy.py
+++ b/backend/tests/test_session_restore_lazy.py
@@ -10,6 +10,7 @@ ensure_session()이 실제로 열람될 때 지연 복원하도록 바뀌었다 
 
 import json
 import os
+import asyncio
 
 import fitz
 import pytest
@@ -66,7 +67,7 @@ def test_only_documents_with_running_job_are_restored_eagerly(isolated_dirs, mon
         upload_module, "resume_incomplete_jobs", lambda sessions: calls.append(dict(sessions))
     )
 
-    upload_module.restore_sessions_from_library()
+    asyncio.run(upload_module.restore_sessions_from_library())
 
     assert "doc-running" in upload_module.sessions, "진행 중인 잡이 있는 문서는 즉시 복원되어야 함"
     assert upload_module.sessions["doc-running"]["pages"], "복원된 세션에는 추출된 페이지가 있어야 함"
@@ -84,7 +85,7 @@ def test_document_without_any_job_status_is_not_restored_eagerly(isolated_dirs, 
 
     monkeypatch.setattr(upload_module, "resume_incomplete_jobs", lambda sessions: None)
 
-    upload_module.restore_sessions_from_library()
+    asyncio.run(upload_module.restore_sessions_from_library())
 
     assert "doc-untouched" not in upload_module.sessions
 
@@ -96,7 +97,7 @@ def test_ensure_session_still_lazily_restores_idle_document_on_demand(isolated_d
     _write_job_status("doc-idle", "completed", isolated_dirs)
 
     monkeypatch.setattr(upload_module, "resume_incomplete_jobs", lambda sessions: None)
-    upload_module.restore_sessions_from_library()
+    asyncio.run(upload_module.restore_sessions_from_library())
     assert "doc-idle" not in upload_module.sessions
 
     assert upload_module.ensure_session("doc-idle") is True
@@ -122,3 +123,18 @@ def test_ensure_session_reuses_disk_cache_across_simulated_restart(isolated_dirs
 
     assert upload_module.ensure_session("doc-idle") is True
     assert upload_module.sessions["doc-idle"]["pages"] == cached_pages
+
+
+def test_recovery_preserves_session_opened_while_parsing(isolated_dirs, monkeypatch):
+    _create_doc(isolated_dirs, "doc-race", monkeypatch)
+    original_extract = upload_module.extract_pages
+    live_session = {"pages": [], "user_edit": "keep"}
+
+    def extract(*args, **kwargs):
+        pages = original_extract(*args, **kwargs)
+        upload_module.sessions["doc-race"] = live_session
+        return pages
+
+    monkeypatch.setattr(upload_module, "extract_pages", extract)
+    assert upload_module.ensure_session("doc-race")
+    assert upload_module.sessions["doc-race"] is live_session

--- a/backend/tests/test_startup_recovery.py
+++ b/backend/tests/test_startup_recovery.py
@@ -1,0 +1,85 @@
+import asyncio
+import threading
+
+
+def test_lifespan_serves_before_recovery_finishes(monkeypatch):
+    import main
+    import services.db as db
+    import services.usage_tracker as usage
+
+    monkeypatch.setattr(db, 'init_db', lambda: None)
+    monkeypatch.setattr(usage, 'init_usage_table', lambda: None)
+
+    async def check():
+        started = asyncio.Event()
+        stopped = asyncio.Event()
+
+        async def recover():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                stopped.set()
+
+        monkeypatch.setattr(main.upload, 'restore_sessions_from_library', recover)
+        async with main.lifespan(main.app):
+            await asyncio.wait_for(started.wait(), 1)
+            assert not stopped.is_set()
+        assert stopped.is_set()
+
+    asyncio.run(check())
+
+
+def test_slow_document_recovery_does_not_block_event_loop(monkeypatch):
+    import routers.upload as upload
+    import services.document_tasks as tasks
+    import services.reparse as reparse
+
+    entered = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(tasks, 'recoverable_tasks', lambda: [{'doc_id': 'slow'}])
+    monkeypatch.setattr(upload, 'list_documents', lambda: [{'id': 'slow'}])
+    monkeypatch.setattr(upload, 'get_job_status', lambda _: None)
+    monkeypatch.setattr(tasks, 'recover_document_tasks', lambda _: None)
+    monkeypatch.setattr(reparse, 'recover_reparse_previews', lambda: None)
+    resumed = []
+    monkeypatch.setattr(upload, 'resume_incomplete_jobs', lambda _: resumed.append(True))
+
+    def restore(_):
+        entered.set()
+        assert release.wait(5), 'event loop was blocked by document restoration'
+
+    monkeypatch.setattr(upload, 'ensure_session', restore)
+
+    async def check():
+        recovery = asyncio.create_task(upload.restore_sessions_from_library())
+        try:
+            assert await asyncio.to_thread(entered.wait, 2)
+            assert not recovery.done()
+            assert not resumed
+        finally:
+            release.set()
+            await recovery
+        assert resumed == [True]
+
+    asyncio.run(check())
+
+
+def test_recovery_error_does_not_fail_lifespan(monkeypatch):
+    import main
+    import services.db as db
+    import services.usage_tracker as usage
+
+    monkeypatch.setattr(db, 'init_db', lambda: None)
+    monkeypatch.setattr(usage, 'init_usage_table', lambda: None)
+
+    async def fail():
+        raise ValueError('invalid persisted task')
+
+    monkeypatch.setattr(main.upload, 'restore_sessions_from_library', fail)
+
+    async def check():
+        async with main.lifespan(main.app):
+            await asyncio.sleep(0)
+
+    asyncio.run(check())

--- a/backend/tests/test_venv_manager.py
+++ b/backend/tests/test_venv_manager.py
@@ -182,6 +182,9 @@ def test_packaged_restart_preserves_bundled_dependencies(tmp_path, engine):
     module = venv_manager.PARSER_PACKAGES[engine][1]
     (packages / module).mkdir(parents=True)
     (packages / module / "__init__.py").write_text("AVAILABLE = True\n")
+    (packages / "startup_hook.pth").write_text(
+        "import sys; sys.exit('optional package hook ran during startup')\n"
+    )
     (packages / "startup_dependency.py").write_text(
         "raise RuntimeError('incompatible parser dependency at startup')\n"
     )

--- a/backend/venv_manager.py
+++ b/backend/venv_manager.py
@@ -11,7 +11,6 @@ Tauri PyInstaller 배포본은 일반 Python 인터프리터가 아니므로 별
 """
 import os
 import shutil
-import site
 import sys
 import tempfile
 
@@ -159,7 +158,10 @@ def _activate_packaged_parser(engine: str) -> None:
     # packages first so their Python code and native extensions stay compatible
     # after restarting with a different parser. Parser-only packages remain
     # available through the appended site-packages directory.
-    site.addsitedir(package_dir)
+    # pip --target wheels need a module search path, not startup .pth hooks.
+    # Executing optional native imports here can crash or hang the whole server.
+    if package_dir not in sys.path:
+        sys.path.append(package_dir)
     _active_engine = engine
 
 

--- a/frontend/src/desktopUpdate.js
+++ b/frontend/src/desktopUpdate.js
@@ -1,0 +1,13 @@
+// Import this helper and restart IPC before stopping the HTTP sidecar.
+export async function applyDesktopUpdate(update, { stopBackend, relaunch, onEvent }) {
+  await update.download(onEvent)
+  await stopBackend()
+  try {
+    await update.install()
+  } catch (error) {
+    // Recover the backend if installation fails after it has been stopped.
+    try { await relaunch() } catch (_) { /* caller displays the installation error */ }
+    throw error
+  }
+  await relaunch()
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
 import './style.css'
+import { applyDesktopUpdate } from './desktopUpdate.js'
 import { pageCoordinates } from './pdfCoordinates.js'
 import './styles/shell.css'
 import './styles/library-page.css'
@@ -4797,41 +4798,31 @@ async function installTauriUpdate() {
     // 설치가 실패한다.
     const { relaunch } = await import('@tauri-apps/plugin-process')
 
-    // Windows 설치 프로그램이 파일을 덮어쓰기 전에 백엔드 sidecar를 먼저
-    // 종료해야 한다 - 계속 떠 있으면 PyInstaller 런타임이 로드한 DLL(예:
-    // MSVCP140.dll)을 OS가 잠그고 있어서 "Error opening file for writing"
-    // 오류로 설치가 멈춘다. downloadAndInstall의 진행 콜백은 await하지
-    // 않고 그냥 호출되므로, 'Finished' 이벤트 시점에 죽이면 설치 시작과
-    // 경쟁 상태가 생길 수 있다 - 다운로드 시작 전에 미리 종료해 둔다
-    // (다운로드 자체는 sidecar 없이도 문제없이 동작한다).
-    try {
-      const { invoke } = await import('@tauri-apps/api/core')
-      await invoke('kill_backend_sidecar')
-    } catch (killErr) {
-      console.warn('sidecar 종료 실패(무시하고 설치 계속):', killErr)
-    }
+    const { invoke } = await import('@tauri-apps/api/core')
 
     let downloadedBytes = 0
     let totalBytes = 0
-    await pendingTauriUpdate.downloadAndInstall((event) => {
-      switch (event.event) {
-        case 'Started':
-          totalBytes = event.data.contentLength || 0
-          setTauriUpdateStatusText('다운로드 시작...')
-          break
-        case 'Progress':
-          downloadedBytes += event.data.chunkLength
-          setTauriUpdateStatusText(totalBytes
-            ? `다운로드 중... ${Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))}%`
-            : '다운로드 중...')
-          break
-        case 'Finished':
-          setTauriUpdateStatusText('설치 중... 곧 앱이 재시작됩니다.')
-          break
+    await applyDesktopUpdate(pendingTauriUpdate, {
+      stopBackend: () => invoke('kill_backend_sidecar'),
+      relaunch,
+      onEvent: (event) => {
+        switch (event.event) {
+          case 'Started':
+            totalBytes = event.data.contentLength || 0
+            setTauriUpdateStatusText('다운로드 시작...')
+            break
+          case 'Progress':
+            downloadedBytes += event.data.chunkLength
+            setTauriUpdateStatusText(totalBytes
+              ? `다운로드 중... ${Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))}%`
+              : '다운로드 중...')
+            break
+          case 'Finished':
+            setTauriUpdateStatusText('설치 중... 곧 앱이 재시작됩니다.')
+            break
+        }
       }
     })
-
-    await relaunch()
   } catch (err) {
     setTauriUpdateStatusText('설치 실패: ' + (err.message || err), '#ef4444')
     if (tauriUpdateInstallBtn) tauriUpdateInstallBtn.disabled = false

--- a/frontend/tests/desktopUpdate.test.js
+++ b/frontend/tests/desktopUpdate.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { applyDesktopUpdate } from '../src/desktopUpdate.js'
+
+function scenario(failure) {
+  const calls = []
+  const step = name => async () => {
+    calls.push(name)
+    if (failure === name) throw new Error(name)
+  }
+  return {
+    calls,
+    update: { download: step('download'), install: step('install') },
+    options: { stopBackend: step('stop'), relaunch: step('relaunch') },
+  }
+}
+test('download failure keeps the backend running', async () => {
+  const s = scenario('download')
+  await assert.rejects(applyDesktopUpdate(s.update, s.options), /download/)
+  assert.deepEqual(s.calls, ['download'])
+})
+test('install waits for confirmed backend shutdown', async () => {
+  const s = scenario('stop')
+  await assert.rejects(applyDesktopUpdate(s.update, s.options), /stop/)
+  assert.deepEqual(s.calls, ['download', 'stop'])
+})
+test('installation failure restarts the app to recover the backend', async () => {
+  const s = scenario('install')
+  await assert.rejects(applyDesktopUpdate(s.update, s.options), /install/)
+  assert.deepEqual(s.calls, ['download', 'stop', 'install', 'relaunch'])
+})
+test('successful update stops the backend only after download', async () => {
+  const s = scenario()
+  await applyDesktopUpdate(s.update, s.options)
+  assert.deepEqual(s.calls, ['download', 'stop', 'install', 'relaunch'])
+})

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,12 +156,23 @@ fn backend_binary_path(app: &tauri::AppHandle) -> PathBuf {
     base.join("easypaper-backend").join(exe_name)
 }
 
-fn kill_sidecar(state: &tauri::State<SidecarState>) {
-    if let Ok(mut guard) = state.0.lock() {
-        if let Some(mut child) = guard.take() {
-            let _ = child.kill();
-            let _ = child.wait();
+fn stop_sidecar(state: &tauri::State<SidecarState>) -> Result<(), String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(child) = guard.as_mut() {
+        if child.try_wait().map_err(|e| e.to_string())?.is_none() {
+            child.kill().map_err(|e| format!("백엔드 종료 실패: {e}"))?;
         }
+        child.wait().map_err(|e| format!("백엔드 종료 확인 실패: {e}"))?;
+    }
+    // Retain the handle on failure so shutdown can retry and installation
+    // cannot proceed under the false assumption that DLL locks were released.
+    guard.take();
+    Ok(())
+}
+
+fn kill_sidecar(state: &tauri::State<SidecarState>) {
+    if let Err(error) = stop_sidecar(state) {
+        log::error!("{}", error);
     }
 }
 
@@ -172,9 +183,9 @@ fn kill_sidecar(state: &tauri::State<SidecarState>) {
 /// 오류로 멈춘다 - 자동 업데이트로 설치를 시작하기 전에 sidecar를 먼저
 /// 종료해 파일 잠금을 풀어줘야 한다.
 #[tauri::command]
-fn kill_backend_sidecar(state: tauri::State<SidecarState>) {
+fn kill_backend_sidecar(state: tauri::State<SidecarState>) -> Result<(), String> {
     log::info!("update install requested, killing sidecar to release locked files");
-    kill_sidecar(&state);
+    stop_sidecar(&state)
 }
 
 /// 앱 시작에 필요한 필수 자원(리소스 디렉토리, sidecar 프로세스 등)을 얻지


### PR DESCRIPTION
## Summary
- 파서 패키지의 `.pth` 시작 훅으로 인한 백엔드 초기화 실패 방지
- 미완료 문서 PDF/OCR 복구를 백그라운드로 분리해 API 시작 차단 방지
- 업데이트 다운로드 성공 후 sidecar를 종료하고, 설치 실패 시 앱 재시작으로 복구
- sidecar 종료 실패를 호출자에게 전달하고 복구 중 세션 덮어쓰기 방지

## Validation
- Python 관련 테스트 60개 통과
- Node 업데이트·시작 화면 테스트 8개 통과
- `cargo check --offline` 통과
- macOS 실제 Tauri 설치·업데이트 후 재시작은 Tauri 빌드 후 검증 예정
